### PR TITLE
Prefixed packages metadata key with an underscore

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -73,11 +73,19 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		protected function get_packaging_metadata( WC_Order $order ) {
 			$shipping_methods = $order->get_shipping_methods();
 			$shipping_method = reset( $shipping_methods );
-			if ( ! $shipping_method || ! isset( $shipping_method[ 'wc_connect_packages' ] ) ) {
+			if ( ! $shipping_method ) {
 				return false;
 			}
 
-			return json_decode( $shipping_method[ 'wc_connect_packages' ], true );
+			if ( isset( $shipping_method[ '_wc_connect_packages' ] ) ) {
+				return json_decode( $shipping_method[ '_wc_connect_packages' ], true );
+			}
+
+			if ( isset( $shipping_method[ 'wc_connect_packages' ] ) ) {
+				return json_decode( $shipping_method[ 'wc_connect_packages' ], true );
+			}
+
+			return false;
 		}
 
 		protected function get_name( WC_Product $product ) {
@@ -159,13 +167,11 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		}
 
 		protected function get_selected_rates( WC_Order $order ) {
-			$shipping_methods = $order->get_shipping_methods();
-			$shipping_method = reset( $shipping_methods );
-			if ( ! $shipping_method || ! isset( $shipping_method[ 'wc_connect_packages' ] ) ) {
+			$packages = $this->get_packaging_metadata( $order );
+			if ( ! $packages ) {
 				return array();
 			}
 
-			$packages = json_decode( $shipping_method[ 'wc_connect_packages' ], true );
 			$rates = array();
 
 			foreach( $packages as $idx => $package ) {

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -333,7 +333,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 						'cost'      => $rate->rate,
 						'calc_tax'  => 'per_item',
 						'meta_data' => array(
-							'wc_connect_packages' => json_encode( $rate->packages ),
+							'_wc_connect_packages' => json_encode( $rate->packages ),
 							__( 'Packaging', 'connectforwoocommerce' ) => $packaging_info
 						),
 					);

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -742,7 +742,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		public function hide_wc_connect_package_meta_data( $hidden_keys ) {
-			$hidden_keys[] = 'wc_connect_packages';
+			array_push( $hidden_keys, 'wc_connect_packages', '_wc_connect_packages' );
 			return $hidden_keys;
 		}
 


### PR DESCRIPTION
Addresses #674

Test steps:
* place an order
* checkout this branch
* verify that the order and labels UI are shown correctly in the orders admin panel
* place an order and verify that it is shown correctly to the merchant as well
* disable Connect
* make a backup copy of your WooCommerce plugin dir
* update WooCommerce to 2.7 (either by pulling the latest from git, or here: https://github.com/woocommerce/woocommerce/releases/tag/2.7.0-beta-1)
* open the order placed after this branch has been checked out
* verify that the package metadata is not shown
* restore version 2.6 of WooCommerce and enable Connect

See https://github.com/Automattic/woocommerce-connect-client/issues/674#issuecomment-270886618 for more info
