### PR TITLE
Cleaning up plugin options on uninstall

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -406,9 +406,9 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				'wc_version' => WC()->version,
 				'weight_unit' => strtolower( get_option( 'woocommerce_weight_unit' ) ),
 				'wp_version' => get_bloginfo( 'version' ),
-				'last_services_update' => get_option( WC_Connect_Options::LAST_SCHEMA_UPDATE, 0 ),
-				'last_heartbeat' => get_option( WC_Connect_Options::LAST_HEARTBEAT, 0 ),
-				'last_rate_request' => get_option( WC_Connect_Options::LAST_RATE_REQUEST, 0 ),
+				'last_services_update' => WC_Connect_Options::get_option( 'services_last_update', 0 ),
+				'last_heartbeat' => WC_Connect_Options::get_option( 'last_heartbeat', 0 ),
+				'last_rate_request' => WC_Connect_Options::get_option( 'last_rate_request', 0 ),
 				'active_services' => $this->wc_connect_loader->get_active_services(),
 				'disable_stats' => Jetpack::is_staging_site(),
 			) );
@@ -490,10 +490,10 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		private function get_guid() {
-			$guid = get_option( WC_Connect_Options::STORE_GUID, false );
+			$guid = WC_Connect_Options::get_option( 'store_guid', false );
 			if ( false === $guid ) {
 				$guid = $this->generate_guid();
-				update_option( WC_Connect_Options::STORE_GUID, $guid );
+				WC_Connect_Options::update_option( 'store_guid', $guid );
 			}
 
 			return $guid;

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -406,9 +406,9 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				'wc_version' => WC()->version,
 				'weight_unit' => strtolower( get_option( 'woocommerce_weight_unit' ) ),
 				'wp_version' => get_bloginfo( 'version' ),
-				'last_services_update' => get_option( 'wc_connect_services_last_update', 0 ),
-				'last_heartbeat' => get_option( 'wc_connect_last_heartbeat', 0 ),
-				'last_rate_request' => get_option( 'wc_connect_last_rate_request', 0 ),
+				'last_services_update' => get_option( WC_Connect_Options::$last_schema_update, 0 ),
+				'last_heartbeat' => get_option( WC_Connect_Options::$last_heartbeat, 0 ),
+				'last_rate_request' => get_option( WC_Connect_Options::$last_rate_request, 0 ),
 				'active_services' => $this->wc_connect_loader->get_active_services(),
 				'disable_stats' => Jetpack::is_staging_site(),
 			) );
@@ -490,10 +490,10 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		private function get_guid() {
-			$guid = get_option( 'wc_connect_store_guid', false );
+			$guid = get_option( WC_Connect_Options::$store_guid, false );
 			if ( false === $guid ) {
 				$guid = $this->generate_guid();
-				update_option( 'wc_connect_store_guid', $guid );
+				update_option( WC_Connect_Options::$store_guid, $guid );
 			}
 
 			return $guid;

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -406,9 +406,9 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				'wc_version' => WC()->version,
 				'weight_unit' => strtolower( get_option( 'woocommerce_weight_unit' ) ),
 				'wp_version' => get_bloginfo( 'version' ),
-				'last_services_update' => get_option( WC_Connect_Options::$last_schema_update, 0 ),
-				'last_heartbeat' => get_option( WC_Connect_Options::$last_heartbeat, 0 ),
-				'last_rate_request' => get_option( WC_Connect_Options::$last_rate_request, 0 ),
+				'last_services_update' => get_option( WC_Connect_Options::LAST_SCHEMA_UPDATE, 0 ),
+				'last_heartbeat' => get_option( WC_Connect_Options::LAST_HEARTBEAT, 0 ),
+				'last_rate_request' => get_option( WC_Connect_Options::LAST_RATE_REQUEST, 0 ),
 				'active_services' => $this->wc_connect_loader->get_active_services(),
 				'disable_stats' => Jetpack::is_staging_site(),
 			) );
@@ -490,10 +490,10 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		private function get_guid() {
-			$guid = get_option( WC_Connect_Options::$store_guid, false );
+			$guid = get_option( WC_Connect_Options::STORE_GUID, false );
 			if ( false === $guid ) {
 				$guid = $this->generate_guid();
-				update_option( WC_Connect_Options::$store_guid, $guid );
+				update_option( WC_Connect_Options::STORE_GUID, $guid );
 			}
 
 			return $guid;

--- a/classes/class-wc-connect-error-notice.php
+++ b/classes/class-wc-connect-error-notice.php
@@ -23,20 +23,18 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 			return self::$inst;
 		}
 
