### PR TITLE
Fetch service schemas before attaching admin hooks

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -351,8 +351,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 
 			$this->load_dependencies();
-			$this->attach_hooks();
 			$this->schedule_service_schemas_fetch();
+			$this->attach_hooks();
 		}
 
 		/**
@@ -566,9 +566,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$schemas = $schemas_store->get_service_schemas();
 
 			if ( ! $schemas ) {
-				add_action( 'admin_init', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
+				$schemas_store->fetch_service_schemas_from_connect_server();
 			} else if ( defined( 'WOOCOMMERCE_CONNECT_FREQUENT_FETCH' ) && WOOCOMMERCE_CONNECT_FREQUENT_FETCH ) {
-				add_action( 'admin_init', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
+				$schemas_store->fetch_service_schemas_from_connect_server();
 			} else if ( ! wp_next_scheduled( 'wc_connect_fetch_service_schemas' ) ) {
 				wp_schedule_event( time(), 'daily', 'wc_connect_fetch_service_schemas' );
 			}


### PR DESCRIPTION
Fixes the issue _"When the user opts in and is redirected to shipping, the new methods are not yet loaded"_.

**Problem**: Fetching the service schemas were scheduled for the `admin_init` action. Our general plugin initialization code happens in the `woocommerce_init` action, which is before. In that initialization code, it's checked if the schemas exist and only attach some hooks if they do. So, just after installing the plugin, those hooks won't be attached _on the first page load_.

**Solution**: Move the schema fetching to _before_ the hooks are attached. This is the simplest solution and the one I implemented.

**Alternative solution** (not implemented): All our code is pretty defensive about schemas not being there. We could just omit the `if($schemas){` conditional entirely ([line 421](https://github.com/Automattic/woocommerce-services/pull/858/files#diff-57ae8afb227e356d71d37582f678a831L421)) and I **think** everything would work just fine. That would require some careful code examination though, just tell me if you prefer this one and I'll do it.