### PR TITLE
Notify admin when cart has items with no dimensions

### DIFF
--- a/classes/class-wc-connect-error-notice.php
+++ b/classes/class-wc-connect-error-notice.php
@@ -61,7 +61,7 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 			);
 ?>
 			<div class='notice notice-error' style="position: relative;">
-				<a href="<?php echo esc_url( $link_dismiss ); ?>" class="notice-dismiss" title="<?php esc_attr_e( 'Dismiss this notice', 'connectforwoocommerce' ); ?>"></a>
+				<a href="<?php echo esc_url( $link_dismiss ); ?>" style="text-decoration: none;" class="notice-dismiss" title="<?php esc_attr_e( 'Dismiss this notice', 'connectforwoocommerce' ); ?>"></a>
 				<p><?php echo $message; ?></p>
 			</div>
 <?php

--- a/classes/class-wc-connect-error-notice.php
+++ b/classes/class-wc-connect-error-notice.php
@@ -56,11 +56,16 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 			$link_dismiss = home_url( add_query_arg( array( 'wc-connect-error-notice' => 'disable' ) ) );
 
 			$message = sprintf(
-				__( 'An error occurred in Connect for WooCommerce. Details are logged <a href="%s">here</a>. Click <a href="%s">here</a> to dismiss.', 'connectforwoocommerce' ),
+				__( 'An error occurred in Connect for WooCommerce. Details are logged <a href="%s">here</a>.', 'connectforwoocommerce' ),
 				$link_status, $link_dismiss
 			);
-
-			echo "<div class='notice notice-error is-dismissible'><p>$message</p></div>";
+?>
+			<div class='notice notice-error' style="position: relative;">
+				<a href="<?php echo esc_url( $link_dismiss ); ?>" class="notice-dismiss" title="<?php esc_attr_e( 'Dismiss this notice', 'connectforwoocommerce' ); ?>"></a>
+				<p><?php echo $message; ?></p>
+			</div>
+<?php
+			echo "";
 		}
 	}
 

--- a/classes/class-wc-connect-error-notice.php
+++ b/classes/class-wc-connect-error-notice.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Show admin notices when errors occur
+ */
+
+// No direct access please
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
+
+	class WC_Connect_Error_Notice {
+
+		private static $inst = null;
+
+		public static function instance() {
+			if ( null === self::$inst ) {
+				self::$inst = new WC_Connect_Error_Notice();
+			}
+
+			return self::$inst;
+		}
+
+		private static $option_key = 'wc_connect_error_notice';
+
+		public function enable_notice() {
+			update_option( $this->$option_key, true );
+		}
+
+		public function disable_notice() {
+			update_option( $this->$option_key, false );
+		}
+
+		public function render_notice() {
+			if ( is_admin() && $this->notice_enabled() ) {
+				$this->show_notice();
+			}
+		}
+
+		private function notice_enabled() {
+			return get_option( self::$option_key, false );
+		}
+
+		private function show_notice() {
+
+		}
+	}
+
+}

--- a/classes/class-wc-connect-error-notice.php
+++ b/classes/class-wc-connect-error-notice.php
@@ -26,15 +26,23 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 		private static $option_key = 'wc_connect_error_notice';
 
 		public function enable_notice() {
-			update_option( $this->$option_key, true );
+			update_option( self::$option_key, true );
 		}
 
 		public function disable_notice() {
-			update_option( $this->$option_key, false );
+			update_option( self::$option_key, false );
 		}
 
 		public function render_notice() {
-			if ( is_admin() && $this->notice_enabled() ) {
+			$error_notice = filter_input( INPUT_GET, 'wc-connect-error-notice' );
+			if ( 'disable' === $error_notice ) {
+				update_option( self::$option_key, false );
+				$url = home_url( remove_query_arg( 'wc-connect-error-notice' ) );
+				wp_safe_redirect( $url );
+				exit;
+			}
+
+			if ( $this->notice_enabled() ) {
 				$this->show_notice();
 			}
 		}
@@ -44,7 +52,15 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 		}
 
 		private function show_notice() {
+			$link_status = admin_url( 'admin.php?page=wc-status&tab=connect' );
+			$link_dismiss = home_url( add_query_arg( array( 'wc-connect-error-notice' => 'disable' ) ) );
 
+			$message = sprintf(
+				__( 'An error occurred in Connect for WooCommerce. Details are logged <a href="%s">here</a>. Click <a href="%s">here</a> to dismiss.', 'connectforwoocommerce' ),
+				$link_status, $link_dismiss
+			);
+
+			echo "<div class='notice notice-error is-dismissible'><p>$message</p></div>";
 		}
 	}
 

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -374,7 +374,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 				'true_text' => __( 'Enabled', 'connectforwoocommerce' ),
 				'false_text' => __( 'Disabled', 'connectforwoocommerce' ),
 				'description' => '',
