### PR TITLE
Add shipping zone pointer

### DIFF
--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -4,6 +4,10 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 
 	class WC_Connect_Nux {
 
+		function __construct() {
+			$this->init_pointers();
+		}
+
 		private function add_shared_notice_styles() {
 			$wc_connect_base_url = defined( 'WOOCOMMERCE_CONNECT_DEV_SERVER_URL' ) ? WOOCOMMERCE_CONNECT_DEV_SERVER_URL : plugins_url( 'dist/', __FILE__ );
 			wp_enqueue_style( 'wc_connect_banner', $wc_connect_base_url . 'woocommerce-connect-client-banner.css' );
@@ -60,6 +64,59 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			$notices[ $notice ] = true;
 			update_option( 'wc_connect_nux_notices', $notices );
 		}
-	}
 
+		private function init_pointers() {
+			add_filter( 'wc_services_pointer_woocommerce_page_wc-settings', array( $this, 'register_add_service_to_zone_pointer' ) );
+		}
+
+		public function show_pointers( $hook ) {
+			/* Get admin pointers for the current admin page.
+			 *
+			 * @since 0.9.6
+			 *
+			 * @param array $pointers Array of pointers.
+			 */
+			$pointers = apply_filters( 'wc_services_pointer_' . $hook, array() );
+
+			if ( ! $pointers || ! is_array( $pointers ) ) {
+				return;
+			}
+
+			$dismissed_pointers = explode( ',', (string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true ) );
+			$valid_pointers = array();
+
+			if( isset( $dismissed_pointers ) ) {
+				foreach ( $pointers as $pointer ) {
+					if ( ! in_array( $pointer['id'], $dismissed_pointers ) ) {
+						$valid_pointers[] =  $pointer;
+					}
+				}
+			} else {
+				$valid_pointers = $pointers;
+			}
+
+			if ( empty( $valid_pointers ) ) {
+				return;
+			}
+
+			wp_enqueue_style( 'wp-pointer' );
+			wp_localize_script( 'wc_services_admin_pointers', 'wcSevicesAdminPointers', $valid_pointers );
+			wp_enqueue_script( 'wc_services_admin_pointers' );
+		}
+
+		public function register_add_service_to_zone_pointer( $pointers ) {
+			$pointers[] = array(
+				'id' => 'wc_services_add_service_to_zone',
+				'target' => 'th.wc-shipping-zone-methods',
+				'options' => array(
+					'content' => sprintf( '<h3>%s</h3><p>%s</p>',
+						__( 'Add WooCommerce Shipping Service to a Zone' ,'woocommerce-services' ),
+						__( 'Choose a zone that is applicable to USPS or Canada Post.', 'woocommerce-services' )
+					),
+					'position' => array( 'edge' => 'right', 'align' => 'left' ),
+				)
+			);
+			return $pointers;
+		}
+	}
 }

--- a/client/admin-pointers.js
+++ b/client/admin-pointers.js
@@ -1,0 +1,35 @@
+/*global wcSevicesAdminPointers, ajaxurl */
+import jQuery from 'jquery';
+
+jQuery( document ).ready( function( $ ) {
+	function show_pointer( pointers, i ) {
+		if ( ! Array.isArray( pointers ) ||
+			! pointers[ i ]
+		) {
+			return;
+		}
+
+		const pointer = pointers[ i ];
+		if ( 'string' !== typeof pointer.target ||
+			'string' !== typeof pointer.id ||
+			'object' !== typeof pointer.options ||
+			'string' !== typeof pointer.options.content
+		) {
+			show_pointer( pointers, i + 1 );
+			return;
+		}
+
+		const options = $.extend( pointer.options, {
+			close: function() {
+				$.post( ajaxurl, {
+					pointer: pointer.id,
+					action: 'dismiss-wp-pointer',
+				} );
+				show_pointer( pointers, i + 1 );
+			},
+		} );
+
+		$( pointer.target ).pointer( options ).pointer( 'open' );
+	}
+	show_pointer( wcSevicesAdminPointers, 0 );
+} );

