### PR TITLE
Fix /rates request.

### DIFF
--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -309,12 +309,11 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 			// TODO: Request rates for all WooCommerce Connect powered methods in
 			// the current shipping zone to avoid each method making an independent request
-			$settings = $this->get_form_settings();
 			$services = array(
 				array(
 					'id'               => $this->id,
 					'instance'         => $this->instance_id,
-					'service_settings' => $settings,
+					'service_settings' => $this->get_form_settings(),
 				),
 			);
 


### PR DESCRIPTION
Break instance settings out into service_settings key as expected by the rates endpoint.
