### PR TITLE
Fix/451 method ids

### DIFF
--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -44,6 +44,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				'paper_size',
 				'packages',
 				'predefined_packages',
+				'shipping_methods_migrated',
 			);
 		}
 

--- a/classes/class-wc-connect-service-schemas-store.php
+++ b/classes/class-wc-connect-service-schemas-store.php
@@ -27,7 +27,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 
 			if ( is_wp_error( $response_body ) ) {
 				$this->logger->debug( $response_body, __FUNCTION__ );
-				return;
+				return false;
 			}
 
 			$this->logger->debug( 'Successfully loaded service schemas from server response.', __FUNCTION__ );
@@ -36,7 +36,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 
 			// If we made it this far, it is safe to store the object
 
-			$this->update_service_schemas( $response_body );
+			return $this->update_service_schemas( $response_body );
 		}
 
 		public function get_service_schemas() {
@@ -44,7 +44,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 		}
 
 		protected function update_service_schemas( $service_schemas ) {
-			WC_Connect_Options::update_option( 'services', $service_schemas );
+			return WC_Connect_Options::update_option( 'services', $service_schemas );
 		}
 
 		public function get_last_fetch_timestamp() {

--- a/classes/class-wc-connect-service-schemas-store.php
+++ b/classes/class-wc-connect-service-schemas-store.php
@@ -34,8 +34,13 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 			$this->update_last_fetch_timestamp();
 			$this->maybe_update_heartbeat();
 
-			// If we made it this far, it is safe to store the object
+			$old_schemas = $this->get_service_schemas();
+			if ( $old_schemas == $response_body ) {
+				//schemas weren't changed, but were fetched without problems
+				return true;
+			}
 
+			// If we made it this far, it is safe to store the object
 			return $this->update_service_schemas( $response_body );
 		}
 
