### PR TITLE
Updates the client to make requests using the updated auth method

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -234,6 +234,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			$headers = array();
 			$lang = strtolower( str_replace( '_', '-', get_locale() ) );
 			$headers['Accept-Language'] = $lang;
+			$headers['Content-Type'] = 'application/json; charset=utf-8';
 			$headers['Accept'] = 'application/vnd.woocommerce-connect.v1';
 			$headers['Authorization'] = $authorization;
 			return $headers;


### PR DESCRIPTION
This PR seeks to update the client to make requests using `wp_remote_request` with our custom signature instead of via the `Jetpack_Client`, now that we're updating how authentication works.

Additionally, this sets some "good practices" settings on the `wp_remote_request` that executes the request to the WCC server. Specifically `redirection=0` for security and `compress=true` for performance.
Also, the WCC URL and the arguments sent to the server are now filterable (makes it easier to test). We can remove this later if we find no legitimate use for this.
Finally, this sets the correct URL for the connection test endpoint.

@allendav @jeffstieler @mdawaffe @nabsul for review
