### PR TITLE
Refactor save button into a component

### DIFF
--- a/client/components/save-form/index.js
+++ b/client/components/save-form/index.js
@@ -1,0 +1,46 @@
+import React, { PropTypes } from 'react';
+import Notice from 'components/notice';
+import FormButton from 'components/forms/form-button';
+import FormButtonsBar from 'components/forms/form-buttons-bar';
+import { translate as __ } from 'lib/mixins/i18n';
+
+const renderFormNotices = ( success, error, dismissSuccess ) => {
+	if ( error ) {
+		return (
+			<Notice status="is-error" text={ error } showDismiss={ false } />
+		);
+	}
+	if ( success ) {
+		return (
+			<Notice
+				className="wcc-form-success"
+				status="is-success"
+				text={ __( 'Your changes have been saved.' ) }
+				showDismiss={ false }
+				onDismissClick={ dismissSuccess }
+				duration={ 2250 }
+			/>
+		);
+	}
+};
+
+const SaveForm = ( { saveForm, isSaving, success, error, dismissSuccess } ) => {
+	return (
+		<FormButtonsBar>
+			{ renderFormNotices( success, error, dismissSuccess ) }
+			<FormButton type="button" onClick={ saveForm }>
+				{ isSaving ? __( 'Saving...' ) : __( 'Save changes' ) }
+			</FormButton>
+		</FormButtonsBar>
+	);
+};
+
+SaveForm.propTypes = {
+	saveForm: PropTypes.func.isRequired,
+	isSaving: PropTypes.bool.isRequired,
+	success: PropTypes.bool,
+	error: PropTypes.string,
+	dismissSuccess: PropTypes.func.isRequired,
+};
+
+export default SaveForm;

--- a/client/lib/save-form/index.js
+++ b/client/lib/save-form/index.js
@@ -1,5 +1,6 @@
 
