### PR TITLE
Show origin and destination fields if they're not normalized on open print flow

### DIFF
--- a/assets/stylesheets/_colors.scss
+++ b/assets/stylesheets/_colors.scss
@@ -6,6 +6,7 @@ $blue-dark:              #005082;
 
 // Grays
 $gray:                   #9e9fa8;
+$gray-text-min:          darken( $gray, 18% );
 
 //Purples
 $purple:                 #96588a;

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -55,7 +55,6 @@
 //@import 'components/gauge/style';
 @import 'components/global-notices/style';
 //@import 'components/gravatar/style';
-@import 'components/gridicon/style';
 //@import 'components/happiness-support/style';
 //@import 'components/header-cake/style';
 //@import 'components/infinite-list/style';

--- a/assets/stylesheets/shipping-label.scss
+++ b/assets/stylesheets/shipping-label.scss
@@ -187,6 +187,7 @@
 
 	.validation-message {
 		margin: -24px -24px 24px -24px;
+		width: inherit;
 
 		 .notice__icon {
 			 display: none;
@@ -274,6 +275,7 @@
 
 .notice.wcc-label-rates__notice {
 	margin: -24px -24px 24px;
+	width: inherit;
 }
 
 // Address

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -285,29 +285,23 @@
 		top: 16px;
 		right: 16px;
 		@include breakpoint( '<660px' ) {
-			top: -4px;
+			top: -5px;
 			right: 0;
 		}
 
 		.notice {
-			margin-left: 164px;
 			max-width: 740px;
-
-			@include breakpoint( '<960px' ) {
-				margin-left: 36px;
-			}
 
 			@include breakpoint( '<780px' ) {
 				margin-left: 0;
 			}
 		}
 
-		// adjust until system fonts get in wp-admin
 		.notice__text {
-			padding: 10px 8px 8px;
+			font-size: 15px;
 
-			@include breakpoint( '<660px' ) {
-				padding: 16px;
+			@include breakpoint( '>660px' ) {
+				margin-top: 1px;
 			}
 		}
 	}
@@ -458,4 +452,9 @@
 		font-style: italic;
 		color: $gray;
 	}
+}
+
+// Gridicons
+.gridicon {
+	fill: currentColor;
 }

--- a/client/components/bulk-checkbox/index.js
+++ b/client/components/bulk-checkbox/index.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 
 const BulkCheckbox = ( { selectedCount, allCount, onToggle } ) => {
 	const allSelected = selectedCount === allCount;

--- a/client/components/field-error/index.js
+++ b/client/components/field-error/index.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import sanitizeHTML from 'lib/utils/sanitize-html';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 
 const FieldError = ( { text } ) => {
 	return (

--- a/client/components/indicators/index.js
+++ b/client/components/indicators/index.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 import sanitizeHTML from 'lib/utils/sanitize-html';
 
 const renderLastUpdated = ( lastUpdated ) => {

--- a/client/components/info-tooltip/index.js
+++ b/client/components/info-tooltip/index.js
@@ -1,6 +1,6 @@
 import React, { PropTypes, Component } from 'react';
 import Tooltip from 'components/tooltip';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 import classNames from 'classnames';
 
 export default class InfoTooltip extends Component {

--- a/client/lib/calypso-boot/index.js
+++ b/client/lib/calypso-boot/index.js
@@ -1,4 +1,4 @@
-import ReactInjection from 'react/lib/ReactInjection';
+import ReactClass from 'react/lib/ReactClass';
 import i18n from '../mixins/i18n';
 
 export default function boot() {
@@ -11,7 +11,7 @@ export default function boot() {
 
 	i18n.initialize( i18nLocaleStringsObject );
 
-	ReactInjection.Class.injectMixin( i18n.mixin );
+	ReactClass.injection.injectMixin( i18n.mixin );
 }
 
 boot();

--- a/client/packages/views/index.js
+++ b/client/packages/views/index.js
@@ -6,7 +6,7 @@ import ActionButtons from 'components/action-buttons';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormButton from 'components/forms/form-button';
 import FoldableCard from 'components/foldable-card';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 import PackagesList from './packages-list';
 import AddPackageDialog from './add-package';
 import { translate as __ } from 'lib/mixins/i18n';

--- a/client/packages/views/packages-list-item.js
+++ b/client/packages/views/packages-list-item.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 import Button from 'components/button';
 import FormCheckbox from 'components/forms/form-checkbox';
 import classNames from 'classnames';

--- a/client/packages/views/packages-list.js
+++ b/client/packages/views/packages-list.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
 import PackagesListItem from './packages-list-item';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 import { translate as __ } from 'lib/mixins/i18n';
 
 const noPackages = () => {

--- a/client/settings/views/services/entry.js
+++ b/client/settings/views/services/entry.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormSelect from 'components/forms/form-select';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 import classNames from 'classnames';
 import NumberInput from 'components/number-field/number-input';
 

--- a/client/settings/views/services/group.js
+++ b/client/settings/views/services/group.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import ShippingServiceEntry from './entry';
 import FoldableCard from 'components/foldable-card';
 import BulkCheckbox from 'components/bulk-checkbox';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 import InfoTooltip from 'components/info-tooltip';
 import { translate as __ } from 'lib/mixins/i18n';
 import { sprintf } from 'sprintf-js';

--- a/client/settings/views/wcc-settings-form/nux-notice.js
+++ b/client/settings/views/wcc-settings-form/nux-notice.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 import { translate as __ } from 'lib/mixins/i18n';
 
 const SettingsNuxNotice = ( { noticeDismissed, dismissNotice } ) => {

--- a/client/shipping-label/state/test/actions.js
+++ b/client/shipping-label/state/test/actions.js
@@ -1,0 +1,192 @@
+import { expect } from 'chai';
+import { openPrintingFlow } from '../actions';
+import sinon from 'sinon';
+
+const context = {
+	storeOptions: {
+		countriesData: {
+			US: '',
+		},
+	},
+};
+
+function createGetStateFn( newProps = { origin: {}, destination: {} } ) {
+	const defaultProps = {
+		ignoreValidation: false,
+		selectNormalized: false,
+		isNormalized: false, // hack to prevent getLabelRates() in openPrintingFlow
+		normalized: '',
+		expanded: true, // hack to prevent getLabelRates() in openPrintingFlow
+		values: {
+			address: 'Some street',
+			postcode: '',
+			state: 'CA',
+			country: 'US',
+			phone: '123',
+		},
+	};
+
+	const origin = Object.assign( {}, defaultProps, newProps.origin );
+	const destination = Object.assign( {}, defaultProps, newProps.destination );
+
+	return function() {
+		return {
+			shippingLabel: {
+				form: {
+					origin,
+					destination,
+					packages: {
+						selected: {},
+					},
+					rates: {
+						values: {},
+					},
+				},
+			},
+		};
+	};
+}
+
+function createGetFormErrorsFn( opts = {} ) {
+	const errors = {};
+	const defaultError = {
+		address: 'This address is not recognized. Please try another.',
+	};
+
+	if ( opts.setOriginError ) {
+		errors.origin = defaultError;
+	}
+
+	if ( opts.setDestinationError ) {
+		errors.destination = defaultError;
+	}
+
+	return function() {
+		return errors;
+	};
+}
+
+describe( 'Shipping label Actions', () => {
+	describe( '#openPrintingFlow', () => {
+		describe( 'origin validation ignored', () => {
+			const dispatchSpy = sinon.spy();
+
+			openPrintingFlow()(
+				dispatchSpy,
+				createGetStateFn( { origin: { ignoreValidation: true } } ),
+				context,
+				createGetFormErrorsFn(
+					{ setOriginError: false, setDestinationError: false }
+				)
+			);
+
+			it( 'toggle origin', () => {
+				expect( dispatchSpy.calledWith( {
+					stepName: 'origin', type: 'TOGGLE_STEP',
+				} ) )
+					.to.equal( true );
+			} );
+			it( 'do not toggle destination', () => {
+				expect( dispatchSpy.calledWith( {
+					stepName: 'destination', type: 'TOGGLE_STEP',
+				} ) )
+					.to.equal( false );
+			} );
+			it( 'open printing flow', () => {
+				expect( dispatchSpy.calledWith( {
+					type: 'OPEN_PRINTING_FLOW',
+				} ) )
+					.to.equal( true );
+			} );
+		} );
+
+		describe( 'origin errors exist', () => {
+			const dispatchSpy = sinon.spy();
+
+			openPrintingFlow()(
+				dispatchSpy,
+				createGetStateFn(),
+				context,
+				createGetFormErrorsFn(
+					{ setOriginError: true, setDestinationError: false }
+				)
+			);
+
+			it( 'toggles origin', () => {
+				expect( dispatchSpy.calledWith( {
+					stepName: 'origin', type: 'TOGGLE_STEP',
+				} ) ).to.equal( true );
+			} );
+			it( 'do not toggle destination', () => {
+				expect( dispatchSpy.calledWith( {
+					stepName: 'destination', type: 'TOGGLE_STEP',
+				} ) ).to.equal( false );
+			} );
+			it( 'open printing flow', () => {
+				expect( dispatchSpy.calledWith( {
+					type: 'OPEN_PRINTING_FLOW',
+				} ) ).to.equal( true );
+			} );
+		} );
+
+		describe( 'destination validation ignored', () => {
+			const dispatchSpy = sinon.spy();
+
+			openPrintingFlow()(
+				dispatchSpy,
+				createGetStateFn( {
+					destination: { ignoreValidation: true },
+				} ),
+				context,
+				createGetFormErrorsFn(
+					{ setOriginError: false, setDestinationError: false }
+				)
+			);
+
+			it( 'toggle destination', () => {
+				expect( dispatchSpy.calledWith( {
+					stepName: 'destination', type: 'TOGGLE_STEP',
+				} ) ).to.equal( true );
+			} );
+			it( 'do not toggle origin', () => {
+				expect( dispatchSpy.calledWith( {
+					stepName: 'origin', type: 'TOGGLE_STEP',
+				} ) ).to.equal( false );
+			} );
+			it( 'open printing flow', () => {
+				expect( dispatchSpy.calledWith( {
+					type: 'OPEN_PRINTING_FLOW',
+				} ) ).to.equal( true );
+			} );
+		} );
+
+		describe( 'destination errors exist', () => {
+			const dispatchSpy = sinon.spy();
+
+			openPrintingFlow()(
+				dispatchSpy,
+				createGetStateFn(),
+				context,
+				createGetFormErrorsFn(
+					{ setOriginError: false, setDestinationError: true }
+				)
+			);
+
+			it( 'toggle destination', () => {
+				expect( dispatchSpy.calledWith( {
+					stepName: 'destination', type: 'TOGGLE_STEP',
+				} ) ).to.equal( true );
+			} );
+			it( 'do not toggle origin', () => {
+				expect( dispatchSpy.calledWith( {
+					stepName: 'origin', type: 'TOGGLE_STEP',
+				} ) ).to.equal( false );
+			} );
+			it( 'open printing flow', () => {
+				expect( dispatchSpy.calledWith( {
+					type: 'OPEN_PRINTING_FLOW',
+				} ) ).to.equal( true );
+			} );
+		} );
+	} );
+} );

--- a/client/shipping-label/views/index.js
+++ b/client/shipping-label/views/index.js
@@ -8,7 +8,7 @@ import RefundDialog from './refund';
 import ReprintDialog from './reprint';
 import TrackingLink from './tracking-link';
 import Spinner from 'components/spinner';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 import Tooltip from 'components/tooltip';
 import formatDate from 'lib/utils/format-date';
 import timeAgo from 'lib/utils/time-ago';

--- a/client/shipping-label/views/purchase/step-container/index.js
+++ b/client/shipping-label/views/purchase/step-container/index.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 import Spinner from 'components/spinner';
 import Card from 'components/card';
 import { translate as __ } from 'lib/mixins/i18n';

--- a/client/shipping-label/views/purchase/steps/packages/item-info.js
+++ b/client/shipping-label/views/purchase/steps/packages/item-info.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import { translate as __ } from 'lib/mixins/i18n';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 import Button from 'components/button';
 
 const ItemInfo = ( { item, itemIndex, packageId, showRemove, openItemMove, removeItem } ) => {

--- a/client/shipping-label/views/purchase/steps/packages/list.js
+++ b/client/shipping-label/views/purchase/steps/packages/list.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import { translate as __ } from 'lib/mixins/i18n';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 import classNames from 'classnames';
 import getPackageDescriptions from './get-package-descriptions';
 

--- a/client/shipping-label/views/purchase/steps/packages/package-info.js
+++ b/client/shipping-label/views/purchase/steps/packages/package-info.js
@@ -5,7 +5,7 @@ import NumberField from 'components/number-field';
 import FormLegend from 'components/forms/form-legend';
 import FormSelect from 'components/forms/form-select';
 import Button from 'components/button';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'gridicons';
 import getBoxDimensions from 'lib/utils/get-box-dimensions';
 import _ from 'lodash';
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,16 +1,16 @@
 {
   "name": "woocommerce-services",
-  "version": "0.9.0",
+  "version": "1.1.1",
   "dependencies": {
     "abab": {
       "version": "1.0.3",
-      "from": "abab@^1.0.0",
+      "from": "abab@^1.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
       "dev": true
     },
     "abbrev": {
       "version": "1.0.9",
-      "from": "abbrev@1.0.x",
+      "from": "abbrev@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
       "dev": true
     },
@@ -26,16 +26,14 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
     },
     "acorn-globals": {
-      "version": "1.0.9",
-      "from": "acorn-globals@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
-      "dev": true,
+      "version": "3.1.0",
+      "from": "acorn-globals@^3.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
       "dependencies": {
         "acorn": {
-          "version": "2.7.0",
-          "from": "acorn@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-          "dev": true
+          "version": "4.0.11",
+          "from": "acorn@>=4.0.4 <5.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz"
         }
       }
     },
@@ -46,21 +44,21 @@
       "dev": true
     },
     "after": {
-      "version": "0.8.1",
-      "from": "after@0.8.1",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
+      "version": "0.8.2",
+      "from": "after@0.8.2",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "dev": true
     },
     "ajv": {
-      "version": "4.8.2",
+      "version": "4.11.3",
       "from": "ajv@^4.7.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.3.tgz",
       "dev": true
     },
     "ajv-keywords": {
-      "version": "1.1.1",
+      "version": "1.5.1",
       "from": "ajv-keywords@^1.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
       "dev": true
     },
     "align-text": {
@@ -86,9 +84,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "2.0.0",
+      "version": "2.1.1",
       "from": "ansi-regex@^2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
     },
     "ansi-styles": {
       "version": "2.2.1",
@@ -108,27 +106,27 @@
       "dev": true
     },
     "append-transform": {
-      "version": "0.3.0",
-      "from": "append-transform@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.3.0.tgz",
+      "version": "0.4.0",
+      "from": "append-transform@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
       "dev": true
     },
     "aproba": {
-      "version": "1.0.4",
-      "from": "aproba@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
+      "version": "1.1.1",
+      "from": "aproba@^1.0.3",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
       "dev": true
     },
     "archiver": {
-      "version": "1.2.0",
+      "version": "1.3.0",
       "from": "archiver@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
       "dev": true,
       "dependencies": {
         "async": {
-          "version": "2.1.2",
+          "version": "2.1.5",
           "from": "async@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
           "dev": true
         }
       }
@@ -179,12 +177,6 @@
       "version": "1.1.1",
       "from": "array-flatten@1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "dev": true
-    },
-    "array-index": {
-      "version": "1.0.0",
-      "from": "array-index@^1.0.0",
-      "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
       "dev": true
     },
     "array-slice": {
@@ -276,9 +268,9 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "6.5.2",
+      "version": "6.7.4",
       "from": "autoprefixer@>=6.3.3 <7.0.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.4.tgz",
       "dev": true
     },
     "aws-sign2": {
@@ -288,25 +280,25 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.5.0",
+      "version": "1.6.0",
       "from": "aws4@^1.2.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "dev": true
     },
     "babel": {
-      "version": "6.5.2",
+      "version": "6.23.0",
       "from": "babel@>=6.5.2 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel/-/babel-6.5.2.tgz"
+      "resolved": "https://registry.npmjs.org/babel/-/babel-6.23.0.tgz"
     },
     "babel-code-frame": {
-      "version": "6.16.0",
-      "from": "babel-code-frame@^6.16.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-code-frame@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz"
     },
     "babel-core": {
-      "version": "6.18.2",
+      "version": "6.23.1",
       "from": "babel-core@>=6.9.1 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.18.2.tgz"
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.23.1.tgz"
     },
     "babel-eslint": {
       "version": "6.1.2",
@@ -315,94 +307,94 @@
       "dev": true
     },
     "babel-generator": {
-      "version": "6.18.0",
-      "from": "babel-generator@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.18.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-generator@^6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.23.0.tgz"
     },
     "babel-helper-bindify-decorators": {
-      "version": "6.18.0",
-      "from": "babel-helper-bindify-decorators@>=6.18.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.18.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-helper-bindify-decorators@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.22.0.tgz"
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "6.18.0",
-      "from": "babel-helper-builder-binary-assignment-operator-visitor@^6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.18.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-helper-builder-binary-assignment-operator-visitor@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.22.0.tgz"
     },
     "babel-helper-builder-react-jsx": {
-      "version": "6.18.0",
-      "from": "babel-helper-builder-react-jsx@^6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.18.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-helper-builder-react-jsx@^6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.23.0.tgz"
     },
     "babel-helper-call-delegate": {
-      "version": "6.18.0",
-      "from": "babel-helper-call-delegate@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.18.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-helper-call-delegate@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.22.0.tgz"
     },
     "babel-helper-define-map": {
-      "version": "6.18.0",
-      "from": "babel-helper-define-map@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-helper-define-map@^6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.23.0.tgz"
     },
     "babel-helper-explode-assignable-expression": {
-      "version": "6.18.0",
-      "from": "babel-helper-explode-assignable-expression@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.18.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-helper-explode-assignable-expression@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.22.0.tgz"
     },
     "babel-helper-explode-class": {
-      "version": "6.18.0",
-      "from": "babel-helper-explode-class@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.18.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-helper-explode-class@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.22.0.tgz"
     },
     "babel-helper-function-name": {
-      "version": "6.18.0",
-      "from": "babel-helper-function-name@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-helper-function-name@^6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.23.0.tgz"
     },
     "babel-helper-get-function-arity": {
-      "version": "6.18.0",
-      "from": "babel-helper-get-function-arity@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-helper-get-function-arity@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz"
     },
     "babel-helper-hoist-variables": {
-      "version": "6.18.0",
-      "from": "babel-helper-hoist-variables@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.18.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-helper-hoist-variables@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.22.0.tgz"
     },
     "babel-helper-optimise-call-expression": {
-      "version": "6.18.0",
-      "from": "babel-helper-optimise-call-expression@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.18.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-helper-optimise-call-expression@^6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.23.0.tgz"
     },
     "babel-helper-regex": {
-      "version": "6.18.0",
-      "from": "babel-helper-regex@^6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.18.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-helper-regex@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.22.0.tgz"
     },
     "babel-helper-remap-async-to-generator": {
-      "version": "6.18.0",
-      "from": "babel-helper-remap-async-to-generator@^6.16.2",
-      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.18.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-helper-remap-async-to-generator@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.22.0.tgz"
     },
     "babel-helper-replace-supers": {
-      "version": "6.18.0",
-      "from": "babel-helper-replace-supers@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.18.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-helper-replace-supers@^6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.23.0.tgz"
     },
     "babel-helpers": {
-      "version": "6.16.0",
-      "from": "babel-helpers@^6.16.0",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-helpers@^6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.23.0.tgz"
     },
     "babel-loader": {
-      "version": "6.2.7",
+      "version": "6.3.2",
       "from": "babel-loader@>=6.2.4 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.2.7.tgz"
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.3.2.tgz"
     },
     "babel-messages": {
-      "version": "6.8.0",
-      "from": "babel-messages@^6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-messages@^6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
     },
     "babel-plugin-add-module-exports": {
       "version": "0.2.1",
@@ -411,14 +403,14 @@
       "dev": true
     },
     "babel-plugin-check-es2015-constants": {
-      "version": "6.8.0",
-      "from": "babel-plugin-check-es2015-constants@^6.3.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-check-es2015-constants@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz"
     },
     "babel-plugin-lodash": {
-      "version": "3.2.9",
+      "version": "3.2.11",
       "from": "babel-plugin-lodash@>=3.2.9 <4.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.2.9.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.2.11.tgz",
       "dev": true
     },
     "babel-plugin-syntax-async-functions": {
@@ -463,7 +455,7 @@
     },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
-      "from": "babel-plugin-syntax-flow@>=6.3.13 <7.0.0",
+      "from": "babel-plugin-syntax-flow@>=6.18.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz"
     },
     "babel-plugin-syntax-jsx": {
@@ -477,255 +469,260 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz"
     },
     "babel-plugin-syntax-trailing-function-commas": {
-      "version": "6.13.0",
-      "from": "babel-plugin-syntax-trailing-function-commas@^6.3.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.13.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-syntax-trailing-function-commas@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz"
     },
     "babel-plugin-transform-async-generator-functions": {
-      "version": "6.17.0",
-      "from": "babel-plugin-transform-async-generator-functions@^6.17.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.17.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-async-generator-functions@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.22.0.tgz"
     },
     "babel-plugin-transform-async-to-generator": {
-      "version": "6.16.0",
-      "from": "babel-plugin-transform-async-to-generator@^6.16.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-async-to-generator@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.22.0.tgz"
     },
     "babel-plugin-transform-class-constructor-call": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-class-constructor-call@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.18.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-class-constructor-call@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.22.0.tgz"
     },
     "babel-plugin-transform-class-properties": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-class-properties@>=6.18.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.18.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-class-properties@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.23.0.tgz"
     },
     "babel-plugin-transform-decorators": {
-      "version": "6.13.0",
-      "from": "babel-plugin-transform-decorators@>=6.13.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.13.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-decorators@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.22.0.tgz"
     },
     "babel-plugin-transform-es2015-arrow-functions": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-arrow-functions@^6.3.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-arrow-functions@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz"
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-block-scoped-functions@^6.3.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-block-scoped-functions@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz"
     },
     "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-es2015-block-scoping@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.18.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-es2015-block-scoping@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.23.0.tgz"
     },
     "babel-plugin-transform-es2015-classes": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-es2015-classes@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.18.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-es2015-classes@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.23.0.tgz"
     },
     "babel-plugin-transform-es2015-computed-properties": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-computed-properties@^6.3.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-computed-properties@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.22.0.tgz"
     },
     "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-es2015-destructuring@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.18.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-es2015-destructuring@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz"
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-duplicate-keys@^6.6.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-duplicate-keys@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.22.0.tgz"
     },
     "babel-plugin-transform-es2015-for-of": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-es2015-for-of@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.18.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-es2015-for-of@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz"
     },
     "babel-plugin-transform-es2015-function-name": {
-      "version": "6.9.0",
-      "from": "babel-plugin-transform-es2015-function-name@^6.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-function-name@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.22.0.tgz"
     },
     "babel-plugin-transform-es2015-literals": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-literals@^6.3.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-literals@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz"
     },
     "babel-plugin-transform-es2015-modules-amd": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-es2015-modules-amd@>=6.18.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.18.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-modules-amd@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.22.0.tgz"
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-es2015-modules-commonjs@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.18.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-es2015-modules-commonjs@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.23.0.tgz"
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-es2015-modules-systemjs@>=6.18.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.18.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-es2015-modules-systemjs@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.23.0.tgz"
     },
     "babel-plugin-transform-es2015-modules-umd": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-es2015-modules-umd@>=6.18.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.18.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-es2015-modules-umd@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.23.0.tgz"
     },
     "babel-plugin-transform-es2015-object-super": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-object-super@^6.3.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-object-super@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.22.0.tgz"
     },
     "babel-plugin-transform-es2015-parameters": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-es2015-parameters@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.18.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-es2015-parameters@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.23.0.tgz"
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-es2015-shorthand-properties@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.18.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-shorthand-properties@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.22.0.tgz"
     },
     "babel-plugin-transform-es2015-spread": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-spread@^6.3.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-spread@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz"
     },
     "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-sticky-regex@^6.3.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-sticky-regex@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.22.0.tgz"
     },
     "babel-plugin-transform-es2015-template-literals": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-template-literals@^6.6.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-template-literals@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz"
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-es2015-typeof-symbol@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.18.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-es2015-typeof-symbol@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz"
     },
     "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.11.0",
