### PR TITLE
Only validate (instance) form fields that have been changed

### DIFF
--- a/client/lib/initialize-state/index.js
+++ b/client/lib/initialize-state/index.js
@@ -20,14 +20,16 @@ const getItemValue = ( schema, value, definitions ) => {
 
 export default ( schema, values ) => {
 	const formValues = {};
+	const pristine = {};
 	Object.keys( schema.properties ).forEach( ( key ) => {
 		formValues[ key ] = getItemValue( schema.properties[ key ], values[ key ], schema.definitions );
+		pristine[ key ] = true;
 	} );
 
 	return {
 		form: {
 			isSaving: false,
-			pristine: true,
+			pristine,
 			currentStep: -1,
 			values: formValues,
 			shippingLabel: {},

--- a/client/main.js
+++ b/client/main.js
@@ -15,6 +15,7 @@ import Settings from './settings';
 import ShippingLabel from './shipping-label';
 import AccountSettings from './account-settings';
 import Packages from './packages';
+import every from 'lodash/every';
 
 ( () => {
 	if ( ! global.wcConnectData ) {
@@ -47,7 +48,7 @@ import Packages from './packages';
 	window.addEventListener( 'beforeunload', ( event ) => {
 		const state = store.getState();
 
-		if ( ! state.form || state.form.pristine || ( state.form.meta && state.form.meta.pristine ) ) {
+		if ( ! state.form || ( state.form.meta && state.form.meta.pristine ) || every( state.form.pristine ) ) {
 			return;
 		}
 		const text = __( 'You have unsaved changes.' );

--- a/client/main.js
+++ b/client/main.js
@@ -15,7 +15,7 @@ import Settings from './settings';
 import ShippingLabel from './shipping-label';
 import AccountSettings from './account-settings';
 import Packages from './packages';
-import every from 'lodash/every';
+import _ from 'lodash';
 
 ( () => {
 	if ( ! global.wcConnectData ) {
@@ -48,7 +48,7 @@ import every from 'lodash/every';
 	window.addEventListener( 'beforeunload', ( event ) => {
 		const state = store.getState();
 
-		if ( ! state.form || ( state.form.meta && state.form.meta.pristine ) || every( state.form.pristine ) ) {
+		if ( ! state.form || ( state.form.meta && state.form.meta.pristine ) || _.every( state.form.pristine ) ) {
 			return;
 		}
 		const text = __( 'You have unsaved changes.' );

--- a/client/settings/state/actions.js
+++ b/client/settings/state/actions.js
@@ -1,4 +1,5 @@
 export const SET_FORM_PROPERTY = 'SET_FORM_PROPERTY';
+export const SET_ALL_PRISTINE = 'SET_ALL_PRISTINE';
 
 export const setFormProperty = ( field, value ) => {
 	return {
@@ -7,3 +8,8 @@ export const setFormProperty = ( field, value ) => {
 		value,
 	};
 };
+
+export const setAllPristine = ( pristineValue ) => ( {
+	type: SET_ALL_PRISTINE,
+	pristineValue,
+} );

--- a/client/settings/state/reducer.js
+++ b/client/settings/state/reducer.js
@@ -1,4 +1,4 @@
-import { SET_FORM_PROPERTY } from './actions';
+import { SET_FORM_PROPERTY, SET_ALL_PRISTINE } from './actions';
 import values from './values/reducer';
 import * as formValueActions from './values/actions';
 import _ from 'lodash';
@@ -22,6 +22,11 @@ reducers[ SET_FORM_PROPERTY ] = ( state, action ) => {
 	}
 	return Object.assign( {}, state, newObj );
 };
+
+reducers[ SET_ALL_PRISTINE ] = ( state, action ) => ( {
+	...state,
+	pristine: _.mapValues( state.pristine, () => action.pristineValue ),
+} );
 
 export default function form( state = {}, action ) {
 	let newState = Object.assign( {}, state );

--- a/client/settings/state/reducer.js
+++ b/client/settings/state/reducer.js
@@ -1,6 +1,7 @@
 import { SET_FORM_PROPERTY } from './actions';
 import values from './values/reducer';
 import * as formValueActions from './values/actions';
+import mapValues from 'lodash/mapValues';
 
 const reducers = {};
 
@@ -8,7 +9,7 @@ reducers[ SET_FORM_PROPERTY ] = ( state, action ) => {
 	const newObj = {};
 	newObj[ action.field ] = action.value;
 	if ( 'success' === action.field && action.value ) {
-		newObj.pristine = true;
+		newObj.pristine = mapValues( state.pristine, () => true );
 	} else if ( 'fieldsStatus' === action.field && action.value ) {
 		Object.keys( action.value ).forEach( ( fieldPath ) => {
 			const fieldStatus = action.value[ fieldPath ];
@@ -30,7 +31,7 @@ export default function form( state = {}, action ) {
 	}
 
 	if ( formValueActions[ action.type ] ) {
-		newState.pristine = false;
+		newState.pristine = { ...state.pristine, [ action.path ]: false };
 
 		// Allow client-side form validation to take over error state when inputs change
 		delete newState.error;

--- a/client/settings/state/reducer.js
+++ b/client/settings/state/reducer.js
@@ -1,7 +1,7 @@
 import { SET_FORM_PROPERTY } from './actions';
 import values from './values/reducer';
 import * as formValueActions from './values/actions';
-import mapValues from 'lodash/mapValues';
+import _ from 'lodash';
 
 const reducers = {};
 
@@ -9,7 +9,7 @@ reducers[ SET_FORM_PROPERTY ] = ( state, action ) => {
 	const newObj = {};
 	newObj[ action.field ] = action.value;
 	if ( 'success' === action.field && action.value ) {
-		newObj.pristine = mapValues( state.pristine, () => true );
+		newObj.pristine = _.mapValues( state.pristine, () => true );
 	} else if ( 'fieldsStatus' === action.field && action.value ) {
 		Object.keys( action.value ).forEach( ( fieldPath ) => {
 			const fieldStatus = action.value[ fieldPath ];

--- a/client/settings/state/test/reducer.js
+++ b/client/settings/state/test/reducer.js
@@ -1,5 +1,5 @@
 import reducer from '../reducer';
-import { setFormProperty } from '../actions';
+import { setFormProperty, setAllPristine } from '../actions';
 import { updateField } from '../values/actions';
 
 const initialState = {
@@ -13,6 +13,9 @@ const initialState = {
 			},
 			value: 1122,
 		},
+	},
+	pristine: {
+		field: true,
 	},
 };
 
@@ -32,6 +35,9 @@ describe( 'Settings reducer', () => {
 					value: 1122,
 				},
 			},
+			pristine: {
+				field: true,
+			},
 		} );
 	} );
 
@@ -45,6 +51,9 @@ describe( 'Settings reducer', () => {
 			textObj: {
 				id: 'newID',
 				newfield: 'some new value',
+			},
+			pristine: {
+				field: true,
 			},
 		} );
 	} );
@@ -62,5 +71,27 @@ describe( 'Settings reducer', () => {
 		const state = reducer( initialState, action );
 
 		expect( state ).to.have.deep.property( 'pristine.some_key', false );
+	} );
+
+	it( 'SET_ALL_PRISTINE', () => {
+		const action = setAllPristine( false );
+		const state = reducer( initialState, action );
+
+		expect( state ).to.eql( {
+			textObj: {
+				field: {
+					id: 'PCKG_A',
+					dimensions: {
+						width: 10,
+						length: 11,
+						height: 23,
+					},
+					value: 1122,
+				},
+			},
+			pristine: {
+				field: false,
+			},
+		} );
 	} );
 } );

--- a/client/settings/state/test/reducer.js
+++ b/client/settings/state/test/reducer.js
@@ -56,4 +56,11 @@ describe( 'Settings reducer', () => {
 
 		expect( state ).to.not.have.property( 'fieldsStatus' );
 	} );
+
+	it( 'UPDATE_FIELD marks pristine false', () => {
+		const action = updateField( 'some_key', 'some value' );
+		const state = reducer( initialState, action );
+
+		expect( state ).to.have.deep.property( 'pristine.some_key', false );
+	} );
 } );

--- a/client/settings/state/values/actions.js
+++ b/client/settings/state/values/actions.js
@@ -27,7 +27,7 @@ export const addArrayFieldItem = ( path, item ) => ( {
 	item,
 } );
 
-export const submit = ( schema, silent ) => ( dispatch, getState, { callbackURL, nonce, submitMethod, formSchema } ) => {
+export const submit = ( schema, silent ) => ( dispatch, getState, { callbackURL, nonce, submitMethod } ) => {
 	silent = ( true === silent );
 
 	const setIsSaving = ( value ) => dispatch( FormActions.setFormProperty( 'isSaving', value ) );
@@ -63,12 +63,12 @@ export const submit = ( schema, silent ) => ( dispatch, getState, { callbackURL,
 		}
 	};
 
-	const coercedValues = coerceFormValues( formSchema, getState().form.values );
+	const coercedValues = coerceFormValues( schema, getState().form.values );
 
 	// Trigger a client-side validation before hitting the server
 	dispatch( FormActions.setAllPristine( false ) );
 
-	const errors = getFormErrors( getState(), formSchema );
+	const errors = getFormErrors( getState(), schema );
 
 	if ( _.isEmpty( errors ) ) {
 		saveForm( setIsSaving, setSuccess, setFieldsStatus, setError, callbackURL, nonce, submitMethod, coercedValues );


### PR DESCRIPTION
Fixes #795.

To test:
* Add a new USPS shipping zone instance
* Verify that the initial form load (with empty origin zip) does not have an error
* Alter the "name" field
* Verify the "origin" has not been validated
* Save the form
* Verify that "origin" has an error (from server)
* Refresh the page - *do not save*
* Enter a single character into "origin"
* Verify that "origin" has an error (from client)