### PR TITLE
Fix IE11 and MS Edge errors

### DIFF
--- a/client/lib/save-form/index.js
+++ b/client/lib/save-form/index.js
@@ -10,8 +10,10 @@ const saveForm = ( setIsSaving, setSuccess, setFieldsStatus, setError, url, nonc
 		headers: {
 			'X-WP-Nonce': nonce,
 		},
-		body: formData ? JSON.stringify( formData ) : null,
 	};
+	if ( formData ) {
+		request.body = JSON.stringify( formData );
+	}
 
 	return fetch( url, request ).then( ( response ) => {
 		setError( null, null );

--- a/client/main.js
+++ b/client/main.js
@@ -1,8 +1,5 @@
-if ( ! global._babelPolyfill ) {
-	require( 'babel-polyfill' );
-}
-
 /*global wcConnectData */
+import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { applyMiddleware, createStore, compose } from 'redux';


### PR DESCRIPTION
Our plugin was completely broken on IE11 and Edge. This is what was happening:

`require()` statements are executed **after** `import` statements, even if they are before in the file. That means that the Polyfill wasn't executed until all the `import`ed JS modules were parsed and executed. This broke IE11 pretty bad. The solution is to include the polyfill using a regular `import`. This will break if there is another React-based plugin in the same page, but for now it's an acceptable tradeoff. It will be fixed when we start using `babel-preset-env` (spiking on it this week).

Also, MS Edge breaks if `fetch()` is called with a request with `body === null`, for some reason. I've changed it to include the `body` property only when there is actually a body.