-      "from": "babel-plugin-transform-es2015-unicode-regex@^6.3.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-unicode-regex@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.22.0.tgz"
     },
     "babel-plugin-transform-exponentiation-operator": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-exponentiation-operator@^6.3.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.8.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-exponentiation-operator@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.22.0.tgz"
     },
     "babel-plugin-transform-export-extensions": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-export-extensions@^6.3.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.8.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-export-extensions@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz"
     },
     "babel-plugin-transform-flow-strip-types": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-flow-strip-types@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.18.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-flow-strip-types@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz"
     },
     "babel-plugin-transform-object-rest-spread": {
-      "version": "6.16.0",
-      "from": "babel-plugin-transform-object-rest-spread@^6.16.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.16.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-object-rest-spread@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz"
     },
     "babel-plugin-transform-react-display-name": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-react-display-name@^6.3.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.8.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-react-display-name@>=6.23.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.23.0.tgz"
     },
     "babel-plugin-transform-react-jsx": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-react-jsx@^6.3.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.8.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-react-jsx@>=6.23.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.23.0.tgz"
     },
     "babel-plugin-transform-react-jsx-self": {
-      "version": "6.11.0",
-      "from": "babel-plugin-transform-react-jsx-self@>=6.11.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.11.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-react-jsx-self@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz"
     },
     "babel-plugin-transform-react-jsx-source": {
-      "version": "6.9.0",
-      "from": "babel-plugin-transform-react-jsx-source@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.9.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-react-jsx-source@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz"
     },
     "babel-plugin-transform-regenerator": {
-      "version": "6.16.1",
-      "from": "babel-plugin-transform-regenerator@^6.16.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-regenerator@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.22.0.tgz"
     },
     "babel-plugin-transform-strict-mode": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-strict-mode@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.18.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-strict-mode@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.22.0.tgz"
     },
     "babel-polyfill": {
-      "version": "6.16.0",
+      "version": "6.23.0",
       "from": "babel-polyfill@>=6.7.4 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
       "dev": true
     },
     "babel-preset-es2015": {
-      "version": "6.18.0",
+      "version": "6.22.0",
       "from": "babel-preset-es2015@>=6.9.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.18.0.tgz"
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.22.0.tgz"
+    },
+    "babel-preset-flow": {
+      "version": "6.23.0",
+      "from": "babel-preset-flow@>=6.23.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz"
     },
     "babel-preset-react": {
-      "version": "6.16.0",
+      "version": "6.23.0",
       "from": "babel-preset-react@>=6.5.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.16.0.tgz"
+      "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.23.0.tgz"
     },
     "babel-preset-stage-1": {
-      "version": "6.16.0",
+      "version": "6.22.0",
       "from": "babel-preset-stage-1@>=6.5.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.16.0.tgz"
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.22.0.tgz"
     },
     "babel-preset-stage-2": {
-      "version": "6.18.0",
-      "from": "babel-preset-stage-2@>=6.16.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.18.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-preset-stage-2@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.22.0.tgz"
     },
     "babel-preset-stage-3": {
-      "version": "6.17.0",
-      "from": "babel-preset-stage-3@^6.17.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.17.0.tgz"
+      "version": "6.22.0",
+      "from": "babel-preset-stage-3@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.22.0.tgz"
     },
     "babel-register": {
-      "version": "6.18.0",
-      "from": "babel-register@>=6.18.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.18.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-register@>=6.23.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.23.0.tgz"
     },
     "babel-runtime": {
-      "version": "6.18.0",
-      "from": "babel-runtime@^6.9.1",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-runtime@^6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
     },
     "babel-template": {
-      "version": "6.16.0",
-      "from": "babel-template@^6.16.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-template@^6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz"
     },
     "babel-traverse": {
-      "version": "6.18.0",
-      "from": "babel-traverse@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.18.0.tgz"
+      "version": "6.23.1",
+      "from": "babel-traverse@^6.23.1",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz"
     },
     "babel-types": {
-      "version": "6.18.0",
-      "from": "babel-types@^6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.18.0.tgz"
+      "version": "6.23.0",
+      "from": "babel-types@^6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
     },
     "babylon": {
-      "version": "6.13.1",
+      "version": "6.15.0",
       "from": "babylon@^6.11.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.13.1.tgz"
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
     },
     "backo2": {
       "version": "1.0.2",
@@ -737,12 +734,6 @@
       "version": "0.4.2",
       "from": "balanced-match@^0.4.1",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-    },
-    "Base64": {
-      "version": "0.2.1",
-      "from": "Base64@~0.2.0",
-      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
-      "dev": true
     },
     "base64-arraybuffer": {
       "version": "0.1.5",
@@ -757,28 +748,15 @@
       "dev": true
     },
     "base64id": {
-      "version": "0.1.0",
-      "from": "base64id@0.1.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
+      "version": "1.0.0",
+      "from": "base64id@1.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
       "dev": true
     },
     "batch": {
       "version": "0.5.3",
       "from": "batch@^0.5.3",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
-      "dev": true
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.0",
-      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-      "dev": true,
-      "optional": true
-    },
-    "benchmark": {
-      "version": "1.0.0",
-      "from": "benchmark@1.0.0",
-      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
       "dev": true
     },
     "better-assert": {
@@ -793,24 +771,16 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
     },
     "binary-extensions": {
-      "version": "1.7.0",
+      "version": "1.8.0",
       "from": "binary-extensions@^1.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
       "dev": true
     },
     "bl": {
-      "version": "1.1.2",
-      "from": "bl@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@>=2.0.5 <2.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "dev": true
-        }
-      }
+      "version": "1.2.0",
+      "from": "bl@^1.0.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.0.tgz",
+      "dev": true
     },
     "blob": {
       "version": "0.0.4",
@@ -826,20 +796,20 @@
     },
     "bluebird": {
       "version": "2.11.0",
-      "from": "bluebird@>=2.9.27 <3.0.0",
+      "from": "bluebird@^2.9.27",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
       "dev": true
     },
     "body-parser": {
-      "version": "1.15.2",
+      "version": "1.16.1",
       "from": "body-parser@^1.12.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.16.1.tgz",
       "dev": true,
       "dependencies": {
         "qs": {
-          "version": "6.2.0",
-          "from": "qs@6.2.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
+          "version": "6.2.1",
+          "from": "qs@6.2.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
           "dev": true
         }
       }
@@ -861,16 +831,22 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "dev": true
     },
+    "browserify-aes": {
+      "version": "0.4.0",
+      "from": "browserify-aes@0.4.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz",
+      "dev": true
+    },
     "browserify-zlib": {
       "version": "0.1.4",
-      "from": "browserify-zlib@~0.1.4",
+      "from": "browserify-zlib@^0.1.4",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "dev": true
     },
     "browserslist": {
-      "version": "1.4.0",
-      "from": "browserslist@>=1.4.0 <1.5.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.4.0.tgz",
+      "version": "1.7.4",
+      "from": "browserslist@>=1.7.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.4.tgz",
       "dev": true
     },
     "buffer": {
@@ -880,9 +856,9 @@
       "dev": true
     },
     "buffer-crc32": {
-      "version": "0.2.5",
+      "version": "0.2.13",
       "from": "buffer-crc32@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "dev": true
     },
     "buffer-shims": {
@@ -895,6 +871,12 @@
       "version": "1.1.1",
       "from": "builtin-modules@^1.0.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "dev": true
+    },
+    "builtin-status-codes": {
+      "version": "3.0.0",
+      "from": "builtin-status-codes@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "dev": true
     },
     "bytes": {
@@ -933,10 +915,16 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "dev": true
     },
+    "caniuse-api": {
+      "version": "1.5.3",
+      "from": "caniuse-api@>=1.5.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.5.3.tgz",
+      "dev": true
+    },
     "caniuse-db": {
-      "version": "1.0.30000578",
-      "from": "caniuse-db@>=1.0.30000576 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000578.tgz",
+      "version": "1.0.30000624",
+      "from": "caniuse-db@>=1.0.30000624 <2.0.0",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000624.tgz",
       "dev": true
     },
     "cardinal": {
@@ -980,14 +968,14 @@
     },
     "circular-json": {
       "version": "0.3.1",
-      "from": "circular-json@^0.3.0",
+      "from": "circular-json@^0.3.1",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
       "dev": true
     },
     "clap": {
-      "version": "1.1.1",
+      "version": "1.1.2",
       "from": "clap@>=1.0.9 <2.0.0",
-      "resolved": "https://registry.npmjs.org/clap/-/clap-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/clap/-/clap-1.1.2.tgz",
       "dev": true
     },
     "classnames": {
@@ -996,9 +984,9 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz"
     },
     "clean-css": {
-      "version": "3.4.20",
+      "version": "3.4.24",
       "from": "clean-css@>=3.3.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.20.tgz",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.24.tgz",
       "dependencies": {
         "commander": {
           "version": "2.8.1",
@@ -1070,7 +1058,7 @@
     },
     "code-point-at": {
       "version": "1.1.0",
-      "from": "code-point-at@>=1.0.0 <2.0.0",
+      "from": "code-point-at@^1.0.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "dev": true
     },
@@ -1081,9 +1069,9 @@
       "dev": true
     },
     "color-convert": {
-      "version": "1.6.0",
+      "version": "1.9.0",
       "from": "color-convert@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "dev": true
     },
     "color-name": {
@@ -1140,7 +1128,7 @@
     },
     "component-closest": {
       "version": "1.0.1",
-      "from": "component-closest@latest",
+      "from": "component-closest@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/component-closest/-/component-closest-1.0.1.tgz"
     },
     "component-emitter": {
@@ -1157,7 +1145,7 @@
     },
     "component-matches-selector": {
       "version": "0.1.6",
-      "from": "component-matches-selector@>=0.1.6 <0.2.0",
+      "from": "component-matches-selector@~0.1.6",
       "resolved": "https://registry.npmjs.org/component-matches-selector/-/component-matches-selector-0.1.6.tgz"
     },
     "component-query": {
@@ -1188,6 +1176,18 @@
           "from": "bytes@2.3.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
           "dev": true
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "dev": true
         }
       }
     },
@@ -1197,18 +1197,10 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
     },
     "concat-stream": {
-      "version": "1.5.2",
-      "from": "concat-stream@^1.4.6",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "dev": true
-        }
-      }
+      "version": "1.6.0",
+      "from": "concat-stream@>=1.4.6 <2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "dev": true
     },
     "confirm-simple": {
       "version": "1.0.3",
@@ -1217,9 +1209,9 @@
       "dev": true
     },
     "connect": {
-      "version": "3.5.0",
+      "version": "3.6.0",
       "from": "connect@>=3.3.5 <4.0.0",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.0.tgz",
       "dev": true
     },
     "connect-history-api-fallback": {
@@ -1236,7 +1228,7 @@
     },
     "console-control-strings": {
       "version": "1.1.0",
-      "from": "console-control-strings@>=1.1.0 <1.2.0",
+      "from": "console-control-strings@~1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "dev": true
     },
@@ -1246,15 +1238,15 @@
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.0.tgz"
     },
     "constants-browserify": {
-      "version": "0.0.1",
-      "from": "constants-browserify@0.0.1",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+      "version": "1.0.0",
+      "from": "constants-browserify@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "dev": true
     },
     "content-disposition": {
-      "version": "0.5.1",
-      "from": "content-disposition@0.5.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
+      "version": "0.5.2",
+      "from": "content-disposition@0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "dev": true
     },
     "content-type": {
@@ -1270,9 +1262,9 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.3.0",
+      "version": "1.4.0",
       "from": "convert-source-map@^1.1.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.4.0.tgz"
     },
     "cookie": {
       "version": "0.3.1",
@@ -1297,10 +1289,16 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "dev": true
     },
+    "crc": {
+      "version": "3.4.4",
+      "from": "crc@>=3.4.4 <4.0.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
+      "dev": true
+    },
     "crc32-stream": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "from": "crc32-stream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-1.0.1.tgz",
       "dev": true
     },
     "cross-env": {
@@ -1330,9 +1328,9 @@
       "dev": true
     },
     "crypto-browserify": {
-      "version": "3.2.8",
-      "from": "crypto-browserify@~3.2.6",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
+      "version": "3.3.0",
+      "from": "crypto-browserify@3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz",
       "dev": true
     },
     "css-color-names": {
@@ -1360,26 +1358,26 @@
       "dev": true
     },
     "cssnano": {
-      "version": "3.8.0",
+      "version": "3.10.0",
       "from": "cssnano@>=2.6.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
       "dev": true
     },
     "csso": {
-      "version": "2.2.1",
-      "from": "csso@>=2.2.1 <2.3.0",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-2.2.1.tgz",
+      "version": "2.3.1",
+      "from": "csso@>=2.3.1 <2.4.0",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.1.tgz",
       "dev": true
     },
     "cssom": {
-      "version": "0.3.1",
-      "from": "cssom@>= 0.3.0 < 0.4.0",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.1.tgz",
+      "version": "0.3.2",
+      "from": "cssom@>= 0.3.2 < 0.4.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
       "dev": true
     },
     "cssstyle": {
       "version": "0.2.37",
-      "from": "cssstyle@>= 0.2.36 < 0.3.0",
+      "from": "cssstyle@>= 0.2.37 < 0.3.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "dev": true
     },
@@ -1402,9 +1400,9 @@
       "dev": true
     },
     "dashdash": {
-      "version": "1.14.0",
+      "version": "1.14.1",
       "from": "dashdash@^1.12.0",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "dev": true,
       "dependencies": {
         "assert-plus": {
@@ -1428,9 +1426,9 @@
       "dev": true
     },
     "debug": {
-      "version": "2.2.0",
+      "version": "2.6.1",
       "from": "debug@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz"
     },
     "decamelize": {
       "version": "1.2.0",
@@ -1455,6 +1453,12 @@
       "version": "0.1.3",
       "from": "deep-is@~0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "dev": true
+    },
+    "default-require-extensions": {
+      "version": "1.0.0",
+      "from": "default-require-extensions@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
       "dev": true
     },
     "defined": {
@@ -1512,7 +1516,7 @@
     },
     "doctrine": {
       "version": "1.5.0",
-      "from": "doctrine@^1.2.2",
+      "from": "doctrine@>=1.2.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
       "dev": true
     },
@@ -1534,21 +1538,20 @@
       "dev": true
     },
     "dompurify": {
-      "version": "0.8.4",
+      "version": "0.8.5",
       "from": "dompurify@>=0.8.0 <0.9.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-0.8.4.tgz"
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "dev": true,
-      "optional": true
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-0.8.5.tgz"
     },
     "ee-first": {
       "version": "1.1.1",
       "from": "ee-first@1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.2.2",
+      "from": "electron-to-chromium@>=1.2.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.2.2.tgz",
       "dev": true
     },
     "emojis-list": {
@@ -1558,7 +1561,7 @@
     },
     "encodeurl": {
       "version": "1.0.1",
-      "from": "encodeurl@>=1.0.1 <1.1.0",
+      "from": "encodeurl@~1.0.1",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
       "dev": true
     },
@@ -1582,36 +1585,44 @@
       }
     },
     "engine.io": {
-      "version": "1.7.2",
-      "from": "engine.io@1.7.2",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.7.2.tgz",
-      "dev": true
-    },
-    "engine.io-client": {
-      "version": "1.7.2",
-      "from": "engine.io-client@1.7.2",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.7.2.tgz",
-      "dev": true
-    },
-    "engine.io-parser": {
-      "version": "1.3.1",
-      "from": "engine.io-parser@1.3.1",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
+      "version": "1.8.3",
+      "from": "engine.io@1.8.3",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.3.tgz",
       "dev": true,
       "dependencies": {
-        "has-binary": {
-          "version": "0.1.6",
-          "from": "has-binary@0.1.6",
-          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
-          "dev": true
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+        "debug": {
+          "version": "2.3.3",
+          "from": "debug@2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "dev": true
         }
       }
+    },
+    "engine.io-client": {
+      "version": "1.8.3",
+      "from": "engine.io-client@1.8.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.3.tgz",
+      "dev": true,
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "from": "component-emitter@1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.3.3",
+          "from": "debug@2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "dev": true
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "1.3.2",
+      "from": "engine.io-parser@1.3.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
+      "dev": true
     },
     "enhanced-resolve": {
       "version": "0.9.1",
@@ -1695,7 +1706,7 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
     },
     "escodegen": {
@@ -1709,13 +1720,6 @@
           "from": "estraverse@>=1.9.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
           "dev": true
-        },
-        "source-map": {
-          "version": "0.2.0",
-          "from": "source-map@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-          "dev": true,
-          "optional": true
         }
       }
     },