-				'value' => $this->logger->is_logging_enabled(),
+				'value' => $this->logger->is_debug_enabled(),
 				'save_on_toggle' => true
 			);
 

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -349,14 +349,25 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 
 			if ( method_exists( 'WC_Admin_Status', 'scan_log_files' ) ) {
 				$logs = WC_Admin_Status::scan_log_files();
+				$latest_file_date = 0;
+				$file = null;
+				$key = null;
 
 				foreach ( $logs as $log_key => $log_file ) {
-					if ( "wc-connect-" === substr( $log_key, 0, 11 ) ) {
-						$complete_log = file( WC_LOG_DIR . $log_file );
-						$data->key = $log_key;
-						$data->file = $log_file;
-						$data->tail = array_slice( $complete_log, -10 );
+				    $log_file = WC_LOG_DIR . $log_file;
+					$file_date = filemtime( $log_file );
+					if ( 'wc-connect-' === substr( $log_key, 0, 11 ) && $latest_file_date < $file_date ) {
+						$latest_file_date = $file_date;
+						$file = $log_file;
+						$key = $log_key;
 					}
+				}
+
+				if ( null !== $file ) {
+					$complete_log = file( $file );
+					$data->key = $key;
+					$data->file = $file;
+					$data->tail = array_slice( $complete_log, -10 );
 				}
 			}
 

--- a/classes/class-wc-connect-logger.php
+++ b/classes/class-wc-connect-logger.php
@@ -78,7 +78,12 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 		 * @param string $message Message to log
 		 * @param string $context Optional context (e.g. a class or function name)
 		 */
-		public function log( $message, $context = '' ) {
+		public function error( $message, $context = '' ) {
+			WC_Connect_Error_Notice::instance()->enable_notice();
+			$this->log( $message, $context );
+		}
+
+		private function log( $message, $context = '' ) {
 			$log_message = $this->format_message( $message, $context );
 			$this->logger->add( 'wc-connect', $log_message );
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {

--- a/classes/class-wc-connect-logger.php
+++ b/classes/class-wc-connect-logger.php
@@ -56,28 +56,34 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 			$this->is_logging_enabled = false;
 		}
 
-		public function is_logging_enabled() {
+		public function is_debug_enabled() {
 			return $this->is_logging_enabled;
 		}
 
 		/**
-		 * Logs messages
+		 * Logs messages only when debugging is enabled
+		 *
+		 * @param string $message Message to log
+		 * @param string $context Optional context (e.g. a class or function name)
+		 */
+		public function debug( $message, $context = '' ) {
+			if ( $this->is_debug_enabled() ) {
+				$this->log( $message, $context );
+			}
+		}
+
+		/**
+		 * Logs messages even if debugging is disabled
 		 *
 		 * @param string $message Message to log
 		 * @param string $context Optional context (e.g. a class or function name)
 		 */
 		public function log( $message, $context = '' ) {
-
-			if ( $this->is_logging_enabled() ) {
-
-				$log_message = $this->format_message( $message, $context );
-				$this->logger->add( 'wc-connect', $log_message );
-				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-					error_log( $log_message );
-				}
-
+			$log_message = $this->format_message( $message, $context );
+			$this->logger->add( 'wc-connect', $log_message );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				error_log( $log_message );
 			}
-
 		}
 
 	}

--- a/classes/class-wc-connect-payment-methods-store.php
+++ b/classes/class-wc-connect-payment-methods-store.php
@@ -33,13 +33,13 @@ if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 			$response_body = $this->api_client->get_payment_methods();
 
 			if ( is_wp_error( $response_body ) ) {
-				$this->logger->log( $response_body, __FUNCTION__ );
+				$this->logger->debug( $response_body, __FUNCTION__ );
 				return;
 			}
 
 			$payment_methods = $this->get_payment_methods_from_response_body( $response_body );
 			if ( is_wp_error( $payment_methods ) ) {
-				$this->logger->log( $payment_methods, __FUNCTION__ );
+				$this->logger->debug( $payment_methods, __FUNCTION__ );
 				return;
 			}
 

--- a/classes/class-wc-connect-service-schemas-store.php
+++ b/classes/class-wc-connect-service-schemas-store.php
@@ -26,11 +26,11 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 			$response_body = $this->api_client->get_service_schemas();
 
 			if ( is_wp_error( $response_body ) ) {
-				$this->logger->log( $response_body, __FUNCTION__ );
+				$this->logger->debug( $response_body, __FUNCTION__ );
 				return;
 			}
 
-			$this->logger->log( 'Successfully loaded service schemas from server response.', __FUNCTION__ );
+			$this->logger->debug( 'Successfully loaded service schemas from server response.', __FUNCTION__ );
 			$this->update_last_fetch_timestamp();
 			$this->maybe_update_heartbeat();
 

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -64,7 +64,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		public function update_account_settings( $settings ) {
 			// simple validation for now
 			if ( ! is_array( $settings ) ) {
-				$this->logger->log( 'Array expected but not received', __FUNCTION__ );
+				$this->logger->debug( 'Array expected but not received', __FUNCTION__ );
 				return false;
 			}
 
@@ -400,7 +400,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				case 'yd':
 					return __('yd', 'connectforwoocommerce');
 				default:
-					$this->logger->log( 'Unexpected measurement unit: ' . $value, __FUNCTION__ );
+					$this->logger->debug( 'Unexpected measurement unit: ' . $value, __FUNCTION__ );
 					return $value;
 			}
 		}

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -48,7 +48,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			do_action( 'wc_connect_service_init', $this, $id_or_instance_id );
 
 			if ( ! $this->service_schema ) {
-				$this->log(
+				$this->debug(
 					'Error. A WC_Connect_Shipping_Method was constructed without an id or instance_id',
 					__FUNCTION__
 				);
@@ -137,18 +137,17 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		 * @param string|WP_Error $message
 		 * @param string $context
 		 */
-		protected function log( $message, $context = '' ) {
+		protected function debug( $message, $context = '' ) {
 
 			$logger = $this->get_logger();
 
 			if ( is_a( $logger, 'WC_Connect_Logger' ) ) {
 
-				$logger->log( $message, $context );
+				$logger->debug( $message, $context );
 
 			}
 
 		}
-
 
 		/**
 		 * Restores any values persisted to the DB for this service instance
@@ -260,7 +259,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			$settings_keys    = get_object_vars( $service_settings );
 
 			if ( empty( $settings_keys ) ) {
-				return $this->log(
+				return $this->debug(
 					sprintf(
 						'Service settings empty. Skipping %s rate request (instance id %d).',
 						$this->id,
@@ -287,7 +286,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			$response_body = $this->api_client->get_shipping_rates( $services, $package, $custom_boxes, $predefined_boxes );
 
 			if ( is_wp_error( $response_body ) ) {
-				$this->log(
+				$this->debug(
 					sprintf(
 						'Error. Unable to get shipping rate(s) for %s instance id %d.',
 						$this->id,
@@ -298,7 +297,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 				$this->set_last_request_failed();
 
-				$this->log( $response_body, __FUNCTION__ );
+				$this->debug( $response_body, __FUNCTION__ );
 				$this->add_fallback_rate( $service_settings );
 				return;
 			}

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -149,6 +149,13 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 		}
 
+		protected function error( $message, $context = '' ) {
+			$logger = $this->get_logger();
+			if ( is_a( $logger, 'WC_Connect_Logger' ) ) {
+				$logger->error( $message, $context );
+			}
+		}
+
 		/**
 		 * Restores any values persisted to the DB for this service instance
 		 * and sets up title for WC core to work properly
@@ -286,7 +293,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			$response_body = $this->api_client->get_shipping_rates( $services, $package, $custom_boxes, $predefined_boxes );
 
 			if ( is_wp_error( $response_body ) ) {
-				$this->debug(
+				$this->error(
 					sprintf(
 						'Error. Unable to get shipping rate(s) for %s instance id %d.',
 						$this->id,
@@ -297,7 +304,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 				$this->set_last_request_failed();
 
-				$this->debug( $response_body, __FUNCTION__ );
+				$this->error( $response_body, __FUNCTION__ );
 				$this->add_fallback_rate( $service_settings );
 				return;
 			}

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -133,7 +133,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		 * Avoids calling methods on an undefined object if no logger was
 		 * injected during the init action in the constructor.
 		 *
-		 * @see WC_Connect_Logger::log()
+		 * @see WC_Connect_Logger::debug()
 		 * @param string|WP_Error $message
 		 * @param string $context
 		 */

--- a/classes/class-wc-connect-tracks.php
+++ b/classes/class-wc-connect-tracks.php
@@ -58,7 +58,7 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 
 		public function record_user_event( $event_type, $data = array() ) {
 			if ( ! function_exists( 'jetpack_tracks_record_event' ) ) {
-				$this->log( 'Error. jetpack_tracks_record_event is not defined.' );
+				$this->debug( 'Error. jetpack_tracks_record_event is not defined.' );
 				return;
 			}
 
@@ -93,13 +93,13 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 
 			$event_type = self::$product_name . '_' . $event_type;
 
-			$this->log( 'Tracked the following event: ' . $event_type );
+			$this->debug( 'Tracked the following event: ' . $event_type );
 			return jetpack_tracks_record_event( $user, $event_type, $data );
 		}
 
-		protected function log( $message ) {
+		protected function debug( $message ) {
 			if ( ! is_null( $this->logger ) ) {
-				$this->logger->log( $message );
+				$this->logger->debug( $message );
 			}
 		}
 

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -75,7 +75,7 @@ class WC_REST_Connect_Account_Settings_Controller extends WP_REST_Controller {
 					$result->get_error_data()
 				)
 			);
-			$this->logger->log( $error, __CLASS__ );
+			$this->logger->debug( $error, __CLASS__ );
 			return $error;
 		}
 

--- a/classes/class-wc-rest-connect-address-normalization-controller.php
+++ b/classes/class-wc-rest-connect-address-normalization-controller.php
@@ -79,7 +79,7 @@ class WC_REST_Connect_Address_Normalization_Controller extends WP_REST_Controlle
 				$response->get_error_message(),
 				array( 'message' => $response->get_error_message() )
 			);
-			$this->logger->log( $error, __CLASS__ );
+			$this->logger->debug( $error, __CLASS__ );
 			return $error;
 		}
 
@@ -89,7 +89,7 @@ class WC_REST_Connect_Address_Normalization_Controller extends WP_REST_Controlle
 				$response->error->message,
 				array( 'message' => $response->error->message )
 			);