-		private static $option_key = 'wc_connect_error_notice';
-
 		public function enable_notice() {
-			update_option( self::$option_key, true );
+			update_option( WC_Connect_Options::$error_notice, true );
 		}
 
 		public function disable_notice() {
-			update_option( self::$option_key, false );
+			update_option( WC_Connect_Options::$error_notice, false );
 		}
 
 		public function render_notice() {
 			$error_notice = filter_input( INPUT_GET, 'wc-connect-error-notice' );
 			if ( 'disable' === $error_notice ) {
-				update_option( self::$option_key, false );
+				update_option( WC_Connect_Options::$error_notice, false );
 				$url = home_url( remove_query_arg( 'wc-connect-error-notice' ) );
 				wp_safe_redirect( $url );
 				exit;
@@ -48,7 +46,7 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 		}
 
 		private function notice_enabled() {
-			return get_option( self::$option_key, false );
+			return get_option( WC_Connect_Options::$error_notice, false );
 		}
 
 		private function show_notice() {

--- a/classes/class-wc-connect-error-notice.php
+++ b/classes/class-wc-connect-error-notice.php
@@ -24,17 +24,17 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 		}
 
 		public function enable_notice() {
-			update_option( WC_Connect_Options::$error_notice, true );
+			update_option( WC_Connect_Options::ERROR_NOTICE, true );
 		}
 
 		public function disable_notice() {
-			update_option( WC_Connect_Options::$error_notice, false );
+			update_option( WC_Connect_Options::ERROR_NOTICE, false );
 		}
 
 		public function render_notice() {
 			$error_notice = filter_input( INPUT_GET, 'wc-connect-error-notice' );
 			if ( 'disable' === $error_notice ) {
-				update_option( WC_Connect_Options::$error_notice, false );
+				update_option( WC_Connect_Options::ERROR_NOTICE, false );
 				$url = home_url( remove_query_arg( 'wc-connect-error-notice' ) );
 				wp_safe_redirect( $url );
 				exit;
@@ -46,7 +46,7 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 		}
 
 		private function notice_enabled() {
-			return get_option( WC_Connect_Options::$error_notice, false );
+			return get_option( WC_Connect_Options::ERROR_NOTICE, false );
 		}
 
 		private function show_notice() {

--- a/classes/class-wc-connect-error-notice.php
+++ b/classes/class-wc-connect-error-notice.php
@@ -24,17 +24,17 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 		}
 
 		public function enable_notice() {
-			update_option( WC_Connect_Options::ERROR_NOTICE, true );
+			WC_Connect_Options::update_option( 'error_notice', true );
 		}
 
 		public function disable_notice() {
-			update_option( WC_Connect_Options::ERROR_NOTICE, false );
+			WC_Connect_Options::update_option( 'error_notice', false );
 		}
 
 		public function render_notice() {
 			$error_notice = filter_input( INPUT_GET, 'wc-connect-error-notice' );
 			if ( 'disable' === $error_notice ) {
-				update_option( WC_Connect_Options::ERROR_NOTICE, false );
+				WC_Connect_Options::update_option( 'error_notice', false );
 				$url = home_url( remove_query_arg( 'wc-connect-error-notice' ) );
 				wp_safe_redirect( $url );
 				exit;
@@ -46,7 +46,7 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 		}
 
 		private function notice_enabled() {
-			return get_option( WC_Connect_Options::ERROR_NOTICE, false );
+			return WC_Connect_Options::get_option( 'error_notice', false );
 		}
 
 		private function show_notice() {

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -240,7 +240,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 
 			foreach ( (array) $enabled_services as $enabled_service ) {
 				$indicator_key = "{$enabled_service->method_id}_{$enabled_service->instance_id}";
-				$failure_timestamp_key = $this->service_settings_store->get_service_failure_timestamp_key( $enabled_service->method_id, $enabled_service->instance_id );
+				$failure_timestamp_key = WC_Connect_Options::get_service_failure_timestamp_key( $enabled_service->method_id, $enabled_service->instance_id );
 				$last_failed_request_timestamp = intval( get_option( $failure_timestamp_key, -1 ) );
 
 				$service_settings_url = esc_url( add_query_arg(

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -240,8 +240,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 
 			foreach ( (array) $enabled_services as $enabled_service ) {
 				$indicator_key = "{$enabled_service->method_id}_{$enabled_service->instance_id}";
-				$failure_timestamp_key = WC_Connect_Options::get_service_failure_timestamp_key( $enabled_service->method_id, $enabled_service->instance_id );
-				$last_failed_request_timestamp = intval( get_option( $failure_timestamp_key, -1 ) );
+				$last_failed_request_timestamp = intval( WC_Connect_Options::get_shipping_method_option( 'failure_timestamp', -1, $enabled_service->method_id, $enabled_service->instance_id ) );
 
 				$service_settings_url = esc_url( add_query_arg(
 					array(

--- a/classes/class-wc-connect-logger.php
+++ b/classes/class-wc-connect-logger.php
@@ -2,8 +2,6 @@
 
 if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 
-	define( 'WOOCOMMERCE_CONNECT_DEBUG_LOGGING_ENABLED_OPTION', 'wc_connect_debug_logging_enabled' );
-
 	class WC_Connect_Logger {
 
 		/**
@@ -17,7 +15,7 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 
 			$this->logger = $logger;
 
-			$this->is_logging_enabled = get_option( WOOCOMMERCE_CONNECT_DEBUG_LOGGING_ENABLED_OPTION, false );
+			$this->is_logging_enabled = get_option( WC_Connect_Options::$debug_enabled, false );
 
 		}
 
@@ -45,14 +43,14 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 		}
 
 		public function enable_logging() {
-			update_option( WOOCOMMERCE_CONNECT_DEBUG_LOGGING_ENABLED_OPTION, true );
+			update_option( WC_Connect_Options::$debug_enabled, true );
 			$this->is_logging_enabled = true;
 			$this->log( "Logging enabled" );
 		}
 
 		public function disable_logging() {
 			$this->log( "Logging disabled" );
-			update_option( WOOCOMMERCE_CONNECT_DEBUG_LOGGING_ENABLED_OPTION, false );
+			update_option( WC_Connect_Options::$debug_enabled, false );
 			$this->is_logging_enabled = false;
 		}
 

--- a/classes/class-wc-connect-logger.php
+++ b/classes/class-wc-connect-logger.php
@@ -15,7 +15,7 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 
 			$this->logger = $logger;
 
-			$this->is_logging_enabled = get_option( WC_Connect_Options::DEBUG_ENABLED, false );
+			$this->is_logging_enabled = WC_Connect_Options::get_option( 'debug_logging_enabled', false );
 
 		}
 
@@ -43,14 +43,14 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 		}
 
 		public function enable_logging() {
-			update_option( WC_Connect_Options::DEBUG_ENABLED, true );
+			WC_Connect_Options::update_option( 'debug_logging_enabled', true );
 			$this->is_logging_enabled = true;
 			$this->log( "Logging enabled" );
 		}
 
 		public function disable_logging() {
 			$this->log( "Logging disabled" );
-			update_option( WC_Connect_Options::DEBUG_ENABLED, false );
+			WC_Connect_Options::update_option( 'debug_logging_enabled', false );
 			$this->is_logging_enabled = false;
 		}
 

--- a/classes/class-wc-connect-logger.php
+++ b/classes/class-wc-connect-logger.php
@@ -15,7 +15,7 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 
 			$this->logger = $logger;
 
-			$this->is_logging_enabled = get_option( WC_Connect_Options::$debug_enabled, false );
+			$this->is_logging_enabled = get_option( WC_Connect_Options::DEBUG_ENABLED, false );
 
 		}
 
@@ -43,14 +43,14 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 		}
 
 		public function enable_logging() {
-			update_option( WC_Connect_Options::$debug_enabled, true );
+			update_option( WC_Connect_Options::DEBUG_ENABLED, true );
 			$this->is_logging_enabled = true;
 			$this->log( "Logging enabled" );
 		}
 
 		public function disable_logging() {
 			$this->log( "Logging disabled" );
-			update_option( WC_Connect_Options::$debug_enabled, false );
+			update_option( WC_Connect_Options::DEBUG_ENABLED, false );
 			$this->is_logging_enabled = false;
 		}
 

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -9,7 +9,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		}
 
 		private function get_notice_states() {
-			$states = WC_Connect_Options::get_option( 'nux_notices', array() );
+			$states = get_user_meta( get_current_user_id(), 'wc_connect_nux_notices', true );
 
 			if ( ! $states ) {
 				return array();

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -9,7 +9,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		}
 
 		private function get_notice_states() {
-			$states = get_option( WC_Connect_Options::$nux_notices, array() );
+			$states = get_option( WC_Connect_Options::NUX_NOTICES, array() );
 
 			if ( ! $states ) {
 				return array();
@@ -27,7 +27,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		public function dismiss_notice( $notice ) {
 			$notices = $this->get_notice_states();
 			$notices[ $notice ] = true;
-			update_option( WC_Connect_Options::$nux_notices, $notices );
+			update_option( WC_Connect_Options::NUX_NOTICES, $notices );
 		}
 
 		private function init_pointers() {

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -9,7 +9,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		}
 
 		private function get_notice_states() {
-			$states = get_user_meta( get_current_user_id(), 'wc_connect_nux_notices', true );
+			$states = get_option( WC_Connect_Options::$nux_notices, array() );
 
 			if ( ! $states ) {
 				return array();
@@ -27,7 +27,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		public function dismiss_notice( $notice ) {
 			$notices = $this->get_notice_states();
 			$notices[ $notice ] = true;
-			update_user_meta( get_current_user_id(), 'wc_connect_nux_notices', $notices );
+			update_option( WC_Connect_Options::$nux_notices, $notices );
 		}
 
 		private function init_pointers() {

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -9,7 +9,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		}
 
 		private function get_notice_states() {
-			$states = get_option( WC_Connect_Options::NUX_NOTICES, array() );
+			$states = WC_Connect_Options::get_option( 'nux_notices', array() );
 
 			if ( ! $states ) {
 				return array();
@@ -27,7 +27,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		public function dismiss_notice( $notice ) {
 			$notices = $this->get_notice_states();
 			$notices[ $notice ] = true;
-			update_option( WC_Connect_Options::NUX_NOTICES, $notices );
+			WC_Connect_Options::update_option( 'nux_notices', $notices );
 		}
 
 		private function init_pointers() {

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -2,21 +2,21 @@
 
 if ( ! class_exists( 'WC_Connect_Options' ) ) {
 	class WC_Connect_Options {
-		public static $tos_accepted = 'wc_connect_tos_accepted';
-		public static $store_guid = 'wc_connect_store_guid';
-		public static $error_notice = 'wc_connect_error_notice';
-		public static $debug_enabled = 'wc_connect_debug_logging_enabled';
-		public static $payment_methods = 'wc_connect_payment_methods';
-		public static $service_schemas = 'wc_connect_services';
-		public static $last_schema_update = 'wc_connect_services_last_update';
-		public static $last_heartbeat = 'wc_connect_last_heartbeat';
-		public static $account_settings = 'wc_connect_account_settings';
-		public static $paper_size = 'wc_connect_paper_size';
-		public static $origin_address = 'wc_connect_origin_address';
-		public static $custom_packages = 'wc_connect_packages';
-		public static $predefined_packages = 'wc_connect_predefined_packages';
-		public static $last_rate_request = 'wc_connect_last_rate_request';
-		public static $nux_notices = 'wc_connect_nux_notices';
+		const TOS_ACCEPTED = 'wc_connect_tos_accepted';
+		const STORE_GUID = 'wc_connect_store_guid';
+		const ERROR_NOTICE = 'wc_connect_error_notice';
+		const DEBUG_ENABLED = 'wc_connect_debug_logging_enabled';
+		const PAYMENT_METHODS = 'wc_connect_payment_methods';
+		const SERVICE_SCHEMAS = 'wc_connect_services';
+		const LAST_SCHEMA_UPDATE = 'wc_connect_services_last_update';
+		const LAST_HEARTBEAT = 'wc_connect_last_heartbeat';
+		const ACCOUNT_SETTINGS = 'wc_connect_account_settings';
+		const PAPER_SIZE = 'wc_connect_paper_size';
+		const ORIGIN_ADDRESS = 'wc_connect_origin_address';
+		const CUSTOM_PACKAGES = 'wc_connect_packages';
+		const PREDEFINED_PACKAGES = 'wc_connect_predefined_packages';
+		const LAST_RATE_REQUEST = 'wc_connect_last_rate_request';
+		const NUX_NOTICES = 'wc_connect_nux_notices';
 
 		/**
 		 * Based on the service id and optional instance, generates the options key that
@@ -70,20 +70,11 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				return;
 			}
 
-			delete_option( self::$tos_accepted );
-			delete_option( self::$store_guid );
-			delete_option( self::$error_notice );
-			delete_option( self::$debug_enabled );
-			delete_option( self::$payment_methods );
-			delete_option( self::$service_schemas );
-			delete_option( self::$last_schema_update );
-			delete_option( self::$last_heartbeat );
-			delete_option( self::$account_settings );
-			delete_option( self::$paper_size );
-			delete_option( self::$origin_address );
-			delete_option( self::$custom_packages );
-			delete_option( self::$predefined_packages );
-			delete_option( self::$last_rate_request );
+			$reflect = new ReflectionClass( get_called_class() );
+			$constants = $reflect->getConstants();
+			foreach ( $constants as $constantName => $constantValue ) {
+				delete_option( $constantValue );
+			}
 
 			self::delete_all_shipping_methods_options();
 		}

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -16,6 +16,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 		public static $custom_packages = 'wc_connect_packages';
 		public static $predefined_packages = 'wc_connect_predefined_packages';
 		public static $last_rate_request = 'wc_connect_last_rate_request';
+		public static $nux_notices = 'wc_connect_nux_notices';
 
 		/**
 		 * Based on the service id and optional instance, generates the options key that

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -44,7 +44,6 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				'paper_size',
 				'packages',
 				'predefined_packages',
-				'nux_notices',
 			);
 		}
 

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -55,7 +55,12 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				return;
 			}
 
-			foreach( self::$grouped_options as $group ) {
+			foreach( self::$grouped_options as $group_key => $group ) {
+				//delete legacy options
+				foreach ( self::get_option_names( $group_key ) as $group_option ) {
+					delete_option( "wc_connect_$group_option" );
+				}
+
 				delete_option( $group );
 			}
 

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -2,81 +2,304 @@
 
 if ( ! class_exists( 'WC_Connect_Options' ) ) {
 	class WC_Connect_Options {
-		const TOS_ACCEPTED = 'wc_connect_tos_accepted';
-		const STORE_GUID = 'wc_connect_store_guid';
-		const ERROR_NOTICE = 'wc_connect_error_notice';
-		const DEBUG_ENABLED = 'wc_connect_debug_logging_enabled';
-		const PAYMENT_METHODS = 'wc_connect_payment_methods';
-		const SERVICE_SCHEMAS = 'wc_connect_services';
-		const LAST_SCHEMA_UPDATE = 'wc_connect_services_last_update';
-		const LAST_HEARTBEAT = 'wc_connect_last_heartbeat';
-		const ACCOUNT_SETTINGS = 'wc_connect_account_settings';
-		const PAPER_SIZE = 'wc_connect_paper_size';
-		const ORIGIN_ADDRESS = 'wc_connect_origin_address';
-		const CUSTOM_PACKAGES = 'wc_connect_packages';
-		const PREDEFINED_PACKAGES = 'wc_connect_predefined_packages';
-		const LAST_RATE_REQUEST = 'wc_connect_last_rate_request';
-		const NUX_NOTICES = 'wc_connect_nux_notices';
+		/**
+		 * An array that maps a grouped option type to an option name.
+		 * @var array
+		 */
+		private static $grouped_options = array(
+			'compact' => 'wc_connect_options',
+		);
 
 		/**
-		 * Based on the service id and optional instance, generates the options key that
-		 * should be used to get/set the service's settings
+		 * Returns an array of option names for a given type.
 		 *
-		 * @param $service_id
-		 * @param $service_instance
+		 * @param string $type The type of option to return. Defaults to 'compact'.
 		 *
-		 * @return string
+		 * @return array
 		 */
-		public static function get_service_settings_key( $service_id, $service_instance = false ) {
-			if ( ! $service_instance ) {
-				return 'woocommerce_' . $service_id . '_form_settings';
+		public static function get_option_names( $type = 'compact' ) {
+			switch ( $type ) {
+				case 'non_compact':
+					return array(
+						'error_notice',
+						'services',
+						'services_last_update',
+						'last_heartbeat',
+						'origin_address',
+						'last_rate_request',
+					);
+				case 'shipping_method':
+					return array(
+						'form_settings',
+						'failure_timestamp',
+					);
 			}
 
-			return 'woocommerce_' . $service_id . '_' . $service_instance . '_form_settings';
+			return array(
+				'tos_accepted',
+				'store_guid',
+				'debug_logging_enabled',
+				'payment_methods',
+				'account_settings',
+				'paper_size',
+				'packages',
+				'predefined_packages',
+				'nux_notices',
+			);
 		}
 
 		/**
-		 * Based on the service id and optional instance, generates the options key that
-		 * should be used to get/set the service's last failure timestamp
-		 *
-		 * @param $service_id
-		 * @param $service_instance
-		 *
-		 * @return string
-		 */
-		public static function get_service_failure_timestamp_key( $service_id, $service_instance = false ) {
-			if ( ! $service_instance ) {
-				return 'woocommerce_' . $service_id . '_failure_timestamp';
-			}
-
-			return 'woocommerce_' . $service_id . '_' . $service_instance . '_failure_timestamp';
-		}
-
-		/**
-		 * Deletes all options related to a shipping method
-		 * @param $service_id
-		 * @param $service_instance
-		 */
-		public static function delete_shipping_method_options( $service_id, $service_instance = false ) {
-			delete_option( self::get_service_settings_key( $service_id, $service_instance ) );
-			delete_option( self::get_service_failure_timestamp_key( $service_id, $service_instance ) );
-		}
-
-		/**
-		 * Deletes all options created by WooCommerce Services
+		 * Deletes all options created by WooCommerce Services, including shipping method options
 		 */
 		public static function delete_all_options() {
 			if ( defined( 'WOOCOMMERCE_CONNECT_DEV_SERVER_URL' ) ) {
 				return;
 			}
 
-			$reflect = new ReflectionClass( get_called_class() );
-			$constants = $reflect->getConstants();
-			foreach ( $constants as $constantName => $constantValue ) {
-				delete_option( $constantValue );
+			foreach( self::$grouped_options as $group ) {
+				delete_option( $group );
+			}
+
+			$non_compacts = self::get_option_names( 'non_compact' );
+			foreach ( $non_compacts as $non_compact ) {
+				delete_option( "wc_connect_$non_compact" );
 			}
 
 			self::delete_all_shipping_methods_options();
+		}
+
+		/**
+		 * Returns the requested option.  Looks in wc_connect_options or wc_connect_$name as appropriate.
+		 *
+		 * @param string $name Option name
+		 * @param mixed $default (optional)
+		 *
+		 * @return mixed
+		 */
+		public static function get_option( $name, $default = false ) {
+			if ( self::is_valid( $name, 'non_compact' ) ) {
+				return get_option( "wc_connect_$name", $default );
+			}
+
+			foreach ( array_keys( self::$grouped_options ) as $group ) {
+				if ( self::is_valid( $name, $group ) ) {
+					return self::get_grouped_option( $group, $name, $default );
+				}
+			}
+
+			trigger_error( sprintf( 'Invalid WooCommerce Services option name: %s', $name ), E_USER_WARNING );
+			return $default;
+		}
+
+		/**
+		 * Updates the single given option.  Updates wc_connect_options or wc_connect_$name as appropriate.
+		 *
+		 * @param string $name Option name
+		 * @param mixed $value Option value
+		 *
+		 * @return bool Was the option successfully updated?
+		 */
+		public static function update_option( $name, $value) {
+			if ( self::is_valid( $name, 'non_compact' ) ) {
+				return update_option( "wc_connect_$name", $value );
+			}
+			foreach ( array_keys( self::$grouped_options ) as $group ) {
+				if ( self::is_valid( $name, $group ) ) {
+					return self::update_grouped_option( $group, $name, $value );
+				}
+			}
+			trigger_error( sprintf( 'Invalid WooCommerce Services option name: %s', $name ), E_USER_WARNING );
+			return false;
+		}
+
+		/**
+		 * Deletes the given option.  May be passed multiple option names as an array.
+		 * Updates wc_connect_options and/or deletes wc_connect_$name as appropriate.
+		 *
+		 * @param string|array $names
+		 *
+		 * @return bool Was the option successfully deleted?
+		 */
+		public static function delete_option( $names ) {
+			$result = true;
+			$names  = (array) $names;
+			if ( ! self::is_valid( $names ) ) {
+				trigger_error( sprintf( 'Invalid WooCommerce Services option names: %s', print_r( $names, 1 ) ), E_USER_WARNING );
+				return false;
+			}
+			foreach ( array_intersect( $names, self::get_option_names( 'non_compact' ) ) as $name ) {
+				if ( ! delete_option( "wc_connect_$name" ) ) {
+					$result = false;
+				}
+			}
+			foreach ( array_keys( self::$grouped_options ) as $group ) {
+				if ( ! self::delete_grouped_option( $group, $names ) ) {
+					$result = false;
+				}
+			}
+			return $result;
+		}
+
+		/**
+		 * Gets a shipping method option
+		 *
+		 * @param $name
+		 * @param $default
+		 * @param $service_id
+		 * @param $service_instance
+		 *
+		 * @return mixed
+		 */
+		public static function get_shipping_method_option( $name, $default, $service_id, $service_instance = false ) {
+			$option_name = self::get_shipping_method_option_name( $name, $service_id, $service_instance );
+
+			if ( ! $option_name ) {
+				trigger_error( sprintf( 'Invalid WooCommerce Services shipping method option name: %s', $name ), E_USER_WARNING );
+				return $default;
+			}
+
+			return get_option( $option_name, $default );
+		}
+
+		/**
+		 * Updates a shipping method option
+		 *
+		 * @param $name
+		 * @param $value
+		 * @param $service_id
+		 * @param $service_instance
+		 *
+		 * @return bool
+		 */
+		public static function update_shipping_method_option( $name, $value, $service_id, $service_instance = false ) {
+			$option_name = self::get_shipping_method_option_name( $name, $service_id, $service_instance );
+
+			if ( ! $option_name ) {
+				trigger_error( sprintf( 'Invalid WooCommerce Services shipping method option name: %s', $name ), E_USER_WARNING );
+				return false;
+			}
+
+			return update_option( $option_name, $value );
+		}
+
+		/**
+		 * Deletes a shipping method option
+		 *
+		 * @param $name
+		 * @param $service_id
+		 * @param $service_instance
+		 *
+		 * @return bool
+		 */
+		public static function delete_shipping_method_option( $name, $service_id, $service_instance = false ) {
+			$option_name = self::get_shipping_method_option_name( $name, $service_id, $service_instance );
+
+			if ( ! $option_name ) {
+				trigger_error( sprintf( 'Invalid WooCommerce Services shipping method option name: %s', $name ), E_USER_WARNING );
+				return false;
+			}
+
+			return delete_option( $option_name );
+		}
+
+		/**
+		 * Deletes all options related to a shipping method
+		 *
+		 * @param $service_id
+		 * @param $service_instance
+		 */
+		public static function delete_shipping_method_options( $service_id, $service_instance = false ) {
+			$option_names = self::get_option_names( 'shipping_method' );
+
+			foreach ( $option_names as $name ) {
+				delete_option( self::get_shipping_method_option_name( $name, $service_id, $service_instance ) );
+			}
+		}
+
+		private static function get_grouped_option( $group, $name, $default ) {
+			$options = get_option( self::$grouped_options[ $group ] );
+			if ( is_array( $options ) && isset( $options[ $name ] ) ) {
+				return $options[ $name ];
+			}
+			return $default;
+		}
+
+		private static function update_grouped_option( $group, $name, $value ) {
+			$options = get_option( self::$grouped_options[ $group ] );
+			if ( ! is_array( $options ) ) {
+				$options = array();
+			}
+			$options[ $name ] = $value;
+			return update_option( self::$grouped_options[ $group ], $options );
+		}
+
+		private static function delete_grouped_option( $group, $names ) {
+			$options = get_option( self::$grouped_options[ $group ], array() );
+			$to_delete = array_intersect( $names, self::get_option_names( $group ), array_keys( $options ) );
+			if ( $to_delete ) {
+				foreach ( $to_delete as $name ) {
+					unset( $options[ $name ] );
+				}
+				return update_option( self::$grouped_options[ $group ], $options );
+			}
+			return true;
+		}
+
+		/**
+		 * Based on the service id and optional instance, generates the option name
+		 *
+		 * @param $name
+		 * @param $service_id
+		 * @param $service_instance
+		 *
+		 * @return string|bool
+		 */
+		private static function get_shipping_method_option_name( $name, $service_id, $service_instance = false ) {
+			if ( ! in_array( $name, self::get_option_names( 'shipping_method' ) ) ) {
+				return false;
+			}
+
+			if ( ! $service_instance ) {
+				return 'woocommerce_' . $service_id . '_' . $name;
+			}
+
+			return 'woocommerce_' . $service_id . '_' . $service_instance . '_' . $name;
+		}
+
+		/**
+		 * Is the option name valid?
+		 *
+		 * @param string      $name  The name of the option
+		 * @param string      $group The name of the group that the option is in. Defaults to compact.
+		 *
+		 * @return bool Is the option name valid?
+		 */
+		private static function is_valid( $name, $group = 'non_compact' ) {
+			$group_keys = array_keys( self::$grouped_options );
+
+			if ( is_array( $name ) ) {
+				$compact_names = array();
+				foreach ( $group_keys as $_group ) {
+					$compact_names = array_merge( $compact_names, self::get_option_names( $_group ) );
+				}
+				$result = array_diff( $name, self::get_option_names( 'non_compact' ), $compact_names );
+				return empty( $result );
+			}
+
+			if ( is_null( $group ) || 'non_compact' === $group ) {
+				if ( in_array( $name, self::get_option_names( $group ) ) ) {
+					return true;
+				}
+			}
+
+			foreach ( array_keys( self::$grouped_options ) as $_group ) {
+				if ( is_null( $group ) || $group === $_group ) {
+					if ( in_array( $name, self::get_option_names( $_group ) ) ) {
+						return true;
+					}
+				}
+			}
+			return false;
 		}
 
 		/**
@@ -90,7 +313,5 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				self::delete_shipping_method_options( $method->method_id, $method->instance_id );
 			}
 		}
-
-
 	}
 }

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -1,0 +1,104 @@
+<?php
+
+if ( ! class_exists( 'WC_Connect_Options' ) ) {
+	class WC_Connect_Options {
+		public static $tos_accepted = 'wc_connect_tos_accepted';
+		public static $store_guid = 'wc_connect_store_guid';
+		public static $error_notice = 'wc_connect_error_notice';
+		public static $debug_enabled = 'wc_connect_debug_logging_enabled';
+		public static $payment_methods = 'wc_connect_payment_methods';
+		public static $service_schemas = 'wc_connect_services';
+		public static $last_schema_update = 'wc_connect_services_last_update';
+		public static $last_heartbeat = 'wc_connect_last_heartbeat';
+		public static $account_settings = 'wc_connect_account_settings';
+		public static $paper_size = 'wc_connect_paper_size';
+		public static $origin_address = 'wc_connect_origin_address';
+		public static $custom_packages = 'wc_connect_packages';
+		public static $predefined_packages = 'wc_connect_predefined_packages';
+		public static $last_rate_request = 'wc_connect_last_rate_request';
+
+		/**
+		 * Based on the service id and optional instance, generates the options key that
+		 * should be used to get/set the service's settings
+		 *
+		 * @param $service_id
+		 * @param $service_instance
+		 *
+		 * @return string
+		 */
+		public static function get_service_settings_key( $service_id, $service_instance = false ) {
+			if ( ! $service_instance ) {
+				return 'woocommerce_' . $service_id . '_form_settings';
+			}
+
+			return 'woocommerce_' . $service_id . '_' . $service_instance . '_form_settings';
+		}
+
+		/**
+		 * Based on the service id and optional instance, generates the options key that
+		 * should be used to get/set the service's last failure timestamp
+		 *
+		 * @param $service_id
+		 * @param $service_instance
+		 *
+		 * @return string
+		 */
+		public static function get_service_failure_timestamp_key( $service_id, $service_instance = false ) {
+			if ( ! $service_instance ) {
+				return 'woocommerce_' . $service_id . '_failure_timestamp';
+			}
+
+			return 'woocommerce_' . $service_id . '_' . $service_instance . '_failure_timestamp';
+		}
+
+		/**
+		 * Deletes all options related to a shipping method
+		 * @param $service_id
+		 * @param $service_instance
+		 */
+		public static function delete_shipping_method_options( $service_id, $service_instance = false ) {
+			delete_option( self::get_service_settings_key( $service_id, $service_instance ) );
+			delete_option( self::get_service_failure_timestamp_key( $service_id, $service_instance ) );
+		}
+
+		/**
+		 * Deletes all options created by WooCommerce Services
+		 */
+		public static function delete_all_options() {
+			if ( defined( 'WOOCOMMERCE_CONNECT_DEV_SERVER_URL' ) ) {
+				return;
+			}
+
+			delete_option( self::$tos_accepted );
+			delete_option( self::$store_guid );
+			delete_option( self::$error_notice );
+			delete_option( self::$debug_enabled );
+			delete_option( self::$payment_methods );
+			delete_option( self::$service_schemas );
+			delete_option( self::$last_schema_update );
+			delete_option( self::$last_heartbeat );
+			delete_option( self::$account_settings );
+			delete_option( self::$paper_size );
+			delete_option( self::$origin_address );
+			delete_option( self::$custom_packages );
+			delete_option( self::$predefined_packages );
+			delete_option( self::$last_rate_request );
+
+			self::delete_all_shipping_methods_options();
+		}
+
+		/**
+		 * Deletes all options of all shipping methods
+		 */
+		private static function delete_all_shipping_methods_options() {
+			global $wpdb;
+			$methods = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}woocommerce_shipping_zone_methods " );
+
+			foreach ( (array) $methods as $method ) {
+				self::delete_shipping_method_options( $method->method_id, $method->instance_id );
+			}
+		}
+
+
+	}
+}

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -221,7 +221,18 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			if ( is_array( $options ) && isset( $options[ $name ] ) ) {
 				return $options[ $name ];
 			}
-			return $default;
+
+			//make the grouped options backwards-compatible and migrate the old options
+			$legacy_name = "wc_connect_$name";
+			$legacy_option = get_option( $legacy_name, false );
+			if ( ! $legacy_option ) {
+				return $default;
+			}
+			if ( self::update_grouped_option( $group, $name, $legacy_option ) ) {
+				delete_option( $legacy_name );
+			}
+
+			return $legacy_option;
 		}
 
 		private static function update_grouped_option( $group, $name, $value ) {

--- a/classes/class-wc-connect-payment-methods-store.php
+++ b/classes/class-wc-connect-payment-methods-store.php
@@ -80,11 +80,11 @@ if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 		}
 
 		public function get_payment_methods() {
-			return get_option( 'wc_connect_payment_methods', array() );
+			return get_option( WC_Connect_Options::$payment_methods, array() );
 		}
 
 		protected function update_payment_methods( $payment_methods ) {
-			update_option( 'wc_connect_payment_methods', $payment_methods );
+			update_option( WC_Connect_Options::$payment_methods, $payment_methods );
 		}
 
 		protected function get_payment_methods_from_response_body( $response_body ) {

--- a/classes/class-wc-connect-payment-methods-store.php
+++ b/classes/class-wc-connect-payment-methods-store.php
@@ -80,11 +80,11 @@ if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 		}
 
 		public function get_payment_methods() {
-			return get_option( WC_Connect_Options::$payment_methods, array() );
+			return get_option( WC_Connect_Options::PAYMENT_METHODS, array() );
 		}
 
 		protected function update_payment_methods( $payment_methods ) {
-			update_option( WC_Connect_Options::$payment_methods, $payment_methods );
+			update_option( WC_Connect_Options::PAYMENT_METHODS, $payment_methods );
 		}
 
 		protected function get_payment_methods_from_response_body( $response_body ) {

--- a/classes/class-wc-connect-payment-methods-store.php
+++ b/classes/class-wc-connect-payment-methods-store.php
@@ -80,11 +80,11 @@ if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 		}
 
 		public function get_payment_methods() {
-			return get_option( WC_Connect_Options::PAYMENT_METHODS, array() );
+			return WC_Connect_Options::get_option( 'payment_methods', array() );
 		}
 
 		protected function update_payment_methods( $payment_methods ) {
-			update_option( WC_Connect_Options::PAYMENT_METHODS, $payment_methods );
+			WC_Connect_Options::update_option( 'payment_methods', $payment_methods );
 		}
 
 		protected function get_payment_methods_from_response_body( $response_body ) {

--- a/classes/class-wc-connect-service-schemas-store.php
+++ b/classes/class-wc-connect-service-schemas-store.php
@@ -40,23 +40,23 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 		}
 
 		public function get_service_schemas() {
-			return get_option( WC_Connect_Options::$service_schemas, null );
+			return get_option( WC_Connect_Options::SERVICE_SCHEMAS, null );
 		}
 
 		protected function update_service_schemas( $service_schemas ) {
-			update_option( WC_Connect_Options::$service_schemas, $service_schemas );
+			update_option( WC_Connect_Options::SERVICE_SCHEMAS, $service_schemas );
 		}
 
 		public function get_last_fetch_timestamp() {
-			return get_option( WC_Connect_Options::$last_schema_update, null );
+			return get_option( WC_Connect_Options::LAST_SCHEMA_UPDATE, null );
 		}
 
 		protected function update_last_fetch_timestamp() {
-			update_option( WC_Connect_Options::$last_schema_update, time() );
+			update_option( WC_Connect_Options::LAST_SCHEMA_UPDATE, time() );
 		}
 
 		protected function maybe_update_heartbeat() {
-			$last_heartbeat = get_option( WC_Connect_Options::$last_heartbeat );
+			$last_heartbeat = get_option( WC_Connect_Options::LAST_HEARTBEAT );
 			$now = time();
 
 			if ( ! $last_heartbeat ) {
@@ -73,7 +73,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 			}
 
 			if ( $should_update ) {
-				update_option( WC_Connect_Options::$last_heartbeat, $now );
+				update_option( WC_Connect_Options::LAST_HEARTBEAT, $now );
 			}
 		}
 

--- a/classes/class-wc-connect-service-schemas-store.php
+++ b/classes/class-wc-connect-service-schemas-store.php
@@ -40,23 +40,23 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 		}
 
 		public function get_service_schemas() {
-			return get_option( WC_Connect_Options::SERVICE_SCHEMAS, null );
+			return WC_Connect_Options::get_option( 'services', null );
 		}
 
 		protected function update_service_schemas( $service_schemas ) {
-			update_option( WC_Connect_Options::SERVICE_SCHEMAS, $service_schemas );
+			WC_Connect_Options::update_option( 'services', $service_schemas );
 		}
 
 		public function get_last_fetch_timestamp() {
-			return get_option( WC_Connect_Options::LAST_SCHEMA_UPDATE, null );
+			return WC_Connect_Options::get_option( 'services_last_update', null );
 		}
 
 		protected function update_last_fetch_timestamp() {
-			update_option( WC_Connect_Options::LAST_SCHEMA_UPDATE, time() );
+			WC_Connect_Options::update_option( 'services_last_update', time() );
 		}
 
 		protected function maybe_update_heartbeat() {
-			$last_heartbeat = get_option( WC_Connect_Options::LAST_HEARTBEAT );
+			$last_heartbeat = WC_Connect_Options::get_option( 'last_heartbeat' );
 			$now = time();
 
 			if ( ! $last_heartbeat ) {
@@ -73,7 +73,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 			}
 
 			if ( $should_update ) {
-				update_option( WC_Connect_Options::LAST_HEARTBEAT, $now );
+				WC_Connect_Options::update_option( 'last_heartbeat', $now );
 			}
 		}
 

--- a/classes/class-wc-connect-service-schemas-store.php
+++ b/classes/class-wc-connect-service-schemas-store.php
@@ -40,23 +40,23 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 		}
 
 		public function get_service_schemas() {
-			return get_option( 'wc_connect_services', null );
+			return get_option( WC_Connect_Options::$service_schemas, null );
 		}
 
 		protected function update_service_schemas( $service_schemas ) {
-			update_option( 'wc_connect_services', $service_schemas );
+			update_option( WC_Connect_Options::$service_schemas, $service_schemas );
 		}
 
 		public function get_last_fetch_timestamp() {
-			return get_option( 'wc_connect_services_last_update', null );
+			return get_option( WC_Connect_Options::$last_schema_update, null );
 		}
 
 		protected function update_last_fetch_timestamp() {
-			update_option( 'wc_connect_services_last_update', time() );
+			update_option( WC_Connect_Options::$last_schema_update, time() );
 		}
 
 		protected function maybe_update_heartbeat() {
-			$last_heartbeat = get_option( 'wc_connect_last_heartbeat' );
+			$last_heartbeat = get_option( WC_Connect_Options::$last_heartbeat );
 			$now = time();
 
 			if ( ! $last_heartbeat ) {
@@ -73,7 +73,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 			}
 
 			if ( $should_update ) {
-				update_option( 'wc_connect_last_heartbeat', $now );
+				update_option( WC_Connect_Options::$last_heartbeat, $now );
 			}
 		}
 

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			$default = array(
 				'selected_payment_method_id' => 0
 			);
-			return get_option( WC_Connect_Options::$account_settings, $default );
+			return get_option( WC_Connect_Options::ACCOUNT_SETTINGS, $default );
 		}
 
 		/**
@@ -68,7 +68,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				return false;
 			}
 
-			return update_option( WC_Connect_Options::$account_settings, $settings );;
+			return update_option( WC_Connect_Options::ACCOUNT_SETTINGS, $settings );;
 		}
 
 		public function get_selected_payment_method_id() {
@@ -100,16 +100,16 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			$wc_address_fields[ 'postcode' ] = '';
 			$wc_address_fields[ 'phone' ] = '';
 
-			$stored_address_fields = get_option( WC_Connect_Options::$origin_address, array() );
+			$stored_address_fields = get_option( WC_Connect_Options::ORIGIN_ADDRESS, array() );
 			return array_merge( $wc_address_fields, $stored_address_fields );
 		}
 
 		public function get_preferred_paper_size() {
-			return get_option( WC_Connect_Options::$paper_size, '' );
+			return get_option( WC_Connect_Options::PAPER_SIZE, '' );
 		}
 
 		public function set_preferred_paper_size( $size ) {
-			return update_option( WC_Connect_Options::$paper_size, $size );
+			return update_option( WC_Connect_Options::PAPER_SIZE, $size );
 		}
 
 		public function update_label_order_meta_data( $order_id, $new_label_data ) {
@@ -124,7 +124,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		}
 
 		public function update_origin_address( $address ) {
-			return update_option( WC_Connect_Options::$origin_address, $address );
+			return update_option( WC_Connect_Options::ORIGIN_ADDRESS, $address );
 		}
 
 		protected function sort_services( $a, $b ) {
@@ -281,7 +281,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @return array
 		 */
 		public function get_packages() {
-			return get_option( WC_Connect_Options::$custom_packages, array() );
+			return get_option( WC_Connect_Options::CUSTOM_PACKAGES, array() );
 		}
 
 		/**
@@ -290,7 +290,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @param array packages
 		 */
 		public function update_packages( $packages ) {
-			update_option( WC_Connect_Options::$custom_packages, $packages );
+			update_option( WC_Connect_Options::CUSTOM_PACKAGES, $packages );
 		}
 
 		/**
@@ -299,7 +299,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @return array
 		 */
 		public function get_predefined_packages() {
-			return get_option( WC_Connect_Options::$predefined_packages, array() );
+			return get_option( WC_Connect_Options::PREDEFINED_PACKAGES, array() );
 		}
 
 		/**
@@ -323,7 +323,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @param array packages
 		 */
 		public function update_predefined_packages( $packages ) {
-			update_option( WC_Connect_Options::$predefined_packages, $packages );
+			update_option( WC_Connect_Options::PREDEFINED_PACKAGES, $packages );
 		}
 
 		public function get_package_lookup_for_service( $service_id ) {

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			$default = array(
 				'selected_payment_method_id' => 0
 			);
-			return get_option( 'wc_connect_account_settings', $default );
+			return get_option( WC_Connect_Options::$account_settings, $default );
 		}
 
 		/**
@@ -68,7 +68,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				return false;
 			}
 
-			return update_option( 'wc_connect_account_settings', $settings );;
+			return update_option( WC_Connect_Options::$account_settings, $settings );;
 		}
 
 		public function get_selected_payment_method_id() {
@@ -100,16 +100,16 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			$wc_address_fields[ 'postcode' ] = '';
 			$wc_address_fields[ 'phone' ] = '';
 
-			$stored_address_fields = get_option( 'wc_connect_origin_address', array() );
+			$stored_address_fields = get_option( WC_Connect_Options::$origin_address, array() );
 			return array_merge( $wc_address_fields, $stored_address_fields );
 		}
 
 		public function get_preferred_paper_size() {
-			return get_option( 'wc_connect_paper_size', '' );
+			return get_option( WC_Connect_Options::$paper_size, '' );
 		}
 
 		public function set_preferred_paper_size( $size ) {
-			return update_option( 'wc_connect_paper_size', $size );
+			return update_option( WC_Connect_Options::$paper_size, $size );
 		}
 
 		public function update_label_order_meta_data( $order_id, $new_label_data ) {
@@ -124,7 +124,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		}
 
 		public function update_origin_address( $address ) {
-			return update_option( 'wc_connect_origin_address', $address );
+			return update_option( WC_Connect_Options::$origin_address, $address );
 		}
 
 		protected function sort_services( $a, $b ) {
@@ -219,7 +219,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @return object|array
 		 */
 		public function get_service_settings( $service_id, $service_instance = false ) {
-			return get_option( $this->get_service_settings_key( $service_id, $service_instance ), array() );
+			return get_option( WC_Connect_Options::get_service_settings_key( $service_id, $service_instance ), array() );
 		}
 
 		/**
@@ -267,7 +267,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			}
 
 			// On success, save the settings to the database and exit
-			update_option( $this->get_service_settings_key( $id, $instance ), $settings );
+			update_option( WC_Connect_Options::get_service_settings_key( $id, $instance ), $settings );
 			// Invalidate shipping rates session cache
 			WC_Cache_Helper::get_transient_version( 'shipping', /* $refresh = */ true );
 			do_action( 'wc_connect_saved_service_settings', $id, $instance, $settings );
@@ -276,46 +276,12 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		}
 
 		/**
-		 * Based on the service id and optional instance, generates the options key that
-		 * should be used to get/set the service's settings
-		 *
-		 * @param string $service_id
-		 * @param integer $service_instance
-		 *
-		 * @return string
-		 */
-		protected function get_service_settings_key( $service_id, $service_instance = false ) {
-			if ( ! $service_instance ) {
-				return 'woocommerce_' . $service_id . '_form_settings';
-			}
-
-			return 'woocommerce_' . $service_id . '_' . $service_instance . '_form_settings';
-		}
-
-		/**
-		 * Based on the service id and optional instance, generates the options key that
-		 * should be used to get/set the service's last failure timestamp
-		 *
-		 * @param string $service_id
-		 * @param integer $service_instance
-		 *
-		 * @return string
-		 */
-		public function get_service_failure_timestamp_key( $service_id, $service_instance = false ) {
-			if ( ! $service_instance ) {
-				return 'woocommerce_' . $service_id . '_failure_timestamp';
-			}
-
-			return 'woocommerce_' . $service_id . '_' . $service_instance . '_failure_timestamp';
-		}
-
-		/**
 		 * Returns a global list of packages
 		 *
 		 * @return array
 		 */
 		public function get_packages() {
-			return get_option( 'wc_connect_packages', array() );
+			return get_option( WC_Connect_Options::$custom_packages, array() );
 		}
 
 		/**
@@ -324,7 +290,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @param array packages
 		 */
 		public function update_packages( $packages ) {
-			update_option( 'wc_connect_packages', $packages );
+			update_option( WC_Connect_Options::$custom_packages, $packages );
 		}
 
 		/**
@@ -333,7 +299,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @return array
 		 */
 		public function get_predefined_packages() {
-			return get_option( 'wc_connect_predefined_packages', array() );
+			return get_option( WC_Connect_Options::$predefined_packages, array() );
 		}
 
 		/**
@@ -357,7 +323,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @param array packages
 		 */
 		public function update_predefined_packages( $packages ) {
-			update_option( 'wc_connect_predefined_packages', $packages );
+			update_option( WC_Connect_Options::$predefined_packages, $packages );
 		}
 
 		public function get_package_lookup_for_service( $service_id ) {

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			$default = array(
 				'selected_payment_method_id' => 0
 			);
-			return get_option( WC_Connect_Options::ACCOUNT_SETTINGS, $default );
+			return WC_Connect_Options::get_option( 'account_settings', $default );
 		}
 
 		/**
@@ -68,7 +68,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				return false;
 			}
 
-			return update_option( WC_Connect_Options::ACCOUNT_SETTINGS, $settings );;
+			return WC_Connect_Options::update_option( 'account_settings', $settings );;
 		}
 
 		public function get_selected_payment_method_id() {
@@ -100,16 +100,16 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			$wc_address_fields[ 'postcode' ] = '';
 			$wc_address_fields[ 'phone' ] = '';
 
-			$stored_address_fields = get_option( WC_Connect_Options::ORIGIN_ADDRESS, array() );
+			$stored_address_fields = WC_Connect_Options::get_option( 'origin_address', array() );
 			return array_merge( $wc_address_fields, $stored_address_fields );
 		}
 
 		public function get_preferred_paper_size() {
-			return get_option( WC_Connect_Options::PAPER_SIZE, '' );
+			return WC_Connect_Options::get_option( 'paper_size', '' );
 		}
 
 		public function set_preferred_paper_size( $size ) {
-			return update_option( WC_Connect_Options::PAPER_SIZE, $size );
+			return WC_Connect_Options::update_option( 'paper_size', $size );
 		}
 
 		public function update_label_order_meta_data( $order_id, $new_label_data ) {
@@ -124,7 +124,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		}
 
 		public function update_origin_address( $address ) {
-			return update_option( WC_Connect_Options::ORIGIN_ADDRESS, $address );
+			return WC_Connect_Options::update_option( 'origin_address', $address );
 		}
 
 		protected function sort_services( $a, $b ) {
@@ -219,7 +219,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @return object|array
 		 */
 		public function get_service_settings( $service_id, $service_instance = false ) {
-			return get_option( WC_Connect_Options::get_service_settings_key( $service_id, $service_instance ), array() );
+			return WC_Connect_Options::get_shipping_method_option( 'form_settings', array(), $service_id, $service_instance );
 		}
 
 		/**
@@ -267,7 +267,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			}
 
 			// On success, save the settings to the database and exit
-			update_option( WC_Connect_Options::get_service_settings_key( $id, $instance ), $settings );
+			WC_Connect_Options::update_shipping_method_option( 'form_settings', $settings, $id, $instance );
 			// Invalidate shipping rates session cache
 			WC_Cache_Helper::get_transient_version( 'shipping', /* $refresh = */ true );
 			do_action( 'wc_connect_saved_service_settings', $id, $instance, $settings );
@@ -281,7 +281,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @return array
 		 */
 		public function get_packages() {
-			return get_option( WC_Connect_Options::CUSTOM_PACKAGES, array() );
+			return WC_Connect_Options::get_option( 'packages', array() );
 		}
 
 		/**
@@ -290,7 +290,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @param array packages
 		 */
 		public function update_packages( $packages ) {
-			update_option( WC_Connect_Options::CUSTOM_PACKAGES, $packages );
+			WC_Connect_Options::update_option( 'packages', $packages );
 		}
 
 		/**
@@ -299,7 +299,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @return array
 		 */
 		public function get_predefined_packages() {
-			return get_option( WC_Connect_Options::PREDEFINED_PACKAGES, array() );
+			return WC_Connect_Options::get_option( 'predefined_packages', array() );
 		}
 
 		/**
@@ -323,7 +323,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @param array packages
 		 */
 		public function update_predefined_packages( $packages ) {
-			update_option( WC_Connect_Options::PREDEFINED_PACKAGES, $packages );
+			WC_Connect_Options::update_option( 'predefined_packages', $packages );
 		}
 
 		public function get_package_lookup_for_service( $service_id ) {

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -375,10 +375,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		}
 
 		public function update_last_rate_request_timestamp() {
-			$previous_timestamp = get_option( WC_Connect_Options::$last_rate_request );
+			$previous_timestamp = get_option( WC_Connect_Options::LAST_RATE_REQUEST );
 			if ( false === $previous_timestamp ||
 				( time() - HOUR_IN_SECONDS ) > $previous_timestamp ) {
-				update_option( WC_Connect_Options::$last_rate_request, time() );
+				update_option( WC_Connect_Options::LAST_RATE_REQUEST, time() );
 			}
 		}
 

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -375,10 +375,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		}
 
 		public function update_last_rate_request_timestamp() {
-			$previous_timestamp = get_option( 'wc_connect_last_rate_request' );
+			$previous_timestamp = get_option( WC_Connect_Options::$last_rate_request );
 			if ( false === $previous_timestamp ||
 				( time() - HOUR_IN_SECONDS ) > $previous_timestamp ) {
-				update_option( 'wc_connect_last_rate_request', time() );
+				update_option( WC_Connect_Options::$last_rate_request, time() );
 			}
 		}
 
@@ -387,7 +387,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				$timestamp = time();
 			}
 
-			update_option( $this->service_settings_store->get_service_failure_timestamp_key( $this->id, $this->instance_id ), $timestamp );
+			update_option( WC_Connect_Options::get_service_failure_timestamp_key( $this->id, $this->instance_id ), $timestamp );
 		}
 
 		public function admin_options() {

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -375,10 +375,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		}
 
 		public function update_last_rate_request_timestamp() {
-			$previous_timestamp = get_option( WC_Connect_Options::LAST_RATE_REQUEST );
+			$previous_timestamp = WC_Connect_Options::get_option( 'last_rate_request' );
 			if ( false === $previous_timestamp ||
 				( time() - HOUR_IN_SECONDS ) > $previous_timestamp ) {
-				update_option( WC_Connect_Options::LAST_RATE_REQUEST, time() );
+				WC_Connect_Options::update_option( 'last_rate_request', time() );
 			}
 		}
 
@@ -387,7 +387,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				$timestamp = time();
 			}
 
-			update_option( WC_Connect_Options::get_service_failure_timestamp_key( $this->id, $this->instance_id ), $timestamp );
+			WC_Connect_Options::update_shipping_method_option( 'failure_timestamp', $timestamp, $this->id, $this->instance_id );
 		}
 
 		public function admin_options() {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -27,6 +27,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require_once( plugin_basename( 'classes/class-wc-connect-options.php' ) );
+
 if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 	define( 'WOOCOMMERCE_CONNECT_MINIMUM_WOOCOMMERCE_VERSION', '2.6' );
@@ -165,7 +167,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		static function plugin_uninstall() {
-			require_once( plugin_basename( 'classes/class-wc-connect-options.php' ) );
 			WC_Connect_Options::delete_all_options();
 		}
 
@@ -346,8 +347,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * @codeCoverageIgnore
 		 */
 		public function init() {
-			require_once( plugin_basename( 'classes/class-wc-connect-options.php' ) );
-
 			if ( ! get_option( WC_Connect_Options::TOS_ACCEPTED, false ) ) {
 				add_action( 'admin_init', array( $this, 'admin_tos_notice' ) );
 				return;

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -162,6 +162,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$tracks = self::load_tracks_for_activation_hooks();
 			$tracks->opted_out();
 			wp_clear_scheduled_hook( 'wc_connect_fetch_service_schemas' );
+		}
+
+		static function plugin_uninstall() {
+			require_once( plugin_basename( 'classes/class-wc-connect-options.php' ) );
 			WC_Connect_Options::delete_all_options();
 		}
 
@@ -865,3 +869,4 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 }
 
 register_deactivation_hook( __FILE__, array( 'WC_Connect_Loader', 'plugin_deactivation' ) );
+register_uninstall_hook( __FILE__, array( 'WC_Connect_Loader', 'plugin_uninstall' ) );

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -347,7 +347,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * @codeCoverageIgnore
 		 */
 		public function init() {
-			if ( ! get_option( WC_Connect_Options::TOS_ACCEPTED, false ) ) {
+			if ( ! WC_Connect_Options::get_option( 'tos_accepted', false ) ) {
 				add_action( 'admin_init', array( $this, 'admin_tos_notice' ) );
 				return;
 			}
@@ -710,7 +710,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			if ( 'accept' === $_GET['wc-connect-notice'] ) {
 				$tracks = self::load_tracks_for_activation_hooks();
 				$tracks->opted_in();
-				update_option( WC_Connect_Options::TOS_ACCEPTED, true );
+				WC_Connect_Options::update_option( 'tos_accepted', true );
 				wp_safe_redirect( admin_url( 'admin.php?page=wc-settings&tab=shipping' ) );
 
 				exit;

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -162,6 +162,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$tracks = self::load_tracks_for_activation_hooks();
 			$tracks->opted_out();
 			wp_clear_scheduled_hook( 'wc_connect_fetch_service_schemas' );
+			WC_Connect_Options::delete_all_options();
 		}
 
 		public function __construct() {
@@ -341,7 +342,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * @codeCoverageIgnore
 		 */
 		public function init() {
-			if ( ! get_option( 'wc_connect_tos_accepted', false ) ) {
+			require_once( plugin_basename( 'classes/class-wc-connect-options.php' ) );
+
+			if ( ! get_option( WC_Connect_Options::$tos_accepted, false ) ) {
 				add_action( 'admin_init', array( $this, 'admin_tos_notice' ) );
 				return;
 			}
@@ -704,8 +707,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			if ( 'accept' === $_GET['wc-connect-notice'] ) {
 				$tracks = self::load_tracks_for_activation_hooks();
 				$tracks->opted_in();
-
-				update_option( 'wc_connect_tos_accepted', true );
+				update_option( WC_Connect_Options::$tos_accepted, true );
 				wp_safe_redirect( admin_url( 'admin.php?page=wc-settings&tab=shipping' ) );
 
 				exit;
@@ -794,6 +796,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		public function shipping_zone_method_deleted( $instance_id, $service_id, $zone_id ) {
 			if ( $this->is_wc_connect_shipping_service( $service_id ) ) {
+				WC_Connect_Options::delete_shipping_method_options(  $service_id, $instance_id );
 				do_action( 'wc_connect_shipping_zone_method_deleted', $instance_id, $service_id, $zone_id );
 			}
 		}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -348,7 +348,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function init() {
 			require_once( plugin_basename( 'classes/class-wc-connect-options.php' ) );
 
-			if ( ! get_option( WC_Connect_Options::$tos_accepted, false ) ) {
+			if ( ! get_option( WC_Connect_Options::TOS_ACCEPTED, false ) ) {
 				add_action( 'admin_init', array( $this, 'admin_tos_notice' ) );
 				return;
 			}
@@ -711,7 +711,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			if ( 'accept' === $_GET['wc-connect-notice'] ) {
 				$tracks = self::load_tracks_for_activation_hooks();
 				$tracks->opted_in();
-				update_option( WC_Connect_Options::$tos_accepted, true );
+				update_option( WC_Connect_Options::TOS_ACCEPTED, true );
 				wp_safe_redirect( admin_url( 'admin.php?page=wc-settings&tab=shipping' ) );
 
 				exit;


### PR DESCRIPTION
Adds #776 

### Careful when testing this one!
Removing the plugin will delete all of the directory contents, including local git repo and node_modules. This happens even if you use symlinks. Obvious, but worth pointing out.

Best checkout this repo separately into a fresh WP/WooCommerce installation, run `npm dist`, update some settings, then delete the plugin and verify that all of the options are gone as well.