@@ -1819,7 +1823,7 @@
     },
     "eventsource": {
       "version": "0.1.6",
-      "from": "eventsource@>=0.1.6 <0.2.0",
+      "from": "eventsource@0.1.6",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
       "dev": true
     },
@@ -1888,11 +1892,35 @@
       }
     },
     "express": {
-      "version": "4.14.0",
+      "version": "4.14.1",
       "from": "express@>=4.13.3 <5.0.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.14.1.tgz",
       "dev": true,
       "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dev": true
+        },
+        "finalhandler": {
+          "version": "0.5.1",
+          "from": "finalhandler@0.5.1",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.1.tgz",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "from": "path-to-regexp@0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "dev": true
+        },
         "qs": {
           "version": "6.2.0",
           "from": "qs@6.2.0",
@@ -1926,9 +1954,9 @@
       "dev": true
     },
     "fast-levenshtein": {
-      "version": "2.0.5",
+      "version": "2.0.6",
       "from": "fast-levenshtein@~2.0.4",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "dev": true
     },
     "fastparse": {
@@ -1944,9 +1972,9 @@
       "dev": true
     },
     "fbjs": {
-      "version": "0.8.5",
+      "version": "0.8.9",
       "from": "fbjs@^0.8.4",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.9.tgz",
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -1980,24 +2008,10 @@
       "dev": true
     },
     "fileset": {
-      "version": "0.2.1",
-      "from": "fileset@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
-      "dev": true,
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "from": "glob@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "from": "minimatch@2.x",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "dev": true
-        }
-      }
+      "version": "2.0.3",
+      "from": "fileset@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+      "dev": true
     },
     "fill-range": {
       "version": "2.2.3",
@@ -2006,9 +2020,9 @@
       "dev": true
     },
     "finalhandler": {
-      "version": "0.5.0",
-      "from": "finalhandler@0.5.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+      "version": "1.0.0",
+      "from": "finalhandler@1.0.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.0.tgz",
       "dev": true
     },
     "find-cache-dir": {
@@ -2022,9 +2036,9 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
     },
     "flat-cache": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "from": "flat-cache@^1.2.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "dev": true
     },
     "flatten": {
@@ -2052,10 +2066,24 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.1.1",
+      "version": "2.1.2",
       "from": "form-data@~2.1.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
       "dev": true
+    },
+    "formatio": {
+      "version": "1.1.1",
+      "from": "formatio@1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "dev": true,
+      "dependencies": {
+        "samsam": {
+          "version": "1.1.3",
+          "from": "samsam@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.3.tgz",
+          "dev": true
+        }
+      }
     },
     "forwarded": {
       "version": "0.1.0",
@@ -2083,13 +2111,12 @@
     "function-bind": {
       "version": "1.1.0",
       "from": "function-bind@^1.0.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
     },
     "gauge": {
-      "version": "2.6.0",
-      "from": "gauge@>=2.6.0 <2.7.0",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
+      "version": "2.7.3",
+      "from": "gauge@~2.7.1",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
       "dev": true
     },
     "gaze": {
@@ -2152,9 +2179,9 @@
       "dev": true
     },
     "globals": {
-      "version": "9.12.0",
-      "from": "globals@^9.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.12.0.tgz"
+      "version": "9.16.0",
+      "from": "globals@>=9.0.0 <10.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.16.0.tgz"
     },
     "globby": {
       "version": "5.0.0",
@@ -2166,23 +2193,36 @@
       "version": "1.1.0",
       "from": "globule@^1.0.0",
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "lodash": {
+          "version": "4.16.6",
+          "from": "lodash@>=4.16.4 <4.17.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
+          "dev": true
+        }
+      }
     },
     "google-libphonenumber": {
-      "version": "2.0.4",
-      "from": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-2.0.4.tgz",
-      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-2.0.4.tgz"
+      "version": "2.0.10",
+      "from": "google-libphonenumber@>=2.0.4 <3.0.0",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-2.0.10.tgz"
     },
     "graceful-fs": {
-      "version": "4.1.10",
+      "version": "4.1.11",
       "from": "graceful-fs@^4.1.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "dev": true
     },
     "graceful-readlink": {
       "version": "1.0.1",
       "from": "graceful-readlink@>= 1.0.0",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+    },
+    "gridicons": {
+      "version": "1.0.0",
+      "from": "gridicons@1.0.0",
+      "resolved": "https://registry.npmjs.org/gridicons/-/gridicons-1.0.0.tgz"
     },
     "growl": {
       "version": "1.9.2",
@@ -2197,9 +2237,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.5",
+      "version": "4.0.6",
       "from": "handlebars@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
       "dev": true,
       "dependencies": {
         "source-map": {
@@ -2219,8 +2259,7 @@
     "has": {
       "version": "1.0.1",
       "from": "has@^1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
     },
     "has-ansi": {
       "version": "2.0.0",
@@ -2288,9 +2327,9 @@
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz"
     },
     "hosted-git-info": {
-      "version": "2.1.5",
+      "version": "2.2.0",
       "from": "hosted-git-info@^2.1.4",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.2.0.tgz",
       "dev": true
     },
     "html-comment-regex": {
@@ -2305,47 +2344,33 @@
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
       "dev": true
     },
-    "http-browserify": {
-      "version": "1.7.0",
-      "from": "http-browserify@^1.3.2",
-      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+    "http-errors": {
+      "version": "1.5.1",
+      "from": "http-errors@~1.5.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
       "dev": true
     },
-    "http-errors": {
-      "version": "1.5.0",
-      "from": "http-errors@~1.5.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
-      "dev": true,
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "from": "inherits@2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "dev": true
-        }
-      }
-    },
     "http-proxy": {
-      "version": "1.15.2",
+      "version": "1.16.2",
       "from": "http-proxy@^1.13.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
       "dev": true
     },
     "http-proxy-middleware": {
-      "version": "0.17.2",
+      "version": "0.17.3",
       "from": "http-proxy-middleware@>=0.17.1 <0.18.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.2.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.3.tgz",
       "dev": true,
       "dependencies": {
         "is-extglob": {
-          "version": "2.1.0",
+          "version": "2.1.1",
           "from": "is-extglob@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "dev": true
         },
         "is-glob": {
           "version": "3.1.0",
-          "from": "is-glob@>=3.0.0 <4.0.0",
+          "from": "is-glob@>=3.1.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "dev": true
         }
@@ -2358,20 +2383,32 @@
       "dev": true
     },
     "https-browserify": {
-      "version": "0.0.0",
-      "from": "https-browserify@0.0.0",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
+      "version": "0.0.1",
+      "from": "https-browserify@0.0.1",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
       "dev": true
     },
     "i18n-calypso": {
       "version": "1.7.0",
       "from": "i18n-calypso@>=1.7.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/i18n-calypso/-/i18n-calypso-1.7.0.tgz"
+      "resolved": "https://registry.npmjs.org/i18n-calypso/-/i18n-calypso-1.7.0.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+        }
+      }
     },
     "iconv-lite": {
-      "version": "0.4.13",
+      "version": "0.4.15",
       "from": "iconv-lite@~0.4.13",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
     },
     "icss-replace-symbols": {
       "version": "1.0.2",
@@ -2386,15 +2423,10 @@
       "dev": true
     },
     "ignore": {
-      "version": "3.2.0",
-      "from": "ignore@^3.1.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.0.tgz",
+      "version": "3.2.4",
+      "from": "ignore@>=3.1.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.4.tgz",
       "dev": true
-    },
-    "immutable": {
-      "version": "3.8.1",
-      "from": "immutable@^3.7.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz"
     },
     "imports-loader": {
       "version": "0.6.5",
@@ -2468,9 +2500,9 @@
       "dev": true
     },
     "invariant": {
-      "version": "2.2.1",
+      "version": "2.2.2",
       "from": "invariant@^2.2.0",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz"
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -2479,15 +2511,15 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.1.1",
-      "from": "ipaddr.js@1.1.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz",
+      "version": "1.2.0",
+      "from": "ipaddr.js@1.2.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz",
       "dev": true
     },
     "is-absolute-url": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "from": "is-absolute-url@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
       "dev": true
     },
     "is-arrayish": {
@@ -2617,9 +2649,9 @@
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
     },
     "is-regex": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "from": "is-regex@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz"
     },
     "is-resolvable": {
       "version": "1.0.0",
@@ -2652,14 +2684,14 @@
     },
     "isarray": {
       "version": "1.0.0",
-      "from": "isarray@>=1.0.0 <1.1.0",
+      "from": "isarray@~1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "dev": true
     },
     "isbinaryfile": {
-      "version": "3.0.1",
+      "version": "3.0.2",
       "from": "isbinaryfile@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.2.tgz",
       "dev": true
     },
     "isexe": {
@@ -2698,16 +2730,16 @@
           "dev": true
         },
         "supports-color": {
-          "version": "3.1.2",
-          "from": "supports-color@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "version": "3.2.3",
+          "from": "supports-color@^3.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "dev": true
         }
       }
     },
     "isparta-loader": {
       "version": "2.0.0",
-      "from": "isparta-loader@latest",
+      "from": "isparta-loader@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/isparta-loader/-/isparta-loader-2.0.0.tgz",
       "dev": true
     },
@@ -2724,53 +2756,61 @@
       "dev": true
     },
     "istanbul-api": {
-      "version": "1.0.0-aplha.10",
+      "version": "1.1.1",
       "from": "istanbul-api@>=1.0.0-alpha <2.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.0.0-aplha.10.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.1.tgz",
+      "dev": true,
+      "dependencies": {
+        "async": {
+          "version": "2.1.5",
+          "from": "async@>=2.1.4 <3.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+          "dev": true
+        }
+      }
     },
     "istanbul-lib-coverage": {
-      "version": "1.0.0",
-      "from": "istanbul-lib-coverage@>=1.0.0-alpha <2.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.0.tgz",
+      "version": "1.0.1",
+      "from": "istanbul-lib-coverage@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.1.tgz",
       "dev": true
     },
     "istanbul-lib-hook": {
-      "version": "1.0.0-alpha.4",
-      "from": "istanbul-lib-hook@>=1.0.0-alpha <2.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.0-alpha.4.tgz",
+      "version": "1.0.0",
+      "from": "istanbul-lib-hook@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.0.tgz",
       "dev": true
     },
     "istanbul-lib-instrument": {
-      "version": "1.2.0",
-      "from": "istanbul-lib-instrument@>=1.0.0-alpha <2.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.2.0.tgz",
+      "version": "1.4.2",
+      "from": "istanbul-lib-instrument@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.4.2.tgz",
       "dev": true
     },
     "istanbul-lib-report": {
       "version": "1.0.0-alpha.3",
-      "from": "istanbul-lib-report@>=1.0.0-alpha <2.0.0",
+      "from": "istanbul-lib-report@>=1.0.0-alpha.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.0.0-alpha.3.tgz",
       "dev": true,
       "dependencies": {
         "supports-color": {
-          "version": "3.1.2",
+          "version": "3.2.3",
           "from": "supports-color@^3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "dev": true
         }
       }
     },
     "istanbul-lib-source-maps": {
-      "version": "1.0.2",
-      "from": "istanbul-lib-source-maps@>=1.0.0-alpha <2.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.0.2.tgz",
+      "version": "1.1.0",
+      "from": "istanbul-lib-source-maps@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.1.0.tgz",
       "dev": true
     },
     "istanbul-reports": {
-      "version": "1.0.0",
-      "from": "istanbul-reports@>=1.0.0-alpha <2.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.0.0.tgz",
+      "version": "1.0.1",
+      "from": "istanbul-reports@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.0.1.tgz",
       "dev": true
     },
     "jade": {
@@ -2879,13 +2919,6 @@
       "from": "jed@1.0.2",
       "resolved": "https://registry.npmjs.org/jed/-/jed-1.0.2.tgz"
     },
-    "jodid25519": {
-      "version": "1.0.2",
-      "from": "jodid25519@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-      "dev": true,
-      "optional": true
-    },
     "js-base64": {
       "version": "2.1.9",
       "from": "js-base64@^2.1.9",
@@ -2898,33 +2931,26 @@
       "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz"
     },
     "js-tokens": {
-      "version": "2.0.0",
-      "from": "js-tokens@^2.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
+      "version": "3.0.1",
+      "from": "js-tokens@^3.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
     },
     "js-yaml": {
-      "version": "3.6.1",
-      "from": "js-yaml@~3.6.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+      "version": "3.7.0",
+      "from": "js-yaml@>=3.7.0 <3.8.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "dev": true
     },
-    "jsbn": {
-      "version": "0.1.0",
-      "from": "jsbn@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-      "dev": true,
-      "optional": true
-    },
     "jsdom": {
-      "version": "9.8.3",
+      "version": "9.11.0",
       "from": "jsdom@>=9.2.1 <10.0.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.11.0.tgz",
       "dev": true,
       "dependencies": {
         "acorn": {
-          "version": "2.7.0",
-          "from": "acorn@>=2.4.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+          "version": "4.0.11",
+          "from": "acorn@>=4.0.4 <5.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz",
           "dev": true
         }
       }
@@ -2959,15 +2985,15 @@
       "dev": true
     },
     "json3": {
-      "version": "3.2.6",
-      "from": "json3@3.2.6",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
+      "version": "3.3.2",
+      "from": "json3@3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "dev": true
     },
     "json5": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "from": "json5@>=0.5.0 <0.6.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
     },
     "jsonify": {
       "version": "0.0.0",
@@ -2976,9 +3002,9 @@
       "dev": true
     },
     "jsonpointer": {
-      "version": "4.0.0",
+      "version": "4.0.1",
       "from": "jsonpointer@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
     },
     "jsprim": {
       "version": "1.3.1",
@@ -2997,9 +3023,9 @@
       "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-0.0.3.tgz"
     },
     "jsx-ast-utils": {
-      "version": "1.3.3",
+      "version": "1.4.0",
       "from": "jsx-ast-utils@^1.2.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.0.tgz",
       "dev": true
     },
     "karma": {
@@ -3053,9 +3079,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "3.1.2",
+          "version": "3.2.3",
           "from": "supports-color@^3.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "dev": true
         }
       }
@@ -3072,10 +3098,22 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
           "dev": true
         },
+        "acorn-globals": {
+          "version": "1.0.9",
+          "from": "acorn-globals@>=1.0.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+          "dev": true
+        },
         "jsdom": {
           "version": "8.5.0",
           "from": "jsdom@>=8.0.0 <9.0.0",
           "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-8.5.0.tgz",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "from": "webidl-conversions@^3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "dev": true
         },
         "whatwg-url": {
@@ -3087,15 +3125,23 @@
       }
     },
     "karma-mocha": {
-      "version": "1.2.0",
+      "version": "1.3.0",
       "from": "karma-mocha@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/karma-mocha/-/karma-mocha-1.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/karma-mocha/-/karma-mocha-1.3.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "from": "minimist@1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "dev": true
+        }
+      }
     },
     "karma-mocha-reporter": {
-      "version": "2.2.0",
+      "version": "2.2.2",
       "from": "karma-mocha-reporter@>=2.0.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/karma-mocha-reporter/-/karma-mocha-reporter-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/karma-mocha-reporter/-/karma-mocha-reporter-2.2.2.tgz",
       "dev": true
     },
     "karma-sourcemap-loader": {
@@ -3105,9 +3151,9 @@
       "dev": true
     },
     "karma-webpack": {
-      "version": "1.8.0",
+      "version": "1.8.1",
       "from": "karma-webpack@>=1.7.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-1.8.1.tgz",
       "dev": true,
       "dependencies": {
         "async": {
@@ -3131,9 +3177,9 @@
       }
     },
     "kind-of": {
-      "version": "3.0.4",
+      "version": "3.1.0",
       "from": "kind-of@^3.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz"
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -3165,19 +3211,19 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "0.2.16",
-      "from": "loader-utils@^0.2.11",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz"
+      "version": "0.2.17",
+      "from": "loader-utils@>=0.2.16 <0.3.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz"
     },
     "lodash": {
-      "version": "4.16.6",
+      "version": "4.17.4",
       "from": "lodash@>=4.16.4 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz"
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
     },
     "lodash-es": {
-      "version": "4.16.6",
+      "version": "4.17.4",
       "from": "lodash-es@>=4.2.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.16.6.tgz"
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz"
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
@@ -3276,14 +3322,8 @@
     },
     "lodash.flatten": {
       "version": "4.4.0",
-      "from": "lodash.flatten@>=4.4.0 <5.0.0",
+      "from": "lodash.flatten@^4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz"
-    },
-    "lodash.indexof": {
-      "version": "4.0.5",
-      "from": "lodash.indexof@>=4.0.5 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.indexof/-/lodash.indexof-4.0.5.tgz",
-      "dev": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -3303,6 +3343,12 @@
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "dev": true
     },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "from": "lodash.memoize@>=4.1.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "dev": true
+    },
     "lodash.pickby": {
       "version": "4.6.0",
       "from": "lodash.pickby@^4.0.0",
@@ -3313,6 +3359,12 @@
       "version": "3.6.1",
       "from": "lodash.restparam@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "from": "lodash.uniq@>=4.3.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "dev": true
     },
     "lodash.words": {
@@ -3347,15 +3399,21 @@
         }
       }
     },
+    "lolex": {
+      "version": "1.5.2",
+      "from": "lolex@>=1.4.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.5.2.tgz",
+      "dev": true
+    },
     "longest": {
       "version": "1.0.1",
       "from": "longest@^1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
     },
     "loose-envify": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "from": "loose-envify@^1.0.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -3365,13 +3423,13 @@
     },
     "lru": {
       "version": "3.1.0",
-      "from": "lru@>=3.1.0 <4.0.0",
+      "from": "lru@^3.1.0",
       "resolved": "https://registry.npmjs.org/lru/-/lru-3.1.0.tgz"
     },
     "lru-cache": {
-      "version": "4.0.1",
+      "version": "4.0.2",
       "from": "lru-cache@^4.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
       "dev": true
     },
     "macaddress": {
@@ -3399,9 +3457,9 @@
       "dev": true
     },
     "math-expression-evaluator": {
-      "version": "1.2.14",
+      "version": "1.2.16",
       "from": "math-expression-evaluator@>=1.2.14 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.14.tgz",
+      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.16.tgz",
       "dev": true
     },
     "media-typer": {
@@ -3411,9 +3469,9 @@
       "dev": true
     },
     "memory-fs": {
-      "version": "0.3.0",
-      "from": "memory-fs@~0.3.0",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+      "version": "0.4.1",
+      "from": "memory-fs@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "dev": true
     },
     "meow": {
@@ -3455,15 +3513,15 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.24.0",
-      "from": "mime-db@~1.24.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+      "version": "1.26.0",
+      "from": "mime-db@~1.26.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.12",
+      "version": "2.1.14",
       "from": "mime-types@~2.1.7",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
       "dev": true
     },
     "minimatch": {
@@ -3493,6 +3551,12 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
           "dev": true
         },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dev": true
