### PR TITLE
Fix HTTP method for account settings endpoint.

### DIFF
--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -10,7 +10,7 @@ if ( class_exists( 'WC_REST_Connect_Account_Settings_Controller' ) ) {
 
 class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_Controller {
 
-	protected $method = 'POST';
+	protected $method = 'PUT';
 	protected $rest_base = 'connect/account/settings';
 
 	public function run( $request ) {


### PR DESCRIPTION
This was errantly changed from PUT to POST in 8e60ee01d5c9f2742b75939fbcb6774483dfb31a.

To test:
* Verify that saving account settings does not work on `master`
* Checkout this branch
* Verify that saving account settings works as expected

Side note: perhaps we should consider restoring the use of the `WP_REST_Server` class constants instead of using string literals for our method definitions. (E.g. `WP_REST_Server::READABLE` instead of `'GET'`)

Doing so isn't called out as a best practice in the [REST documentation](https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-custom-endpoints/), but is shown in some example code.