### PR TITLE
Fix IE & Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "autoprefixer": "^6.3.3",
     "babel-eslint": "^6.0.3",
     "babel-plugin-add-module-exports": "^0.1.3",
+    "babel-polyfill": "^6.7.4",
     "chai": "3.5.0",
     "cross-env": "^1.0.7",
     "css-loader": "^0.23.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ var webpack = require( 'webpack' ),
 module.exports = {
 	cache: true,
 	entry: {
-		'woocommerce-connect-client': './client/main.js',
+		'woocommerce-connect-client': [ 'babel-polyfill', './client/main.js' ],
 	},
 	output: {
 		path: path.join( __dirname, 'dist' ),


### PR DESCRIPTION
So we're using `fetch` and a few other es6 features (`Object.assign`) but not providing a polyfill for it for browsers that don't support it, like Edge, IE and possibly others. Oops.

This PR seeks to add a `fetch` polyfill using [this technique](http://mts.io/2015/04/08/webpack-shims-polyfills/) as well as include the [`babel-polyfill`](https://babeljs.io/docs/usage/polyfill/) module for other es6 features.

This fixes IE11 and Edge bugs -- fixes #246 and fixes #247 

Note: this PR builds on top of #249 because it relies on babel 6 features.  Will need to land #249 first and then rebase this one.

To test:
- Checkout this PR
- If you haven't yet for #249, you'll need to do the `rm -rf node_modules`, `npm cache clean`, `npm install` dance
- `npm install` to get the two new loaders and `babel-polyfill`
- either `npm start` or `npm run dist` based on whether or not your site has `WOOCOMMERCE_CONNECT_DEV_SERVER_URL` configured
- Check that the form renders and saves correctly in IE11, MS Edge and any other browsers you might have

cc @allendav @jeffstieler @nabsul @mikeyarce 