-			$this->logger->log( $error, __CLASS__ );
+			$this->logger->debug( $error, __CLASS__ );
 			return $error;
 		}
 

--- a/classes/class-wc-rest-connect-self-help-controller.php
+++ b/classes/class-wc-rest-connect-self-help-controller.php
@@ -61,7 +61,7 @@ class WC_REST_Connect_Self_Help_Controller extends WP_REST_Controller {
 				__( 'Unable to update settings. The form data could not be read.', 'connectforwoocommerce' ),
 				array( 'status' => 400 )
 			);
-			$this->logger->log( $error, __CLASS__ );
+			$this->logger->debug( $error, __CLASS__ );
 			return $error;
 		}
 

--- a/classes/class-wc-rest-connect-services-controller.php
+++ b/classes/class-wc-rest-connect-services-controller.php
@@ -73,7 +73,7 @@ class WC_REST_Connect_Services_Controller extends WP_REST_Controller {
 				__( 'Unable to update service settings. Form data is missing service ID.', 'connectforwoocommerce' ),
 				array( 'status' => 400 )
 			);
-			$this->logger->log( $error, __CLASS__ );
+			$this->logger->debug( $error, __CLASS__ );
 			return $error;
 		}
 
@@ -85,7 +85,7 @@ class WC_REST_Connect_Services_Controller extends WP_REST_Controller {
 				__( 'Unable to update service settings. The form data could not be read.', 'connectforwoocommerce' ),
 				array( 'status' => 400 )
 			);
