### PR TITLE
Make it possible to run webpack dev server under windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "start": "NODE_ENV=development ./node_modules/.bin/webpack-dev-server --hot --inline --watch --content-base dist --port 8085",
+    "startwin": "set NODE_ENV=development & npm run webpack-dev-server",
+    "webpack-dev-server": "webpack-dev-server --hot --inline --watch --content-base dist --port 8085",
     "dist": "NODE_ENV=production ./node_modules/.bin/webpack -p --config webpack.production.config.js",
     "eslint": "./node_modules/.bin/eslint client/",
     "check-shrinkwrap": "./node_modules/.bin/npm-shrinkwrap-check",


### PR DESCRIPTION
I've been experimenting with Windows a little bit and I needed to make a few changes to get `webpack-dev-server` to run correctly on windows.

cc @nabsul as you're probably the only one with a Windows machine to help test ;)
