### PR TITLE
Removed enabled field from shipping method

### DIFF
--- a/classes/class-wc-connect-services-validator.php
+++ b/classes/class-wc-connect-services-validator.php
@@ -163,7 +163,7 @@ if ( ! class_exists( 'WC_Connect_Services_Validator' ) ) {
 
 		/**
 		 * Validates a particular service's required properties, especially the parts of the
-		 * properties that WC relies on like enabled and title
+		 * properties that WC relies on and title
 		 *
 		 * @param string $service_id
 		 * @param object $service_settings_properties
@@ -172,7 +172,6 @@ if ( ! class_exists( 'WC_Connect_Services_Validator' ) ) {
 		 */
 		protected function validate_service_settings_required_properties( $service_id, $service_settings_properties ) {
 			$required_properties = array(
-				'enabled',
 				'title'
 			);
 

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -52,7 +52,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				$this->method_description = '';
 				$this->supports = array();
 				$this->title = '';
-				$this->enabled = 'no';
 			} else {
 				$this->id = $this->service->id;
 				$this->method_title = $this->service->method_title;
@@ -62,11 +61,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 					'instance-settings'
 				);
 
-				// Set title and enabled to default values
+				// Set title to default value
 				$this->title = $this->service->method_title;
-				$this->enabled = 'yes';
 
-				// Load form values from options, updating title and enabled if present
+				// Load form values from options, updating title if present
 				$this->init_form_settings();
 
 				// Process any changes to values present in $_POST
@@ -143,35 +141,14 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 		/**
 		 * Restores any values persisted to the DB for this service instance
-		 * and sets up both enabled and title for WC core to work properly
+		 * and sets up title for WC core to work properly
 		 *
 		 */
 		protected function init_form_settings() {
 
 			$form_settings = $this->get_form_settings();
 
-			// We need to initialize the instance property $this->enabled
-			// to "yes" or "no" (which WC expects instead of a boolean)
-			if ( array_key_exists( 'enabled', $form_settings ) ) {
-				$enabled = $form_settings['enabled'];
-				if ( is_bool( $enabled ) ) {
-					$this->enabled = $enabled ? 'yes' : 'no';
-				} else {
-					// If we can't comprehend the setting, go
-					// ahead and mark it disabled and log a warning
-					$this->enabled = 'no';
-					$this->log(
-						sprintf(
-							'Warning. Unrecognized value for \'Enabled\' when updating settings for %s instance id %d. Setting to NOT enabled.',
-							$this->id,
-							$this->instance_id
-						),
-						__FUNCTION__
-					);
-				}
-			}
-
-			// We also need to initialize the instance title ($this->title)
+			// We need to initialize the instance title ($this->title)
 			// from the settings blob
 			if ( array_key_exists( 'title', $form_settings ) ) {
 				$this->title = $form_settings['title'];
@@ -237,7 +214,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			// Whitelist settings sent to the validation endpoint using the schema
 			if ( isset( $schema->properties ) ) {
 				foreach ( (array) $schema->properties as $field_name => $properties ) {
-					// Special handling is needed to turn checkboxes like enabled back into booleans
+					// Special handling is needed to turn checkboxes back into booleans
 					// since our form returns 'on' for checkboxes if they are checked and omits
 					// the key if they are not checked
 					if ( 'boolean' === $properties->type ) {

--- a/tests/php/test_wc-connect-services-validator.php
+++ b/tests/php/test_wc-connect-services-validator.php
@@ -25,12 +25,6 @@ class WP_Test_WC_Connect_Services_Validator extends WC_Unit_Test_Case {
 						'type' => 'object',
 						'required' => array(),
 						'properties' => (object) array(
-							'enabled' => (object) array(
-								'type' => 'boolean',
-								'title' => 'Enable/Disable',
-								'description' => 'Enable this shipping method',
-								'default' => false
-							),
 							'title' => (object) array(
 								'type' => 'string',
 								'title' => 'Method Title',
@@ -132,10 +126,6 @@ class WP_Test_WC_Connect_Services_Validator extends WC_Unit_Test_Case {
 		$service_settings_properties_object = self::get_golden_services();
 		$service_settings_properties_object->shipping[0]->service_settings->properties = array();
 
-		// service settings properties should have enabled
-		$service_settings_enabled_required = self::get_golden_services();
-		unset( $service_settings_enabled_required->shipping[0]->service_settings->properties->enabled );
-
 		// service settings properties should have title
 		$service_settings_title_required = self::get_golden_services();
 		unset( $service_settings_title_required->shipping[0]->service_settings->properties->title );
@@ -158,7 +148,6 @@ class WP_Test_WC_Connect_Services_Validator extends WC_Unit_Test_Case {
 			'service settings required should be an array' => array( $service_settings_required_array, 'service_settings_property_wrong_type' ),
 			'service settings should have properties' => array( $service_settings_properties_required, 'service_settings_missing_required_property' ),
 			'service settings properties should be an object' => array( $service_settings_properties_object, 'service_settings_property_wrong_type' ),
-			'service settings properties should have enabled' => array( $service_settings_enabled_required, 'service_properties_missing_required_property' ),
 			'service settings properties should have title' => array( $service_settings_title_required, 'service_properties_missing_required_property' ),
 		);
 


### PR DESCRIPTION
Since WooCommerce core handles it now for us.

Fixes #87 

See https://github.com/Automattic/woocommerce-connect-server/pull/144 for test instructions

cc @jkudish @jeffstieler @nabsul for code review