-			$this->logger->log( $error, __CLASS__ );
+			$this->logger->debug( $error, __CLASS__ );
 			return $error;
 		}
 
@@ -102,7 +102,7 @@ class WC_REST_Connect_Services_Controller extends WP_REST_Controller {
 					$validation_result->get_error_data()
 				)
 			);
-			$this->logger->log( $error, __CLASS__ );
+			$this->logger->debug( $error, __CLASS__ );
 			return $error;
 		}
 

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -86,7 +86,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WP_REST_Controller {
 				$response->get_error_message(),
 				array( 'message' => $response->get_error_message() )
 			);
-			$this->logger->log( $error, __CLASS__ );
+			$this->logger->debug( $error, __CLASS__ );
 			return $error;
 		}
 
@@ -105,7 +105,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WP_REST_Controller {
 					$label_data->error->message,
 					array( 'message' => $label_data->error->message )
 				);
-				$this->logger->log( $error, __CLASS__ );
+				$this->logger->debug( $error, __CLASS__ );
 				return $error;
 			}
 			$label_ids[] = $label_data->label->label_id;

--- a/classes/class-wc-rest-connect-shipping-label-refund-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-refund-controller.php
@@ -73,7 +73,7 @@ class WC_REST_Connect_Shipping_Label_Refund_Controller extends WP_REST_Controlle
 				'message' => $response->get_error_message(),
 			), $response->get_error_code() );
 
