### PR TITLE
Include JSON parse error in service settings update repsonse

### DIFF
--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -59,10 +59,8 @@ class WC_REST_Connect_Account_Settings_Controller extends WP_REST_Controller {
 	}
 
 	public function update_items( $request ) {
-		$request_body = $request->get_body();
-		$settings = json_decode( $request_body, true, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
-
-		$result = $this->settings_store->update_account_settings( $settings );
+		$settings = $request->get_json_params();
+		$result   = $this->settings_store->update_account_settings( $settings );
 
 		if ( is_wp_error( $result ) ) {
 			$error = new WP_Error( 'save_failed',

--- a/classes/class-wc-rest-connect-address-normalization-controller.php
+++ b/classes/class-wc-rest-connect-address-normalization-controller.php
@@ -59,17 +59,17 @@ class WC_REST_Connect_Address_Normalization_Controller extends WP_REST_Controlle
 	}
 
 	public function update_items( $request ) {
-		$request = json_decode( $request->get_body(), false, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
-		$name = $request->address->name;
-		unset( $request->address->name );
-		$company = $request->address->company;
-		unset( $request->address->company );
-		$phone = $request->address->phone;
-		unset( $request->address->phone );
+		$data    = $request->get_json_params();
+		$address = $data['address'];
+		$name    = $address['name'];
+		$company = $address['company'];
+		$phone   = $address['phone'];
+
+		unset( $address['name'], $address['company'], $address['phone'] );
 
 		$body = array(
-			'destination' => $request->address,
-			'carrier' => 'usps',
+			'destination' => $address,
+			'carrier'     => 'usps', // TODO: remove hardcoding
 		);
 		$response = $this->api_client->send_address_normalization_request( $body );
 
@@ -108,10 +108,12 @@ class WC_REST_Connect_Address_Normalization_Controller extends WP_REST_Controlle
 	 * Validate the requester's permissions
 	 */
 	public function update_items_permissions_check( $request ) {
-		$request = json_decode( $request->get_body(), false, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
-		if ( 'origin' === $request->type ) {
+		$data = $request->get_json_params();
+
+		if ( 'origin' === $data['type'] ) {
 			return current_user_can( 'manage_woocommerce' ); // Only an admin can normalize the origin address
 		}
+
 		return true; // non-authenticated service for the 'destination' address
 	}
 

--- a/classes/class-wc-rest-connect-packages-controller.php
+++ b/classes/class-wc-rest-connect-packages-controller.php
@@ -53,8 +53,7 @@ class WC_REST_Connect_Packages_Controller extends WP_REST_Controller {
 	}
 
 	public function update_items( $request ) {
-		$request_body = $request->get_body();
-		$packages = json_decode( $request_body, true, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
+		$packages = $request->get_json_params();
 
 		$this->service_settings_store->update_packages( $packages[ 'custom' ] );
 		$this->service_settings_store->update_predefined_packages( $packages[ 'predefined' ] );

--- a/classes/class-wc-rest-connect-self-help-controller.php
+++ b/classes/class-wc-rest-connect-self-help-controller.php
@@ -51,12 +51,9 @@ class WC_REST_Connect_Self_Help_Controller extends WP_REST_Controller {
 	 * Attempts to update the settings on a particular service and instance
 	 */
 	public function update_items( $request ) {
+		$settings = $request->get_json_params();
 
-		$request_params = $request->get_params();
-		$request_body = $request->get_body();
-		$settings = json_decode( $request_body, false, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
-
-		if ( empty( $settings ) || ! is_object( $settings ) || ! property_exists( $settings, 'wcc_debug_on' ) ) {
+		if ( empty( $settings ) || ! array_key_exists( 'wcc_debug_on', $settings ) ) {
 			$error = new WP_Error( 'bad_form_data',
 				__( 'Unable to update settings. The form data could not be read.', 'woocommerce-services' ),
 				array( 'status' => 400 )
@@ -65,7 +62,7 @@ class WC_REST_Connect_Self_Help_Controller extends WP_REST_Controller {
 			return $error;
 		}
 
-		if ( 1 == $settings->wcc_debug_on ) {
+		if ( 1 == $settings['wcc_debug_on'] ) {
 			$this->logger->enable_logging();
 		} else {
 			$this->logger->disable_logging();

--- a/classes/class-wc-rest-connect-services-controller.php
+++ b/classes/class-wc-rest-connect-services-controller.php
@@ -96,7 +96,10 @@ class WC_REST_Connect_Services_Controller extends WP_REST_Controller {
 		if ( empty( $settings ) ) {
 			$error = new WP_Error( 'bad_form_data',
 				__( 'Unable to update service settings. The form data could not be read.', 'woocommerce-services' ),
-				array( 'status' => 400 )
+				array(
+					'status'     => 400,
+					'error_code' => json_last_error(),
+				)
 			);
 			$this->logger->debug( $error, __CLASS__ );
 			return $error;

--- a/classes/class-wc-rest-connect-services-controller.php
+++ b/classes/class-wc-rest-connect-services-controller.php
@@ -75,7 +75,6 @@ class WC_REST_Connect_Services_Controller extends WP_REST_Controller {
 	 * Attempts to update the settings on a particular service and instance
 	 */
 	public function update_item( $request ) {
-
 		$request_params = $request->get_params();
 
 		$id = array_key_exists( 'id', $request_params ) ? $request_params['id'] : '';
@@ -90,16 +89,12 @@ class WC_REST_Connect_Services_Controller extends WP_REST_Controller {
 			return $error;
 		}
 
-		$request_body = $request->get_body();
-		$settings = json_decode( $request_body, false, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
+		$settings = $request->get_json_params();
 
 		if ( empty( $settings ) ) {
 			$error = new WP_Error( 'bad_form_data',
 				__( 'Unable to update service settings. The form data could not be read.', 'woocommerce-services' ),
-				array(
-					'status'     => 400,
-					'error_code' => json_last_error(),
-				)
+				array( 'status' => 400 )
 			);
 			$this->logger->debug( $error, __CLASS__ );
 			return $error;

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -59,11 +59,8 @@ class WC_REST_Connect_Shipping_Label_Controller extends WP_REST_Controller {
 	}
 
 	public function update_items( $request ) {
-		$carrier = 'usps'; //TODO: remove hardcoding
-
-		$request_body = $request->get_body();
-		$settings = json_decode( $request_body, true, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
-
+		$carrier  = 'usps'; //TODO: remove hardcoding
+		$settings = $request->get_json_params();
 		$order_id = $settings[ 'order_id' ];
 
 		$settings[ 'payment_method_id' ] = $this->settings_store->get_selected_payment_method_id();

--- a/classes/class-wc-rest-connect-shipping-rates-controller.php
+++ b/classes/class-wc-rest-connect-shipping-rates-controller.php
@@ -64,8 +64,7 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WP_REST_Controller {
 	 * @return array|WP_Error
 	 */
 	public function update_items( $request ) {
-		$request_body = $request->get_body();
-		$payload      = json_decode( $request_body, true, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
+		$payload = $request->get_json_params();
 
 		// This is the earliest point in the printing label flow where we are sure that
 		// the merchant wants to ship from this exact address (normalized or otherwise)

--- a/client/account-settings/state/actions.js
+++ b/client/account-settings/state/actions.js
@@ -32,6 +32,7 @@ export const saveForm = ( onSaveSuccess, onSaveFailure ) => ( dispatch, getState
 		credentials: 'same-origin',
 		headers: {
 			'X-WP-Nonce': nonce,
+			'Content-Type': 'application/json',
 		},
 		body: JSON.stringify( getState().form.data ),
 	};

--- a/client/lib/save-form/index.js
+++ b/client/lib/save-form/index.js
@@ -9,6 +9,7 @@ const saveForm = ( setIsSaving, setSuccess, setFieldsStatus, setError, url, nonc
 		credentials: 'same-origin',
 		headers: {
 			'X-WP-Nonce': nonce,
+			'Content-Type': 'application/json',
 		},
 		body: formData ? JSON.stringify( formData ) : null,
 	};

--- a/client/packages/state/actions.js
+++ b/client/packages/state/actions.js
@@ -83,6 +83,7 @@ export const saveForm = ( onSaveSuccess, onSaveFailure ) => ( dispatch, getState
 		credentials: 'same-origin',
 		headers: {
 			'X-WP-Nonce': nonce,
+			'Content-Type': 'application/json',
 		},
 		body: JSON.stringify( getState().form.packages ),
 	};

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -514,6 +514,34 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$rest_address_normalization_controller = new WC_REST_Connect_Address_Normalization_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_address_normalization_controller( $rest_address_normalization_controller );
 			$rest_address_normalization_controller->register_routes();
+
+			add_filter( 'rest_request_before_callbacks', array( $this, 'log_rest_api_errors' ), 10, 3 );
+		}
+
+		/**
+		 * Log any WP_Errors encountered before our REST API callbacks
+		 *
+		 * Note: intended to be hooked into 'rest_request_before_callbacks'
+		 *
+		 * @param WP_HTTP_Response $response Result to send to the client. Usually a WP_REST_Response.
+		 * @param WP_REST_Server   $handler  ResponseHandler instance (usually WP_REST_Server).
+		 * @param WP_REST_Request  $request  Request used to generate the response.
+		 *
+		 * @return mixed - pass through value of $response.
+		 */
+		public function log_rest_api_errors( $response, $handler, $request ) {
+			if ( ! is_wp_error( $response ) ) {
+				return $response;
+			}
+
+			if ( 0 === strpos( $request->get_route(), '/wc/v1/connect/' ) ) {
+				$route_info = $request->get_method() . ' ' . $request->get_route();
+
+				$this->get_logger()->error( $response, $route_info );
+				$this->get_logger()->error( $route_info, $request->get_body() );
+			}
+
+			return $response;
 		}
 
 		/**


### PR DESCRIPTION
Include the encountered JSON error in the response when service settings update fails.

See: https://wordpress.org/support/topic/shipping-zones-not-being-accepted/

Initially this started with just adding the numeric JSON decoding error to the response, but after finding the WP REST API classes builtin handling of JSON errors, it switched to a refactoring of our REST API usage.

This PR seeks to add the `Content-Type: application/json` header to WP REST API requests (in order to invoke the built in handling), and remove the manual `json_decode()`ing of those request bodies.

To test:
* Send bad JSON to any WP REST API endpoint added by WCS
* Verify that an error is returned
* Verify that the error and request info is logged
* Verify that all existing functionality works in the /wp-admin/ (packages save, settings save, account settings save, address normalize, label rates request)