### PR TITLE
Remove section header and enabled toggle

### DIFF
--- a/client/views/usps-settings/index.js
+++ b/client/views/usps-settings/index.js
@@ -108,11 +108,6 @@ const Settings = ( props ) => {
 	}
 	return (
 		<div>
-			<SectionHeader label="USPS Shipping">
-				<FormToggle id="enabled" name="enabled" checked={ true } readOnly={ true }>
-					<FormLabel htmlFor="enabled" style={ { float: 'left' } }>Enable</FormLabel>
-				</FormToggle>
-			</SectionHeader>
 			<SettingsGroup
 				group={ layout[0] }
 				schema={ schema }


### PR DESCRIPTION
- remove the toggle: we're not using it
- remove the section header: it just duplicates the title which is already above

Fixes #179
