### PR TITLE
Flat rate services - checkboxes always enabled

### DIFF
--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -692,7 +692,6 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 				'formSchema'         => $this->get_form_schema(),
 				'formLayout'         => $this->get_form_layout(),
 				'formData'           => $this->get_form_data(),
-				'predefinedPackages' => array(),
 				'callbackURL'        => get_rest_url( null, "/wc/v1/connect/self-help" ),
 				'nonce'              => wp_create_nonce( 'wp_rest' ),
 				'rootView'           => $root_view,

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -135,7 +135,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 			foreach ( $predefined_packages_schema as $group ) {
 				foreach ( $group->definitions as $package ) {
-					if ( ! in_array( $package->id, $enabled_predefined_packages ) ) {
+					if ( ! $package->is_flat_rate && ! in_array( $package->id, $enabled_predefined_packages ) ) {
 						continue;
 					}
 

--- a/client/packages/views/index.js
+++ b/client/packages/views/index.js
@@ -46,6 +46,11 @@ const Packages = ( props ) => {
 
 			_.forEach( servicePackages, ( predefGroup, groupId ) => {
 				const groupPackages = predefGroup.definitions;
+				const nonFlatRates = _.reject( groupPackages, 'is_flat_rate' );
+				if ( ! nonFlatRates.length ) {
+					return;
+				}
+
 				const summary = predefSummary( serviceSelected, groupPackages );
 
 				elements.push( <FoldableCard

--- a/client/packages/views/index.js
+++ b/client/packages/views/index.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import CompactCard from 'components/card/compact';
 import FormSectionHeading from 'components/forms/form-section-heading';
+import FormCheckbox from 'components/forms/form-checkbox';
 import ActionButtons from 'components/action-buttons';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormButton from 'components/forms/form-button';
@@ -38,6 +39,24 @@ const Packages = ( props ) => {
 		return sprintf( 1 === selectedCount ? __( '%d package selected' ) : __( '%d packages selected' ), selectedCount );
 	};
 
+	const renderPredefHeader = ( title, selected, packages, serviceId, groupId ) => {
+		if ( ! selected ) {
+			return null;
+		}
+
+		const allPackageIds = packages.map( ( def ) => def.id );
+		const selectedAll = 0 === _.difference( allPackageIds, selected ).length;
+		return (
+			<div className="wcc-predefined-packages-group-header" >
+				<FormCheckbox
+					checked={ selectedAll }
+					onClick={ ( event ) => event.stopPropagation() }
+					onChange={ () => props.toggleAll( serviceId, groupId ) } />
+				{ title }
+			</div>
+		);
+	};
+
 	const renderPredefinedPackages = () => {
 		const elements = [];
 
@@ -55,7 +74,7 @@ const Packages = ( props ) => {
 
 				elements.push( <FoldableCard
 					key={ `${serviceId}_${groupId}` }
-					header={ predefGroup.title }
+					header={ renderPredefHeader( predefGroup.title, serviceSelected, groupPackages, serviceId, groupId ) }
 					summary={ summary }
 					expandedSummary={ summary }
 					clickableHeader={ true }

--- a/client/packages/views/packages-list.js
+++ b/client/packages/views/packages-list.js
@@ -1,11 +1,9 @@
 import React, { PropTypes } from 'react';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
-import FormCheckbox from 'components/forms/form-checkbox';
 import PackagesListItem from './packages-list-item';
 import Gridicon from 'components/gridicon';
 import { translate as __ } from 'lib/mixins/i18n';
-import _ from 'lodash';
 
 const noPackages = () => {
 	return (
@@ -18,17 +16,7 @@ const noPackages = () => {
 	);
 };
 
-const PackagesList = ( { packages, dimensionUnit, editable, selected, serviceId, groupId, removePackage, editPackage, toggleAll, togglePackage } ) => {
-	const renderSelectAll = () => {
-		if ( ! selected ) {
-			return null;
-		}
-
-		const allPackageIds = packages.map( ( def ) => def.id );
-		const selectedAll = 0 === _.difference( allPackageIds, selected ).length;
-		return <FormLegend className="package-actions"><FormCheckbox checked={ selectedAll } onChange={ () => toggleAll( serviceId, groupId ) }/></FormLegend>;
-	};
-
+const PackagesList = ( { packages, dimensionUnit, editable, selected, serviceId, removePackage, editPackage, togglePackage } ) => {
 	const renderPackageListItem = ( pckg, idx ) => {
 		const isSelected = selected && selected.includes( pckg.id );
 
@@ -52,7 +40,7 @@ const PackagesList = ( { packages, dimensionUnit, editable, selected, serviceId,
 	return (
 		<FormFieldset className="wcc-shipping-packages-list">
 			<div className="wcc-shipping-packages-list-header">
-				{ renderSelectAll() }
+				<FormLegend className="package-actions"/>
 				<FormLegend className="package-type">{ __( 'Type' ) }</FormLegend>
 				<FormLegend className="package-name">{ __( 'Name' ) }</FormLegend>
 				<FormLegend className="package-dimensions">{ __( 'Dimensions (L x W x H)' ) }</FormLegend>

--- a/client/packages/views/style.scss
+++ b/client/packages/views/style.scss
@@ -181,3 +181,9 @@
 		box-shadow: none;
 	}
 }
+
+.wcc-predefined-packages-group-header {
+	.form-checkbox {
+		margin-right: 8px;
+	}
+}

--- a/client/settings/index.js
+++ b/client/settings/index.js
@@ -7,7 +7,7 @@ import form from './state/reducer';
 // from calypso
 import notices from 'state/notices/reducer';
 
-export default ( { formData, formSchema, formLayout, storeOptions, predefinedPackages } ) => ( {
+export default ( { formData, formSchema, formLayout, storeOptions } ) => ( {
 	getReducer() {
 		return combineReducers( {
 			form,
@@ -30,7 +30,6 @@ export default ( { formData, formSchema, formLayout, storeOptions, predefinedPac
 		<SettingsView
 			storeOptions={ storeOptions }
 			schema={ formSchema }
-			layout={ formLayout }
-			predefinedPackages={ predefinedPackages } />
+			layout={ formLayout } />
 	),
 } );

--- a/client/settings/views/index.js
+++ b/client/settings/views/index.js
@@ -18,7 +18,6 @@ Settings.propTypes = {
 	storeOptions: PropTypes.object.isRequired,
 	schema: PropTypes.object.isRequired,
 	layout: PropTypes.array.isRequired,
-	predefinedPackages: PropTypes.array.isRequired,
 };
 
 export default Settings;

--- a/client/settings/views/services/entry.js
+++ b/client/settings/views/services/entry.js
@@ -4,7 +4,6 @@ import FormSelect from 'components/forms/form-select';
 import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 import NumberInput from 'components/number-field/number-input';
-import { translate as __ } from 'lib/mixins/i18n';
 
 const ShippingServiceEntry = ( props ) => {
 	const {
@@ -12,7 +11,6 @@ const ShippingServiceEntry = ( props ) => {
 		updateValue,
 		errors,
 		service,
-		isManageable,
 	} = props;
 
 	const {
@@ -25,24 +23,23 @@ const ShippingServiceEntry = ( props ) => {
 	const hasError = errors[ service.id ];
 
 	return (
-		<div className={ classNames( 'wcc-shipping-service-entry', { 'wcc-error': hasError } ) } title={ isManageable ? '' : __( 'You can manage this service after enabling the corresponding package in the Packaging Manager' ) }>
+		<div className={ classNames( 'wcc-shipping-service-entry', { 'wcc-error': hasError } ) } >
 			<label className="wcc-shipping-service-entry-title">
 				<FormCheckbox
-					checked={ enabled && isManageable }
-					disabled={ ! isManageable }
+					checked={ enabled }
 					onChange={ ( event ) => updateValue( 'enabled', event.target.checked ) }
 				/>
 				<span>{ name }</span>
 			</label>
 			{ hasError ? <Gridicon icon="notice" /> : null }
 			<NumberInput
-				disabled={ ! enabled || ! isManageable }
+				disabled={ ! enabled }
 				value={ adjustment }
 				onChange={ ( event ) => updateValue( 'adjustment', event.target.value ) }
 				isError={ hasError }
 			/>
 			<FormSelect
-				disabled={ ! enabled || ! isManageable }
+				disabled={ ! enabled }
 				value={ adjustment_type }
 				onChange={ ( event ) => updateValue( 'adjustment_type', event.target.value ) }
 			>
@@ -67,7 +64,6 @@ ShippingServiceEntry.propTypes = {
 	currencySymbol: PropTypes.string.isRequired,
 	updateValue: PropTypes.func.isRequired,
 	settingsKey: PropTypes.string.isRequired,
-	isManageable: PropTypes.bool.isRequired,
 };
 
 ShippingServiceEntry.defaultProps = {

--- a/client/settings/views/services/group.js
+++ b/client/settings/views/services/group.js
@@ -31,7 +31,6 @@ const ShippingServiceGroup = ( props ) => {
 		services,
 		updateValue,
 		errors,
-		predefinedPackages,
 	} = props;
 	const actionButton = (
 		<button className="foldable-card__action foldable-card__expand" type="button">
@@ -39,20 +38,18 @@ const ShippingServiceGroup = ( props ) => {
 			<Gridicon icon="chevron-down" size={ 24 } />
 		</button>
 	);
-	//filter out the services that have a disabled corresponding predefined package
-	const manageableServices = services.filter( ( service ) => ! service.predefined_package || predefinedPackages.includes( service.predefined_package ) );
-	const allChecked = _.every( manageableServices, ( service ) => service.enabled );
+	const allChecked = _.every( services, ( service ) => service.enabled );
 	const renderHeader = () => {
 		return <div className="wcc-shipping-services-group-header">
 			<CheckBox
 				onClick={ ( event ) => event.stopPropagation() }
-				onChange={ ( event ) => updateAll( event, updateValue, manageableServices ) }
+				onChange={ ( event ) => updateAll( event, updateValue, services ) }
 				checked={ allChecked }
 			/>
 			{ title }
 		</div>;
 	};
-	const summary = summaryLabel( manageableServices );
+	const summary = summaryLabel( services );
 
 	return (
 		<FoldableCard
@@ -82,7 +79,6 @@ const ShippingServiceGroup = ( props ) => {
 				<ShippingServiceEntry
 					{ ...props }
 					{ ...{ service } }
-					isManageable={ manageableServices.includes( service ) }
 					updateValue={ ( key, val ) => updateValue( [ service.id ].concat( key ), val ) }
 					key={ idx }
 				/>
@@ -104,7 +100,6 @@ ShippingServiceGroup.propTypes = {
 		adjustment_type: PropTypes.string,
 	} ) ).isRequired,
 	updateValue: PropTypes.func.isRequired,
-	predefinedPackages: PropTypes.array.isRequired,
 };
 
 export default ShippingServiceGroup;

--- a/client/settings/views/services/index.js
+++ b/client/settings/views/services/index.js
@@ -12,7 +12,6 @@ const ShippingServiceGroups = ( {
 	description,
 	services,
 	settings,
-	predefinedPackages,
 	currencySymbol,
 	updateValue,
 	settingsKey,
@@ -39,7 +38,6 @@ const ShippingServiceGroups = ( {
 				key={ serviceGroup }
 				title={ serviceGroups[ serviceGroup ][ 0 ].group_name }
 				services={ serviceGroups[ serviceGroup ] }
-				predefinedPackages={ predefinedPackages }
 				currencySymbol={ currencySymbol }
 				updateValue={ updateValue }
 				settingsKey={ settingsKey }
@@ -68,7 +66,6 @@ ShippingServiceGroups.propTypes = {
 	currencySymbol: PropTypes.string,
 	updateValue: PropTypes.func.isRequired,
 	settingsKey: PropTypes.string.isRequired,
-	predefinedPackages: PropTypes.array.isRequired,
 };
 
 ShippingServiceGroups.defaultProps = {

--- a/client/settings/views/wcc-settings-form/index.js
+++ b/client/settings/views/wcc-settings-form/index.js
@@ -30,7 +30,6 @@ WCCSettingsForm.propTypes = {
 	storeOptions: PropTypes.object.isRequired,
 	schema: PropTypes.object.isRequired,
 	layout: PropTypes.array.isRequired,
-	predefinedPackages: PropTypes.array.isRequired,
 };
 
 function mapStateToProps( state, props ) {

--- a/client/settings/views/wcc-settings-form/settings-group.js
+++ b/client/settings/views/wcc-settings-form/settings-group.js
@@ -97,7 +97,6 @@ SettingsGroup.propTypes = {
 	} ),
 	schema: PropTypes.object.isRequired,
 	storeOptions: PropTypes.object.isRequired,
-	predefinedPackages: PropTypes.array.isRequired,
 	saveForm: PropTypes.func.isRequired,
 	form: PropTypes.object.isRequired,
 	formActions: PropTypes.object.isRequired,

--- a/client/settings/views/wcc-settings-form/settings-item.js
+++ b/client/settings/views/wcc-settings-form/settings-item.js
@@ -18,7 +18,6 @@ const SettingsItem = ( {
 	form,
 	layout,
 	schema,
-	predefinedPackages,
 	formValueActions,
 	storeOptions,
 	errors,
@@ -92,7 +91,6 @@ const SettingsItem = ( {
 					services={ schema.definitions.services }
 					title={ fieldSchema.title }
 					description={ fieldSchema.description }
-					predefinedPackages={ predefinedPackages }
 					settings={ fieldValue }
 					currencySymbol={ storeOptions.currency_symbol }
 					updateValue={ updateSubValue }
@@ -199,7 +197,6 @@ SettingsItem.propTypes = {
 		PropTypes.object.isRequired,
 	] ).isRequired,
 	schema: PropTypes.object.isRequired,
-	predefinedPackages: PropTypes.array.isRequired,
 	storeOptions: PropTypes.object.isRequired,
 	form: PropTypes.object.isRequired,
 	formValueActions: PropTypes.object.isRequired,

--- a/client/shipping-label/views/purchase/steps/packages/package-info.js
+++ b/client/shipping-label/views/purchase/steps/packages/package-info.js
@@ -82,11 +82,15 @@ const PackageInfo = ( { packageId, selected, all, flatRateGroups, unpacked, dime
 
 		return (
 			<FormSelect onChange={ packageOptionChange } value={ pckg.box_id }>
-				{ _.map( groups, ( group, groupId ) => (
-					<optgroup label={ group.title } key={ groupId } >
+				{ _.map( groups, ( group, groupId ) => {
+					if ( _.isEmpty( group.definitions ) ) {
+						return null;
+					}
+
+					return <optgroup label={ group.title } key={ groupId }>
 						{ _.map( group.definitions, renderPackageOption ) }
-					</optgroup>
-				) ) }
+					</optgroup>;
+				} ) }
 			</FormSelect>
 		);
 	};

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -543,7 +543,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				'formSchema'         => $service_schema->service_settings,
 				'formLayout'         => $service_schema->form_layout,
 				'formData'           => $settings_store->get_service_settings( $id, $instance ),
-				'predefinedPackages' => $settings_store->get_predefined_packages_for_service( $id ),
 				'callbackURL'        => get_rest_url( null, $path ),
 				'nonce'              => wp_create_nonce( 'wp_rest' ),
 				'rootView'           => 'wc-connect-service-settings',


### PR DESCRIPTION
Fixes #818

This does the following things:
* removes the flat rate packages from the packaging manager screen
* the flat rate services are always enabled
* when enabling a flat rate service the corresponding package is treated as enabled automatically

To test:
* checkout the server branch at Automattic/woocommerce-connect-server#750
* verify that it's possible to enable flat rate services
* request rates and verify that the flat rates are coming back
* place an order and verify that the flat rate packages are still visible in the packaging manager