### PR TITLE
Update method signature to match parent class

### DIFF
--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -254,7 +254,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		 *
 		 * @return bool
 		 */
-		public function process_admin_options() {
+		public function process_admin_options( $post_data = array() ) {
 
 			$settings = $this->get_posted_form_settings();
 


### PR DESCRIPTION
Strict Standards: Declaration of WC_Connect_Shipping_Method::process_admin_options() should be compatible with WC_Shipping_Method::process_admin_options($post_data = Array) in /home/nabeel/Projects/woocommerce-connect-client/classes/class-wc-connect-shipping-method.php on line 5

@allendav @jeffstieler @jkudish 