+        },
         "escape-string-regexp": {
           "version": "1.0.2",
           "from": "escape-string-regexp@1.0.2",
@@ -3515,6 +3579,12 @@
           "version": "0.3.0",
           "from": "minimatch@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "dev": true
         },
         "supports-color": {
@@ -3558,9 +3628,9 @@
       }
     },
     "moment": {
-      "version": "2.15.2",
+      "version": "2.17.1",
       "from": "moment@>=2.6.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.2.tgz"
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.17.1.tgz"
     },
     "moment-timezone": {
       "version": "0.4.0",
@@ -3568,9 +3638,9 @@
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.0.tgz"
     },
     "ms": {
-      "version": "0.7.1",
-      "from": "ms@0.7.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+      "version": "0.7.2",
+      "from": "ms@0.7.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
     },
     "mute-stream": {
       "version": "0.0.5",
@@ -3579,9 +3649,15 @@
       "dev": true
     },
     "nan": {
-      "version": "2.4.0",
+      "version": "2.5.1",
       "from": "nan@^2.3.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz",
+      "dev": true
+    },
+    "native-promise-only": {
+      "version": "0.8.1",
+      "from": "native-promise-only@>=0.8.1 <0.9.0",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
       "dev": true
     },
     "negotiator": {
@@ -3591,9 +3667,9 @@
       "dev": true
     },
     "node-emoji": {
-      "version": "1.4.1",
+      "version": "1.5.1",
       "from": "node-emoji@>=1.4.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.5.1.tgz",
       "dev": true
     },
     "node-fetch": {
@@ -3602,38 +3678,16 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz"
     },
     "node-gyp": {
-      "version": "3.4.0",
+      "version": "3.5.0",
       "from": "node-gyp@^3.3.1",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz",
-      "dev": true,
-      "dependencies": {
-        "npmlog": {
-          "version": "3.1.2",
-          "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0||>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
-          "dev": true
-        }
-      }
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.5.0.tgz",
+      "dev": true
     },
     "node-libs-browser": {
-      "version": "0.6.0",
-      "from": "node-libs-browser@^0.6.0",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.6.0.tgz",
-      "dev": true,
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "from": "readable-stream@^1.1.13",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "dev": true
-        }
-      }
+      "version": "0.7.0",
+      "from": "node-libs-browser@>=0.7.0 <0.8.0",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz",
+      "dev": true
     },
     "node-notifier": {
       "version": "4.6.1",
@@ -3656,15 +3710,9 @@
       }
     },
     "node-sass": {
-      "version": "3.11.2",
+      "version": "3.13.1",
       "from": "node-sass@>=3.7.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.11.2.tgz",
-      "dev": true
-    },
-    "node-uuid": {
-      "version": "1.4.7",
-      "from": "node-uuid@~1.4.7",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.13.1.tgz",
       "dev": true
     },
     "nomnomnomnom": {
@@ -3718,15 +3766,15 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "1.7.0",
+      "version": "1.9.0",
       "from": "normalize-url@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.0.tgz",
       "dev": true
     },
     "npmlog": {
-      "version": "4.0.0",
-      "from": "npmlog@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.0.tgz",
+      "version": "4.0.2",
+      "from": "npmlog@^4.0.0",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
       "dev": true
     },
     "null-loader": {
@@ -3748,7 +3796,7 @@
     },
     "nwmatcher": {
       "version": "1.3.9",
-      "from": "nwmatcher@>= 1.3.7 < 2.0.0",
+      "from": "nwmatcher@>= 1.3.9 < 2.0.0",
       "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.9.tgz",
       "dev": true
     },
@@ -3759,9 +3807,9 @@
       "dev": true
     },
     "object-assign": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "from": "object-assign@^4.0.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
     },
     "object-component": {
       "version": "0.0.3",
@@ -3861,9 +3909,9 @@
       }
     },
     "os-browserify": {
-      "version": "0.1.2",
-      "from": "os-browserify@~0.1.2",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+      "version": "0.2.1",
+      "from": "os-browserify@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
       "dev": true
     },
     "os-homedir": {
@@ -3883,9 +3931,9 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
     },
     "osenv": {
-      "version": "0.1.3",
+      "version": "0.1.4",
       "from": "osenv@0",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "dev": true
     },
     "pako": {
@@ -3913,33 +3961,27 @@
       "dev": true
     },
     "parsejson": {
-      "version": "0.0.1",
-      "from": "parsejson@0.0.1",
-      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
+      "version": "0.0.3",
+      "from": "parsejson@0.0.3",
+      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
       "dev": true
     },
     "parseqs": {
-      "version": "0.0.2",
-      "from": "parseqs@0.0.2",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
+      "version": "0.0.5",
+      "from": "parseqs@0.0.5",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "dev": true
     },
     "parseuri": {
-      "version": "0.0.4",
-      "from": "parseuri@0.0.4",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
+      "version": "0.0.5",
+      "from": "parseuri@0.0.5",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "dev": true
     },
     "parseurl": {
       "version": "1.3.1",
       "from": "parseurl@~1.3.1",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-      "dev": true
-    },
-    "path-array": {
-      "version": "1.0.1",
-      "from": "path-array@^1.0.0",
-      "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
       "dev": true
     },
     "path-browserify": {
@@ -3971,10 +4013,18 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "0.1.7",
-      "from": "path-to-regexp@0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "dev": true
+      "version": "1.7.0",
+      "from": "path-to-regexp@>=1.7.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "1.1.0",
@@ -4016,15 +4066,15 @@
       "dev": true
     },
     "postcss": {
-      "version": "5.2.5",
-      "from": "postcss@^5.2.5",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.5.tgz",
+      "version": "5.2.14",
+      "from": "postcss@>=5.2.14 <6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.14.tgz",
       "dev": true,
       "dependencies": {
         "supports-color": {
-          "version": "3.1.2",
-          "from": "supports-color@^3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "version": "3.2.3",
+          "from": "supports-color@^3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "dev": true
         }
       }
@@ -4036,15 +4086,15 @@
       "dev": true
     },
     "postcss-colormin": {
-      "version": "2.2.1",
+      "version": "2.2.2",
       "from": "postcss-colormin@>=2.1.8 <3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
       "dev": true
     },
     "postcss-convert-values": {
-      "version": "2.4.1",
+      "version": "2.6.1",
       "from": "postcss-convert-values@>=2.3.4 <3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
       "dev": true
     },
     "postcss-discard-comments": {
@@ -4054,9 +4104,9 @@
       "dev": true
     },
     "postcss-discard-duplicates": {
-      "version": "2.0.1",
+      "version": "2.0.2",
       "from": "postcss-discard-duplicates@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.2.tgz",
       "dev": true
     },
     "postcss-discard-empty": {
@@ -4072,9 +4122,9 @@
       "dev": true
     },
     "postcss-discard-unused": {
-      "version": "2.2.2",
+      "version": "2.2.3",
       "from": "postcss-discard-unused@>=2.2.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "dev": true
     },
     "postcss-filter-plugins": {
@@ -4096,15 +4146,15 @@
       "dev": true
     },
     "postcss-merge-longhand": {
-      "version": "2.0.1",
+      "version": "2.0.2",
       "from": "postcss-merge-longhand@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
       "dev": true
     },
     "postcss-merge-rules": {
-      "version": "2.0.10",
+      "version": "2.1.2",
       "from": "postcss-merge-rules@>=2.0.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
       "dev": true
     },
     "postcss-message-helpers": {
@@ -4126,15 +4176,15 @@
       "dev": true
     },
     "postcss-minify-params": {
-      "version": "1.0.5",
+      "version": "1.2.2",
       "from": "postcss-minify-params@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "dev": true
     },
     "postcss-minify-selectors": {
-      "version": "2.0.5",
+      "version": "2.1.1",
       "from": "postcss-minify-selectors@>=2.0.4 <3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "dev": true
     },
     "postcss-modules-extract-imports": {
@@ -4190,33 +4240,33 @@
       "dev": true
     },
     "postcss-normalize-charset": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "from": "postcss-normalize-charset@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "dev": true
     },
     "postcss-normalize-url": {
-      "version": "3.0.7",
+      "version": "3.0.8",
       "from": "postcss-normalize-url@>=3.0.7 <4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "dev": true
     },
     "postcss-ordered-values": {
-      "version": "2.2.2",
+      "version": "2.2.3",
       "from": "postcss-ordered-values@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
       "dev": true
     },
     "postcss-reduce-idents": {
-      "version": "2.3.1",
+      "version": "2.4.0",
       "from": "postcss-reduce-idents@>=2.2.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "dev": true
     },
     "postcss-reduce-initial": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "from": "postcss-reduce-initial@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "dev": true
     },
     "postcss-reduce-transforms": {
@@ -4226,15 +4276,15 @@
       "dev": true
     },
     "postcss-selector-parser": {
-      "version": "2.2.1",
-      "from": "postcss-selector-parser@^2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.1.tgz",
+      "version": "2.2.2",
+      "from": "postcss-selector-parser@^2.2.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.2.tgz",
       "dev": true
     },
     "postcss-svgo": {
-      "version": "2.1.5",
+      "version": "2.1.6",
       "from": "postcss-svgo@>=2.1.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "dev": true
     },
     "postcss-unique-selectors": {
@@ -4250,9 +4300,9 @@
       "dev": true
     },
     "postcss-zindex": {
-      "version": "2.1.1",
+      "version": "2.2.0",
       "from": "postcss-zindex@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "dev": true
     },
     "prelude-ls": {
@@ -4274,9 +4324,9 @@
       "dev": true
     },
     "private": {
-      "version": "0.1.6",
+      "version": "0.1.7",
       "from": "private@^0.1.6",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz"
     },
     "process": {
       "version": "0.11.9",
@@ -4302,9 +4352,9 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
     },
     "proxy-addr": {
-      "version": "1.1.2",
-      "from": "proxy-addr@>=1.1.2 <1.2.0",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
+      "version": "1.1.3",
+      "from": "proxy-addr@>=1.1.3 <1.2.0",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.3.tgz",
       "dev": true
     },
     "prr": {
@@ -4332,15 +4382,15 @@
       "dev": true
     },
     "qs": {
-      "version": "6.3.0",
+      "version": "6.3.1",
       "from": "qs@>=6.3.0 <6.4.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.1.tgz",
       "dev": true
     },
     "query-string": {
-      "version": "4.2.3",
+      "version": "4.3.2",
       "from": "query-string@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.2.tgz",
       "dev": true
     },
     "querystring": {
@@ -4351,7 +4401,7 @@
     },
     "querystring-es3": {
       "version": "0.2.1",
-      "from": "querystring-es3@~0.2.0",
+      "from": "querystring-es3@^0.2.0",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "dev": true
     },
@@ -4362,9 +4412,9 @@
       "dev": true
     },
     "randomatic": {
-      "version": "1.1.5",
+      "version": "1.1.6",
       "from": "randomatic@^1.1.3",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
       "dev": true
     },
     "range-parser": {
@@ -4374,9 +4424,9 @@
       "dev": true
     },
     "raw-body": {
-      "version": "2.1.7",
-      "from": "raw-body@~2.1.7",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+      "version": "2.2.0",
+      "from": "raw-body@~2.2.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
       "dev": true
     },
     "raw-loader": {
@@ -4386,30 +4436,30 @@
       "dev": true
     },
     "react": {
-      "version": "15.3.2",
+      "version": "15.4.2",
       "from": "react@>=15.1.0 <16.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.3.2.tgz"
+      "resolved": "https://registry.npmjs.org/react/-/react-15.4.2.tgz"
     },
     "react-addons-create-fragment": {
-      "version": "15.3.2",
+      "version": "15.4.2",
       "from": "react-addons-create-fragment@>=0.14.3 <0.15.0||>=15.1.0 <16.0.0",
-      "resolved": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-15.3.2.tgz"
+      "resolved": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-15.4.2.tgz"
     },
     "react-addons-test-utils": {
-      "version": "15.3.2",
+      "version": "15.4.2",
       "from": "react-addons-test-utils@>=15.1.0 <16.0.0",
-      "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.4.2.tgz",
       "dev": true
     },
     "react-dom": {
-      "version": "15.3.2",
+      "version": "15.4.2",
       "from": "react-dom@>=15.1.0 <16.0.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.3.2.tgz"
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.4.2.tgz"
     },
     "react-redux": {
-      "version": "4.4.5",
+      "version": "4.4.6",
       "from": "react-redux@>=4.4.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-4.4.5.tgz"
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-4.4.6.tgz"
     },
     "read-pkg": {
       "version": "1.1.0",
@@ -4424,9 +4474,9 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "2.1.5",
+      "version": "2.2.3",
       "from": "readable-stream@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
       "dev": true
     },
     "readdirp": {
@@ -4448,9 +4498,9 @@
       "dev": true
     },
     "redbox-react": {
-      "version": "1.3.2",
+      "version": "1.3.4",
       "from": "redbox-react@>=1.2.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/redbox-react/-/redbox-react-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/redbox-react/-/redbox-react-1.3.4.tgz",
       "dev": true
     },
     "redent": {
@@ -4480,18 +4530,10 @@
       "dev": true
     },
     "reduce-function-call": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "from": "reduce-function-call@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": {
-          "version": "0.1.0",
-          "from": "balanced-match@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
-          "dev": true
-        }
-      }
+      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
+      "dev": true
     },
     "redux": {
       "version": "3.6.0",
@@ -4499,24 +4541,29 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.6.0.tgz"
     },
     "redux-thunk": {
-      "version": "2.1.0",
+      "version": "2.2.0",
       "from": "redux-thunk@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz"
     },
     "regenerate": {
-      "version": "1.3.1",
+      "version": "1.3.2",
       "from": "regenerate@^1.2.1",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
     },
     "regenerator-runtime": {
-      "version": "0.9.6",
-      "from": "regenerator-runtime@>=0.9.5 <0.10.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz"
+      "version": "0.10.3",
+      "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz"
+    },
+    "regenerator-transform": {
+      "version": "0.9.8",
+      "from": "regenerator-transform@0.9.8",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.8.tgz"
     },
     "regex-cache": {
       "version": "0.4.3",
       "from": "regex-cache@^0.4.2",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+      "resolved": "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "dev": true
     },
     "regexpu-core": {
@@ -4558,9 +4605,9 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
     },
     "request": {
-      "version": "2.78.0",
-      "from": "request@>=2.55.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.78.0.tgz",
+      "version": "2.79.0",
+      "from": "request@^2.79.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
       "dev": true
     },
     "require-directory": {
@@ -4577,7 +4624,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "from": "require-uncached@>=1.0.2 <2.0.0",
+      "from": "require-uncached@^1.0.2",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "dev": true
     },
@@ -4594,7 +4641,7 @@
     },
     "resolve": {
       "version": "1.1.7",
-      "from": "resolve@1.1.x",
+      "from": "resolve@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
     },
     "resolve-from": {
@@ -4615,9 +4662,9 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
     },
     "rimraf": {
-      "version": "2.5.4",
-      "from": "rimraf@^2.2.8",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+      "version": "2.6.0",
+      "from": "rimraf@>=2.2.8 <3.0.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.0.tgz",
       "dev": true
     },
     "ripemd160": {
@@ -4638,6 +4685,12 @@
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
       "dev": true
     },
+    "samsam": {
+      "version": "1.2.1",
+      "from": "samsam@>=1.1.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
+      "dev": true
+    },
     "sass-graph": {
       "version": "2.1.2",
       "from": "sass-graph@^2.1.1",
@@ -4651,9 +4704,9 @@
       "dev": true
     },
     "sax": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "from": "sax@~1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz",
       "dev": true
     },
     "script-loader": {
@@ -4669,21 +4722,51 @@
       "dev": true
     },
     "send": {
-      "version": "0.14.1",
-      "from": "send@0.14.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
-      "dev": true
+      "version": "0.14.2",
+      "from": "send@0.14.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.14.2.tgz",
+      "dev": true,
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dev": true,
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "dev": true
+            }
+          }
+        }
+      }
     },
     "serve-index": {
       "version": "1.8.0",
       "from": "serve-index@^1.7.2",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "dev": true
+        }
+      }
     },
     "serve-static": {
-      "version": "1.11.1",
-      "from": "serve-static@>=1.11.1 <1.12.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
+      "version": "1.11.2",
+      "from": "serve-static@>=1.11.2 <1.12.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.2.tgz",
       "dev": true
     },
     "set-blocking": {
@@ -4698,10 +4781,15 @@
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "dev": true
     },
+    "setimmediate": {
+      "version": "1.0.5",
+      "from": "setimmediate@^1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+    },
     "setprototypeof": {
-      "version": "1.0.1",
-      "from": "setprototypeof@1.0.1",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
+      "version": "1.0.2",
+      "from": "setprototypeof@1.0.2",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
       "dev": true
     },
     "sha.js": {
@@ -4711,9 +4799,9 @@
       "dev": true
     },
     "shelljs": {
-      "version": "0.7.5",
+      "version": "0.7.6",
       "from": "shelljs@>=0.7.0 <0.8.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.5.tgz",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.6.tgz",
       "dev": true
     },
     "shellwords": {
@@ -4729,10 +4817,24 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.1",
+      "version": "3.0.2",
       "from": "signal-exit@^3.0.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "dev": true
+    },
+    "sinon": {
+      "version": "2.0.0-pre.5",
+      "from": "sinon@2.0.0-pre.5",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.0.0-pre.5.tgz",
+      "dev": true,
+      "dependencies": {
+        "diff": {
+          "version": "3.2.0",
+          "from": "diff@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+          "dev": true
+        }
+      }
     },
     "slash": {
       "version": "1.0.0",
@@ -4752,49 +4854,55 @@
       "dev": true
     },
     "socket.io": {
-      "version": "1.5.1",
+      "version": "1.7.3",
       "from": "socket.io@>=1.4.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.5.1.tgz",
-      "dev": true
-    },
-    "socket.io-adapter": {
-      "version": "0.4.0",
-      "from": "socket.io-adapter@0.4.0",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.3.tgz",
       "dev": true,
       "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+        "debug": {
+          "version": "2.3.3",
+          "from": "debug@2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "dev": true
         },
-        "socket.io-parser": {
-          "version": "2.2.2",
-          "from": "socket.io-parser@2.2.2",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
-          "dev": true,
-          "dependencies": {
-            "debug": {
-              "version": "0.7.4",
-              "from": "debug@0.7.4",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-              "dev": true
-            }
-          }
+        "object-assign": {
+          "version": "4.1.0",
+          "from": "object-assign@4.1.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+          "dev": true
+        }
+      }
+    },
+    "socket.io-adapter": {
+      "version": "0.5.0",
+      "from": "socket.io-adapter@0.5.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "from": "debug@2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "dev": true
         }
       }
     },
     "socket.io-client": {
-      "version": "1.5.1",
-      "from": "socket.io-client@1.5.1",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.5.1.tgz",
+      "version": "1.7.3",
+      "from": "socket.io-client@1.7.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.3.tgz",
       "dev": true,
       "dependencies": {
         "component-emitter": {
-          "version": "1.2.0",
-          "from": "component-emitter@1.2.0",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
+          "version": "1.2.1",
+          "from": "component-emitter@1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.3.3",
+          "from": "debug@2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "dev": true
         }
       }
@@ -4805,16 +4913,22 @@
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
       "dev": true,
       "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dev": true
+        },
         "isarray": {
           "version": "0.0.1",
           "from": "isarray@0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "dev": true
         },
-        "json3": {
-          "version": "3.3.2",
-          "from": "json3@3.3.2",
-          "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "dev": true
         }
       }
@@ -4823,24 +4937,26 @@
       "version": "0.3.18",
       "from": "sockjs@>=0.3.15 <0.4.0",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "uuid": {
+          "version": "2.0.3",
+          "from": "uuid@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "dev": true
+        }
+      }
     },
     "sockjs-client": {
-      "version": "1.1.1",
+      "version": "1.1.2",
       "from": "sockjs-client@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.2.tgz",
       "dev": true,
       "dependencies": {
         "faye-websocket": {
-          "version": "0.11.0",
+          "version": "0.11.1",
           "from": "faye-websocket@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.0.tgz",
-          "dev": true
-        },
-        "json3": {
-          "version": "3.3.2",
-          "from": "json3@^3.3.2",
-          "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
           "dev": true
         }
       }
@@ -4852,9 +4968,9 @@
       "dev": true
     },
     "source-list-map": {
-      "version": "0.1.6",
+      "version": "0.1.8",
       "from": "source-list-map@^0.1.4",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
       "dev": true
     },
     "source-map": {
@@ -4863,9 +4979,9 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
     },
     "source-map-support": {
-      "version": "0.4.6",
+      "version": "0.4.11",
       "from": "source-map-support@>=0.4.2 <0.5.0",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.6.tgz"
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.11.tgz"
     },
     "spdx-correct": {
       "version": "1.0.2",
@@ -4891,9 +5007,9 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
     "sshpk": {
-      "version": "1.10.1",
+      "version": "1.10.2",
       "from": "sshpk@^1.7.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
       "dev": true,
       "dependencies": {
         "assert-plus": {
@@ -4911,35 +5027,27 @@
       "dev": true
     },
     "statuses": {
-      "version": "1.3.0",
-      "from": "statuses@>= 1.3.0 < 2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
+      "version": "1.3.1",
+      "from": "statuses@>= 1.3.1 < 2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "dev": true
     },
     "stream-browserify": {
-      "version": "1.0.0",
-      "from": "stream-browserify@^1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
-      "dev": true,
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "from": "readable-stream@^1.0.27-1",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "dev": true
-        }
-      }
+      "version": "2.0.1",
+      "from": "stream-browserify@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "dev": true
     },
     "stream-cache": {
       "version": "0.0.2",
       "from": "stream-cache@~0.0.1",
       "resolved": "https://registry.npmjs.org/stream-cache/-/stream-cache-0.0.2.tgz",
+      "dev": true
+    },
+    "stream-http": {
+      "version": "2.6.3",
+      "from": "stream-http@>=2.3.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.6.3.tgz",
       "dev": true
     },
     "strict-uri-encode": {
@@ -5007,9 +5115,9 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
     },
     "svg-url-loader": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "from": "svg-url-loader@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/svg-url-loader/-/svg-url-loader-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/svg-url-loader/-/svg-url-loader-1.1.1.tgz",
       "dev": true,
       "dependencies": {
         "file-loader": {
@@ -5019,17 +5127,17 @@
           "dev": true
         },
         "loader-utils": {
-          "version": "0.2.15",
-          "from": "loader-utils@0.2.15",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.15.tgz",
+          "version": "0.2.16",
+          "from": "loader-utils@0.2.16",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
           "dev": true
         }
       }
     },
     "svgo": {
-      "version": "0.7.1",
+      "version": "0.7.2",
       "from": "svgo@>=0.7.0 <0.8.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
       "dev": true
     },
     "symbol-observable": {
@@ -5038,9 +5146,9 @@
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz"
     },
     "symbol-tree": {
-      "version": "3.1.4",
-      "from": "symbol-tree@>= 3.1.0 < 4.0.0",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.1.4.tgz",
+      "version": "3.2.2",
+      "from": "symbol-tree@^3.2.1",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
       "dev": true
     },
     "table": {
@@ -5081,6 +5189,12 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
       "dev": true
     },
