### PR TITLE
Don’t instantiate the WC_Connect_Logger class.

### DIFF
--- a/classes/class-wc-connect-logger.php
+++ b/classes/class-wc-connect-logger.php
@@ -30,7 +30,7 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
          */
         protected static function format_message( $message, $context = '' ) {
 
-            $formatted_message = '';
+			$formatted_message = $message;
 
             if ( is_wp_error( $message ) ) {
                 $formatted_message = $message->get_error_code() . ' ' . $message->get_error_message();


### PR DESCRIPTION
There’s no need to create a singleton instance to enforce a single instance of the logger object. A static utility class is all we need.

Ping @allendav @jkudish @nabsul for review.
