### PR TITLE
Don't allow merchants to enter label dialog before selecting a payment method

### DIFF
--- a/assets/stylesheets/shipping-label.scss
+++ b/assets/stylesheets/shipping-label.scss
@@ -47,6 +47,7 @@
 
 		.wcc-metabox__new-label-button {
 			width: 100%;
+			margin-top: 16px;
 		}
 
 		.wcc-metabox-label-item__actions {

--- a/assets/stylesheets/shipping-label.scss
+++ b/assets/stylesheets/shipping-label.scss
@@ -2,6 +2,11 @@
 	margin-bottom: 0;
 	text-align: center;
 
+	.wcc-metabox-label-payment .gridicon.notice__icon {
+		align-self: flex-start;
+		margin-top: 8px;
+	}
+
 	.wcc-metabox-label-item {
 		padding: 16px;
 		border-bottom: 1px solid #eee;

--- a/client/shipping-label/index.js
+++ b/client/shipping-label/index.js
@@ -7,7 +7,7 @@ import _ from 'lodash';
 // from calypso
 import notices from 'state/notices/reducer';
 
-export default ( { formData, labelsData, paperSize, storeOptions } ) => ( {
+export default ( { formData, labelsData, paperSize, storeOptions, paymentMethod } ) => ( {
 	getReducer() {
 		return combineReducers( {
 			shippingLabel,
@@ -30,6 +30,7 @@ export default ( { formData, labelsData, paperSize, storeOptions } ) => ( {
 			shippingLabel: {
 				labels: labelsData || [],
 				paperSize,
+				paymentMethod,
 				form: {
 					orderId: formData.order_id,
 					origin: {

--- a/client/shipping-label/views/index.js
+++ b/client/shipping-label/views/index.js
@@ -84,8 +84,8 @@ class ShippingLabelRootView extends Component {
 				<PurchaseLabelDialog
 					{ ...this.props.shippingLabel }
 					{ ...this.props } />
-				<Button className="wcc-metabox__new-label-button" onClick={ this.props.labelActions.openPrintingFlow } >
 				{ this.renderPaymentInfo() }
+				<Button className="wcc-metabox__new-label-button" disabled={ ! paymentMethod } onClick={ this.props.labelActions.openPrintingFlow } >
 					{ __( 'Create new label' ) }
 				</Button>
 			</div>

--- a/client/shipping-label/views/index.js
+++ b/client/shipping-label/views/index.js
@@ -63,7 +63,7 @@ class ShippingLabelRootView extends Component {
 							cardDigits: `<strong>${paymentMethod}</strong>`,
 						}
 					) } }></p>
-					<p><a href={ '#' }>Manage cards</a></p>
+					<p><a href="admin.php?page=wc-settings&tab=connect">{ __( 'Manage cards' ) }</a></p>
 				</Notice>
 			);
 		}
@@ -71,7 +71,7 @@ class ShippingLabelRootView extends Component {
 		return (
 			<Notice status="is-error" isCompact={ true } showDismiss={ false } className="wcc-metabox-label-payment inline">
 				<p>{ __( 'There are no cards saved on your account. Please add one to purchase labels.' ) }</p>
-				<p><a href={ '#' }>Add new cards</a></p>
+				<p><a href="admin.php?page=wc-settings&tab=connect">{ __( 'Add new cards' ) }</a></p>
 			</Notice>
 		);
 	}

--- a/client/shipping-label/views/index.js
+++ b/client/shipping-label/views/index.js
@@ -69,9 +69,9 @@ class ShippingLabelRootView extends Component {
 		}
 
 		return (
-			<Notice status="is-error" isCompact={ true } showDismiss={ false } className="wcc-metabox-label-payment inline">
-				<p>{ __( 'There are no cards saved on your account. Please add one to purchase labels.' ) }</p>
-				<p><a href="admin.php?page=wc-settings&tab=connect">{ __( 'Add new cards' ) }</a></p>
+			<Notice isCompact={ true } showDismiss={ false } className="wcc-metabox-label-payment inline">
+				<p>{ __( 'To purchase shipping labels, you will first need to add a credit card.' ) }</p>
+				<p><a href="admin.php?page=wc-settings&tab=connect">{ __( 'Add a credit card' ) }</a></p>
 			</Notice>
 		);
 	}

--- a/client/shipping-label/views/index.js
+++ b/client/shipping-label/views/index.js
@@ -28,6 +28,7 @@ class ShippingLabelRootView extends Component {
 		this.renderLabel = this.renderLabel.bind( this );
 		this.openTooltip = this.openTooltip.bind( this );
 		this.closeTooltip = this.closeTooltip.bind( this );
+		this.renderLabelButton = this.renderLabelButton.bind( this );
 		this.renderPaymentInfo = this.renderPaymentInfo.bind( this );
 
 		this.needToFetchLabelsStatus = true;
@@ -76,6 +77,14 @@ class ShippingLabelRootView extends Component {
 		);
 	}
 
+	renderLabelButton() {
+		return (
+			<Button className="wcc-metabox__new-label-button" onClick={ this.props.labelActions.openPrintingFlow } >
+				{ __( 'Create new label' ) }
+			</Button>
+		);
+	}
+
 	renderPurchaseLabelFlow() {
 		const paymentMethod = this.props.shippingLabel.paymentMethod;
 
@@ -84,10 +93,8 @@ class ShippingLabelRootView extends Component {
 				<PurchaseLabelDialog
 					{ ...this.props.shippingLabel }
 					{ ...this.props } />
-				{ this.renderPaymentInfo() }
-				<Button className="wcc-metabox__new-label-button" disabled={ ! paymentMethod } onClick={ this.props.labelActions.openPrintingFlow } >
-					{ __( 'Create new label' ) }
-				</Button>
+				{ this.renderPaymentInfo( paymentMethod ) }
+				{ paymentMethod && this.renderLabelButton() }
 			</div>
 		);
 	}

--- a/client/shipping-label/views/index.js
+++ b/client/shipping-label/views/index.js
@@ -64,7 +64,7 @@ class ShippingLabelRootView extends Component {
 							cardDigits: `<strong>${paymentMethod}</strong>`,
 						}
 					) } }></p>
-					<p><a href="admin.php?page=wc-settings&tab=connect">{ __( 'Manage cards' ) }</a></p>
+					<p><a href="admin.php?page=wc-settings&tab=shipping&section=label-settings">{ __( 'Manage cards' ) }</a></p>
 				</Notice>
 			);
 		}
@@ -72,7 +72,7 @@ class ShippingLabelRootView extends Component {
 		return (
 			<Notice isCompact={ true } showDismiss={ false } className="wcc-metabox-label-payment inline">
 				<p>{ __( 'To purchase shipping labels, you will first need to add a credit card.' ) }</p>
-				<p><a href="admin.php?page=wc-settings&tab=connect">{ __( 'Add a credit card' ) }</a></p>
+				<p><a href="admin.php?page=wc-settings&tab=shipping&section=label-settings">{ __( 'Add a credit card' ) }</a></p>
 			</Notice>
 		);
 	}

--- a/client/shipping-label/views/index.js
+++ b/client/shipping-label/views/index.js
@@ -19,6 +19,7 @@ import getFormErrors from 'shipping-label/state/selectors/errors';
 import canPurchase from 'shipping-label/state/selectors/can-purchase';
 import _ from 'lodash';
 import { sprintf } from 'sprintf-js';
+import Notice from 'components/notice';
 
 class ShippingLabelRootView extends Component {
 	constructor( props ) {
@@ -27,6 +28,7 @@ class ShippingLabelRootView extends Component {
 		this.renderLabel = this.renderLabel.bind( this );
 		this.openTooltip = this.openTooltip.bind( this );
 		this.closeTooltip = this.closeTooltip.bind( this );
+		this.renderPaymentInfo = this.renderPaymentInfo.bind( this );
 
 		this.needToFetchLabelsStatus = true;
 
@@ -49,13 +51,41 @@ class ShippingLabelRootView extends Component {
 		this.setState( { showTooltips } );
 	}
 
+	renderPaymentInfo() {
+		const paymentMethod = this.props.shippingLabel.paymentMethod;
+
+		if ( paymentMethod ) {
+			return (
+				<Notice isCompact={ true } showDismiss={ false } className="wcc-metabox-label-payment inline">
+					<p dangerouslySetInnerHTML={ { __html: sprintf(
+						__( 'Labels will be purchased using card ending: %(cardDigits)s.' ),
+						{
+							cardDigits: `<strong>${paymentMethod}</strong>`,
+						}
+					) } }></p>
+					<p><a href={ '#' }>Manage cards</a></p>
+				</Notice>
+			);
+		}
+
+		return (
+			<Notice status="is-error" isCompact={ true } showDismiss={ false } className="wcc-metabox-label-payment inline">
+				<p>{ __( 'There are no cards saved on your account. Please add one to purchase labels.' ) }</p>
+				<p><a href={ '#' }>Add new cards</a></p>
+			</Notice>
+		);
+	}
+
 	renderPurchaseLabelFlow() {
+		const paymentMethod = this.props.shippingLabel.paymentMethod;
+
 		return (
 			<div className="wcc-metabox-label-item" >
 				<PurchaseLabelDialog
 					{ ...this.props.shippingLabel }
 					{ ...this.props } />
 				<Button className="wcc-metabox__new-label-button" onClick={ this.props.labelActions.openPrintingFlow } >
+				{ this.renderPaymentInfo() }
 					{ __( 'Create new label' ) }
 				</Button>
 			</div>

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -378,7 +378,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$tracks                = new WC_Connect_Tracks( $logger );
 			$help_view             = new WC_Connect_Help_View( $schemas_store, $settings_store, $logger );
 			$nux                   = new WC_Connect_Nux();
-			$shipping_label        = new WC_Connect_Shipping_Label( $api_client, $settings_store, $schemas_store, $nux );
+			$shipping_label        = new WC_Connect_Shipping_Label( $api_client, $settings_store, $schemas_store, $nux, $payment_methods_store );
 
 			$this->set_logger( $logger );
 			$this->set_api_client( $api_client );

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -378,7 +378,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$tracks                = new WC_Connect_Tracks( $logger );
 			$help_view             = new WC_Connect_Help_View( $schemas_store, $settings_store, $logger );
 			$nux                   = new WC_Connect_Nux();
-			$shipping_label        = new WC_Connect_Shipping_Label( $api_client, $settings_store, $schemas_store, $nux, $payment_methods_store );
+			$shipping_label        = new WC_Connect_Shipping_Label( $api_client, $settings_store, $schemas_store, $payment_methods_store );
 
 			$this->set_logger( $logger );
 			$this->set_api_client( $api_client );


### PR DESCRIPTION
Fixes #549.

To test:
* With a credit card selected for payment - go to an order detail page
* Verify that an info notice shows the last 4 digits of the card selected for labels
* Verify that the "manage cards" link goes to the correct settings page
* With **no** credit card selected for payment - go to an order detail page
* Verify that an info notice states that you need to select a card to print labels
* Verify that the "add card" link goes to the correct settings page 
* Verify that no "create label" button is shown