+    "text-encoding": {
+      "version": "0.6.2",
+      "from": "text-encoding@0.6.2",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.2.tgz",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "from": "text-table@~0.2.0",
@@ -5094,15 +5208,27 @@
       "dev": true
     },
     "timers-browserify": {
-      "version": "1.4.2",
-      "from": "timers-browserify@^1.0.1",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "version": "2.0.2",
+      "from": "timers-browserify@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.31",
+      "from": "tmp@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
       "dev": true
     },
     "to-array": {
       "version": "0.1.4",
       "from": "to-array@0.1.4",
       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "dev": true
+    },
+    "to-arraybuffer": {
+      "version": "1.0.1",
+      "from": "to-arraybuffer@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "dev": true
     },
     "to-fast-properties": {
@@ -5123,7 +5249,7 @@
     },
     "tough-cookie": {
       "version": "2.3.2",
-      "from": "tough-cookie@^2.3.1",
+      "from": "tough-cookie@^2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "dev": true
     },
@@ -5138,6 +5264,11 @@
       "from": "trim-newlines@^1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "dev": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "from": "trim-right@^1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
     },
     "tryit": {
       "version": "1.0.3",
@@ -5157,13 +5288,6 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
       "dev": true
     },
-    "tweetnacl": {
-      "version": "0.14.3",
-      "from": "tweetnacl@>=0.14.0 <0.15.0",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-      "dev": true,
-      "optional": true
-    },
     "type-check": {
       "version": "0.3.2",
       "from": "type-check@~0.3.2",
@@ -5177,26 +5301,26 @@
       "dev": true
     },
     "type-is": {
-      "version": "1.6.13",
-      "from": "type-is@~1.6.13",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+      "version": "1.6.14",
+      "from": "type-is@~1.6.14",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
       "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
-      "from": "typedarray@~0.0.5",
+      "from": "typedarray@^0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.11",
-      "from": "ua-parser-js@>=0.7.9 <0.8.0",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.11.tgz"
+      "version": "0.7.12",
+      "from": "ua-parser-js@^0.7.9",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz"
     },
     "uglify-js": {
-      "version": "2.7.4",
+      "version": "2.7.5",
       "from": "uglify-js@>=2.7.3 <2.8.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
@@ -5254,9 +5378,9 @@
       "dev": true
     },
     "uniqid": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "from": "uniqid@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
       "dev": true
     },
     "uniqs": {
@@ -5272,9 +5396,9 @@
       "dev": true
     },
     "url": {
-      "version": "0.10.3",
-      "from": "url@~0.10.1",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "version": "0.11.0",
+      "from": "url@>=0.11.0 <0.12.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "dev": true,
       "dependencies": {
         "punycode": {
@@ -5300,9 +5424,9 @@
       }
     },
     "url-parse": {
-      "version": "1.1.7",
+      "version": "1.1.8",
       "from": "url-parse@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.8.tgz",
       "dev": true
     },
     "user-home": {
@@ -5312,9 +5436,9 @@
       "dev": true
     },
     "useragent": {
-      "version": "2.1.9",
+      "version": "2.1.12",
       "from": "useragent@>=2.1.6 <3.0.0",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.12.tgz",
       "dev": true,
       "dependencies": {
         "lru-cache": {
@@ -5327,7 +5451,7 @@
     },
     "util": {
       "version": "0.10.3",
-      "from": "util@~0.10.3",
+      "from": "util@^0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "dev": true,
       "dependencies": {
@@ -5352,9 +5476,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "2.0.3",
-      "from": "uuid@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+      "version": "3.0.1",
+      "from": "uuid@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -5392,6 +5516,12 @@
       "from": "void-elements@^2.0.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
     },
+    "walkdir": {
+      "version": "0.0.11",
+      "from": "walkdir@>=0.0.11 <0.0.12",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
+      "dev": true
+    },
     "watchpack": {
       "version": "0.2.9",
       "from": "watchpack@^0.2.1",
@@ -5407,15 +5537,15 @@
       }
     },
     "webidl-conversions": {
-      "version": "3.0.1",
-      "from": "webidl-conversions@^3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "version": "4.0.1",
+      "from": "webidl-conversions@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.1.tgz",
       "dev": true
     },
     "webpack": {
-      "version": "1.13.3",
+      "version": "1.14.0",
       "from": "webpack@>=1.13.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.13.3.tgz",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.14.0.tgz",
       "dev": true,
       "dependencies": {
         "interpret": {
@@ -5424,18 +5554,24 @@
           "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
           "dev": true
         },
+        "memory-fs": {
+          "version": "0.3.0",
+          "from": "memory-fs@~0.3.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+          "dev": true
+        },
         "supports-color": {
-          "version": "3.1.2",
+          "version": "3.2.3",
           "from": "supports-color@^3.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "dev": true
         }
       }
     },
     "webpack-core": {
-      "version": "0.6.8",
-      "from": "webpack-core@~0.6.0",
-      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
+      "version": "0.6.9",
+      "from": "webpack-core@~0.6.9",
+      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
       "dev": true,
       "dependencies": {
         "source-map": {
@@ -5447,21 +5583,21 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "1.8.4",
+      "version": "1.10.1",
       "from": "webpack-dev-middleware@>=1.0.11 <2.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.10.1.tgz",
       "dev": true
     },
     "webpack-dev-server": {
-      "version": "1.16.2",
+      "version": "1.16.3",
       "from": "webpack-dev-server@>=1.14.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.2.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.3.tgz",
       "dev": true,
       "dependencies": {
         "supports-color": {
-          "version": "3.1.2",
+          "version": "3.2.3",
           "from": "supports-color@^3.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "dev": true
         }
       }
@@ -5473,15 +5609,15 @@
       "dev": true
     },
     "webpack-notifier": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "from": "webpack-notifier@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-notifier/-/webpack-notifier-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-notifier/-/webpack-notifier-1.5.0.tgz",
       "dev": true
     },
     "webpack-sources": {
-      "version": "0.1.2",
+      "version": "0.1.4",
       "from": "webpack-sources@^0.1.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.4.tgz",
       "dev": true
     },
     "websocket-driver": {
@@ -5500,18 +5636,34 @@
       "version": "1.0.1",
       "from": "whatwg-encoding@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.13",
+          "from": "iconv-lite@0.4.13",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+          "dev": true
+        }
+      }
     },
     "whatwg-fetch": {
-      "version": "1.0.0",
+      "version": "2.0.2",
       "from": "whatwg-fetch@>=0.10.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.2.tgz"
     },
     "whatwg-url": {
-      "version": "3.0.0",
-      "from": "whatwg-url@^3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-3.0.0.tgz",
-      "dev": true
+      "version": "4.4.0",
+      "from": "whatwg-url@>=4.3.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.4.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "from": "webidl-conversions@^3.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "dev": true
+        }
+      }
     },
     "whet.extend": {
       "version": "0.9.9",
@@ -5520,9 +5672,9 @@
       "dev": true
     },
     "which": {
-      "version": "1.2.11",
+      "version": "1.2.12",
       "from": "which@^1.2.9",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
       "dev": true
     },
     "which-module": {
@@ -5533,7 +5685,7 @@
     },
     "wide-align": {
       "version": "1.1.0",
-      "from": "wide-align@>=1.1.0 <2.0.0",
+      "from": "wide-align@^1.1.0",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
       "dev": true
     },