-			$this->logger->log( $response, __CLASS__ );
+			$this->logger->debug( $response, __CLASS__ );
 			return $response;
 		}
 

--- a/classes/class-wc-rest-connect-shipping-label-status-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-status-controller.php
@@ -67,7 +67,7 @@ class WC_REST_Connect_Shipping_Label_Status_Controller extends WP_REST_Controlle
 				$response->get_error_message(),
 				array( 'message' => $response->get_error_message() )
 			);
-			$this->logger->log( $error, __CLASS__ );
+			$this->logger->debug( $error, __CLASS__ );
 			return $error;
 		}
 

--- a/classes/class-wc-rest-connect-shipping-labels-preview-controller.php
+++ b/classes/class-wc-rest-connect-shipping-labels-preview-controller.php
@@ -73,7 +73,7 @@ class WC_REST_Connect_Shipping_Labels_Preview_Controller extends WP_REST_Control
 		$raw_response = $this->api_client->get_labels_preview_pdf( $params );
 
 		if ( is_wp_error( $raw_response ) ) {
-			$this->logger->log( $raw_response, __CLASS__ );
+			$this->logger->debug( $raw_response, __CLASS__ );
 			return $raw_response;
 		}
 

--- a/classes/class-wc-rest-connect-shipping-labels-print-controller.php
+++ b/classes/class-wc-rest-connect-shipping-labels-print-controller.php
@@ -78,7 +78,7 @@ class WC_REST_Connect_Shipping_Labels_Print_Controller extends WP_REST_Controlle
 					'status' => 400
 				)
 			);
-			$this->logger->log( $error, __CLASS__ );
+			$this->logger->debug( $error, __CLASS__ );
 			return $error;
 		}
 		$params[ 'labels' ] = array();
@@ -94,7 +94,7 @@ class WC_REST_Connect_Shipping_Labels_Print_Controller extends WP_REST_Controlle
 		$raw_response = $this->api_client->get_labels_print_pdf( $params );
 
 		if ( is_wp_error( $raw_response ) ) {
-			$this->logger->log( $raw_response, __CLASS__ );
+			$this->logger->debug( $raw_response, __CLASS__ );
 			return $raw_response;
 		}
 

--- a/classes/class-wc-rest-connect-shipping-rates-controller.php
+++ b/classes/class-wc-rest-connect-shipping-rates-controller.php
@@ -82,7 +82,7 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WP_REST_Controller {
 				$response->get_error_message(),
 				array( 'message' => $response->get_error_message() )
 			);
