### PR TITLE
Prevent label rates requests when packaging data is errant

### DIFF
--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -239,8 +239,12 @@ export const confirmAddressSuggestion = ( group ) => ( dispatch, getState, { sto
 
 	const errors = getFormErrors( getState(), storeOptions );
 
-	// Make sure packaging is error free before fetching new rates after address confirmation
-	if ( hasNonEmptyLeaves( errors.packages ) ) {
+	// If all prerequisite steps are error free, fetch new rates
+	if (
+		hasNonEmptyLeaves( errors.origin ) ||
+		hasNonEmptyLeaves( errors.destination ) ||
+		hasNonEmptyLeaves( errors.packages )
+	) {
 		return;
 	}
 

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -256,6 +256,17 @@ export const submitAddressForNormalization = ( group ) => ( dispatch, getState, 
 				expandFirstErroneousStep( dispatch, getState, storeOptions, group );
 			};
 
+			const errors = getFormErrors( getState(), storeOptions );
+
+			// If all prerequisite steps are error free, fetch new rates
+			if (
+				hasNonEmptyLeaves( errors.origin ) ||
+				hasNonEmptyLeaves( errors.destination ) ||
+				hasNonEmptyLeaves( errors.packages )
+			) {
+				return;
+			}
+
 			getLabelRates( dispatch, getState, handleRatesResponse, { getRatesURL, nonce } );
 		}
 	};

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -237,6 +237,13 @@ export const confirmAddressSuggestion = ( group ) => ( dispatch, getState, { sto
 		expandFirstErroneousStep( dispatch, getState, storeOptions, group );
 	};
 
+	const errors = getFormErrors( getState(), storeOptions );
+
+	// Make sure packaging is error free before fetching new rates after address confirmation
+	if ( hasNonEmptyLeaves( errors.packages ) ) {
+		return;
+	}
+
 	getLabelRates( dispatch, getState, handleResponse, { getRatesURL, nonce } );
 };
 

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -174,7 +174,8 @@ export const openPrintingFlow = () => ( dispatch, getState, context ) => {
 			form.destination.isNormalized &&
 			_.isEqual( form.destination.values, form.destination.normalized ) &&
 			_.isEmpty( form.rates.available ) &&
-			form.packages.all && Object.keys( form.packages.all ).length
+			form.packages.all && Object.keys( form.packages.all ).length &&
+			! hasNonEmptyLeaves( errors.packages )
 		) {
 			return getLabelRates( dispatch, getState, showPreviewAfterRateFetch, { getRatesURL, nonce } );
 		}


### PR DESCRIPTION
This is a fix for https://github.com/Automattic/woocommerce-connect-server/issues/775, which was thought to be a server side issue.

To test:
* Manually create an order with a product that has invalid or missing weight/dimensions info, but with a destination address that will automatically pass normalization
* Open create label dialog
* Verify that the Packaging step is open with errors, and rates are not requested
* Reopen the Destination step, click "use this address"
* Verify that the Packaging step is open with errors, and rates are not requested
* Reopen the Destination step, enter in an address that will trigger a non-trivial normalization result
* Click "use this address"
* Verify that the Packaging step is open with errors, and rates are not requested