### PR TITLE
Allow the `target` attribute in form explanations

### DIFF
--- a/client/components/text-field/index.js
+++ b/client/components/text-field/index.js
@@ -17,7 +17,7 @@ const TextField = ( { id, schema, value, placeholder, updateValue } ) => {
 				placeholder={ placeholder }
 				value={ value }
 				onChange={ handleChangeEvent } />
-			<FormSettingExplanation dangerouslySetInnerHTML={ { __html: sanitize( schema.description ) } } />
+			<FormSettingExplanation dangerouslySetInnerHTML={ { __html: sanitize( schema.description, { ADD_ATTR: [ 'target' ] } ) } } />
 		</FormFieldset>
 	);
 };


### PR DESCRIPTION
Allows the `target` attribute to be added to anchor tags in the text field explanation, so that we can specify external links to open externally (which we already specify when sending that string from the server)

To test: make sure that the form renders correctly and that the "sign up for your own account" link opens externally.

Fixes #214 
