### PR TITLE
Add tcomb as an explicit dependency to avoid a problem that

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "jsdom": "8.0.4",
     "mocha": "2.4.5",
     "react-addons-test-utils": "0.14.7",
+    "tcomb": "2.7.0",
     "tcomb-form": "0.8.1",
     "tcomb-json-schema": "0.2.5",
     "webpack": "1.12.13"


### PR DESCRIPTION
causes booleans to render as input text instead of checkbox when using node v4.3.

Fixes #37 

To test:
Setup for node v4.3.1, npm 2.4.12
rm -rf node_modules/
npm install
webpack
Cmd Shift R while on the settings page of an instance of WooCommerce Connect's USPS Shipping Method to cause the browser to force a reload of bundle.js
Verify you get a checkbox for the enabled field (not a input type text)

cc @jeffstieler @jkudish for review
