### PR TITLE
Bust the shipping rates session cache every time the settings of a shipping method change

### DIFF
--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -268,6 +268,8 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 
 			// On success, save the settings to the database and exit
 			update_option( $this->get_service_settings_key( $id, $instance ), $settings );
+			// Invalidate shipping rates session cache
+			WC_Cache_Helper::get_transient_version( 'shipping', /* $refresh = */ true );
 			do_action( 'wc_connect_saved_service_settings', $id, $instance, $settings );
 
 			return true;


### PR DESCRIPTION
The internal WooCommerce session cache that caches shipping rates wasn't being busted when one of our shipping methods config was being updated. This lead to an annoying bug (most noticeable when testing) when the changes made to the shipping method didn't appear to work.

Looking at the WooCommerce codebase, this cache-busting is done pretty much whenever anything shipping-zone-related is done, we just needed to add it to our own methods.

To reproduce:
* Get an USPS shipping method working.
* Buy something on the store.
* On the checkout, note that you will receive some USPS rates.
* In another tab, go to the USPS method config and make some changes. For example, add an obvious `adjustment` to one of the returned services.
* In the checkout, delete the last number of the ZIP code and type it again.

Before this change, after doing all that, the same rates would have been returned.
Now, the rates will be up-to-date (with the newly configured adjustment for example).