### PR TITLE
Rename all the user-facing strings from our old branding (connect for woocommerce) to the new branding (woocommerce services)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ WooCommerce Services development is now in BETA - this means that you should exp
 
 WooCommerce Services makes basic eCommerce features like shipping more reliable by taking the burden off of your site’s infrastructure.
 
-With Connect, critical services are hosted on Automattic’s best-in-class infrastructure, rather than relying on your store’s hosting. That means your store will be more stable and faster.
+With WooCommerce Services, critical services are hosted on Automattic’s best-in-class infrastructure, rather than relying on your store’s hosting. That means your store will be more stable and faster.
 
 The emphasis for initial release of WooCommerce Services is shipping simplified. We are providing Shipping Zones-compatible USPS and Canada Post shipping methods and USPS shipping labels (stamps). Shipping Zones are [an exciting new feature of WooCommerce 2.6](https://woocommerce.wordpress.com/2016/02/10/shipping-zones-to-ship-with-2-6/).
 

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -356,7 +356,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 				foreach ( $logs as $log_key => $log_file ) {
 				    $log_file = WC_LOG_DIR . $log_file;
 					$file_date = filemtime( $log_file );
-					if ( 'wc-connect-' === substr( $log_key, 0, 11 ) && $latest_file_date < $file_date ) {
+					if ( 'wc-services-' === substr( $log_key, 0, 12 ) && $latest_file_date < $file_date ) {
 						$latest_file_date = $file_date;
 						$file = $log_file;
 						$key = $log_key;

--- a/classes/class-wc-connect-logger.php
+++ b/classes/class-wc-connect-logger.php
@@ -85,7 +85,7 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 
 		private function log( $message, $context = '' ) {
 			$log_message = $this->format_message( $message, $context );
-			$this->logger->add( 'wc-connect', $log_message );
+			$this->logger->add( 'wc-services', $log_message );
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 				error_log( $log_message );
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -15,7 +15,7 @@ Hosted services for WooCommerce, including free real-time USPS and Canada Post r
 
 WooCommerce Services makes basic eCommerce features like shipping more reliable by taking the burden off of your site’s infrastructure.
 
-With Connect, critical services are hosted on Automattic’s best-in-class infrastructure, rather than relying on your store’s hosting. That means your store will be more stable and faster.
+With WooCommerce Services, critical services are hosted on Automattic’s best-in-class infrastructure, rather than relying on your store’s hosting. That means your store will be more stable and faster.
 
 To use the features, simply install this plugin and activate the ones you want directly in your dashboard. As we add more services, you’ll see more features available directly in WooCommerce - making setup simpler.
 
@@ -40,7 +40,7 @@ This section describes how to install the plugin and get it working.
 
 == Frequently Asked Questions ==
 
-= What services are included in Connect? =
+= What services are included? =
 
 For this first release, we’re including free real-time USPS and Canada Post Shipping rates in checkout. We are also including discounted USPS shipping labels for domestic packages. More services will roll out over upcoming releases.
 


### PR DESCRIPTION
Some occurences were missed in the previous PR ( https://github.com/Automattic/woocommerce-services/pull/844#discussion_r97836123 )

We would still need to rename our hooks, filters and class names and `wp_options` entries, but that's a rabbit hole with much much lower priority.