-			$this->logger->log( $error, __CLASS__ );
+			$this->logger->debug( $error, __CLASS__ );
 			return $error;
 		}
 

--- a/tests/php/test_class-wc-connect-shipping-method.php
+++ b/tests/php/test_class-wc-connect-shipping-method.php
@@ -107,7 +107,7 @@ class WP_Test_WC_Connect_Shipping_Method extends WP_UnitTestCase {
 
 		$shipping_method = $this->getMockBuilder( 'WC_Connect_Shipping_Method' )
 			->setConstructorArgs( array( 1 ) )
-			->setMethods( array( 'is_valid_package_destination', 'get_service_settings', 'log' ) )
+			->setMethods( array( 'is_valid_package_destination', 'get_service_settings', 'debug' ) )
 			->getMock();
 
 		$shipping_method->expects( $this->any() )
@@ -119,7 +119,7 @@ class WP_Test_WC_Connect_Shipping_Method extends WP_UnitTestCase {
 			->will( $this->returnValue( new stdClass() ) );
 
 		$shipping_method->expects( $this->once() )
-			->method( 'log' )
+			->method( 'debug' )
 			->with(
 				$this->stringContains( 'Service settings empty.' ),
 				$this->anything()

--- a/tests/php/test_woocommerce-connect-tracks.php
+++ b/tests/php/test_woocommerce-connect-tracks.php
@@ -11,7 +11,7 @@ abstract class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 	public function setUp() {
 		$this->logger = $this->getMockBuilder( 'WC_Connect_Logger' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'log' ) )
+			->setMethods( array( 'debug' ) )
 			->getMock();
 
 		$this->tracks = new WC_Connect_Tracks( $this->logger );

--- a/tests/php/test_woocommerce-connect-tracks.php
+++ b/tests/php/test_woocommerce-connect-tracks.php
@@ -22,7 +22,7 @@ class WP_Test_WC_Connect_Tracks_No_Jetpack extends WP_Test_WC_Connect_Tracks {
 
 	public function test_no_jetpack() {
 		$this->logger->expects( $this->once() )
-			->method( 'log' )
+			->method( 'debug' )
 			->with(
 				$this->stringContains( 'Error' ),
 				$this->anything()
@@ -44,7 +44,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		// $record will contain the args received by jetpack_tracks_record_event
 
 		$this->logger->expects( $this->once() )
-			->method( 'log' )
+			->method( 'debug' )
 			->with(
 				$this->stringContains( 'woocommerceconnect_test' ),
 				$this->anything()
@@ -67,7 +67,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 	public function test_opted_in() {
 
 		$this->logger->expects( $this->once() )
-			->method( 'log' )
+			->method( 'debug' )
 			->with(
 				$this->stringContains( 'woocommerceconnect_opted_in' ),
 				$this->anything()
@@ -91,7 +91,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 	public function test_opted_out() {
 
 		$this->logger->expects( $this->once() )
-			->method( 'log' )
+			->method( 'debug' )
 			->with(
 				$this->stringContains( 'woocommerceconnect_opted_out' ),
 				$this->anything()
@@ -120,7 +120,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		// rather then the less precise for all versions
 		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
 			$this->logger->expects( $this->exactly(2) )
-				->method( 'log' )
+				->method( 'debug' )
 				->withConsecutive(
 					array(
 						$this->stringContains( 'woocommerceconnect_saved_service_settings' ),
@@ -133,14 +133,14 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 				);
 		} else {
 			$this->logger->expects( $this->at(0) )
-				->method( 'log' )
+				->method( 'debug' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_saved_service_settings' ),
 					$this->anything()
 				);
 
 			$this->logger->expects( $this->at(1) )
-				->method( 'log' )
+				->method( 'debug' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_saved_usps_settings' ),
 					$this->anything()
@@ -158,7 +158,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		// rather then the less precise for all versions
 		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
 			$this->logger->expects( $this->exactly(2) )
-				->method( 'log' )
+				->method( 'debug' )
 				->withConsecutive(
 					array(
 						$this->stringContains( 'woocommerceconnect_shipping_zone_method_added' ),
@@ -171,14 +171,14 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 				);
 		} else {
 			$this->logger->expects( $this->at(0) )
-				->method( 'log' )
+				->method( 'debug' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_method_added' ),
 					$this->anything()
 				);
 
 			$this->logger->expects( $this->at(1) )
-				->method( 'log' )
+				->method( 'debug' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_usps_added' ),
 					$this->anything()
@@ -196,7 +196,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		// rather then the less precise for all versions
 		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
 			$this->logger->expects( $this->exactly(2) )
-				->method( 'log' )
+				->method( 'debug' )
 				->withConsecutive(
 					array(
 						$this->stringContains( 'woocommerceconnect_shipping_zone_method_deleted' ),
@@ -209,14 +209,14 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 				);
 		} else {
 			$this->logger->expects( $this->at(0) )
-				->method( 'log' )
+				->method( 'debug' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_method_deleted' ),
 					$this->anything()
 				);
 
 			$this->logger->expects( $this->at(1) )
-				->method( 'log' )
+				->method( 'debug' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_canada_post_deleted' ),
 					$this->anything()
@@ -234,7 +234,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		// rather then the less precise for all versions
 		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
 			$this->logger->expects( $this->exactly(2) )
-				->method( 'log' )
+				->method( 'debug' )
 				->withConsecutive(
 					array(
 						$this->stringContains( 'woocommerceconnect_shipping_zone_method_enabled' ),
@@ -247,14 +247,14 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 				);
 		} else {
 			$this->logger->expects( $this->at(0) )
-				->method( 'log' )
+				->method( 'debug' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_method_enabled' ),
 					$this->anything()
 				);
 
 			$this->logger->expects( $this->at(1) )
-				->method( 'log' )
+				->method( 'debug' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_usps_enabled' ),
 					$this->anything()
@@ -272,7 +272,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		// rather then the less precise for all versions
 		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
 			$this->logger->expects( $this->exactly(2) )
-				->method( 'log' )
+				->method( 'debug' )
 				->withConsecutive(
 					array(
 						$this->stringContains( 'woocommerceconnect_shipping_zone_method_disabled' ),
@@ -285,14 +285,14 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 				);
 		} else {
 			$this->logger->expects( $this->at(0) )
-				->method( 'log' )
+				->method( 'debug' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_method_disabled' ),
 					$this->anything()
 				);
 
 			$this->logger->expects( $this->at(1) )
-				->method( 'log' )
+				->method( 'debug' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_usps_disabled' ),
 					$this->anything()

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -430,7 +430,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			//////////////////////////////////////////////////////////////////////////////
 
 			if ( ! class_exists( 'WP_REST_Controller' ) ) {
-				$this->logger->log( 'Error. WP_REST_Controller could not be found', __FUNCTION__ );
+				$this->logger->debug( 'Error. WP_REST_Controller could not be found', __FUNCTION__ );
 				return;
 			}
 

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -338,6 +338,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * Load all plugin dependencies.
 		 */
 		public function load_dependencies() {
+			require_once( plugin_basename( 'classes/class-wc-connect-error-notice.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-logger.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-api-client.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-service-schemas-validator.php' ) );
@@ -380,6 +381,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			require_once( plugin_basename( 'classes/class-wc-connect-settings-pages.php' ) );
 			$settings_pages = new WC_Connect_Settings_Pages( $this->payment_methods_store, $this->service_settings_store, $this->service_schemas_store, $this->logger );
 			$this->set_settings_pages( $settings_pages );
+
+			add_action( 'admin_notices', array( WC_Connect_Error_Notice::instance(), 'render_notice' ) );
 		}
 
 		/**


### PR DESCRIPTION
Closes #794
Closes #793
Closes #791
Closes #821

- Add debug vs error messages in logger (errors are logged even if the debug switch is disabled)
- When an error is logged, trigger a dismissable notice in the admin page to review logs
- Log shipping rates issues as errors instead of debug messages

To Test:

- Try to get shipping rates at checkout with an item that doesn't have dimensions
- Go to the admin panel
- Observe the admin notice
- Click the link to go to the Connect status page
- Click the dismiss button to make the message go away