--- a/client/test/mock-jquery.js
+++ b/client/test/mock-jquery.js
@@ -1,0 +1,3 @@
+/* global jQuery */
+/*eslint no-unused-vars: 0*/
+jQuery = () => ( { ready: () => {} } );

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,7 +11,7 @@ module.exports = function( config ) {
 	config.set({
 		browsers: [ 'jsdom' ],
 		frameworks: [ 'mocha', 'chai' ],
-		files: [ testFile ],
+		files: [ 'client/test/mock-jquery.js', testFile ],
 		preprocessors: {
 			[ testFile ]: [ 'webpack', 'sourcemap' ],
 		},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,11 +22,15 @@ module.exports = {
 	entry: {
 		'woocommerce-services': [ './client/main.js' ],
 		'woocommerce-services-banner': [ './assets/stylesheets/banner.scss' ],
+		'woocommerce-services-admin-pointers': [ './client/admin-pointers.js' ],
 	},
 	output: {
 		path: path.join( __dirname, 'dist' ),
 		filename: '[name].js',
 		publicPath: 'http://localhost:8085/',
+	},
+	externals: {
+		'jquery': 'jQuery',
 	},
 	devtool: '#inline-source-map',
 	module: {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -437,6 +437,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'woocommerce_admin_shipping_fields', array( $this, 'add_shipping_phone_to_order_fields' ) );
 			add_filter( 'woocommerce_get_order_address', array( $this, 'get_shipping_phone_from_order' ), 10, 3 );
 			add_action( 'admin_init', array( $this->nux, 'check_notice_dismissal' ) );
+			add_action( 'admin_enqueue_scripts', array( $this->nux, 'show_pointers' ) );
 		}
 
 		/**
@@ -656,6 +657,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$wc_connect_base_url = defined( 'WOOCOMMERCE_CONNECT_DEV_SERVER_URL' ) ? WOOCOMMERCE_CONNECT_DEV_SERVER_URL : plugins_url( 'dist/', __FILE__ );
 			wp_register_style( 'wc_connect_admin', $wc_connect_base_url . 'woocommerce-services.css', array( 'noticons', 'dashicons' ) );
 			wp_register_script( 'wc_connect_admin', $wc_connect_base_url . 'woocommerce-services.js', array(), false, true );
+			wp_register_script( 'wc_services_admin_pointers', $wc_connect_base_url . 'woocommerce-services-admin-pointers.js', array( 'wp-pointer', 'jquery' ), false, true );
 
 			require_once( plugin_basename( 'i18n/strings.php' ) );
 			wp_localize_script( 'wc_connect_admin', 'i18nLocaleStrings', $i18nStrings );

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -146,6 +146,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		protected $service_object_cache = array();
 
+		protected $wc_connect_base_url;
+
 		static function load_tracks_for_activation_hooks() {
 			require_once( plugin_basename( 'classes/class-wc-connect-logger.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-tracks.php' ) );
@@ -168,6 +170,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		public function __construct() {
+			$this->wc_connect_base_url = trailingslashit( defined( 'WOOCOMMERCE_CONNECT_DEV_SERVER_URL' ) ? WOOCOMMERCE_CONNECT_DEV_SERVER_URL : plugins_url( 'dist/', __FILE__ ) );
 			add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
 			add_action( 'woocommerce_init', array( $this, 'init' ) );
 		}
@@ -654,10 +657,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			wp_register_style( 'noticons', plugins_url( 'assets/stylesheets/noticons.css', __FILE__ ), array(), '20150727' );
 			wp_register_style( 'dashicons', plugins_url( 'assets/stylesheets/dashicons.css', __FILE__ ), array(), '20150727' );
 
-			$wc_connect_base_url = defined( 'WOOCOMMERCE_CONNECT_DEV_SERVER_URL' ) ? WOOCOMMERCE_CONNECT_DEV_SERVER_URL : plugins_url( 'dist/', __FILE__ );
-			wp_register_style( 'wc_connect_admin', $wc_connect_base_url . 'woocommerce-services.css', array( 'noticons', 'dashicons' ) );
-			wp_register_script( 'wc_connect_admin', $wc_connect_base_url . 'woocommerce-services.js', array(), false, true );
-			wp_register_script( 'wc_services_admin_pointers', $wc_connect_base_url . 'woocommerce-services-admin-pointers.js', array( 'wp-pointer', 'jquery' ), false, true );
+			wp_register_style( 'wc_connect_admin', $this->wc_connect_base_url . 'woocommerce-services.css', array( 'noticons', 'dashicons' ) );
+			wp_register_script( 'wc_connect_admin', $this->wc_connect_base_url . 'woocommerce-services.js', array(), false, true );
+			wp_register_script( 'wc_services_admin_pointers', $this->wc_connect_base_url . 'woocommerce-services-admin-pointers.js', array( 'wp-pointer', 'jquery' ), false, true );
 
 			require_once( plugin_basename( 'i18n/strings.php' ) );
 			wp_localize_script( 'wc_connect_admin', 'i18nLocaleStrings', $i18nStrings );
@@ -700,8 +702,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		public function admin_banner_styles() {
-			$wc_connect_base_url = defined( 'WOOCOMMERCE_CONNECT_DEV_SERVER_URL' ) ? WOOCOMMERCE_CONNECT_DEV_SERVER_URL : plugins_url( 'dist/', __FILE__ );
-			wp_enqueue_style( 'wc_connect_banner', $wc_connect_base_url . 'woocommerce-services-banner.css' );
+			wp_enqueue_style( 'wc_connect_banner', $this->wc_connect_base_url . 'woocommerce-services-banner.css' );
 		}
 
 		public function show_tos_notice() {


### PR DESCRIPTION
This PR adds a pointer to the shipping zone page. The pointer is dismissible, and multiple pointers can eventually be shown on the same page in sequence, and on other pages.

The pointer does not point up from the '+' button like this:

![original](https://cloud.githubusercontent.com/assets/11487924/22233853/8627b05c-e1c1-11e6-8e25-8a88db80a469.png)

Instead, it looks like this:

<img width="1489" alt="current-pointers" src="https://cloud.githubusercontent.com/assets/11487924/22233966/6fd324a2-e1c2-11e6-8d2c-b609e3b3fb2a.png">


cc @kellychoffman  ^

The reason is because the zones are added via js in WC, and I didn't see a way to hook in after they're added to avoid a race condition which would potentially make our pointers not show up at all.

Should we add styles that will match the pointers to our admin notices?