### PR TITLE
update onFieldChange

### DIFF
--- a/client/actions/settings.js
+++ b/client/actions/settings.js
@@ -1,8 +1,8 @@
-export const UPDATE_TEXT_FIELD = 'UPDATE_TEXT_FIELD';
+const UPDATE_SETTINGS_FIELD = 'UPDATE_SETTINGS_FIELD';
 
 export function onFieldChange( event ) {
 	return {
-		type: UPDATE_TEXT_FIELD,
+		type: UPDATE_SETTINGS_FIELD,
 		key: event.target.name,
 		value: ( 'checkbox' === event.target.type ) ? event.target.checked : event.target.value
 	};

--- a/tests/js/test_settings.js
+++ b/tests/js/test_settings.js
@@ -12,7 +12,7 @@ import TestUtils from 'react-addons-test-utils';
 /**
  * Internal dependencies
  */
-import Settings from '../../client/views/usps';
+import { onFieldChange } from '../../client/actions/settings';
 
 describe( 'Settings', () => {
 	before( () => {
@@ -25,5 +25,43 @@ describe( 'Settings', () => {
 
 	it( 'test suite should work', () => {
 		expect( true ).to.be.ok;
+	} );
+} );
+
+describe( 'Settings actions', () => {
+	it( '#onFieldChange()', () => {
+		const event =  {
+			target: {
+				name: 'testField',
+				value: 'testValue',
+				type: 'text'
+			},
+		};
+
+		const action = onFieldChange( event );
+
+		expect( action ).to.eql( {
+			type: 'UPDATE_SETTINGS_FIELD',
+			key: 'testField',
+			value: 'testValue',
+		} );
+	} );
+
+	it( '#onFieldChange() checkbox', () => {
+		const event =  {
+			target: {
+				name: 'testCheckboxField',
+				checked: true,
+				type: 'checkbox'
+			},
+		};
+
+		const action = onFieldChange( event );
+
+		expect( action ).to.eql( {
+			type: 'UPDATE_SETTINGS_FIELD',
+			key: 'testCheckboxField',
+			value: true,
+		} );
 	} );
 } );


### PR DESCRIPTION
- change the action name to be more generic
- add tests for the action

fixes #120 

Note: the location of tests will probably change as I think we need to re-organize this a bit (see #106)

cc @jeffstieler @allendav @nabsul for review
