### PR TITLE
Bump minimum versions of WordPress & Jetpack required (only in the documentation).

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,9 @@ If you're filing a bug, specific steps to reproduce are helpful. Please include 
 
 ## Setting up USPS shipping with the WooCommerce Services
 
-1. Install or update to [WordPress 4.5](https://wordpress.org/download/) or higher.
-2. Install and activate [WooCommerce 2.6 or higher](https://wordpress.org/plugins/woocommerce/). WooCommerce Services will NOT work with WooCommerce 2.5 or older.
-3. Install and activate [Jetpack 3.9.6 or higher](https://wordpress.org/plugins/jetpack/).
+1. Install or update to [WordPress 4.6 or higher](https://wordpress.org/download/).
+2. Install and activate [WooCommerce 2.6 or higher](https://wordpress.org/plugins/woocommerce/).
+3. Install and activate [Jetpack 4.6 or higher](https://wordpress.org/plugins/jetpack/).
 4. Connect your Jetpack to WordPress.com. Although there is no specific module you need to activate, WooCommerce Services requires the Jetpack connection to authenticate with the WooCommerce Services server.
 5. Install and activate this feature plugin.
 6. Add at least one product with weight and dimensions.

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce Services ===
 Contributors: automattic, woothemes, allendav, kellychoffman, jkudish, jeffstieler, nabsul, robobot3000, danreylop, mikeyarce, shaunkuschel
 Tags: canada-post, shipping, stamps, usps, woocommerce
-Requires at least: 4.6.1
+Requires at least: 4.6
 Tested up to: 4.7.2
 Stable tag: 1.1.1
 License: GPLv2 or later


### PR DESCRIPTION
Fixes #691 

Although our plugin technically works with a much older version of Jetpack, it makes sense to recommend the most recent one (4.6). And, since Jetpack 4.6 requires WordPress 4.6, I've also changed that version requirement.