### PR TITLE
Changed all the success notices durations to make them more consistent

### DIFF
--- a/client/account-settings/views/index.js
+++ b/client/account-settings/views/index.js
@@ -16,9 +16,9 @@ const AccountSettingsRootView = ( props ) => {
 
 	const onSaveSuccess = () => {
 		props.actions.setFormMetaProperty( 'pristine', true );
-		props.noticeActions.successNotice( __( 'Your payment method has been updated.' ), { duration: 2250 } );
+		props.noticeActions.successNotice( __( 'Your payment method has been updated.' ), { duration: 5000 } );
 	};
-	const onSaveFailure = () => props.noticeActions.errorNotice( __( 'Unable to update your payment method. Please try again.' ), { duration: 7000 } );
+	const onSaveFailure = () => props.noticeActions.errorNotice( __( 'Unable to update your payment method. Please try again.' ) );
 	const onSaveChanges = () => props.actions.saveForm( onSaveSuccess, onSaveFailure );
 
 	const paymentMethodDescriptionFormat = __( 'Manage your payment methods on %(startLink)sWordPress.com%(endLink)s' );

--- a/client/packages/views/index.js
+++ b/client/packages/views/index.js
@@ -75,8 +75,8 @@ const Packages = ( props ) => {
 		return elements;
 	};
 
-	const onSaveSuccess = () => props.noticeActions.successNotice( __( 'Your packages have been saved.' ), { duration: 2250 } );
-	const onSaveFailure = () => props.noticeActions.errorNotice( __( 'Unable to save your packages. Please try again.' ), { duration: 7000 } );
+	const onSaveSuccess = () => props.noticeActions.successNotice( __( 'Your packages have been saved.' ), { duration: 5000 } );
+	const onSaveFailure = () => props.noticeActions.errorNotice( __( 'Unable to save your packages. Please try again.' ) );
 	const onSaveChanges = () => props.saveForm( onSaveSuccess, onSaveFailure );
 
 	const buttons = [

--- a/client/settings/state/values/actions.js
+++ b/client/settings/state/values/actions.js
@@ -35,7 +35,7 @@ export const submit = ( schema, silent ) => ( dispatch, getState, { callbackURL,
 		dispatch( FormActions.setFormProperty( 'success', value ) );
 		if ( ! silent && true === value ) {
 			dispatch( NoticeActions.successNotice( __( 'Your changes have been saved.' ), {
-				duration: 2250,
+				duration: 5000,
 			} ) );
 		}
 	};
@@ -44,9 +44,7 @@ export const submit = ( schema, silent ) => ( dispatch, getState, { callbackURL,
 		dispatch( FormActions.setFormProperty( 'fieldsStatus', value ) );
 
 		if ( ! silent ) {
-			dispatch( NoticeActions.errorNotice( __( 'There was a problem with one or more entries. Please fix the errors below and try saving again.' ), {
-				duration: 7000,
-			} ) );
+			dispatch( NoticeActions.errorNotice( __( 'There was a problem with one or more entries. Please fix the errors below and try saving again.' ) ) );
 		}
 	};
 
@@ -55,15 +53,11 @@ export const submit = ( schema, silent ) => ( dispatch, getState, { callbackURL,
 
 		if ( ! silent ) {
 			if ( _.isString( value ) ) {
-				dispatch( NoticeActions.errorNotice( value, {
-					duration: 7000,
-				} ) );
+				dispatch( NoticeActions.errorNotice( value ) );
 			}
 
 			if ( _.isObject( value ) ) {
-				dispatch( NoticeActions.errorNotice( __( 'There was a problem with one or more entries. Please fix the errors below and try saving again.' ), {
-					duration: 7000,
-				} ) );
+				dispatch( NoticeActions.errorNotice( __( 'There was a problem with one or more entries. Please fix the errors below and try saving again.' ) ) );
 			}
 		}
 	};


### PR DESCRIPTION
Fixes #837

Changed all the success notices to show for 5 seconds, like in Calypso. Except for the "Label purchased" notice which is permanent.

All the error notices permanent (but dismissable). Before, there were some of them that lasted 7 seconds. Since they dissapear when the user navigates to another page anyway, it's unlikely that errors will "pile up", even if the user doesn't dismiss them.