### PR TITLE
Change request to services enumeration endpoint from GET to POST

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,4 +1,4 @@
-# GET /services
+# POST /services
 
 ## Example Request
 

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -19,7 +19,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 * @return array|WP_Error
 		 */
 		public function get_services() {
-			return $this->request( 'GET', '/services' );
+			return $this->request( 'POST', '/services' );
 		}
 
 


### PR DESCRIPTION
Fixes #77 

To test locally, first spin up the server with its pull request https://github.com/Automattic/woocommerce-connect-server/pull/125 

Then, add this to woocommerce-connect-client.php

```
if ( ! defined( 'WOOCOMMERCE_CONNECT_SERVER_URL' ) ) {
    define( 'WOOCOMMERCE_CONNECT_SERVER_URL', 'http://Lyra.local:5000/' );
}
```

replacing it with your local connect server’s location

and add these lines near the top of class-wc-connect-api-client.php authorization_header to fake a token:

```
    protected function authorization_header() {
        $token = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
        $token = new stdClass();
        $token->secret = "askjdflasjdlfkajsldfkjaslkdf.asdkfjlaskjdflajskd";
        $token->external_user_id = 0;
```

Then, look in wp-admin > WooCommerce > System Status > Logs > wc-connect to verify you are getting the following:

```
03-16-2016 @ 10:50:26 - Successfully loaded service schemas from server response. (fetch_services_from_connect_server)
```

Alternatively, you may go to the Shipping Zones settings page and verify that both USPS and Canada Post are displayed in the drop down after clicking Add Shipping Method.

cc @jeffstieler @nabsul @jkudish for review
