### PR TITLE
Added a dotted underline to the "Label #N" title on the labels list, to make it clearer that there is a tooltip

### DIFF
--- a/assets/stylesheets/shipping-label.scss
+++ b/assets/stylesheets/shipping-label.scss
@@ -33,7 +33,6 @@
 				font-weight: bold;
 				font-size: 14px;
 				color: $gray-dark;
-				cursor: help;
 			}
 		}
 

--- a/assets/stylesheets/shipping-label.scss
+++ b/assets/stylesheets/shipping-label.scss
@@ -33,6 +33,10 @@
 				font-weight: bold;
 				font-size: 14px;
 				color: $gray-dark;
+				cursor: help;
+				text-decoration: underline;
+				text-decoration-color: $gray-dark;
+				text-decoration-style: dotted;
 			}
 		}
 

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -352,6 +352,7 @@
 	@import '../../client/account-settings/views/payment-method/style';
 	@import '../../client/account-settings/views/payment-method-selector/style';
 	@import '../../client/components/indicators/style';
+	@import '../../client/components/info-tooltip/style';
 	@import '../../client/components/text/style';
 	@import '../../client/components/text-area/style';
 	@import '../../client/components/toggle/style';

--- a/client/components/info-tooltip/index.js
+++ b/client/components/info-tooltip/index.js
@@ -40,7 +40,7 @@ export default class InfoTooltip extends Component {
 				onMouseEnter={ this.openTooltip }
 				onMouseLeave={ this.closeTooltip }
 				className={ this.props.className }
-				style={ { cursor: 'help' } } >
+				style={ { cursor: 'help', color: 'black' } } >
 				<Gridicon ref="icon" icon="info-outline" size={ 18 } />
 				{ this.state.showTooltip &&
 					<Tooltip
@@ -50,7 +50,8 @@ export default class InfoTooltip extends Component {
 						onClose={ this.closeTooltip }
 						position={ this.props.position }
 						context={ this.refs && this.refs.icon }>
-						<div style={ { maxWidth: this.props.maxWidth } } >
+						<div className="wc-connect-popover-contents"
+							style={ { maxWidth: this.props.maxWidth } } >
 							{ this.props.children }
 						</div>
 					</Tooltip>

--- a/client/components/info-tooltip/index.js
+++ b/client/components/info-tooltip/index.js
@@ -1,7 +1,7 @@
 import React, { PropTypes, Component } from 'react';
-
 import Tooltip from 'components/tooltip';
 import Gridicon from 'components/gridicon';
+import classNames from 'classnames';
 
 export default class InfoTooltip extends Component {
 	static propTypes = {
@@ -39,8 +39,7 @@ export default class InfoTooltip extends Component {
 			<span
 				onMouseEnter={ this.openTooltip }
 				onMouseLeave={ this.closeTooltip }
-				className={ this.props.className }
-				style={ { cursor: 'help', color: 'black' } } >
+				className={ classNames( 'info-tooltip', this.props.className ) } >
 				<Gridicon ref="icon" icon="info-outline" size={ 18 } />
 				{ this.state.showTooltip &&
 					<Tooltip

--- a/client/components/info-tooltip/style.scss
+++ b/client/components/info-tooltip/style.scss
@@ -1,0 +1,4 @@
+.info-tooltip {
+	cursor: help;
+	color: $gray-dark;
+}

--- a/client/shipping-label/views/index.js
+++ b/client/shipping-label/views/index.js
@@ -9,7 +9,7 @@ import ReprintDialog from './reprint';
 import TrackingLink from './tracking-link';
 import Spinner from 'components/spinner';
 import Gridicon from 'components/gridicon';
-import InfoTooltip from 'components/info-tooltip';
+import Tooltip from 'components/tooltip';
 import formatDate from 'lib/utils/format-date';
 import timeAgo from 'lib/utils/time-ago';
 import * as ShippingLabelActions from 'shipping-label/state/actions';
@@ -136,18 +136,26 @@ class ShippingLabelRootView extends Component {
 		return (
 			<span>
 				<span className="wcc-metabox-label-item__detail"
+						onMouseEnter={ () => this.openTooltip( index ) }
+						onMouseLeave={ () => this.closeTooltip( index ) }
 						ref={ 'label-details-' + index }>
 					{ sprintf( __( 'Label #%s' ), label.label_id ) }
 				</span>
-				<InfoTooltip
+				<Tooltip
+					className="wc-connect-popover"
+					isVisible={ this.state.showTooltips[ index ] }
+					onClose={ () => this.closeTooltip( index ) }
 					position="top"
-					maxWidth={ 300 } >
-					<h3>{ label.package_name }</h3>
-					<p>{ label.service_name }</p>
-					<ul>
-						{ label.product_names.map( ( productName, productIdx ) => <li key={ productIdx }>{ productName }</li> ) }
-					</ul>
-				</InfoTooltip>
+					showOnMobile
+					context={ this.refs && this.refs[ 'label-details-' + index ] } >
+					<div className="wc-connect-popover-contents">
+						<h3>{ label.package_name }</h3>
+						<p>{ label.service_name }</p>
+						<ul>
+							{ label.product_names.map( ( productName, productIdx ) => <li key={ productIdx }>{ productName }</li> ) }
+						</ul>
+					</div>
+				</Tooltip>
 			</span>
 		);
 	}

--- a/client/shipping-label/views/index.js
+++ b/client/shipping-label/views/index.js
@@ -9,7 +9,7 @@ import ReprintDialog from './reprint';
 import TrackingLink from './tracking-link';
 import Spinner from 'components/spinner';
 import Gridicon from 'components/gridicon';
-import Tooltip from 'components/tooltip';
+import InfoTooltip from 'components/info-tooltip';
 import formatDate from 'lib/utils/format-date';
 import timeAgo from 'lib/utils/time-ago';
 import * as ShippingLabelActions from 'shipping-label/state/actions';
@@ -136,25 +136,18 @@ class ShippingLabelRootView extends Component {
 		return (
 			<span>
 				<span className="wcc-metabox-label-item__detail"
-						onMouseEnter={ () => this.openTooltip( index ) }
-						onMouseLeave={ () => this.closeTooltip( index ) }
 						ref={ 'label-details-' + index }>
 					{ sprintf( __( 'Label #%s' ), label.label_id ) }
 				</span>
-				<Tooltip
-					className="wc-connect-popover"
-					isVisible={ this.state.showTooltips[ index ] }
-					onClose={ () => this.closeTooltip( index ) }
+				<InfoTooltip
 					position="top"
-					context={ this.refs && this.refs[ 'label-details-' + index ] } >
-					<div className="wc-connect-popover-contents">
-						<h3>{ label.package_name }</h3>
-						<p>{ label.service_name }</p>
-						<ul>
-							{ label.product_names.map( ( productName, productIdx ) => <li key={ productIdx }>{ productName }</li> ) }
-						</ul>
-					</div>
-				</Tooltip>
+					maxWidth={ 300 } >
+					<h3>{ label.package_name }</h3>
+					<p>{ label.service_name }</p>
+					<ul>
+						{ label.product_names.map( ( productName, productIdx ) => <li key={ productIdx }>{ productName }</li> ) }
+					</ul>
+				</InfoTooltip>
 			</span>
 		);
 	}


### PR DESCRIPTION
Added a dotted underline to the "Label #N" title on the labels list, to make it clearer that there is a tooltip there.

![dot](https://cloud.githubusercontent.com/assets/1715800/22212798/612696b4-e168-11e6-90e4-63d94109a286.png)

Right now, `text-decoration` is only well supported in Firefox (see [support table](http://caniuse.com/#feat=text-decoration)). In other browsers, it will just display a solid black line, not a dotted dark-gray line.

The other option is using a `border-bottom: 1px dotted $gray-dark;`, but that feels too hacky. @kellychoffman what do you think?