### PR TITLE
Show 'updated TOS' and other notices

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -258,6 +258,15 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		/**
+		 * Requests the available notices for this site from the Connect for WooCommerce Server
+		 */
+		public function get_notices( $last_retrieved_id, $site_language ) {
+			$json = '{"id":1,"title":"A new notice","body":"Our terms of service have <a href=\"https://wordpress.com/\">changed</a>.","button":"Okay","requires_receipt":true}';
+			$response = json_decode( $json );
+			return $response;
+		}
+
+		/**
 		 * Tests the connection to the Connect for WooCommerce Server
 		 *
 		 * @return true|WP_Error

--- a/classes/class-wc-connect-remote-notices-store.php
+++ b/classes/class-wc-connect-remote-notices-store.php
@@ -21,10 +21,15 @@ if ( ! class_exists( 'WC_Connect_Remote_Notices_Store' ) ) {
 
 		public function __construct( WC_Connect_API_Client $api_client ) {
 			$this->api_client = $api_client;
+			add_action( 'admin_notices', array( $this, 'display_notices' ) );
 		}
 
 		public function set_notices( $notices ) {
 			update_option( 'wc_connect_remote_notices', $notices );
+		}
+
+		public function get_notices() {
+			return get_option( 'wc_connect_remote_notices', null );
 		}
 
 		public function fetch_notices_from_connect_server() {
@@ -36,6 +41,26 @@ if ( ! class_exists( 'WC_Connect_Remote_Notices_Store' ) ) {
 				'button' => wp_strip_all_tags( $response->button ),
 			);
 			$this->set_notices( $notices );
+		}
+
+		public function display_notices() {
+			// TODO: show more than one notice
+			$notices = $this->get_notices();
+			$this->display_notice( $notices->title , $notices->body, $notices->button );
+		}
+
+		public function display_notice( $title, $body, $button ) {
+			?>
+			<div class="notice notice-info">
+				<h1><?php echo esc_html( $title ); ?></h1>
+				<p><?php echo wp_kses( $body, $this->allowed_html ); ?></p>
+				<p>
+					<a class="button-primary">
+						<?php echo esc_html( $button ); ?>
+					</a>
+				</p>
+			</div>
+			<?php
 		}
 	}
 }

--- a/classes/class-wc-connect-remote-notices-store.php
+++ b/classes/class-wc-connect-remote-notices-store.php
@@ -1,0 +1,41 @@
+<?php
+
+if ( ! class_exists( 'WC_Connect_Remote_Notices_Store' ) ) {
+
+	class WC_Connect_Remote_Notices_Store {
+
+		/**
+		 * @var WC_Connect_API_Client
+		 */
+		protected $api_client;
+
+		protected $allowed_html = array(
+			 'a' => array(
+				 'href' => array(),
+				 'title' => array(),
+			 ),
+			 'br' => array(),
+			 'em' => array(),
+			 'strong' => array(),
+		 );
+
+		public function __construct( WC_Connect_API_Client $api_client ) {
+			$this->api_client = $api_client;
+		}
+
+		public function set_notices( $notices ) {
+			update_option( 'wc_connect_remote_notices', $notices );
+		}
+
+		public function fetch_notices_from_connect_server() {
+			$response = $this->api_client->get_notices( 1, 'en-us' );
+			// TODO: save more than one notice
+			$notices = (object) array(
+				'title' => wp_strip_all_tags( $response->title ),
+				'body' => wp_kses( $response->body, $this->allowed_html ),
+				'button' => wp_strip_all_tags( $response->button ),
+			);
+			$this->set_notices( $notices );
+		}
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,7 @@
+<?php
+// if uninstall.php is not called by WordPress, die
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	die;
+}
+
+delete_option( 'wc_connect_remote_notices' );


### PR DESCRIPTION
This is an in-progress PR for #770. Currently it:
- has a fake API call that returns some dummy data
- saves the data to wp_options
- displays a notice with the data

## Next Steps:
- [ ] decide on object structure for list notices received & saved
- [ ] display only the latest notice from TOS
- [ ] save the last retrieved notice id in wp_options
- [ ] let user dismiss notice
- [ ] updating the wp_option with new data
- [ ] log: when notice is received 
- [ ] log: when notice is dismissed

## About the notices

Here are things we care about for each notice.
- id
- title
- body
- button text
- should_log_response
- ^ type: info, success, etc
- ^ subject: TOS, other
- ^ pages it should be displayed on ('all' for TOS)
- ^ people it should be displayed to ('store owner' for TOS)

^ means that those items will not be added now, but may be added later as needed

What will not be built in this iteration
- logic for showing multiple types of notices (TOS at the same time as non-TOS, for example, and non-TOS with other non-TOS)
- notice types: info/success, and tos/non-tos
- pages to display notice on

The object received will probably look like:
```
{
  tos: [
    {
      id: 1,
      title: '',
      body: '',
      should_log_dismissal: true,
      can_display_with_others: false,
      type: 'info',
      pages: 'all',
      people: ['store-owner']
    }
  ],
  others: [...]
}
```