### PR TITLE
The services store doesn't need access to the services response

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -14,14 +14,37 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 	class WC_Connect_API_Client {
 
 		/**
+		 * @var WC_Connect_Services_Validator
+		 */
+		protected $validator;
+
+		public function __construct(
+			WC_Connect_Services_Validator $validator
+		) {
+
+			$this->validator = $validator;
+
+		}
+
+		/**
 		 * Requests the available services for this site from the WooCommerce Connect Server
 		 *
 		 * @return array|WP_Error
 		 */
 		public function get_services() {
-			return $this->request( 'POST', '/services' );
-		}
+			$response_body = $this->request( 'POST', '/services' );
 
+			if ( is_wp_error( $response_body ) ) {
+				return $response_body;
+			}
+
+			$result = $this->validator->validate_services( $response_body );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+
+			return $response_body;
+		}
 
 		/**
 		 * Validates the settings for a given service with the WooCommerce Connect Server

--- a/classes/class-wc-connect-services-store.php
+++ b/classes/class-wc-connect-services-store.php
@@ -14,20 +14,13 @@ if ( ! class_exists( 'WC_Connect_Services_Store' ) ) {
 		 */
 		protected $logger;
 
-		/**
-		 * @var WC_Connect_Services_Validator
-		 */
-		protected $validator;
-
 		public function __construct(
 			WC_Connect_API_Client $api_client,
-			WC_Connect_Logger $logger,
-			WC_Connect_Services_Validator $validator
+			WC_Connect_Logger $logger
 		) {
 
 			$this->api_client = $api_client;
 			$this->logger     = $logger;
-			$this->validator  = $validator;
 
 		}
 
@@ -38,20 +31,6 @@ if ( ! class_exists( 'WC_Connect_Services_Store' ) ) {
 			if ( is_wp_error( $response_body ) ) {
 				$this->logger->log(
 					$response_body,
-					__FUNCTION__
-				);
-
-				return;
-			}
-
-			$result = $this->validator->validate_services( $response_body );
-			if ( is_wp_error( $result ) ) {
-				$this->logger->log(
-					$result,
-					__FUNCTION__
-				);
-				$this->logger->log(
-					'One or more service schemas failed to validate. Will not store services in options.',
 					__FUNCTION__
 				);
 

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -116,9 +116,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			require_once( plugin_basename( 'classes/class-wc-connect-services-store.php' ) );
 
 			$logger     = new WC_Connect_Logger( new WC_Logger() );
-			$api_client = new WC_Connect_API_Client();
 			$validator  = new WC_Connect_Services_Validator();
-			$store      = new WC_Connect_Services_Store( $api_client, $logger, $validator );
+			$api_client = new WC_Connect_API_Client( $validator );
+			$store      = new WC_Connect_Services_Store( $api_client, $logger );
 
 			$this->set_logger( $logger );
 			$this->set_api_client( $api_client );


### PR DESCRIPTION
validator.  Just the API layer does.

Fixes #66 

To test:
- Ensure you can continue to receive services (e.g. make sure that with this PR that no validation errors are being logged in wp-admin > WooCommerce > System Status > Logs > wc-connect)
- Then, tweak class-wc-connect-services-validator.php to force a validation problem (e.g. change id to idxx near line 72)
- Ensure you get a warning that the service sent an invalid schema

cc @jeffstieler @jkudish @nabsul for code review
