### PR TITLE
Update: Small screen styles

### DIFF
--- a/assets/stylesheets/components/foldable-card/style.scss
+++ b/assets/stylesheets/components/foldable-card/style.scss
@@ -99,7 +99,7 @@ button.foldable-card__action {
   display: flex;
   align-items: center;
   flex: 2 1;
-  margin-right: 8px;
+  margin-right: 16px;
   font-size: 14px;
 
   @include breakpoint( '<480px' ) {

--- a/assets/stylesheets/shipping-services.scss
+++ b/assets/stylesheets/shipping-services.scss
@@ -22,6 +22,15 @@
 	display: flex;
 	width: 100%;
 
+	@include breakpoint( '<480px' ) {
+		padding: 4px 0;
+		border-bottom: 1px solid $gray-light;
+
+		&:last-child {
+			border-bottom: 0;
+		}
+	}
+
 	.wcc-shipping-service-entry-title {
 		flex-grow: 1;
 	}
@@ -31,7 +40,9 @@
 		margin: 8px;
 		padding: 6px 12px;
 		font-size: 13px;
+		min-width: 42px;
 	}
+
 	.form-select {
 		padding: 6px 32px 5px 14px;
 		font-size: 13px;


### PR DESCRIPTION
Small screen clean up. 

Before:
<img width="389" alt="screen shot 2016-04-25 at 12 05 28 pm" src="https://cloud.githubusercontent.com/assets/5835847/14794788/d523ceae-0ae2-11e6-87fd-e4e69605986e.png">

After: 
<img width="397" alt="screen shot 2016-04-25 at 12 35 15 pm" src="https://cloud.githubusercontent.com/assets/5835847/14794789/d52aaf62-0ae2-11e6-8ece-34827c525edc.png">

Overall less crowded now. Can also enter in a 2 digit % or $ amount without being hidden.

@jkudish or @jeffstieler for review
