### PR TITLE
Make it easier to use fake jetpack token.

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -263,7 +263,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			return $headers;
 		}
 
-		private function get_jetpack_token() {
+		private function get_access_token() {
 			if ( ! defined( 'WOOCOMMERCE_CONNECT_FAKE_JETPACK_TOKEN' ) ) {
 				return Jetpack_Data::get_access_token( 0 );
 			}
@@ -275,7 +275,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		protected function authorization_header() {
-			$token = $this->get_jetpack_token();
+			$token = $this->get_access_token();
 			if ( ! $token || empty( $token->secret ) ) {
 				return new WP_Error( 'missing_token', 'Unable to send request to WooCommerce Connect server. Jetpack Token is missing' );
 			}


### PR DESCRIPTION
The reason I'd like to add this method is so that setting up the client to work on localhost, and with a locally running woocommerce connect server can be done only by adding some defines in wp-config.php.

This way there's no risk of accidentally checking in test code to the repo.

@allendav @jeffstieler @jkudish 
