### PR TITLE
Fix Purchase Label Dialog cards not resizing to fill the width of the dialog on IE11

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -310,8 +310,8 @@
 
 	// WP style conflict resets
 	.card {
-		min-width: initial;
-		max-width: initial;
+		min-width: 0;
+		max-width: none;
 	}
 
 	.wp-admin & {


### PR DESCRIPTION
Fixes #906

CSS `initial` value for properties isn't supported in IE. I've changed the `initial` usages for the default values (`0` for `min-width` and `none` for `max-width`), that's exactly equivalent but works in IE :)

To test:
* Open the Purchase Label UI in IE11 in a wide monitor.
* See that the steps take the whole available horizontal space.