### PR TITLE
Shipping Entry UX improvements

### DIFF
--- a/client/components/shipping-service-groups/shipping-services-entry.js
+++ b/client/components/shipping-service-groups/shipping-services-entry.js
@@ -12,16 +12,20 @@ const ShippingServiceEntry = ( {
 	updateValue,
 } ) => (
 	<div className="wcc-shipping-service-entry">
-		<FormCheckbox
-			checked={ enabled }
-			onChange={ ( event ) => updateValue( 'enabled', event.target.checked ) }
-		/>
-		<span className="wcc-shipping-service-entry-title">{ title }</span>
+		<label className="wcc-shipping-service-entry-title">
+			<FormCheckbox
+				checked={ enabled }
+				onChange={ ( event ) => updateValue( 'enabled', event.target.checked ) }
+			/>
+			{ title }
+		</label>
 		<FormTextInput
+			disabled={ ! enabled }
 			value={ adjustment }
 			onChange={ ( event ) => updateValue( 'adjustment', Number.parseFloat( event.target.value ) ) }
 		/>
 		<FormSelect
+			disabled={ ! enabled }
 			value={ adjustment_type }
 			onChange={ ( event ) => updateValue( 'adjustment_type', event.target.value ) }
 		>


### PR DESCRIPTION
- Make the service label into a proper `<label>` element so that clicking it triggers the checkbox
- Disable the adjustment and price/percentage fields based on whether or not the service is enabled

Fixes #177 and fixes #178 

cc @allendav @jeffstieler @nabsul 
