### PR TITLE
Add default form values from schema.

### DIFF
--- a/src/views/settings.js
+++ b/src/views/settings.js
@@ -22,17 +22,11 @@ module.exports = React.createClass( {
 
 		// Pull field names and default values from the JSON Schema object
 		if ( ( 'object' === schema.type ) && _.isPlainObject( schema.properties ) ) {
-
 			defaults = _.transform( schema.properties, function( result, fieldMeta, fieldName ) {
-
 				if ( _.has( fieldMeta, 'default' ) ) {
-
 					result[ fieldName ] = fieldMeta.default;
-
 				}
-
 			} );
-
 		}
 
 		return {


### PR DESCRIPTION
Fixes #43.

To test:
- Add a Canada Post shipping method to a shipping zone, then go to it's settings
- Confirm the initial form has "Canada Post" in the title field
- Change the value to anything else, hit "Save Changes"
- Confirm the form now has the new value, not the default
