### PR TITLE
Restore tracks event when users accept the Terms of Services.

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -702,8 +702,12 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 
 			if ( 'accept' === $_GET['wc-connect-notice'] ) {
+				$tracks = self::load_tracks_for_activation_hooks();
+				$tracks->opted_in();
+
 				update_option( 'wc_connect_tos_accepted', true );
 				wp_safe_redirect( admin_url( 'admin.php?page=wc-settings&tab=shipping' ) );
+
 				exit;
 			}
 


### PR DESCRIPTION
Restore tracks event when users accept the Terms of Services.

This was errantly removed in https://github.com/Automattic/woocommerce-services/commit/8612b81cfe02967316e1b8f5b8c33cb6386a0325