### PR TITLE
Converting service settings to an object on save to the database

### DIFF
--- a/classes/class-wc-rest-connect-services-controller.php
+++ b/classes/class-wc-rest-connect-services-controller.php
@@ -89,7 +89,7 @@ class WC_REST_Connect_Services_Controller extends WP_REST_Controller {
 			return $error;
 		}
 
-		$settings = $request->get_json_params();
+		$settings = ( object ) $request->get_json_params();
 
 		if ( empty( $settings ) ) {
 			$error = new WP_Error( 'bad_form_data',


### PR DESCRIPTION
Fixes a problem where the settings would get converted to an `array` instead of `object` when passed to the PHP backend (side effect of the changes from #883)

The code expects this to be an object in multiple places, especially in `WC_Connect_Shipping_Method`. One of the side effects is that the shipping method title will always be default on the shipping settings screen.

To test:
* create a new shipping method, set a custom title, save
* verify that everything works as expected (rates fetch and shipping settings page)