### PR TITLE
Rename the "shipping label" tab to "shipping labels"

### DIFF
--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -57,7 +57,7 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 			}
 
 			$shipping_tabs[ 'package-settings' ] = __( 'Packages', 'connectforwoocommerce' );
-			$shipping_tabs[ 'label-settings'] = __( 'Shipping Label', 'connectforwoocommerce' );
+			$shipping_tabs[ 'label-settings'] = __( 'Shipping Labels', 'connectforwoocommerce' );
 			return $shipping_tabs;
 		}
 


### PR DESCRIPTION
Rename the "shipping label" tab to "shipping labels" to be more consistent with the plural forms used in the rest of the tabs in shipping settings