### PR TITLE
Allow calculation of tax rates on shipping rates

### DIFF
--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -250,7 +250,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				'id'        => self::format_rate_id( 'fallback', $this->id, 0 ),
 				'label'     => self::format_rate_title( $this->service_schema->carrier_name ),
 				'cost'      => $service_settings->fallback_rate,
-				'calc_tax'  => 'per_item',
 			);
 
 			$this->add_rate( $rate_to_add );
@@ -355,7 +354,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 						'id'        => self::format_rate_id( $instance->id, $instance->instance, $rate_idx ),
 						'label'     => self::format_rate_title( $rate->title ),
 						'cost'      => $rate->rate,
-						'calc_tax'  => 'per_item',
 						'meta_data' => array(
 							'wc_connect_packages' => json_encode( $rate->packages ),
 							__( 'Packaging', 'woocommerce-services' ) => $packaging_info


### PR DESCRIPTION
Fixes: #895 

Remove calc_tax field from tax rates so that tax rates can be optionally calculated for shipping rates

To Test:
- Configure WooCommerce to add tax to shipping rates.
- Notice that in master taxes are not added, but they are in this rate
- Test that other tax configurations still work as expected

Thanks to @mikejolley for quickly pointing out the solution to this problem