@@ -109,21 +114,21 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 		 * @return array|bool An array of supported shipping method ids or false if schema does not support method_id
 		 */
 		public function get_all_shipping_method_ids() {
+			$shipping_method_ids = array();
 			$service_schemas = $this->get_service_schemas();
 			if ( ! is_object( $service_schemas ) || ! property_exists( $service_schemas, 'shipping' ) || ! is_array( $service_schemas->shipping ) ) {
-				return false;
+				return $shipping_method_ids;
 			}
 
-			$service_schema_ids = array();
 			foreach ( $service_schemas->shipping as $service_schema ) {
 				if ( ! property_exists( $service_schema, 'method_id' ) ) {
-					return false;
+					continue;
 				}
 
-				$service_schema_ids[] = $service_schema->method_id;
+				$shipping_method_ids[] = $service_schema->method_id;
 			}
 
-			return $service_schema_ids;
+			return $shipping_method_ids;
 		}
 
 		/**

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -237,12 +237,12 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 
 				$new_method_id = $service_schema->method_id;
 
-				$query = $wpdb->prepare(
-					"UPDATE {$wpdb->prefix}woocommerce_shipping_zone_methods " .
-					"SET method_id=%s " .
-					"WHERE instance_id=%s AND method_id=%s",
-					$new_method_id, $instance_id, $service_id);
-				$wpdb->query( $query );
+				$wpdb->update(
+					"{$wpdb->prefix}woocommerce_shipping_zone_methods",
+					array( 'method_id' => $new_method_id ),
+					array( 'instance_id' => $instance_id, 'method_id' => $service_id ),
+					array( '%s' ),
+					array( '%d', '%s' ) );
 
 				//update the migrated service settings
 				WC_Connect_Options::update_shipping_method_option( 'form_settings', $service_settings, $new_method_id, $instance_id );

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -214,8 +214,9 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * Checks if the shipping method ids have been migrated to the "wc_services_*" format and migrates them
 		 */
 		public function migrate_legacy_services() {
-			if ( WC_Connect_Options::get_option( 'shipping_methods_migrated', false )
-				|| ! $this->service_schemas_store->get_all_shipping_method_ids() ) {
+			if ( WC_Connect_Options::get_option( 'shipping_methods_migrated', false ) //check if the method have already been migrated
+				|| ! $this->service_schemas_store->fetch_service_schemas_from_connect_server() //ensure the latest schemas are fetched
+				|| ! $this->service_schemas_store->get_all_shipping_method_ids() ) { //verify that the schemas contain the method_id field
 				return;
 			}
 
@@ -229,11 +230,6 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				$service_id = $legacy_service->method_id;
 				$instance_id = $legacy_service->instance_id;
 				$service_schema = $this->service_schemas_store->get_service_schema_by_id( $service_id );
-				if ( ! property_exists( $service_schema, 'method_id' ) ) {
-					//schemas not ready for migration yet. Wait for them to be updated
-					return;
-				}
-
 				$service_settings = $this->get_service_settings( $service_id, $instance_id );
 				if ( ! is_object( $service_settings ) ) {
 					continue;

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -156,19 +156,21 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @return array
 		 */
 		public function get_enabled_services() {
-
-			$enabled_services = array();
-
-			$shipping_services = $this->service_schemas_store->get_all_service_ids_of_type( 'shipping' );
+			$shipping_services = $this->service_schemas_store->get_all_shipping_method_ids();
 			if ( empty( $shipping_services ) ) {
-				return $enabled_services;
+				return array();
 			}
+			return $this->get_enabled_services_by_ids( $shipping_services );
+		}
+
+		public function get_enabled_services_by_ids( $service_ids ) {
+			$enabled_services = array();
 
 			// Note: We use esc_sql here instead of prepare because we are using WHERE IN
 			// https://codex.wordpress.org/Function_Reference/esc_sql
 
 			$escaped_list = '';
-			foreach ( $shipping_services as $shipping_service ) {
+			foreach ( $service_ids as $shipping_service ) {
 				if ( ! empty( $escaped_list ) ) {
 					$escaped_list .= ',';
 				}
@@ -189,7 +191,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			}
 
 			foreach ( (array) $methods as $method ) {
-				$service_schema = $this->service_schemas_store->get_service_schema_by_id( $method->method_id );
+				$service_schema = $this->service_schemas_store->get_service_schema_by_method_id( $method->method_id );
 				$service_settings = $this->get_service_settings( $method->method_id, $method->instance_id );
 				if ( is_object( $service_settings ) && property_exists( $service_settings, 'title' ) ) {
 					$title = $service_settings->title;
@@ -206,7 +208,53 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 
 			usort( $enabled_services, array( $this, 'sort_services' ) );
 			return $enabled_services;
+		}
 
+		/**
+		 * Checks if the shipping method ids have been migrated to the "wc_services_*" format and migrates them
+		 */
+		public function migrate_legacy_services() {
+			if ( WC_Connect_Options::get_option( 'shipping_methods_migrated', false )
+				|| ! $this->service_schemas_store->get_all_shipping_method_ids() ) {
+				return;
+			}
+
+			global $wpdb;
+
+			//old services used the id field instead of method_id
+			$shipping_service_ids = $this->service_schemas_store->get_all_service_ids_of_type( 'shipping' );
+			$legacy_services = $this->get_enabled_services_by_ids( $shipping_service_ids );
+
+			foreach ( $legacy_services as $legacy_service ) {
+				$service_id = $legacy_service->method_id;
+				$instance_id = $legacy_service->instance_id;
+				$service_schema = $this->service_schemas_store->get_service_schema_by_id( $service_id );
+				if ( ! property_exists( $service_schema, 'method_id' ) ) {
+					//schemas not ready for migration yet. Wait for them to be updated
+					return;
+				}
+
+				$service_settings = $this->get_service_settings( $service_id, $instance_id );
+				if ( ! is_object( $service_settings ) ) {
+					continue;
+				}
+
+				$new_method_id = $service_schema->method_id;
+
+				$query = $wpdb->prepare(
+					"UPDATE {$wpdb->prefix}woocommerce_shipping_zone_methods " .
+					"SET method_id=%s " .
+					"WHERE instance_id=%s AND method_id=%s",
+					$new_method_id, $instance_id, $service_id);
+				$wpdb->query( $query );
+
+				//update the migrated service settings
+				WC_Connect_Options::update_shipping_method_option( 'form_settings', $service_settings, $new_method_id, $instance_id );
+				//delete the old service settings
+				WC_Connect_Options::delete_shipping_method_options( $service_id, $instance_id );
+			}
+
+			WC_Connect_Options::update_option( 'shipping_methods_migrated', true );
 		}
 
 		/**
@@ -241,7 +289,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 					);
 				}
 			} else {
-				$service_schema = $this->service_schemas_store->get_service_schema_by_id( $id );
+				$service_schema = $this->service_schemas_store->get_service_schema_by_method_id( $id );
 				if ( ! $service_schema ) {
 					wp_send_json_error(
 						array(

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -215,8 +215,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 */
 		public function migrate_legacy_services() {
 			if ( WC_Connect_Options::get_option( 'shipping_methods_migrated', false ) //check if the method have already been migrated
-				|| ! $this->service_schemas_store->fetch_service_schemas_from_connect_server() //ensure the latest schemas are fetched
-				|| ! $this->service_schemas_store->get_all_shipping_method_ids() ) { //verify that the schemas contain the method_id field
+				|| ! $this->service_schemas_store->fetch_service_schemas_from_connect_server() ) { //ensure the latest schemas are fetched
 				return;
 			}
 
@@ -231,7 +230,8 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				$instance_id = $legacy_service->instance_id;
 				$service_schema = $this->service_schemas_store->get_service_schema_by_id( $service_id );
 				$service_settings = $this->get_service_settings( $service_id, $instance_id );
-				if ( ! is_object( $service_settings ) ) {
+				if ( ( is_array( $service_settings ) && ! $service_settings ) //check for an empty array
+					|| ( ! is_array( $service_settings ) && ! is_object( $service_settings ) ) ) { //settings are neither an array nor an object
 					continue;
 				}
 

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -58,7 +58,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				$this->supports = array();
 				$this->title = '';
 			} else {
-				$this->id = $this->service_schema->id;
+				$this->id = $this->service_schema->method_id;
 				$this->method_title = $this->service_schema->method_title;
 				$this->method_description = $this->service_schema->method_description;
 				$this->supports = array(
@@ -280,7 +280,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			// the current shipping zone to avoid each method making an independent request
 			$services = array(
 				array(
-					'id'               => $this->id,
+					'id'               => $this->service_schema->id,
 					'instance'         => $this->instance_id,
 					'service_settings' => $service_settings,
 				),

--- a/tests/php/test_woocommerce-connect-client.php
+++ b/tests/php/test_woocommerce-connect-client.php
@@ -69,11 +69,11 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 
 		$store = $this->getMockBuilder( 'WC_Connect_Service_Schemas_Store' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'get_all_service_ids_of_type' ) )
+			->setMethods( array( 'get_all_shipping_method_ids' ) )
 			->getMock();
 
 		$store->expects( $this->any() )
-			->method( 'get_all_service_ids_of_type' )
+			->method( 'get_all_shipping_method_ids' )
 			->will( $this->returnValue( $service_data ) );
 
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -625,9 +625,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 */
 		public function woocommerce_shipping_methods( $shipping_methods ) {
 			$shipping_service_ids = $this->get_service_schemas_store()->get_all_shipping_method_ids();
-			if ( ! $shipping_service_ids ) {
-				return $shipping_methods;
-			}
 
 			foreach ( $shipping_service_ids as $shipping_service_id ) {
 				$shipping_methods[ $shipping_service_id ] = $this->get_service_object_by_id( 'WC_Connect_Shipping_Method', $shipping_service_id );
@@ -642,11 +639,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 *
 		 */
 		public function woocommerce_load_shipping_methods() {
-
 			$shipping_service_ids = $this->get_service_schemas_store()->get_all_shipping_method_ids();
-			if ( ! $shipping_service_ids ) {
-				return;
-			}
 
 			foreach ( $shipping_service_ids as $shipping_service_id ) {
 				$shipping_method = $this->get_service_object_by_id( 'WC_Connect_Shipping_Method', $shipping_service_id );
@@ -678,9 +671,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			global $wpdb;
 			$active_shipping_services = array();
 			$shipping_service_ids = $this->get_service_schemas_store()->get_all_shipping_method_ids();
-			if ( ! $shipping_service_ids ) {
-				return $active_shipping_services;
-			}
 
 			foreach ( $shipping_service_ids as $shipping_service_id ) {
 				$is_active = $wpdb->get_var( $wpdb->prepare(
@@ -797,9 +787,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		public function is_wc_connect_shipping_service( $service_id ) {
 			$shipping_service_ids = $this->get_service_schemas_store()->get_all_shipping_method_ids();
-			if ( ! $shipping_service_ids ) {
-				return false;
-			}
 			return in_array( $service_id, $shipping_service_ids );
 		}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -529,26 +529,27 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * to get the service instance form layout and settings bundled inside wcConnectData
 		 * as the form container is emitted into the body's HTML
 		 */
-		public function localize_and_enqueue_service_script( $id, $instance = false ) {
+		public function localize_and_enqueue_service_script( $method_id, $instance = false ) {
 			if ( ! function_exists( 'get_rest_url' ) ) {
 				return;
 			}
 
 			$settings_store = $this->get_service_settings_store();
 			$schemas_store = $this->get_service_schemas_store();
-			$service_schema = $schemas_store->get_service_schema_by_id_or_instance_id( $instance ? $instance : $id );
+			$service_schema = $schemas_store->get_service_schema_by_id_or_instance_id( $instance ? $instance : $method_id );
 
 			if ( ! $service_schema ) {
 				return;
 			}
 
-			$path = $instance ? "/wc/v1/connect/services/{$id}/{$instance}" : "/wc/v1/connect/services/{$id}";
+			$service_id = $service_schema->id;
+			$path = $instance ? "/wc/v1/connect/services/{$service_id}/{$instance}" : "/wc/v1/connect/services/{$service_id}";
 
 			$admin_array = array(
 				'storeOptions'       => $settings_store->get_store_options(),
 				'formSchema'         => $service_schema->service_settings,
 				'formLayout'         => $service_schema->form_layout,
-				'formData'           => $settings_store->get_service_settings( $id, $instance ),
+				'formData'           => $settings_store->get_service_settings( $method_id, $instance ),
 				'callbackURL'        => get_rest_url( null, $path ),
 				'nonce'              => wp_create_nonce( 'wp_rest' ),
 				'rootView'           => 'wc-connect-service-settings',

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -354,6 +354,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			$this->load_dependencies();
 			$this->schedule_service_schemas_fetch();
+			$this->service_settings_store->migrate_legacy_services();
 			$this->attach_hooks();
 		}
 
@@ -623,8 +624,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * @return mixed
 		 */
 		public function woocommerce_shipping_methods( $shipping_methods ) {
-
-			$shipping_service_ids = $this->get_service_schemas_store()->get_all_service_ids_of_type( 'shipping' );
+			$shipping_service_ids = $this->get_service_schemas_store()->get_all_shipping_method_ids();
 
 			foreach ( $shipping_service_ids as $shipping_service_id ) {
 				$shipping_methods[ $shipping_service_id ] = $this->get_service_object_by_id( 'WC_Connect_Shipping_Method', $shipping_service_id );
@@ -640,7 +640,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 */
 		public function woocommerce_load_shipping_methods() {
 
-			$shipping_service_ids = $this->get_service_schemas_store()->get_all_service_ids_of_type( 'shipping' );
+			$shipping_service_ids = $this->get_service_schemas_store()->get_all_shipping_method_ids();
 
 			foreach ( $shipping_service_ids as $shipping_service_id ) {
 				$shipping_method = $this->get_service_object_by_id( 'WC_Connect_Shipping_Method', $shipping_service_id );
@@ -671,7 +671,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function get_active_shipping_services() {
 			global $wpdb;
 			$active_shipping_services = array();
-			$shipping_service_ids = $this->get_service_schemas_store()->get_all_service_ids_of_type( 'shipping' );
+			$shipping_service_ids = $this->get_service_schemas_store()->get_all_shipping_method_ids();
 
 			foreach ( $shipping_service_ids as $shipping_service_id ) {
 				$is_active = $wpdb->get_var( $wpdb->prepare(
@@ -787,7 +787,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		public function is_wc_connect_shipping_service( $service_id ) {
-			$shipping_service_ids = $this->get_service_schemas_store()->get_all_service_ids_of_type( 'shipping' );
+			$shipping_service_ids = $this->get_service_schemas_store()->get_all_shipping_method_ids();
 			return in_array( $service_id, $shipping_service_ids );
 		}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -625,6 +625,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 */
 		public function woocommerce_shipping_methods( $shipping_methods ) {
 			$shipping_service_ids = $this->get_service_schemas_store()->get_all_shipping_method_ids();
+			if ( ! $shipping_service_ids ) {
+				return $shipping_methods;
+			}
 
 			foreach ( $shipping_service_ids as $shipping_service_id ) {
 				$shipping_methods[ $shipping_service_id ] = $this->get_service_object_by_id( 'WC_Connect_Shipping_Method', $shipping_service_id );
@@ -641,6 +644,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function woocommerce_load_shipping_methods() {
 
 			$shipping_service_ids = $this->get_service_schemas_store()->get_all_shipping_method_ids();
+			if ( ! $shipping_service_ids ) {
+				return;
+			}
 
 			foreach ( $shipping_service_ids as $shipping_service_id ) {
 				$shipping_method = $this->get_service_object_by_id( 'WC_Connect_Shipping_Method', $shipping_service_id );
@@ -672,6 +678,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			global $wpdb;
 			$active_shipping_services = array();
 			$shipping_service_ids = $this->get_service_schemas_store()->get_all_shipping_method_ids();
+			if ( ! $shipping_service_ids ) {
+				return $active_shipping_services;
+			}
 
 			foreach ( $shipping_service_ids as $shipping_service_id ) {
 				$is_active = $wpdb->get_var( $wpdb->prepare(
@@ -788,6 +797,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		public function is_wc_connect_shipping_service( $service_id ) {
 			$shipping_service_ids = $this->get_service_schemas_store()->get_all_shipping_method_ids();
+			if ( ! $shipping_service_ids ) {
+				return false;
+			}
 			return in_array( $service_id, $shipping_service_ids );
 		}
 


### PR DESCRIPTION
Fixes #451 

The CL does two things:
* switches to using `method_id` instead of `id` to identify shipping zone methods
* on the first plugin load it migrates the existing services to also use `method_id`

To test:
* checkout Automattic/woocommerce-connect-server#785
* verify that every service-related request (saving and loading settings, requesting rates) works as expected
* also the WooCommerce USPS plugin should work now side by side with WooCommerce Services