### PR TITLE
Point support docs link to the new document URL.

### DIFF
--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -434,7 +434,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 					__( 'Our team is here for you. View our <a href="%1$s">support docs</a> or <a href="%2$s">report a bug</a>', 'woocommerce-services' ),
 					array(  'a' => array( 'href' => array() ) )
 				),
-				esc_url( 'https://docs.woocommerce.com/document/woocommerce-connect-faq/' ),
+				esc_url( 'https://docs.woocommerce.com/document/woocommerce-services/' ),
 				esc_url( 'https://wordpress.org/support/plugin/woocommerce-services' )
 			);
 


### PR DESCRIPTION
Fixes #872.

To test:
* Go to WooCommerce > System Status > WooCommerce Services
* Verify the "support docs" link goes to https://docs.woocommerce.com/document/woocommerce-services/, not the FAQ page