### PR TITLE
Add success notice to form save.

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -55,5 +55,6 @@
 
   // WCC Components
   @import '../../client/components/shipping/packages/style';
+  @import '../../client/views/usps-settings/style';
 
 }

--- a/client/views/usps-settings/index.js
+++ b/client/views/usps-settings/index.js
@@ -26,6 +26,7 @@ const handleSaveForm = ( event, props ) => {
 		props.formActions.setField( 'isSaving', false );
 		if ( result.success ) {
 			props.formActions.setField( 'error', null );
+			props.formActions.setField( 'success', true );
 		} else if ( 'validation_failure' === result.data.error ) {
 			props.formActions.setField( 'error', result.data.message );
 		}
@@ -105,7 +106,19 @@ const Settings = ( props ) => {
 				<Notice status="is-error" text={ form.error } showDismiss={ false } />
 			);
 		}
-	}
+		if ( form.success ) {
+			return (
+				<Notice
+					className="wcc-form-success"
+					status="is-success"
+					text="Your changes have been saved."
+					showDismiss={ false }
+					onDismissClick={ () => props.formActions.setField( 'success', null ) }
+					duration={ 2250 }
+				/>
+			);
+		}
+	};
 	return (
 		<div>
 			<SettingsGroup

--- a/client/views/usps-settings/style.scss
+++ b/client/views/usps-settings/style.scss
@@ -1,0 +1,12 @@
+.wcc-form-success {
+  animation: disappear .3s ease-in-out 2s;
+}
+
+@keyframes disappear {
+  0% {
+	opacity: 1;
+  }
+  100% {
+	opacity: 0;
+  }
+}


### PR DESCRIPTION
Fixes #189.

To test:
- Save form with valid values
- Verify that a green success notice appears and fades out.