-const saveForm = ( url, nonce, formData ) => {
+const saveForm = ( setIsSaving, setSuccess, setError, url, nonce, formData ) => {
+	setIsSaving( true );
 	const request = {
 		method: 'PUT',
 		credentials: 'same-origin',
@@ -10,9 +11,24 @@ const saveForm = ( url, nonce, formData ) => {
 	};
 
 	return fetch( url, request ).then( response => {
-		return response.json();
-	} ).catch( () => {
-		// TODO: Handler errors
+		setIsSaving( false );
+		setError( null );
+		setSuccess( false );
+
+		return response.json().then( json => {
+			if ( json.success ) {
+				return setSuccess( true );
+			}
+
+			if ( json.data && 'validation_failure' === json.data.error ) {
+				return setError( json.data.message );
+			}
+
+			return setError( JSON.stringify( json ) )
+		} );
+	} ).catch( ( e ) => {
+		setIsSaving( false );
+		setError( e );
 	} );
 };
 

--- a/client/main.js
+++ b/client/main.js
@@ -26,7 +26,7 @@ if ( window.i18nLocaleStrings ) {
 
 i18n.initialize( i18nLocaleStringsObject );
 
-const saveFormData = data => saveForm( callbackURL, nonce, data );
+const saveFormData = ( isSaving, setSuccess, setError, data ) => saveForm( isSaving, setSuccess, setError, callbackURL, nonce, data );
 
 const store = configureStore( initializeState( formSchema, formData ) );
 

--- a/client/views/usps-settings/index.js
+++ b/client/views/usps-settings/index.js
@@ -2,8 +2,6 @@ import React, { PropTypes } from 'react';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
-import FormButton from 'components/forms/form-button';
-import FormButtonsBar from 'components/forms/form-buttons-bar';
 import CompactCard from 'components/card/compact';
 import ShippingServiceGroups from 'components/shipping-service-groups';
 import { bindActionCreators } from 'redux';
@@ -11,24 +9,9 @@ import { connect } from 'react-redux';
 import * as SettingsActions from 'state/settings/actions';
 import * as FormActions from 'state/form/actions';
 import SettingsGroup from './render-group';
-import Notice from 'components/notice';
 import { translate as __ } from 'lib/mixins/i18n';
 import RadioButtons from 'components/radio-buttons';
-
-const handleSaveForm = ( event, props ) => {
-	event.preventDefault();
-	props.formActions.setField( 'isSaving', true );
-
-	props.saveFormData( props.settings ).then( ( result ) => {
-		props.formActions.setField( 'isSaving', false );
-		if ( result.success ) {
-			props.formActions.setField( 'error', null );
-			props.formActions.setField( 'success', true );
-		} else if ( 'validation_failure' === result.data.error ) {
-			props.formActions.setField( 'error', result.data.message );
-		}
-	} );
-};
+import SaveForm from 'components/save-form';
 
 const findLayoutInfo = ( layout, target ) => {
 	for ( let groupIdx = 0; groupIdx < layout.length; groupIdx++ ) {
@@ -43,27 +26,15 @@ const findLayoutInfo = ( layout, target ) => {
 };
 
 const Settings = ( props ) => {
-	const { settings, form, wooCommerceSettings, settingsActions, schema, layout } = props;
+	const { settings, form, wooCommerceSettings, settingsActions, formActions, schema, layout, saveFormData } = props;
 	const { updateSettingsField, updateSettingsObjectSubField } = settingsActions;
-	const renderFormErrors = () => {
-		if ( form.error ) {
-			return (
-				<Notice status="is-error" text={ form.error } showDismiss={ false } />
-			);
-		}
-		if ( form.success ) {
-			return (
-				<Notice
-					className="wcc-form-success"
-					status="is-success"
-					text={ __( 'Your changes have been saved.' ) }
-					showDismiss={ false }
-					onDismissClick={ () => props.formActions.setField( 'success', null ) }
-					duration={ 2250 }
-				/>
-			);
-		}
-	};
+	const { setField } = formActions;
+	const setIsSaving = ( value ) => setField( 'isSaving', value );
+	const setSuccess = ( value ) => setField( 'success', value );
+	const setError = ( value ) => setField( 'error', value );
+	const dismissSuccess = () => setField( 'success', false );
+	const saveForm = () => saveFormData( setIsSaving, setSuccess, setError, settings );
+
 	return (
 		<div>
 			<SettingsGroup
@@ -94,12 +65,13 @@ const Settings = ( props ) => {
 				/>
 			</CompactCard>
 			<CompactCard className="save-button-bar">
-				<FormButtonsBar>
-					{ renderFormErrors() }
-					<FormButton onClick={ ( event ) => handleSaveForm( event, props ) }>
-						{ form.isSaving ? __( 'Saving...' ) : __( 'Save changes' ) }
-					</FormButton>
-				</FormButtonsBar>
+				<SaveForm
+					saveForm={ saveForm }
+					isSaving={ form.isSaving }
+					success={ form.success }
+					error={ form.error }
+					dismissSuccess={ dismissSuccess }
+				/>
 			</CompactCard>
 		</div>
 	);
@@ -110,6 +82,7 @@ Settings.propTypes = {
 	formActions: PropTypes.object.isRequired,
 	wooCommerceSettings: PropTypes.object.isRequired,
 	settings: PropTypes.object.isRequired,
+	form: PropTypes.object.isRequired,
 	schema: PropTypes.object.isRequired,
 	layout: PropTypes.array.isRequired,
 	saveFormData: PropTypes.func.isRequired,


### PR DESCRIPTION
This this change, the save button is factored out into a component that is only concerned with the view. Management of the state ( isSaving, setError, etc.) is handled via callbacks that are passed from the container to lib/save-form.

This is a refactor, so functionality should be identical to the current code.

Suggested featured to test:
- Save button text switches between "Save changes" and "Saving..."
- Green success message is shown on success
- Error message is shown if save is unsuccessful
