### PR TITLE
Implement sass loading via webpack

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Settings from './views/usps';
+import '../assets/stylesheets/style.scss';
 
 document.addEventListener( 'DOMContentLoaded', () => {
 	ReactDOM.render(

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-addons-test-utils": "0.14.7",
     "react-hot-loader": "^1.3.0",
     "sass-loader": "^3.1.2",
+    "style-loader": "^0.13.0",
     "tcomb": "2.7.0",
     "tcomb-form": "0.8.1",
     "tcomb-json-schema": "0.2.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,10 +1,11 @@
 var webpack = require( 'webpack' ),
+	ExtractTextPlugin = require( 'extract-text-webpack-plugin' ),
 	path = require( 'path' );
 
 module.exports = {
 	cache: true,
 	entry: {
-		'woocommerce-connect-client': './client/main.js'
+		'woocommerce-connect-client': './client/main.js',
 	},
 	output: {
 		path: path.join( __dirname, 'dist' ),
@@ -18,6 +19,10 @@ module.exports = {
 				loader: 'json-loader'
 			},
 			{
+				test: /\.scss$/,
+				loader: ExtractTextPlugin.extract( 'style', 'css?minimize!sass' )
+			},
+			{
 				test: /\.html$/,
 				loader: 'html-loader'
 			},
@@ -25,6 +30,12 @@ module.exports = {
 				test: /\.jsx?$/,
 				loader: 'babel-loader'
 			}
+		]
+	},
+	sassLoader: {
+		includePaths: [
+			path.resolve( __dirname, './node_modules/wp-calypso/client' ),
+			path.resolve( __dirname, './node_modules/wp-calypso/assets/stylesheets' ),
 		]
 	},
 	resolve: {
@@ -41,5 +52,8 @@ module.exports = {
 		fallback: [
 			path.join( __dirname, 'node_modules', 'wp-calypso', 'node_modules' )
 		]
-	}
+	},
+	plugins: [
+		new ExtractTextPlugin( '[name].css' ),
+	],
 };

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -293,7 +293,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			wp_enqueue_style( 'noticons', plugins_url( 'assets/stylesheets/noticons.css', __FILE__ ), array(), '20150727' );
 			wp_enqueue_style( 'dashicons', plugins_url( 'assets/stylesheets/dashicons.css', __FILE__ ), array(), '20150727' );
 
-			wp_enqueue_style( 'wc_connect_shipping_admin', plugins_url( 'dist/style.css', __FILE__ ), array( 'noticons', 'dashicons' ) );
+			wp_enqueue_style( 'wc_connect_shipping_admin', plugins_url( 'dist/woocommerce-connect-client.css', __FILE__ ), array( 'noticons', 'dashicons' ) );
 			wp_register_script( 'wc_connect_shipping_admin', plugins_url( 'dist/woocommerce-connect-client.js', __FILE__ ), array(), false, true );
 
 		}


### PR DESCRIPTION
This PR adds the needed webpack loaders + the extract text plugin to enable us to generate + load styles via webpack. Fixes #97 

To test:
- Checkout this branch
- `npm install`
- Empty the contents of the `dist` folder
- Run `npm run webpack`
- Check that both the js and css file is generated in `dist`
- Verify that the shipping settings form still renders (as per screenshot below)

![screenshot from 2016-03-23 11-22-41](https://cloud.githubusercontent.com/assets/260253/13996126/9a5cd242-f0e9-11e5-85ec-a8d1202c3102.png)

cc @nabsul @allendav @jeffstieler 
