### PR TITLE
Allow the jetpack token to be filtered for development

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -265,6 +265,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 
 		protected function authorization_header() {
 			$token = Jetpack_Data::get_access_token( 0 );
+			$token = apply_filters( 'wc_connect_jetpack_access_token', $token );
 			if ( ! $token || empty( $token->secret ) ) {
 				return new WP_Error( 'missing_token', 'Unable to send request to WooCommerce Connect server. Jetpack Token is missing' );
 			}


### PR DESCRIPTION
Fixes #184

To test, drop this as wp-content/plugins/dev.php and activate it in wp-admin > Plugins

``` php
<?php
/*
Plugin Name: Dev
Plugin URI: http://wordpress.org/plugins/
Description: Does dev things
Author: Allen Snook
Version: 1.0
Author URI: http://allendav.com
*/

function allendav_wc_connect_jetpack_access_token( $token ) {
        $token = new stdClass();
        $token->secret = "askjdflasjdlfkajsldfkjaslkdf.asdkfjlaskjdflajskd";
        $token->external_user_id = 0;
        return $token;
}

add_filter( 'wc_connect_jetpack_access_token', 'allendav_wc_connect_jetpack_access_token' );
```
