### PR TITLE
Properly decode and sanitize rate labels

### DIFF
--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -322,7 +322,17 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				foreach ( (array) $instance->rates as $rate_idx => $rate ) {
 					$rate_to_add = array(
 						'id'       => sprintf( '%s:%d:%d', $instance->id, $instance->instance, $rate_idx ),
-						'label'    => $rate->title,
+						'label'    => wp_kses(
+							html_entity_decode( $rate->title ),
+							array(
+								'sup' => array(),
+								'del' => array(),
+								'small' => array(),
+								'em' => array(),
+								'i' => array(),
+								'strong' => array(),
+							)
+						),
 						'cost'     => $rate->rate,
 						'calc_tax' => 'per_item'
 					);


### PR DESCRIPTION
Decode html entities from rate labels and pass them through `wp_kses` with a limited set of allowed tags so that things like TM, (c) and other useful annotations come thru to the user at checkout.

Fixes #186 

cc @allendav @jeffstieler @nabsul 
