### PR TITLE
Remove extraneous save button

### DIFF
--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -347,6 +347,9 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		}
 
 		public function admin_options() {
+			// hide WP native save button on settings page
+			global $hide_save_button;
+			$hide_save_button = true;
 
 			$this->localize_and_enqueue_form_script();
 


### PR DESCRIPTION
This PR seeks to remove the extraneous save button on the USPS shipping page set global to not show the WordPress "native" save button. Fixes #151

To test: 
- Add all the possible shipping zones (flat, free, local pickup, USPS, Canada Post [still there for now])
- Make sure the save button is there on all the native methods
- Make sure the button isn't there on the USPS settings page [and Canada Post for now]
- Make sure the button is there on all the other WooCommerce settings pages

cc @allendav @nabsul @jeffstieler
