### PR TITLE
Fix shipping method instance settings retrieval bug.

### DIFF
--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -297,7 +297,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			}
 
 			// Validate settings with WCC server
-			$response_body = $this->api_client->validate_service_settings( $id, $settings );
+			$response_body = $this->api_client->validate_service_settings( $service_schema->id, $settings );
 
 			if ( is_wp_error( $response_body ) ) {
 				// TODO - handle multiple error messages when the validation endpoint can return them

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -558,27 +558,26 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * to get the service instance form layout and settings bundled inside wcConnectData
 		 * as the form container is emitted into the body's HTML
 		 */
-		public function localize_and_enqueue_service_script( $method_id, $instance = false ) {
+		public function localize_and_enqueue_service_script( $id, $instance = false ) {
 			if ( ! function_exists( 'get_rest_url' ) ) {
 				return;
 			}
 
 			$settings_store = $this->get_service_settings_store();
 			$schemas_store = $this->get_service_schemas_store();
-			$service_schema = $schemas_store->get_service_schema_by_id_or_instance_id( $instance ? $instance : $method_id );
+			$service_schema = $schemas_store->get_service_schema_by_id_or_instance_id( $instance ? $instance : $id );
 
 			if ( ! $service_schema ) {
 				return;
 			}
 
-			$service_id = $service_schema->id;
-			$path = $instance ? "/wc/v1/connect/services/{$service_id}/{$instance}" : "/wc/v1/connect/services/{$service_id}";
+			$path = $instance ? "/wc/v1/connect/services/{$id}/{$instance}" : "/wc/v1/connect/services/{$id}";
 
 			$admin_array = array(
 				'storeOptions'       => $settings_store->get_store_options(),
 				'formSchema'         => $service_schema->service_settings,
 				'formLayout'         => $service_schema->form_layout,
-				'formData'           => $settings_store->get_service_settings( $method_id, $instance ),
+				'formData'           => $settings_store->get_service_settings( $id, $instance ),
 				'callbackURL'        => get_rest_url( null, $path ),
 				'nonce'              => wp_create_nonce( 'wp_rest' ),
 				'rootView'           => 'wc-connect-service-settings',


### PR DESCRIPTION
Fix bug where settings were retrieved from a different option key than they were saved to.

Revert 7fea6f705877158de92b8580c2573adac62691e6 and use the id provide in the services schema to build WCS server request.

To test:
* On `master`
* Change some values in a USPS shipping method instance, click save
* Refresh page
* Verify that the _old_ values reappear
* On `fix/shipping-method-instance-settings-retrieval-bug`
* Change some values in a USPS shipping method instance, click save
* Refresh page
* Verify that the *new* values reappear