@@ -5546,14 +5698,7 @@
     "with": {
       "version": "5.1.1",
       "from": "with@>=5.0.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz",
-      "dependencies": {
-        "acorn-globals": {
-          "version": "3.0.0",
-          "from": "acorn-globals@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.0.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz"
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -5564,12 +5709,12 @@
     "wp-calypso": {
       "version": "0.17.0",
       "from": "automattic/wp-calypso",
-      "resolved": "git://github.com/automattic/wp-calypso.git#8fa4b40fbd2fa7588596e08f8b79096028883e6e",
+      "resolved": "git://github.com/automattic/wp-calypso.git#c1fbbf0d09629399d85aab102f3bbe9432e1ecb7",
       "dependencies": {
         "abbrev": {
-          "version": "1.0.9",
-          "from": "abbrev@1.0.9",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+          "version": "1.1.0",
+          "from": "abbrev@1.1.0",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
         },
         "abstract-leveldown": {
           "version": "2.4.1",
@@ -5587,9 +5732,9 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
         },
         "after": {
-          "version": "0.8.2",
-          "from": "after@0.8.2",
-          "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
+          "version": "0.8.1",
+          "from": "after@0.8.1",
+          "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
         },
         "align-text": {
           "version": "0.1.4",
@@ -5601,15 +5746,10 @@
           "from": "amdefine@1.0.1",
           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
         },
-        "ansi": {
-          "version": "0.3.1",
-          "from": "ansi@0.3.1",
-          "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
-        },
         "ansi-regex": {
-          "version": "2.0.0",
-          "from": "ansi-regex@2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+          "version": "2.1.1",
+          "from": "ansi-regex@2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
         },
         "ansi-styles": {
           "version": "2.2.1",
@@ -5620,6 +5760,11 @@
           "version": "1.3.0",
           "from": "anymatch@1.3.0",
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz"
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "from": "aproba@1.1.1",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz"
         },
         "are-we-there-yet": {
           "version": "1.1.2",
@@ -5645,11 +5790,6 @@
           "version": "1.1.1",
           "from": "array-flatten@1.1.1",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
-        },
-        "array-index": {
-          "version": "1.0.0",
-          "from": "array-index@1.0.0",
-          "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz"
         },
         "array-union": {
           "version": "1.0.2",
@@ -5697,9 +5837,9 @@
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
         },
         "ast-types": {
-          "version": "0.9.0",
-          "from": "ast-types@0.9.0",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.0.tgz"
+          "version": "0.9.5",
+          "from": "ast-types@0.9.5",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.5.tgz"
         },
         "async": {
           "version": "0.9.0",
@@ -5742,14 +5882,14 @@
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "aws4": {
-          "version": "1.5.0",
-          "from": "aws4@1.5.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
+          "version": "1.6.0",
+          "from": "aws4@1.6.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
         },
         "babel-code-frame": {
-          "version": "6.16.0",
-          "from": "babel-code-frame@6.16.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
+          "version": "6.22.0",
+          "from": "babel-code-frame@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
@@ -5776,9 +5916,9 @@
           }
         },
         "babel-generator": {
-          "version": "6.18.0",
-          "from": "babel-generator@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.18.0.tgz",
+          "version": "6.23.0",
+          "from": "babel-generator@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.23.0.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.5.6",
@@ -5788,69 +5928,69 @@
           }
         },
         "babel-helper-builder-binary-assignment-operator-visitor": {
-          "version": "6.18.0",
-          "from": "babel-helper-builder-binary-assignment-operator-visitor@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.18.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-helper-builder-binary-assignment-operator-visitor@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.22.0.tgz"
         },
         "babel-helper-builder-react-jsx": {
-          "version": "6.18.0",
-          "from": "babel-helper-builder-react-jsx@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.18.0.tgz"
+          "version": "6.23.0",
+          "from": "babel-helper-builder-react-jsx@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.23.0.tgz"
         },
         "babel-helper-call-delegate": {
-          "version": "6.18.0",
-          "from": "babel-helper-call-delegate@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.18.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-helper-call-delegate@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.22.0.tgz"
         },
         "babel-helper-define-map": {
-          "version": "6.18.0",
-          "from": "babel-helper-define-map@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz"
+          "version": "6.23.0",
+          "from": "babel-helper-define-map@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.23.0.tgz"
         },
         "babel-helper-explode-assignable-expression": {
-          "version": "6.18.0",
-          "from": "babel-helper-explode-assignable-expression@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.18.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-helper-explode-assignable-expression@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.22.0.tgz"
         },
         "babel-helper-function-name": {
-          "version": "6.18.0",
-          "from": "babel-helper-function-name@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz"
+          "version": "6.23.0",
+          "from": "babel-helper-function-name@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.23.0.tgz"
         },
         "babel-helper-get-function-arity": {
-          "version": "6.18.0",
-          "from": "babel-helper-get-function-arity@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-helper-get-function-arity@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz"
         },
         "babel-helper-hoist-variables": {
-          "version": "6.18.0",
-          "from": "babel-helper-hoist-variables@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.18.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-helper-hoist-variables@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.22.0.tgz"
         },
         "babel-helper-optimise-call-expression": {
-          "version": "6.18.0",
-          "from": "babel-helper-optimise-call-expression@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.18.0.tgz"
+          "version": "6.23.0",
+          "from": "babel-helper-optimise-call-expression@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.23.0.tgz"
         },
         "babel-helper-regex": {
-          "version": "6.18.0",
-          "from": "babel-helper-regex@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.18.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-helper-regex@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.22.0.tgz"
         },
         "babel-helper-remap-async-to-generator": {
-          "version": "6.18.0",
-          "from": "babel-helper-remap-async-to-generator@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.18.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-helper-remap-async-to-generator@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.22.0.tgz"
         },
         "babel-helper-replace-supers": {
-          "version": "6.18.0",
-          "from": "babel-helper-replace-supers@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.18.0.tgz"
+          "version": "6.23.0",
+          "from": "babel-helper-replace-supers@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.23.0.tgz"
         },
         "babel-helpers": {
-          "version": "6.16.0",
-          "from": "babel-helpers@6.16.0",
-          "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz"
+          "version": "6.23.0",
+          "from": "babel-helpers@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.23.0.tgz"
         },
         "babel-loader": {
           "version": "6.2.4",
@@ -5858,9 +5998,9 @@
           "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.2.4.tgz"
         },
         "babel-messages": {
-          "version": "6.8.0",
-          "from": "babel-messages@6.8.0",
-          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
+          "version": "6.23.0",
+          "from": "babel-messages@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
         },
         "babel-plugin-add-module-exports": {
           "version": "0.2.1",
@@ -5868,9 +6008,9 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz"
         },
         "babel-plugin-check-es2015-constants": {
-          "version": "6.8.0",
-          "from": "babel-plugin-check-es2015-constants@6.8.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-plugin-check-es2015-constants@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz"
         },
         "babel-plugin-lodash": {
           "version": "3.2.0",
@@ -5913,19 +6053,19 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz"
         },
         "babel-plugin-syntax-trailing-function-commas": {
-          "version": "6.13.0",
-          "from": "babel-plugin-syntax-trailing-function-commas@6.13.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.13.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-plugin-syntax-trailing-function-commas@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz"
         },
         "babel-plugin-transform-async-generator-functions": {
-          "version": "6.17.0",
-          "from": "babel-plugin-transform-async-generator-functions@6.17.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.17.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-async-generator-functions@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.22.0.tgz"
         },
         "babel-plugin-transform-async-to-generator": {
-          "version": "6.16.0",
-          "from": "babel-plugin-transform-async-to-generator@6.16.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-async-to-generator@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.22.0.tgz"
         },
         "babel-plugin-transform-class-properties": {
           "version": "6.9.1",
@@ -5933,114 +6073,119 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.9.1.tgz"
         },
         "babel-plugin-transform-es2015-arrow-functions": {
-          "version": "6.8.0",
-          "from": "babel-plugin-transform-es2015-arrow-functions@6.8.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-arrow-functions@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz"
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
-          "version": "6.8.0",
-          "from": "babel-plugin-transform-es2015-block-scoped-functions@6.8.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-block-scoped-functions@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz"
         },
         "babel-plugin-transform-es2015-block-scoping": {
-          "version": "6.18.0",
-          "from": "babel-plugin-transform-es2015-block-scoping@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.18.0.tgz"
+          "version": "6.23.0",
+          "from": "babel-plugin-transform-es2015-block-scoping@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.23.0.tgz"
         },
         "babel-plugin-transform-es2015-classes": {
-          "version": "6.18.0",
-          "from": "babel-plugin-transform-es2015-classes@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.18.0.tgz"
+          "version": "6.23.0",
+          "from": "babel-plugin-transform-es2015-classes@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.23.0.tgz"
         },
         "babel-plugin-transform-es2015-computed-properties": {
-          "version": "6.8.0",
-          "from": "babel-plugin-transform-es2015-computed-properties@6.8.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-computed-properties@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.22.0.tgz"
         },
         "babel-plugin-transform-es2015-destructuring": {
-          "version": "6.18.0",
-          "from": "babel-plugin-transform-es2015-destructuring@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.18.0.tgz"
+          "version": "6.23.0",
+          "from": "babel-plugin-transform-es2015-destructuring@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz"
         },
         "babel-plugin-transform-es2015-duplicate-keys": {
-          "version": "6.8.0",
-          "from": "babel-plugin-transform-es2015-duplicate-keys@6.8.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-duplicate-keys@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.22.0.tgz"
         },
         "babel-plugin-transform-es2015-for-of": {
-          "version": "6.18.0",
-          "from": "babel-plugin-transform-es2015-for-of@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.18.0.tgz"
+          "version": "6.23.0",
+          "from": "babel-plugin-transform-es2015-for-of@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz"
         },
         "babel-plugin-transform-es2015-function-name": {
-          "version": "6.9.0",
-          "from": "babel-plugin-transform-es2015-function-name@6.9.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-function-name@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.22.0.tgz"
         },
         "babel-plugin-transform-es2015-literals": {
-          "version": "6.8.0",
-          "from": "babel-plugin-transform-es2015-literals@6.8.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-literals@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz"
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
-          "version": "6.18.0",
-          "from": "babel-plugin-transform-es2015-modules-commonjs@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.18.0.tgz"
+          "version": "6.23.0",
+          "from": "babel-plugin-transform-es2015-modules-commonjs@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.23.0.tgz"
         },
         "babel-plugin-transform-es2015-object-super": {
-          "version": "6.8.0",
-          "from": "babel-plugin-transform-es2015-object-super@6.8.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-object-super@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.22.0.tgz"
         },
         "babel-plugin-transform-es2015-parameters": {
-          "version": "6.18.0",
-          "from": "babel-plugin-transform-es2015-parameters@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.18.0.tgz"
+          "version": "6.23.0",
+          "from": "babel-plugin-transform-es2015-parameters@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.23.0.tgz"
         },
         "babel-plugin-transform-es2015-shorthand-properties": {
-          "version": "6.18.0",
-          "from": "babel-plugin-transform-es2015-shorthand-properties@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.18.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-shorthand-properties@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.22.0.tgz"
         },
         "babel-plugin-transform-es2015-spread": {
-          "version": "6.8.0",
-          "from": "babel-plugin-transform-es2015-spread@6.8.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-spread@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz"
         },
         "babel-plugin-transform-es2015-sticky-regex": {
-          "version": "6.8.0",
-          "from": "babel-plugin-transform-es2015-sticky-regex@6.8.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-sticky-regex@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.22.0.tgz"
         },
         "babel-plugin-transform-es2015-template-literals": {
-          "version": "6.8.0",
-          "from": "babel-plugin-transform-es2015-template-literals@6.8.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-template-literals@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz"
         },
         "babel-plugin-transform-es2015-typeof-symbol": {
-          "version": "6.18.0",
-          "from": "babel-plugin-transform-es2015-typeof-symbol@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.18.0.tgz"
+          "version": "6.23.0",
+          "from": "babel-plugin-transform-es2015-typeof-symbol@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz"
         },
         "babel-plugin-transform-es2015-unicode-regex": {
-          "version": "6.11.0",
-          "from": "babel-plugin-transform-es2015-unicode-regex@6.11.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-unicode-regex@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.22.0.tgz"
         },
         "babel-plugin-transform-exponentiation-operator": {
-          "version": "6.8.0",
-          "from": "babel-plugin-transform-exponentiation-operator@6.8.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.8.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-exponentiation-operator@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.22.0.tgz"
         },
         "babel-plugin-transform-export-extensions": {
           "version": "6.8.0",
           "from": "babel-plugin-transform-export-extensions@6.8.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.8.0.tgz"
         },
+        "babel-plugin-transform-imports": {
+          "version": "1.1.0",
+          "from": "babel-plugin-transform-imports@1.1.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-imports/-/babel-plugin-transform-imports-1.1.0.tgz"
+        },
         "babel-plugin-transform-object-rest-spread": {
-          "version": "6.16.0",
-          "from": "babel-plugin-transform-object-rest-spread@6.16.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.16.0.tgz"
+          "version": "6.23.0",
+          "from": "babel-plugin-transform-object-rest-spread@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz"
         },
         "babel-plugin-transform-react-display-name": {
           "version": "6.8.0",
@@ -6053,9 +6198,9 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.8.0.tgz"
         },
         "babel-plugin-transform-regenerator": {
-          "version": "6.16.1",
-          "from": "babel-plugin-transform-regenerator@6.16.1",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz"
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-regenerator@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.22.0.tgz"
         },
         "babel-plugin-transform-runtime": {
           "version": "6.9.0",
@@ -6063,9 +6208,9 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.9.0.tgz"
         },
         "babel-plugin-transform-strict-mode": {
-          "version": "6.18.0",
-          "from": "babel-plugin-transform-strict-mode@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.18.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-strict-mode@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.22.0.tgz"
         },
         "babel-preset-es2015": {
           "version": "6.9.0",
@@ -6078,9 +6223,9 @@
           "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.5.0.tgz"
         },
         "babel-preset-stage-3": {
-          "version": "6.17.0",
-          "from": "babel-preset-stage-3@6.17.0",
-          "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.17.0.tgz"
+          "version": "6.22.0",
+          "from": "babel-preset-stage-3@6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.22.0.tgz"
         },
         "babel-register": {
           "version": "6.9.0",
@@ -6100,29 +6245,29 @@
           }
         },
         "babel-runtime": {
-          "version": "6.18.0",
-          "from": "babel-runtime@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
+          "version": "6.23.0",
+          "from": "babel-runtime@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
         },
         "babel-template": {
-          "version": "6.16.0",
-          "from": "babel-template@6.16.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
+          "version": "6.23.0",
+          "from": "babel-template@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz"
         },
         "babel-traverse": {
-          "version": "6.18.0",
-          "from": "babel-traverse@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.18.0.tgz"
+          "version": "6.23.1",
+          "from": "babel-traverse@6.23.1",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz"
         },
         "babel-types": {
-          "version": "6.18.0",
-          "from": "babel-types@6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.18.0.tgz"
+          "version": "6.23.0",
+          "from": "babel-types@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
         },
         "babylon": {
-          "version": "6.13.1",
-          "from": "babylon@6.13.1",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.13.1.tgz"
+          "version": "6.15.0",
+          "from": "babylon@6.15.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
         },
         "backo2": {
           "version": "1.0.2",
@@ -6133,6 +6278,11 @@
           "version": "0.4.2",
           "from": "balanced-match@0.4.2",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+        },
+        "base62": {
+          "version": "0.1.1",
+          "from": "base62@0.1.1",
+          "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
         },
         "Base64": {
           "version": "0.2.1",
@@ -6170,9 +6320,9 @@
           "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
         },
         "binary-extensions": {
-          "version": "1.7.0",
-          "from": "binary-extensions@1.7.0",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.7.0.tgz"
+          "version": "1.8.0",
+          "from": "binary-extensions@1.8.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz"
         },
         "bindings": {
           "version": "1.2.1",
@@ -6180,19 +6330,14 @@
           "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
         },
         "bl": {
-          "version": "1.0.3",
-          "from": "bl@1.0.3",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
+          "version": "1.2.0",
+          "from": "bl@1.2.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.0.tgz",
           "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            },
             "readable-stream": {
-              "version": "2.0.6",
-              "from": "readable-stream@2.0.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+              "version": "2.2.2",
+              "from": "readable-stream@2.2.2",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
             }
           }
         },
@@ -6207,19 +6352,29 @@
           "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
         },
         "bluebird": {
-          "version": "3.4.6",
-          "from": "bluebird@3.4.6",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz"
+          "version": "2.11.0",
+          "from": "bluebird@2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
         },
         "body-parser": {
-          "version": "1.15.2",
-          "from": "body-parser@1.15.2",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz",
+          "version": "1.16.1",
+          "from": "body-parser@1.16.1",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.16.1.tgz",
           "dependencies": {
+            "debug": {
+              "version": "2.6.1",
+              "from": "debug@2.6.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz"
+            },
+            "ms": {
+              "version": "0.7.2",
+              "from": "ms@0.7.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+            },
             "qs": {
-              "version": "6.2.0",
-              "from": "qs@6.2.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
+              "version": "6.2.1",
+              "from": "qs@6.2.1",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
             }
           }
         },
@@ -6261,14 +6416,7 @@
         "buffer": {
           "version": "4.9.1",
           "from": "buffer@4.9.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            }
-          }
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz"
         },
         "buffer-shims": {
           "version": "1.0.0",
@@ -6318,9 +6466,9 @@
           }
         },
         "caniuse-db": {
-          "version": "1.0.30000574",
-          "from": "caniuse-db@1.0.30000574",
-          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000574.tgz"
+          "version": "1.0.30000623",
+          "from": "caniuse-db@1.0.30000623",
+          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000623.tgz"
         },
         "caseless": {
           "version": "0.11.0",
@@ -6380,9 +6528,9 @@
           "resolved": "https://registry.npmjs.org/classnames/-/classnames-1.1.1.tgz"
         },
         "clean-css": {
-          "version": "3.4.20",
-          "from": "clean-css@3.4.20",
-          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.20.tgz",
+          "version": "3.4.24",
+          "from": "clean-css@3.4.24",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.24.tgz",
           "dependencies": {
             "commander": {
               "version": "2.8.1",
@@ -6417,9 +6565,9 @@
           "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
         },
         "code-point-at": {
-          "version": "1.0.1",
-          "from": "code-point-at@1.0.1",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz"
+          "version": "1.1.0",
+          "from": "code-point-at@1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
         },
         "colors": {
           "version": "0.6.2",
@@ -6491,11 +6639,6 @@
           "from": "concat-stream@1.5.2",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
           "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            },
             "readable-stream": {
               "version": "2.0.6",
               "from": "readable-stream@2.0.6",
@@ -6507,6 +6650,11 @@
           "version": "1.1.0",
           "from": "console-browserify@1.1.0",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "from": "console-control-strings@1.1.0",
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
         },
         "constant-case": {
           "version": "1.1.2",
@@ -6529,9 +6677,9 @@
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
         },
         "convert-source-map": {
-          "version": "1.3.0",
-          "from": "convert-source-map@1.3.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz"
+          "version": "1.4.0",
+          "from": "convert-source-map@1.4.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.4.0.tgz"
         },
         "cookie": {
           "version": "0.1.2",
@@ -6552,6 +6700,23 @@
           "version": "2.1.0",
           "from": "cookiejar@2.1.0",
           "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.0.tgz"
+        },
+        "copy-webpack-plugin": {
+          "version": "3.0.1",
+          "from": "copy-webpack-plugin@3.0.1",
+          "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-3.0.1.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "6.0.4",
+              "from": "glob@6.0.4",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
+            },
+            "minimatch": {
+              "version": "3.0.3",
+              "from": "minimatch@3.0.3",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+            }
+          }
         },
         "core-js": {
           "version": "2.4.1",
@@ -6598,15 +6763,10 @@
           "from": "currently-unhandled@0.4.1",
           "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz"
         },
-        "d": {
-          "version": "0.1.1",
-          "from": "d@0.1.1",
-          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-        },
         "dashdash": {
-          "version": "1.14.0",
-          "from": "dashdash@1.14.0",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+          "version": "1.14.1",
+          "from": "dashdash@1.14.1",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -6646,9 +6806,9 @@
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
         },
         "delegate": {
-          "version": "3.1.0",
-          "from": "delegate@3.1.0",
-          "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.1.0.tgz"
+          "version": "3.1.1",
+          "from": "delegate@3.1.1",
+          "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.1.1.tgz"
         },
         "delegates": {
           "version": "1.0.0",
@@ -6660,11 +6820,6 @@
           "from": "depd@1.1.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
-        "desandro-matches-selector": {
-          "version": "2.0.1",
-          "from": "desandro-matches-selector@2.0.1",
-          "resolved": "https://registry.npmjs.org/desandro-matches-selector/-/desandro-matches-selector-2.0.1.tgz"
-        },
         "destroy": {
           "version": "1.0.3",
           "from": "destroy@1.0.3",
@@ -6674,6 +6829,11 @@
           "version": "4.0.0",
           "from": "detect-indent@4.0.0",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz"
+        },
+        "doctrine": {
+          "version": "2.0.0",
+          "from": "doctrine@2.0.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz"
         },
         "dom-helpers": {
           "version": "2.4.0",
@@ -6730,24 +6890,17 @@
         "draft-js": {
           "version": "0.8.1",
           "from": "draft-js@0.8.1",
-          "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.8.1.tgz",
-          "dependencies": {
-            "immutable": {
-              "version": "3.7.6",
-              "from": "immutable@3.7.6",
-              "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz"
-            }
-          }
-        },
-        "duplexer2": {
-          "version": "0.0.2",
-          "from": "duplexer2@0.0.2",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.8.1.tgz"
         },
         "ee-first": {
           "version": "1.1.1",
           "from": "ee-first@1.1.1",
           "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+        },
+        "element-class": {
+          "version": "0.2.2",
+          "from": "element-class@0.2.2",
+          "resolved": "https://registry.npmjs.org/element-class/-/element-class-0.2.2.tgz"
         },
         "email-validator": {
           "version": "1.0.1",
@@ -6758,6 +6911,11 @@
           "version": "1.0.0",
           "from": "emitter-component@1.0.0",
           "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.0.0.tgz"
+        },
+        "emoji-text": {
+          "version": "0.2.6",
+          "from": "emoji-text@0.2.6",
+          "resolved": "https://registry.npmjs.org/emoji-text/-/emoji-text-0.2.6.tgz"
         },
         "emojis-list": {
           "version": "2.1.0",
@@ -6798,15 +6956,15 @@
           "from": "engine.io-parser@1.2.4",
           "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
           "dependencies": {
-            "after": {
-              "version": "0.8.1",
-              "from": "after@0.8.1",
-              "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
-            },
             "has-binary": {
               "version": "0.1.6",
               "from": "has-binary@0.1.6",
               "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz"
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             }
           }
         },
@@ -6849,20 +7007,17 @@
           "from": "error-ex@1.3.0",
           "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
         },
-        "es5-ext": {
-          "version": "0.10.12",
-          "from": "es5-ext@0.10.12",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
-        },
-        "es6-iterator": {
-          "version": "2.0.0",
-          "from": "es6-iterator@2.0.0",
-          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
-        },
-        "es6-symbol": {
-          "version": "3.1.0",
-          "from": "es6-symbol@3.1.0",
-          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
+        "es3ify": {
+          "version": "0.1.4",
+          "from": "es3ify@0.1.4",
+          "resolved": "https://registry.npmjs.org/es3ify/-/es3ify-0.1.4.tgz",
+          "dependencies": {
+            "esprima-fb": {
+              "version": "3001.1.0-dev-harmony-fb",
+              "from": "esprima-fb@3001.1.0-dev-harmony-fb",
+              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+            }
+          }
         },
         "es6-templates": {
           "version": "0.2.3",
@@ -6889,10 +7044,15 @@
           "from": "escape-string-regexp@1.0.3",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
         },
+        "esmangle-evaluator": {
+          "version": "1.0.1",
+          "from": "esmangle-evaluator@1.0.1",
+          "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.1.tgz"
+        },
         "esprima": {
-          "version": "3.1.1",
-          "from": "esprima@3.1.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.1.tgz"
+          "version": "3.1.3",
+          "from": "esprima@3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
         },
         "estree-walker": {
           "version": "0.2.1",
@@ -6909,20 +7069,15 @@
           "from": "etag@1.7.0",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
         },
-        "ev-emitter": {
-          "version": "1.0.3",
-          "from": "ev-emitter@1.0.3",
-          "resolved": "https://registry.npmjs.org/ev-emitter/-/ev-emitter-1.0.3.tgz"
-        },
         "events": {
           "version": "1.0.2",
           "from": "events@1.0.2",
           "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
         },
-        "execspawn": {
-          "version": "1.0.1",
-          "from": "execspawn@1.0.1",
-          "resolved": "https://registry.npmjs.org/execspawn/-/execspawn-1.0.1.tgz"
+        "exenv": {
+          "version": "1.2.0",
+          "from": "exenv@1.2.0",
+          "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.0.tgz"
         },
         "expand-brackets": {
           "version": "0.1.5",
@@ -6986,10 +7141,27 @@
           "from": "extsprintf@1.0.2",
           "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
         },
+        "falafel": {
+          "version": "1.2.0",
+          "from": "falafel@1.2.0",
+          "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
+          "dependencies": {
+            "acorn": {
+              "version": "1.2.2",
+              "from": "acorn@1.2.2",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            }
+          }
+        },
         "fast-future": {
-          "version": "1.0.1",
-          "from": "fast-future@1.0.1",
-          "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.1.tgz"
+          "version": "1.0.2",
+          "from": "fast-future@1.0.2",
+          "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz"
         },
         "fast-luhn": {
           "version": "1.0.3",
@@ -7007,9 +7179,9 @@
           "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-2.1.1.tgz"
         },
         "fbjs": {
-          "version": "0.8.5",
-          "from": "fbjs@0.8.5",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.5.tgz",
+          "version": "0.8.9",
+          "from": "fbjs@0.8.9",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.9.tgz",
           "dependencies": {
             "core-js": {
               "version": "1.2.7",
@@ -7074,10 +7246,10 @@
             }
           }
         },
-        "fizzy-ui-utils": {
-          "version": "2.0.3",
-          "from": "fizzy-ui-utils@2.0.3",
-          "resolved": "https://registry.npmjs.org/fizzy-ui-utils/-/fizzy-ui-utils-2.0.3.tgz"
+        "flag-icon-css": {
+          "version": "2.3.0",
+          "from": "flag-icon-css@2.3.0",
+          "resolved": "https://registry.npmjs.org/flag-icon-css/-/flag-icon-css-2.3.0.tgz"
         },
         "flux": {
           "version": "2.1.1",
@@ -7111,6 +7283,11 @@
           "from": "for-own@0.1.4",
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz"
         },
+        "foreach": {
+          "version": "2.0.5",
+          "from": "foreach@2.0.5",
+          "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+        },
         "foreachasync": {
           "version": "3.0.0",
           "from": "foreachasync@3.0.0",
@@ -7122,14 +7299,14 @@
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
-          "version": "2.1.1",
-          "from": "form-data@2.1.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.1.tgz"
+          "version": "2.1.2",
+          "from": "form-data@2.1.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz"
         },
         "formidable": {
-          "version": "1.0.17",
-          "from": "formidable@1.0.17",
-          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
+          "version": "1.1.1",
+          "from": "formidable@1.1.1",
+          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz"
         },
         "forwarded": {
           "version": "0.1.0",
@@ -7141,6 +7318,11 @@
           "from": "fresh@0.3.0",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
         },
+        "fs-extra": {
+          "version": "0.26.7",
+          "from": "fs-extra@0.26.7",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz"
+        },
         "fs.realpath": {
           "version": "1.0.0",
           "from": "fs.realpath@1.0.0",
@@ -7151,15 +7333,20 @@
           "from": "fstream@1.0.10",
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz"
         },
+        "fuse.js": {
+          "version": "2.6.1",
+          "from": "fuse.js@2.6.1",
+          "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-2.6.1.tgz"
+        },
         "gather-stream": {
           "version": "1.0.0",
           "from": "gather-stream@1.0.0",
           "resolved": "https://registry.npmjs.org/gather-stream/-/gather-stream-1.0.0.tgz"
         },
         "gauge": {
-          "version": "1.2.7",
-          "from": "gauge@1.2.7",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz"
+          "version": "2.7.3",
+          "from": "gauge@2.7.3",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz"
         },
         "gaze": {
           "version": "1.1.2",
@@ -7186,20 +7373,15 @@
           "from": "get-document@1.0.0",
           "resolved": "https://registry.npmjs.org/get-document/-/get-document-1.0.0.tgz"
         },
-        "get-size": {
-          "version": "2.0.2",
-          "from": "get-size@2.0.2",
-          "resolved": "https://registry.npmjs.org/get-size/-/get-size-2.0.2.tgz"
-        },
         "get-stdin": {
           "version": "4.0.1",
           "from": "get-stdin@4.0.1",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
         },
         "get-video-id": {
-          "version": "1.1.0",
-          "from": "get-video-id@1.1.0",
-          "resolved": "https://registry.npmjs.org/get-video-id/-/get-video-id-1.1.0.tgz"
+          "version": "2.1.0",
+          "from": "get-video-id@2.1.0",
+          "resolved": "https://registry.npmjs.org/get-video-id/-/get-video-id-2.1.0.tgz"
         },
         "getpass": {
           "version": "0.1.6",
@@ -7212,21 +7394,6 @@
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
             }
           }
-        },
-        "ghreleases": {
-          "version": "1.0.5",
-          "from": "ghreleases@1.0.5",
-          "resolved": "https://registry.npmjs.org/ghreleases/-/ghreleases-1.0.5.tgz"
-        },
-        "ghrepos": {
-          "version": "2.0.0",
-          "from": "ghrepos@2.0.0",
-          "resolved": "https://registry.npmjs.org/ghrepos/-/ghrepos-2.0.0.tgz"
-        },
-        "ghutils": {
-          "version": "3.2.1",
-          "from": "ghutils@3.2.1",
-          "resolved": "https://registry.npmjs.org/ghutils/-/ghutils-3.2.1.tgz"
         },
         "github-from-package": {
           "version": "0.0.0",
@@ -7249,9 +7416,9 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
         },
         "globals": {
-          "version": "9.12.0",
-          "from": "globals@9.12.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.12.0.tgz"
+          "version": "9.15.0",
+          "from": "globals@9.15.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.15.0.tgz"
         },
         "globby": {
           "version": "3.0.1",
@@ -7298,19 +7465,24 @@
           }
         },
         "good-listener": {
-          "version": "1.2.0",
-          "from": "good-listener@1.2.0",
-          "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.0.tgz"
+          "version": "1.2.1",
+          "from": "good-listener@1.2.1",
+          "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.1.tgz"
         },
         "graceful-fs": {
-          "version": "4.1.10",
-          "from": "graceful-fs@4.1.10",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz"
+          "version": "4.1.11",
+          "from": "graceful-fs@4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
         },
         "graceful-readlink": {
           "version": "1.0.1",
           "from": "graceful-readlink@1.0.1",
           "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+        },
+        "gridicons": {
+          "version": "1.0.0",
+          "from": "gridicons@1.0.0",
+          "resolved": "https://registry.npmjs.org/gridicons/-/gridicons-1.0.0.tgz"
         },
         "har-validator": {
           "version": "2.0.6",
@@ -7339,6 +7511,11 @@
           "from": "hard-source-webpack-plugin@0.0.42",
           "resolved": "https://registry.npmjs.org/hard-source-webpack-plugin/-/hard-source-webpack-plugin-0.0.42.tgz",
           "dependencies": {
+            "bluebird": {
+              "version": "3.4.7",
+              "from": "bluebird@3.4.7",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz"
+            },
             "source-map": {
               "version": "0.5.6",
               "from": "source-map@0.5.6",
@@ -7354,7 +7531,14 @@
         "has-binary": {
           "version": "0.1.7",
           "from": "has-binary@0.1.7",
-          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz"
+          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            }
+          }
         },
         "has-cors": {
           "version": "1.1.0",
@@ -7397,9 +7581,9 @@
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
         },
         "hosted-git-info": {
-          "version": "2.1.5",
-          "from": "hosted-git-info@2.1.5",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
+          "version": "2.2.0",
+          "from": "hosted-git-info@2.2.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.2.0.tgz"
         },
         "html-loader": {
           "version": "0.4.0",
@@ -7456,9 +7640,16 @@
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz"
         },
         "http-errors": {
-          "version": "1.5.0",
-          "from": "http-errors@1.5.0",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz"
+          "version": "1.5.1",
+          "from": "http-errors@1.5.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.3",
+              "from": "inherits@2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            }
+          }
         },
         "http-signature": {
           "version": "1.1.1",
@@ -7470,15 +7661,10 @@
           "from": "https-browserify@0.0.0",
           "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
         },
-        "hyperquest": {
-          "version": "1.2.0",
-          "from": "hyperquest@1.2.0",
-          "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-1.2.0.tgz"
-        },
         "i18n-calypso": {
-          "version": "1.6.2",
-          "from": "i18n-calypso@1.6.2",
-          "resolved": "https://registry.npmjs.org/i18n-calypso/-/i18n-calypso-1.6.2.tgz",
+          "version": "1.7.0",
+          "from": "i18n-calypso@1.7.0",
+          "resolved": "https://registry.npmjs.org/i18n-calypso/-/i18n-calypso-1.7.0.tgz",
           "dependencies": {
             "async": {
               "version": "1.5.2",
@@ -7489,28 +7675,38 @@
               "version": "2.9.0",
               "from": "commander@2.9.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+            },
+            "glob": {
+              "version": "7.1.1",
+              "from": "glob@7.1.1",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+            },
+            "minimatch": {
+              "version": "3.0.3",
+              "from": "minimatch@3.0.3",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
             }
           }
         },
         "iconv-lite": {
-          "version": "0.4.13",
-          "from": "iconv-lite@0.4.13",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+          "version": "0.4.15",
+          "from": "iconv-lite@0.4.15",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
         },
         "ieee754": {
           "version": "1.1.8",
           "from": "ieee754@1.1.8",
           "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
         },
-        "imagesloaded": {
-          "version": "4.1.1",
-          "from": "imagesloaded@4.1.1",
-          "resolved": "https://registry.npmjs.org/imagesloaded/-/imagesloaded-4.1.1.tgz"
+        "immediate": {
+          "version": "3.0.6",
+          "from": "immediate@3.0.6",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz"
         },
         "immutable": {
-          "version": "3.8.1",
-          "from": "immutable@3.8.1",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz"
+          "version": "3.7.6",
+          "from": "immutable@3.7.6",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz"
         },
         "imports-loader": {
           "version": "0.6.5",
@@ -7552,6 +7748,11 @@
           "from": "ini@1.3.4",
           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
         },
+        "inline-process-browser": {
+          "version": "1.0.0",
+          "from": "inline-process-browser@1.0.0",
+          "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-1.0.0.tgz"
+        },
         "interpolate-components": {
           "version": "1.1.0",
           "from": "interpolate-components@1.1.0",
@@ -7563,9 +7764,9 @@
           "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
         },
         "invariant": {
-          "version": "2.2.1",
-          "from": "invariant@2.2.1",
-          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz"
+          "version": "2.2.2",
+          "from": "invariant@2.2.2",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz"
         },
         "invert-kv": {
           "version": "1.0.0",
@@ -7693,9 +7894,9 @@
           "resolved": "https://registry.npmjs.org/is-valid-month/-/is-valid-month-1.0.0.tgz"
         },
         "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+          "version": "1.0.0",
+          "from": "isarray@1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "isexe": {
           "version": "1.1.2",
@@ -7705,14 +7906,7 @@
         "isobject": {
           "version": "2.1.0",
           "from": "isobject@2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            }
-          }
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
         },
         "isomorphic-fetch": {
           "version": "2.2.1",
@@ -7744,20 +7938,20 @@
           "from": "js-base64@2.1.9",
           "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
         },
+        "js-sha1": {
+          "version": "0.4.1",
+          "from": "js-sha1@0.4.1",
+          "resolved": "https://registry.npmjs.org/js-sha1/-/js-sha1-0.4.1.tgz"
+        },
         "js-tokens": {
-          "version": "2.0.0",
-          "from": "js-tokens@2.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
+          "version": "3.0.1",
+          "from": "js-tokens@3.0.1",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
         },
         "jsesc": {
           "version": "1.3.0",
           "from": "jsesc@1.3.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz"
-        },
-        "jshashes": {
-          "version": "1.0.5",
-          "from": "jshashes@1.0.5",
-          "resolved": "https://registry.npmjs.org/jshashes/-/jshashes-1.0.5.tgz"
         },
         "json-loader": {
           "version": "0.5.4",
@@ -7784,10 +7978,10 @@
           "from": "json5@0.4.0",
           "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
         },
-        "jsonist": {
-          "version": "1.3.0",
-          "from": "jsonist@1.3.0",
-          "resolved": "https://registry.npmjs.org/jsonist/-/jsonist-1.3.0.tgz"
+        "jsonfile": {
+          "version": "2.4.0",
+          "from": "jsonfile@2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz"
         },
         "jsonpointer": {
           "version": "2.0.0",
@@ -7804,6 +7998,23 @@
           "from": "jstimezonedetect@1.0.5",
           "resolved": "https://registry.npmjs.org/jstimezonedetect/-/jstimezonedetect-1.0.5.tgz"
         },
+        "jstransform": {
+          "version": "3.0.0",
+          "from": "jstransform@3.0.0",
+          "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-3.0.0.tgz",
+          "dependencies": {
+            "esprima-fb": {
+              "version": "3001.1.0-dev-harmony-fb",
+              "from": "esprima-fb@3001.1.0-dev-harmony-fb",
+              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+            },
+            "source-map": {
+              "version": "0.1.31",
+              "from": "source-map@0.1.31",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz"
+            }
+          }
+        },
         "key-mirror": {
           "version": "1.0.1",
           "from": "key-mirror@1.0.1",
@@ -7815,9 +8026,14 @@
           "resolved": "https://registry.npmjs.org/keymaster/-/keymaster-1.6.2.tgz"
         },
         "kind-of": {
-          "version": "3.0.4",
-          "from": "kind-of@3.0.4",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz"
+          "version": "3.1.0",
+          "from": "kind-of@3.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz"
+        },
+        "klaw": {
+          "version": "1.3.1",
+          "from": "klaw@1.3.1",
+          "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz"
         },
         "lazy-cache": {
           "version": "1.0.4",
@@ -7830,9 +8046,9 @@
           "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
         },
         "level": {
-          "version": "1.5.0",
-          "from": "level@1.5.0",
-          "resolved": "https://registry.npmjs.org/level/-/level-1.5.0.tgz"
+          "version": "1.6.0",
+          "from": "level@1.6.0",
+          "resolved": "https://registry.npmjs.org/level/-/level-1.6.0.tgz"
         },
         "level-codec": {
           "version": "6.1.0",
@@ -7850,14 +8066,14 @@
           "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz"
         },
         "level-packager": {
-          "version": "1.2.0",
-          "from": "level-packager@1.2.0",
-          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-1.2.0.tgz"
+          "version": "1.2.1",
+          "from": "level-packager@1.2.1",
+          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-1.2.1.tgz"
         },
         "leveldown": {
-          "version": "1.5.0",
-          "from": "leveldown@1.5.0",
-          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.5.0.tgz",
+          "version": "1.6.0",
+          "from": "leveldown@1.6.0",
+          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.6.0.tgz",
           "dependencies": {
             "abstract-leveldown": {
               "version": "2.6.1",
@@ -7871,6 +8087,11 @@
           "from": "levelup@1.3.3",
           "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.3.tgz"
         },
+        "lie": {
+          "version": "3.0.2",
+          "from": "lie@3.0.2",
+          "resolved": "https://registry.npmjs.org/lie/-/lie-3.0.2.tgz"
+        },
         "load-json-file": {
           "version": "1.1.0",
           "from": "load-json-file@1.1.0",
@@ -7882,28 +8103,16 @@
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
           "dependencies": {
             "json5": {
-              "version": "0.5.0",
-              "from": "json5@0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
+              "version": "0.5.1",
+              "from": "json5@0.5.1",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
             }
           }
         },
         "localforage": {
-          "version": "1.4.0",
-          "from": "localforage@1.4.0",
-          "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.4.0.tgz",
-          "dependencies": {
-            "asap": {
-              "version": "1.0.0",
-              "from": "asap@1.0.0",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
-            },
-            "promise": {
-              "version": "5.0.0",
-              "from": "promise@5.0.0",
-              "resolved": "https://registry.npmjs.org/promise/-/promise-5.0.0.tgz"
-            }
-          }
+          "version": "1.4.3",
+          "from": "localforage@1.4.3",
+          "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.4.3.tgz"
         },
         "lodash": {
           "version": "4.15.0",
@@ -7915,30 +8124,15 @@
           "from": "lodash.assign@4.2.0",
           "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
         },
-        "lodash.debounce": {
-          "version": "4.0.8",
-          "from": "lodash.debounce@4.0.8",
-          "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz"
+        "lodash.flatten": {
+          "version": "4.4.0",
+          "from": "lodash.flatten@4.4.0",
+          "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz"
         },
-        "lodash.omit": {
-          "version": "4.5.0",
-          "from": "lodash.omit@4.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz"
-        },
-        "lodash.pad": {
-          "version": "4.5.1",
-          "from": "lodash.pad@4.5.1",
-          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz"
-        },
-        "lodash.padend": {
-          "version": "4.6.1",
-          "from": "lodash.padend@4.6.1",
-          "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz"
-        },
-        "lodash.padstart": {
-          "version": "4.6.1",
-          "from": "lodash.padstart@4.6.1",
-          "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz"
+        "lodash.kebabcase": {
+          "version": "4.1.1",
+          "from": "lodash.kebabcase@4.1.1",
+          "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz"
         },
         "longest": {
           "version": "1.0.1",
@@ -7946,9 +8140,9 @@
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
         },
         "loose-envify": {
-          "version": "1.3.0",
-          "from": "loose-envify@1.3.0",
-          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz"
+          "version": "1.3.1",
+          "from": "loose-envify@1.3.1",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
         },
         "loud-rejection": {
           "version": "1.6.0",
@@ -7965,10 +8159,15 @@
           "from": "lower-case-first@1.0.2",
           "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz"
         },
+        "lru": {
+          "version": "3.1.0",
+          "from": "lru@3.1.0",
+          "resolved": "https://registry.npmjs.org/lru/-/lru-3.1.0.tgz"
+        },
         "lru-cache": {
-          "version": "4.0.1",
-          "from": "lru-cache@4.0.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz"
+          "version": "4.0.2",
+          "from": "lru-cache@4.0.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz"
         },
         "lunr": {
           "version": "0.5.7",
@@ -7985,11 +8184,6 @@
           "from": "marked@0.3.5",
           "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz"
         },
-        "masonry-layout": {
-          "version": "4.1.1",
-          "from": "masonry-layout@4.1.1",
-          "resolved": "https://registry.npmjs.org/masonry-layout/-/masonry-layout-4.1.1.tgz"
-        },
         "media-typer": {
           "version": "0.3.0",
           "from": "media-typer@0.3.0",
@@ -8000,15 +8194,10 @@
           "from": "memory-fs@0.3.0",
           "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
           "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            },
             "readable-stream": {
-              "version": "2.1.5",
-              "from": "readable-stream@2.1.5",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
+              "version": "2.2.2",
+              "from": "readable-stream@2.2.2",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
             }
           }
         },
@@ -8045,14 +8234,14 @@
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         },
         "mime-db": {
-          "version": "1.24.0",
-          "from": "mime-db@1.24.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+          "version": "1.26.0",
+          "from": "mime-db@1.26.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
         },
         "mime-types": {
-          "version": "2.1.12",
-          "from": "mime-types@2.1.12",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
+          "version": "2.1.14",
+          "from": "mime-types@2.1.14",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz"
         },
         "minimatch": {
           "version": "2.0.10",
@@ -8102,9 +8291,9 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
         "nan": {
-          "version": "2.4.0",
-          "from": "nan@2.4.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
+          "version": "2.5.1",
+          "from": "nan@2.5.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz"
         },
         "ncname": {
           "version": "1.0.0",
@@ -8121,10 +8310,27 @@
           "from": "neo-async@1.8.2",
           "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-1.8.2.tgz"
         },
+        "node-abi": {
+          "version": "1.3.3",
+          "from": "node-abi@1.3.3",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-1.3.3.tgz"
+        },
         "node-contains": {
           "version": "1.0.0",
           "from": "node-contains@1.0.0",
           "resolved": "https://registry.npmjs.org/node-contains/-/node-contains-1.0.0.tgz"
+        },
+        "node-dir": {
+          "version": "0.1.16",
+          "from": "node-dir@0.1.16",
+          "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.16.tgz",
+          "dependencies": {
+            "minimatch": {
+              "version": "3.0.3",
+              "from": "minimatch@3.0.3",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+            }
+          }
         },
         "node-fetch": {
           "version": "1.6.3",
@@ -8132,9 +8338,9 @@
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz"
         },
         "node-gyp": {
-          "version": "3.4.0",
-          "from": "node-gyp@3.4.0",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz",
+          "version": "3.5.0",
+          "from": "node-gyp@3.5.0",
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.5.0.tgz",
           "dependencies": {
             "minimatch": {
               "version": "3.0.3",
@@ -8147,18 +8353,6 @@
           "version": "0.6.0",
           "from": "node-libs-browser@0.6.0",
           "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.6.0.tgz"
-        },
-        "node-ninja": {
-          "version": "1.0.2",
-          "from": "node-ninja@1.0.2",
-          "resolved": "https://registry.npmjs.org/node-ninja/-/node-ninja-1.0.2.tgz",
-          "dependencies": {
-            "minimatch": {
-              "version": "3.0.3",
-              "from": "minimatch@3.0.3",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
-            }
-          }
         },
         "node-sass": {
           "version": "3.7.0",
@@ -8176,11 +8370,6 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
-        },
-        "node-uuid": {
-          "version": "1.4.7",
-          "from": "node-uuid@1.4.7",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
         },
         "noop-logger": {
           "version": "0.1.1",
@@ -8208,9 +8397,9 @@
           "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
         },
         "npmlog": {
-          "version": "2.0.4",
-          "from": "npmlog@2.0.4",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz"
+          "version": "4.0.2",
+          "from": "npmlog@4.0.2",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz"
         },
         "num2fraction": {
           "version": "1.2.2",
@@ -8228,14 +8417,19 @@
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
         },
         "object-assign": {
-          "version": "4.1.0",
-          "from": "object-assign@4.1.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+          "version": "4.1.1",
+          "from": "object-assign@4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
         },
         "object-component": {
           "version": "0.0.3",
           "from": "object-component@0.0.3",
           "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
+        },
+        "object-keys": {
+          "version": "1.0.11",
+          "from": "object-keys@1.0.11",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
         },
         "object.omit": {
           "version": "2.0.1",
@@ -8283,20 +8477,20 @@
           "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
         },
         "osenv": {
-          "version": "0.1.3",
-          "from": "osenv@0.1.3",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz"
-        },
-        "outlayer": {
-          "version": "2.1.0",
-          "from": "outlayer@2.1.0",
-          "resolved": "https://registry.npmjs.org/outlayer/-/outlayer-2.1.0.tgz"
+          "version": "0.1.4",
+          "from": "osenv@0.1.4",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
         },
         "page": {
           "version": "1.6.4",
           "from": "page@1.6.4",
           "resolved": "https://registry.npmjs.org/page/-/page-1.6.4.tgz",
           "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            },
             "path-to-regexp": {
               "version": "1.2.1",
               "from": "path-to-regexp@1.2.1",
@@ -8359,11 +8553,6 @@
           "from": "pascal-case@1.1.2",
           "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz"
         },
-        "path-array": {
-          "version": "1.0.1",
-          "from": "path-array@1.0.1",
-          "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz"
-        },
         "path-browserify": {
           "version": "0.0.0",
           "from": "path-browserify@0.0.0",
@@ -8384,11 +8573,6 @@
           "from": "path-is-absolute@1.0.1",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
         },
-        "path-parser": {
-          "version": "1.0.2",
-          "from": "path-parser@1.0.2",
-          "resolved": "https://registry.npmjs.org/path-parser/-/path-parser-1.0.2.tgz"
-        },
         "path-to-regexp": {
           "version": "0.1.7",
           "from": "path-to-regexp@0.1.7",
@@ -8408,11 +8592,6 @@
           "version": "3.0.0",
           "from": "percentage-regex@3.0.0",
           "resolved": "https://registry.npmjs.org/percentage-regex/-/percentage-regex-3.0.0.tgz"
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "from": "performance-now@0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
         },
         "phone": {
           "version": "1.0.8",
@@ -8440,9 +8619,9 @@
           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
         },
         "postcss": {
-          "version": "5.2.5",
-          "from": "postcss@5.2.5",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.5.tgz",
+          "version": "5.2.13",
+          "from": "postcss@5.2.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.13.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
@@ -8473,16 +8652,11 @@
           "from": "postcss-value-parser@3.3.0",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
         },
-        "prebuild": {
-          "version": "4.4.0",
-          "from": "prebuild@4.4.0",
-          "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-4.4.0.tgz",
+        "prebuild-install": {
+          "version": "2.1.0",
+          "from": "prebuild-install@2.1.0",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.1.0.tgz",
           "dependencies": {
-            "async": {
-              "version": "1.5.2",
-              "from": "async@1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-            },
             "minimist": {
               "version": "1.2.0",
               "from": "minimist@1.2.0",
@@ -8495,10 +8669,15 @@
           "from": "preserve@0.2.0",
           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
         },
+        "prismjs": {
+          "version": "1.6.0",
+          "from": "prismjs@1.6.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.6.0.tgz"
+        },
         "private": {
-          "version": "0.1.6",
-          "from": "private@0.1.6",
-          "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+          "version": "0.1.7",
+          "from": "private@0.1.7",
+          "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz"
         },
         "process": {
           "version": "0.11.9",
@@ -8536,9 +8715,9 @@
           "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
         },
         "pump": {
-          "version": "1.0.1",
-          "from": "pump@1.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.1.tgz"
+          "version": "1.0.2",
+          "from": "pump@1.0.2",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz"
         },
         "punycode": {
           "version": "1.4.1",
@@ -8575,15 +8754,10 @@
           "from": "querystring-es3@0.2.1",
           "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
         },
-        "raf": {
-          "version": "3.3.0",
-          "from": "raf@3.3.0",
-          "resolved": "https://registry.npmjs.org/raf/-/raf-3.3.0.tgz"
-        },
         "randomatic": {
-          "version": "1.1.5",
-          "from": "randomatic@1.1.5",
-          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
+          "version": "1.1.6",
+          "from": "randomatic@1.1.6",
+          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz"
         },
         "range-parser": {
           "version": "1.0.3",
@@ -8591,9 +8765,9 @@
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
         },
         "raw-body": {
-          "version": "2.1.7",
-          "from": "raw-body@2.1.7",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz"
+          "version": "2.2.0",
+          "from": "raw-body@2.2.0",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz"
         },
         "rc": {
           "version": "1.1.6",
@@ -8608,34 +8782,34 @@
           }
         },
         "react": {
-          "version": "15.3.0",
-          "from": "react@15.3.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-15.3.0.tgz"
+          "version": "15.4.0",
+          "from": "react@15.4.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-15.4.0.tgz"
         },
         "react-addons-create-fragment": {
-          "version": "15.3.0",
-          "from": "react-addons-create-fragment@15.3.0",
-          "resolved": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-15.3.0.tgz"
+          "version": "15.4.0",
+          "from": "react-addons-create-fragment@15.4.0",
+          "resolved": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-15.4.0.tgz"
         },
         "react-addons-css-transition-group": {
-          "version": "15.3.0",
-          "from": "react-addons-css-transition-group@15.3.0",
-          "resolved": "https://registry.npmjs.org/react-addons-css-transition-group/-/react-addons-css-transition-group-15.3.0.tgz"
+          "version": "15.4.0",
+          "from": "react-addons-css-transition-group@15.4.0",
+          "resolved": "https://registry.npmjs.org/react-addons-css-transition-group/-/react-addons-css-transition-group-15.4.0.tgz"
         },
         "react-addons-linked-state-mixin": {
-          "version": "15.3.0",
-          "from": "react-addons-linked-state-mixin@15.3.0",
-          "resolved": "https://registry.npmjs.org/react-addons-linked-state-mixin/-/react-addons-linked-state-mixin-15.3.0.tgz"
+          "version": "15.4.0",
+          "from": "react-addons-linked-state-mixin@15.4.0",
+          "resolved": "https://registry.npmjs.org/react-addons-linked-state-mixin/-/react-addons-linked-state-mixin-15.4.0.tgz"
         },
         "react-addons-shallow-compare": {
-          "version": "15.3.0",
-          "from": "react-addons-shallow-compare@15.3.0",
-          "resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.3.0.tgz"
+          "version": "15.4.0",
+          "from": "react-addons-shallow-compare@15.4.0",
+          "resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.4.0.tgz"
         },
         "react-addons-update": {
-          "version": "15.3.0",
-          "from": "react-addons-update@15.3.0",
-          "resolved": "https://registry.npmjs.org/react-addons-update/-/react-addons-update-15.3.0.tgz"
+          "version": "15.4.0",
+          "from": "react-addons-update@15.4.0",
+          "resolved": "https://registry.npmjs.org/react-addons-update/-/react-addons-update-15.4.0.tgz"
         },
         "react-click-outside": {
           "version": "2.1.0",
@@ -8647,20 +8821,42 @@
           "from": "react-day-picker@2.4.1",
           "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-2.4.1.tgz"
         },
+        "react-docgen": {
+          "version": "2.13.0",
+          "from": "react-docgen@2.13.0",
+          "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-2.13.0.tgz",
+          "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "from": "async@1.5.2",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+            },
+            "babylon": {
+              "version": "5.8.38",
+              "from": "babylon@5.8.38",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz"
+            },
+            "commander": {
+              "version": "2.9.0",
+              "from": "commander@2.9.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+            }
+          }
+        },
         "react-dom": {
-          "version": "15.3.0",
-          "from": "react-dom@15.3.0",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.3.0.tgz"
+          "version": "15.4.0",
+          "from": "react-dom@15.4.0",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.4.0.tgz"
         },
         "react-is-deprecated": {
           "version": "0.1.2",
           "from": "react-is-deprecated@0.1.2",
           "resolved": "https://registry.npmjs.org/react-is-deprecated/-/react-is-deprecated-0.1.2.tgz"
         },
-        "react-masonry-component": {
-          "version": "4.2.2",
-          "from": "react-masonry-component@4.2.2",
-          "resolved": "https://registry.npmjs.org/react-masonry-component/-/react-masonry-component-4.2.2.tgz"
+        "react-modal": {
+          "version": "1.6.5",
+          "from": "react-modal@1.6.5",
+          "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-1.6.5.tgz"
         },
         "react-pure-render": {
           "version": "1.0.2",
@@ -8672,32 +8868,10 @@
           "from": "react-redux@4.4.5",
           "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-4.4.5.tgz"
         },
-        "react-tap-event-plugin": {
-          "version": "1.0.0",
-          "from": "react-tap-event-plugin@1.0.0",
-          "resolved": "https://registry.npmjs.org/react-tap-event-plugin/-/react-tap-event-plugin-1.0.0.tgz",
-          "dependencies": {
-            "core-js": {
-              "version": "1.2.7",
-              "from": "core-js@1.2.7",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
-            },
-            "fbjs": {
-              "version": "0.2.1",
-              "from": "fbjs@0.2.1",
-              "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.2.1.tgz"
-            },
-            "whatwg-fetch": {
-              "version": "0.9.0",
-              "from": "whatwg-fetch@0.9.0",
-              "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
-            }
-          }
-        },
         "react-virtualized": {
-          "version": "7.9.1",
-          "from": "react-virtualized@7.9.1",
-          "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-7.9.1.tgz",
+          "version": "8.8.1",
+          "from": "react-virtualized@8.8.1",
+          "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-8.8.1.tgz",
           "dependencies": {
             "classnames": {
               "version": "2.2.5",
@@ -8724,34 +8898,36 @@
         "readable-stream": {
           "version": "1.1.14",
           "from": "readable-stream@1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            }
+          }
         },
         "readdirp": {
           "version": "2.1.0",
           "from": "readdirp@2.1.0",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
           "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            },
             "minimatch": {
               "version": "3.0.3",
               "from": "minimatch@3.0.3",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
             },
             "readable-stream": {
-              "version": "2.1.5",
-              "from": "readable-stream@2.1.5",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
+              "version": "2.2.2",
+              "from": "readable-stream@2.2.2",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
             }
           }
         },
         "recast": {
-          "version": "0.11.15",
-          "from": "recast@0.11.15",
-          "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.15.tgz",
+          "version": "0.11.21",
+          "from": "recast@0.11.21",
+          "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.21.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.5.6",
@@ -8781,14 +8957,19 @@
           "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-1.0.0.tgz"
         },
         "regenerate": {
-          "version": "1.3.1",
-          "from": "regenerate@1.3.1",
-          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz"
+          "version": "1.3.2",
+          "from": "regenerate@1.3.2",
+          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
         },
         "regenerator-runtime": {
-          "version": "0.9.5",
-          "from": "regenerator-runtime@0.9.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
+          "version": "0.10.1",
+          "from": "regenerator-runtime@0.10.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz"
+        },
+        "regenerator-transform": {
+          "version": "0.9.8",
+          "from": "regenerator-transform@0.9.8",
+          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.8.tgz"
         },
         "regex-cache": {
           "version": "0.4.3",
@@ -8843,14 +9024,19 @@
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
         },
         "request": {
-          "version": "2.76.0",
-          "from": "request@2.76.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.76.0.tgz",
+          "version": "2.79.0",
+          "from": "request@2.79.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
           "dependencies": {
             "qs": {
               "version": "6.3.0",
               "from": "qs@6.3.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
+            },
+            "uuid": {
+              "version": "3.0.1",
+              "from": "uuid@3.0.1",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
             }
           }
         },
@@ -8865,9 +9051,9 @@
           "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
         },
         "resolve": {
-          "version": "1.1.7",
-          "from": "resolve@1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+          "version": "1.2.0",
+          "from": "resolve@1.2.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz"
         },
         "right-align": {
           "version": "0.1.3",
@@ -8941,9 +9127,9 @@
           "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz"
         },
         "select": {
-          "version": "1.1.0",
-          "from": "select@1.1.0",
-          "resolved": "https://registry.npmjs.org/select/-/select-1.1.0.tgz"
+          "version": "1.1.2",
+          "from": "select@1.1.2",
+          "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz"
         },
         "semver": {
           "version": "5.1.0",
@@ -9019,10 +9205,15 @@
           "from": "set-immediate-shim@1.0.1",
           "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
         },
+        "setimmediate": {
+          "version": "1.0.5",
+          "from": "setimmediate@1.0.5",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+        },
         "setprototypeof": {
-          "version": "1.0.1",
-          "from": "setprototypeof@1.0.1",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
+          "version": "1.0.2",
+          "from": "setprototypeof@1.0.2",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz"
         },
         "sha.js": {
           "version": "2.2.6",
@@ -9035,19 +9226,14 @@
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
         },
         "signal-exit": {
-          "version": "3.0.1",
-          "from": "signal-exit@3.0.1",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz"
+          "version": "3.0.2",
+          "from": "signal-exit@3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
         },
         "simple-get": {
           "version": "1.4.3",
           "from": "simple-get@1.4.3",
           "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz"
-        },
-        "simple-mime": {
-          "version": "0.1.0",
-          "from": "simple-mime@0.1.0",
-          "resolved": "https://registry.npmjs.org/simple-mime/-/simple-mime-0.1.0.tgz"
         },
         "slash": {
           "version": "1.0.0",
@@ -9064,6 +9250,11 @@
           "from": "sntp@1.0.9",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
         },
+        "social-logos": {
+          "version": "1.0.1",
+          "from": "social-logos@1.0.1",
+          "resolved": "https://registry.npmjs.org/social-logos/-/social-logos-1.0.1.tgz"
+        },
         "socket.io-client": {
           "version": "1.4.5",
           "from": "socket.io-client@1.4.5",
@@ -9078,13 +9269,18 @@
               "version": "1.1.2",
               "from": "component-emitter@1.1.2",
               "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             }
           }
         },
         "source-list-map": {
-          "version": "0.1.6",
-          "from": "source-list-map@0.1.6",
-          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.6.tgz"
+          "version": "0.1.8",
+          "from": "source-list-map@0.1.8",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz"
         },
         "source-map": {
           "version": "0.1.39",
@@ -9123,57 +9319,22 @@
           "from": "spdx-license-ids@1.2.2",
           "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
         },
-        "srcset": {
-          "version": "1.0.0",
-          "from": "srcset@1.0.0",
-          "resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz"
-        },
         "sshpk": {
-          "version": "1.10.1",
-          "from": "sshpk@1.10.1",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+          "version": "1.10.2",
+          "from": "sshpk@1.10.2",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
               "from": "assert-plus@1.0.0",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.0",
-              "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-              "optional": true
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-              "optional": true
-            },
-            "jodid25519": {
-              "version": "1.0.2",
-              "from": "jodid25519@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-              "optional": true
-            },
-            "jsbn": {
-              "version": "0.1.0",
-              "from": "jsbn@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-              "optional": true
-            },
-            "tweetnacl": {
-              "version": "0.14.3",
-              "from": "tweetnacl@>=0.14.0 <0.15.0",
-              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-              "optional": true
             }
           }
         },
         "statuses": {
-          "version": "1.3.0",
-          "from": "statuses@1.3.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
+          "version": "1.3.1",
+          "from": "statuses@1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
         },
         "store": {
           "version": "1.3.16",
@@ -9240,27 +9401,22 @@
               "from": "form-data@1.0.0-rc4",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
             },
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            },
             "qs": {
               "version": "6.3.0",
               "from": "qs@6.3.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
             },
             "readable-stream": {
-              "version": "2.1.5",
-              "from": "readable-stream@2.1.5",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
+              "version": "2.2.2",
+              "from": "readable-stream@2.2.2",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
             }
           }
         },
         "supports-color": {
-          "version": "3.1.2",
-          "from": "supports-color@3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+          "version": "3.2.3",
+          "from": "supports-color@3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
         },
         "swap-case": {
           "version": "1.1.2",
@@ -9278,24 +9434,19 @@
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
         },
         "tar-fs": {
-          "version": "1.14.0",
-          "from": "tar-fs@1.14.0",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.14.0.tgz"
+          "version": "1.15.0",
+          "from": "tar-fs@1.15.0",
+          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.0.tgz"
         },
         "tar-stream": {
           "version": "1.5.2",
           "from": "tar-stream@1.5.2",
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
           "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            },
             "readable-stream": {
-              "version": "2.1.5",
-              "from": "readable-stream@2.1.5",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
+              "version": "2.2.2",
+              "from": "readable-stream@2.2.2",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
             }
           }
         },
@@ -9309,6 +9460,11 @@
           "from": "through2@0.6.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            },
             "readable-stream": {
               "version": "1.0.34",
               "from": "readable-stream@1.0.34",
@@ -9398,6 +9554,11 @@
           "from": "trim-newlines@1.0.0",
           "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
         },
+        "trim-right": {
+          "version": "1.0.1",
+          "from": "trim-right@1.0.1",
+          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+        },
         "tty-browserify": {
           "version": "0.0.0",
           "from": "tty-browserify@0.0.0",
@@ -9414,14 +9575,14 @@
           "resolved": "https://registry.npmjs.org/tween.js/-/tween.js-16.3.1.tgz"
         },
         "twemoji": {
-          "version": "1.3.2",
-          "from": "twemoji@1.3.2",
-          "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-1.3.2.tgz"
+          "version": "2.2.5",
+          "from": "twemoji@2.2.5",
+          "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-2.2.5.tgz"
         },
         "type-is": {
-          "version": "1.6.13",
-          "from": "type-is@1.6.13",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz"
+          "version": "1.6.14",
+          "from": "type-is@1.6.14",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz"
         },
         "typedarray": {
           "version": "0.0.6",
@@ -9429,9 +9590,9 @@
           "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
         },
         "ua-parser-js": {
-          "version": "0.7.10",
-          "from": "ua-parser-js@0.7.10",
-          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz"
+          "version": "0.7.12",
+          "from": "ua-parser-js@0.7.12",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz"
         },
         "uglify-js": {
           "version": "2.7.0",
@@ -9470,6 +9631,33 @@
           "from": "unpipe@1.0.0",
           "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
         },
+        "unreachable-branch-transform": {
+          "version": "0.3.0",
+          "from": "unreachable-branch-transform@0.3.0",
+          "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.3.0.tgz",
+          "dependencies": {
+            "ast-types": {
+              "version": "0.8.15",
+              "from": "ast-types@0.8.15",
+              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz"
+            },
+            "esprima-fb": {
+              "version": "15001.1001.0-dev-harmony-fb",
+              "from": "esprima-fb@15001.1001.0-dev-harmony-fb",
+              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+            },
+            "recast": {
+              "version": "0.10.43",
+              "from": "recast@0.10.43",
+              "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz"
+            },
+            "source-map": {
+              "version": "0.5.6",
+              "from": "source-map@0.5.6",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            }
+          }
+        },
         "unzip-response": {
           "version": "1.0.2",
           "from": "unzip-response@1.0.2",
@@ -9502,11 +9690,6 @@
             }
           }
         },
-        "url-template": {
-          "version": "2.0.8",
-          "from": "url-template@2.0.8",
-          "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz"
-        },
         "user-home": {
           "version": "1.1.1",
           "from": "user-home@1.1.1",
@@ -9526,11 +9709,6 @@
           "version": "1.0.2",
           "from": "util-deprecate@1.0.2",
           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-        },
-        "util-extend": {
-          "version": "1.0.3",
-          "from": "util-extend@1.0.3",
-          "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz"
         },
         "utils-merge": {
           "version": "1.0.0",
@@ -9607,9 +9785,9 @@
           }
         },
         "webpack-core": {
-          "version": "0.6.8",
-          "from": "webpack-core@0.6.8",
-          "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
+          "version": "0.6.9",
+          "from": "webpack-core@0.6.9",
+          "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
@@ -9631,9 +9809,9 @@
           }
         },
         "webpack-sources": {
-          "version": "0.1.2",
-          "from": "webpack-sources@0.1.2",
-          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.2.tgz",
+          "version": "0.1.4",
+          "from": "webpack-sources@0.1.4",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.4.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.5.6",
@@ -9642,20 +9820,30 @@
             }
           }
         },
+        "wemoji": {
+          "version": "0.1.9",
+          "from": "wemoji@0.1.9",
+          "resolved": "https://registry.npmjs.org/wemoji/-/wemoji-0.1.9.tgz"
+        },
         "whatwg-fetch": {
-          "version": "1.0.0",
-          "from": "whatwg-fetch@1.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz"
+          "version": "2.0.2",
+          "from": "whatwg-fetch@2.0.2",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.2.tgz"
         },
         "which": {
-          "version": "1.2.11",
-          "from": "which@1.2.11",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz"
+          "version": "1.2.12",
+          "from": "which@1.2.12",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz"
         },
         "which-module": {
           "version": "1.0.0",
           "from": "which-module@1.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
+        },
+        "wide-align": {
+          "version": "1.1.0",
+          "from": "wide-align@1.1.0",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
         },
         "window-size": {
           "version": "0.1.0",
@@ -9675,7 +9863,14 @@
         "wpcom": {
           "version": "5.3.0",
           "from": "wpcom@5.3.0",
-          "resolved": "https://registry.npmjs.org/wpcom/-/wpcom-5.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/wpcom/-/wpcom-5.3.0.tgz",
+          "dependencies": {
+            "wpcom-xhr-request": {
+              "version": "1.0.0",
+              "from": "wpcom-xhr-request@1.0.0",
+              "resolved": "https://registry.npmjs.org/wpcom-xhr-request/-/wpcom-xhr-request-1.0.0.tgz"
+            }
+          }
         },
         "wpcom-oauth": {
           "version": "0.3.3",
@@ -9732,14 +9927,14 @@
           "resolved": "https://registry.npmjs.org/wpcom-proxy-request/-/wpcom-proxy-request-3.0.0.tgz"
         },
         "wpcom-xhr-request": {
-          "version": "1.0.0",
-          "from": "wpcom-xhr-request@1.0.0",
-          "resolved": "https://registry.npmjs.org/wpcom-xhr-request/-/wpcom-xhr-request-1.0.0.tgz"
+          "version": "1.1.0",
+          "from": "wpcom-xhr-request@1.1.0",
+          "resolved": "https://registry.npmjs.org/wpcom-xhr-request/-/wpcom-xhr-request-1.1.0.tgz"
         },
         "wrap-ansi": {
-          "version": "2.0.0",
-          "from": "wrap-ansi@2.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz"
+          "version": "2.1.0",
+          "from": "wrap-ansi@2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
         },
         "wrappy": {
           "version": "1.0.2",
@@ -9818,9 +10013,9 @@
       }
     },
     "wrap-ansi": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "from": "wrap-ansi@^2.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "dev": true
     },
     "wrappy": {
@@ -9835,9 +10030,9 @@
       "dev": true
     },
     "ws": {
-      "version": "1.1.1",
-      "from": "ws@1.1.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
+      "version": "1.1.2",
+      "from": "ws@1.1.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.2.tgz",
       "dev": true
     },
     "wtf-8": {
@@ -9860,14 +10055,14 @@
     },
     "xml-name-validator": {
       "version": "2.0.1",
-      "from": "xml-name-validator@>= 2.0.1 < 3.0.0",
+      "from": "xml-name-validator@^2.0.1",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
       "dev": true
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.1",
-      "from": "xmlhttprequest-ssl@1.5.1",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz",
+      "version": "1.5.3",
+      "from": "xmlhttprequest-ssl@1.5.3",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
       "dev": true
     },
     "xtend": {
@@ -9914,9 +10109,9 @@
       "dev": true
     },
     "zip-stream": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "from": "zip-stream@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.1.1.tgz",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "redbox-react": "^1.2.2",
     "sass-loader": "^3.1.2",
     "shelljs": "^0.7.0",
+    "sinon": "2.0.0-pre.5",
     "style-loader": "^0.13.0",
     "svg-url-loader": "^1.1.0",
     "url-loader": "^0.5.7",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "debug": "^2.2.0",
     "dompurify": "^0.8.0",
     "google-libphonenumber": "^2.0.4",
+    "gridicons": "1.0.0",
     "i18n-calypso": "^1.7.0",
     "is-my-json-valid": "^2.13.1",
     "lodash": "^4.16.4",


### PR DESCRIPTION
Fixes #870

Before, the origin and destination fields would not open until the normalization was finished:

<img width="1113" alt="before" src="https://cloud.githubusercontent.com/assets/11487924/22677140/6fed9024-ecbe-11e6-9a83-8284044c7cee.png">

Now, they'll both open if there are still things for the user to do, i.e. there are errors, or we're ignoring validation:

![after](https://cloud.githubusercontent.com/assets/11487924/22677152/8856d6ca-ecbe-11e6-819e-99d34f19df33.gif)

The unit tests are not complete. They are missing the cases where:
1. There are errors for either origin or destination address - this is because mocking `getFormErrors` was taking too long. I think the best way forward is to add it as a param to `openPrintingFlow`
2. The fields should _not_ open - this is because the toggle action will still be dispatched in `expandStepAfterAction` on line 202. This happens because the `getState` function will not actually return the new state with the `expanded` props. Thinking on the best way around this. Ideas welcome.

In the interest of shipping (our deadline is Feb 7), I think we can skip the extra unit tests, so I'm making this as review-ready.

FAQ
Q: Why are you using sinon 2 (i.e. `sinon@next`) instead of the current version 1.17.7? 
A: So it's compatible with webpack

Q: Why aren't you using sinon-chai to make use of the beautiful `have.been.calledWith()`
A: It's incompatible with sinon 2