### PR TITLE
Fix typo in property name.

### DIFF
--- a/classes/class-wc-rest-connect-packages-controller.php
+++ b/classes/class-wc-rest-connect-packages-controller.php
@@ -16,8 +16,8 @@ class WC_REST_Connect_Packages_Controller extends WC_REST_Connect_Base_Controlle
 	public function run( $request ) {
 		$packages = $request->get_json_params();
 
-		$this->service_settings_store->update_packages( $packages[ 'custom' ] );
-		$this->service_settings_store->update_predefined_packages( $packages[ 'predefined' ] );
+		$this->settings_store->update_packages( $packages[ 'custom' ] );
+		$this->settings_store->update_predefined_packages( $packages[ 'predefined' ] );
 
 		return new WP_REST_Response( array( 'success' => true ), 200 );
 	}


### PR DESCRIPTION
The initial refactor of the packages REST controller missed the variable that was renamed. See 8e60ee01d5c9f2742b75939fbcb6774483dfb31a.

To test:
* Try saving packages with the code on `master`
* Verify that it fails
* Checkout this branch
* Save packages
* Verify success