### PR TITLE
NUX: Shipping zones: Update copy to be more clear

### DIFF
--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -75,8 +75,8 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				'target' => 'th.wc-shipping-zone-methods',
 				'options' => array(
 					'content' => sprintf( '<h3>%s</h3><p>%s</p>',
-						__( 'Add WooCommerce Shipping Service to a Zone' ,'woocommerce-services' ),
-						__( 'Choose a zone that is applicable to USPS or Canada Post.', 'woocommerce-services' )
+						__( 'Add a WooCommerce shipping services to a Zone' ,'woocommerce-services' ),
+						__( 'To ship products to customers using USPS or Canada Post, you will need to add them as a shipping method to an applicable zone. If you don't have any zones, add one first.', 'woocommerce-services' )
 					),
 					'position' => array( 'edge' => 'right', 'align' => 'left' ),
 				)


### PR DESCRIPTION
The current copy isn't quite clear and the title and content are a bit redundant. It also doesn't take into account new users, who haven't set up any zones yet.

Currently:

<img width="551" alt="screen shot 2017-02-07 at 1 20 56 pm" src="https://cloud.githubusercontent.com/assets/5835847/22710058/2d8862b0-ed39-11e6-87d6-b51b139ab09f.png">

This PR changes the copy to:

To ship products to customers using USPS or Canada Post, you will need to add them as a shipping method to an applicable zone. If you don't have any zones, add one first.