### PR TITLE
When origin address is empty, don't immediately validate its fields

### DIFF
--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -98,6 +98,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			$wc_address_fields[ 'address_2' ] = '';
 			$wc_address_fields[ 'city' ] = '';
 			$wc_address_fields[ 'postcode' ] = '';
+			$wc_address_fields[ 'phone' ] = '';
 
 			$stored_address_fields = get_option( 'wc_connect_origin_address', array() );
 			return array_merge( $wc_address_fields, $stored_address_fields );

--- a/client/shipping-label/index.js
+++ b/client/shipping-label/index.js
@@ -23,6 +23,9 @@ export default ( { formData, labelsData, paperSize, storeOptions } ) => ( {
 	},
 
 	getInitialState() {
+		// The phone field is never prefilled, so if it's present it means the address is fully valid
+		const hasOriginAddress = Boolean( formData.origin.phone );
+
 		return {
 			shippingLabel: {
 				labels: labelsData || [],
@@ -31,8 +34,10 @@ export default ( { formData, labelsData, paperSize, storeOptions } ) => ( {
 					orderId: formData.order_id,
 					origin: {
 						values: formData.origin,
-						isNormalized: Boolean( formData.origin.phone ), // If the phone field is filled, we assume it's an already normalized address
-						normalized: formData.origin.phone ? formData.origin : null,
+						isNormalized: hasOriginAddress,
+						normalized: hasOriginAddress ? formData.origin : null,
+						// If no origin address is stored, mark all fields as "ignore validation" so the UI doesn't immediately show errors
+						ignoreValidation: hasOriginAddress ? null : _.mapValues( formData.origin, () => true ),
 						selectNormalized: true,
 						normalizationInProgress: false,
 						allowChangeCountry: false,

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -219,6 +219,13 @@ export const editAddress = ( group ) => {
 	};
 };
 
+export const removeIgnoreValidation = ( group ) => {
+	return {
+		type: REMOVE_IGNORE_VALIDATION,
+		group,
+	};
+};
+
 export const confirmAddressSuggestion = ( group ) => ( dispatch, getState, { storeOptions, getRatesURL, nonce } ) => {
 	dispatch( {
 		type: CONFIRM_ADDRESS_SUGGESTION,
@@ -254,7 +261,7 @@ export const submitAddressForNormalization = ( group ) => ( dispatch, getState, 
 
 	let state = getState().shippingLabel.form[ group ];
 	if ( state.ignoreValidation ) {
-		dispatch( { type: REMOVE_IGNORE_VALIDATION, group } );
+		dispatch( removeIgnoreValidation( group ) );
 		const errors = getFormErrors( getState(), storeOptions );
 		if ( hasNonEmptyLeaves( errors[ group ] ) ) {
 			return;

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -14,6 +14,7 @@ export const OPEN_PRINTING_FLOW = 'OPEN_PRINTING_FLOW';
 export const EXIT_PRINTING_FLOW = 'EXIT_PRINTING_FLOW';
 export const TOGGLE_STEP = 'TOGGLE_STEP';
 export const UPDATE_ADDRESS_VALUE = 'UPDATE_ADDRESS_VALUE';
+export const REMOVE_IGNORE_VALIDATION = 'REMOVE_IGNORE_VALIDATION';
 export const ADDRESS_NORMALIZATION_IN_PROGRESS = 'ADDRESS_NORMALIZATION_IN_PROGRESS';
 export const ADDRESS_NORMALIZATION_COMPLETED = 'ADDRESS_NORMALIZATION_COMPLETED';
 export const SELECT_NORMALIZED_ADDRESS = 'SELECT_NORMALIZED_ADDRESS';
@@ -146,11 +147,11 @@ export const openPrintingFlow = () => ( dispatch, getState, context ) => {
 	let errors = getFormErrors( getState(), storeOptions );
 	const promisesQueue = [];
 
-	if ( ! hasNonEmptyLeaves( errors.origin ) && ! origin.isNormalized && ! origin.normalizationInProgress ) {
+	if ( ! origin.ignoreValidation && ! hasNonEmptyLeaves( errors.origin ) && ! origin.isNormalized && ! origin.normalizationInProgress ) {
 		promisesQueue.push( normalizeAddress( dispatch, origin.values, 'origin', addressNormalizationURL, nonce ) );
 	}
 
-	if ( ! hasNonEmptyLeaves( errors.destination ) && ! destination.isNormalized && ! destination.normalizationInProgress ) {
+	if ( ! destination.ignoreValidation && ! hasNonEmptyLeaves( errors.destination ) && ! destination.isNormalized && ! destination.normalizationInProgress ) {
 		promisesQueue.push( normalizeAddress( dispatch, destination.values, 'destination', addressNormalizationURL, nonce ) );
 	}
 
@@ -251,9 +252,17 @@ export const submitAddressForNormalization = ( group ) => ( dispatch, getState, 
 		}
 	};
 
-	const state = getState().shippingLabel.form[ group ];
+	let state = getState().shippingLabel.form[ group ];
+	if ( state.ignoreValidation ) {
+		dispatch( { type: REMOVE_IGNORE_VALIDATION, group } );
+		const errors = getFormErrors( getState(), storeOptions );
+		if ( hasNonEmptyLeaves( errors[ group ] ) ) {
+			return;
+		}
+		state = getState().shippingLabel.form[ group ];
+	}
 	if ( state.isNormalized && _.isEqual( state.values, state.normalized ) ) {
-		handleNormalizeResponse();
+		handleNormalizeResponse( true );
 		return;
 	}
 	normalizeAddress( dispatch, getState().shippingLabel.form[ group ].values, group, addressNormalizationURL, nonce )

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -3,6 +3,7 @@ import {
 	EXIT_PRINTING_FLOW,
 	TOGGLE_STEP,
 	UPDATE_ADDRESS_VALUE,
+	REMOVE_IGNORE_VALIDATION,
 	ADDRESS_NORMALIZATION_IN_PROGRESS,
 	ADDRESS_NORMALIZATION_COMPLETED,
 	SELECT_NORMALIZED_ADDRESS,
@@ -87,7 +88,22 @@ reducers[ UPDATE_ADDRESS_VALUE ] = ( state, { group, name, value } ) => {
 	if ( 'country' === name ) {
 		return reducers[ UPDATE_ADDRESS_VALUE ]( newState, { group, name: 'state', value: '' } );
 	}
+	if ( state.form[ group ].ignoreValidation ) {
+		newState.form[ group ].ignoreValidation = { ...state.form[ group ].ignoreValidation,
+			[ name ]: false,
+		};
+	}
 	return newState;
+};
+
+reducers[ REMOVE_IGNORE_VALIDATION ] = ( state, { group } ) => {
+	return { ...state,
+		form: { ...state.form,
+			[ group ]: { ...state.form[ group ],
+				ignoreValidation: null,
+			},
+		},
+	};
 };
 
 reducers[ ADDRESS_NORMALIZATION_IN_PROGRESS ] = ( state, { group } ) => {

--- a/client/shipping-label/state/selectors/errors.js
+++ b/client/shipping-label/state/selectors/errors.js
@@ -4,7 +4,7 @@ import { isValidPhone } from 'lib/utils/phone-format';
 import { sprintf } from 'sprintf-js';
 import _ from 'lodash';
 
-const getAddressErrors = ( { values, isNormalized, normalized, selectNormalized }, countriesData ) => {
+const getAddressErrors = ( { values, isNormalized, normalized, selectNormalized, ignoreValidation }, countriesData ) => {
 	if ( isNormalized && ! normalized ) {
 		// If the address is normalized but the server didn't return a normalized address, then it's
 		// invalid and must register as an error
@@ -37,6 +37,14 @@ const getAddressErrors = ( { values, isNormalized, normalized, selectNormalized 
 		if ( ! _.isEmpty( countriesData[ country ].states ) && ! state ) {
 			errors.state = __( 'This field is required' );
 		}
+	}
+
+	if ( ignoreValidation ) {
+		Object.keys( errors ).forEach( ( field ) => {
+			if ( ignoreValidation[ field ] ) {
+				delete errors[ field ];
+			}
+		} );
 	}
 
 	return errors;


### PR DESCRIPTION
Fixes #813 

To avoid the overwhelming "everything is red!!!1!" experience when the merchant opens the Purchase Label dialog without an stored Origin address, I've tweaked the validation logic to only kick in when a particular field is edited.

To test:
* Remove the origin address from your settings. That's the `wc_connect_origin_address` option. You can just also go to `classes/class-wc-connect-service-settings-store.php`, function `get_origin_address()`, put this in at the start: `update_option( 'wc_connect_origin_address', array() );` and reload the Order page once.
* Go print a label. You should see the "Origin address" step expanded but no visible errors.
* Once you edit a field such as the ZIP code, you see the error (if any) on that field, but not on the rest.
* You can click the "Use this address" button any time, and that will do a full validation (only local validation if there are invalid fields).

Because #811, the UX on this isn't ideal yet, but it's still an improvement.

To the reviewers: I'm OK with the solution but not with the variable names. My brain can't think on anything better than `ignoreValidation`. Plz help, thx.