### PR TITLE
Use only GET and POST HTTP methods to play nice with mod_security most common rules

### DIFF
--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -10,7 +10,7 @@ if ( class_exists( 'WC_REST_Connect_Account_Settings_Controller' ) ) {
 
 class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_Controller {
 
-	protected $method = 'PUT';
+	protected $method = 'POST';
 	protected $rest_base = 'connect/account/settings';
 
 	public function run( $request ) {

--- a/classes/class-wc-rest-connect-self-help-controller.php
+++ b/classes/class-wc-rest-connect-self-help-controller.php
@@ -10,7 +10,7 @@ if ( class_exists( 'WC_REST_Connect_Self_Help_Controller' ) ) {
 
 class WC_REST_Connect_Self_Help_Controller extends WC_REST_Connect_Base_Controller {
 
-	protected $method = 'PUT';
+	protected $method = 'POST';
 	protected $rest_base = 'connect/self-help';
 
 	public function run( $request ) {

--- a/classes/class-wc-rest-connect-services-controller.php
+++ b/classes/class-wc-rest-connect-services-controller.php
@@ -10,7 +10,7 @@ if ( class_exists( 'WC_REST_Connect_Services_Controller' ) ) {
 
 class WC_REST_Connect_Services_Controller extends WC_REST_Connect_Base_Controller {
 
-	protected $method = 'PUT';
+	protected $method = 'POST';
 	protected $rest_base = 'connect/services/(?P<id>[a-z_]+)\/(?P<instance>[\d]+)';
 
 	/**

--- a/client/account-settings/state/actions.js
+++ b/client/account-settings/state/actions.js
@@ -28,7 +28,7 @@ export const saveForm = ( onSaveSuccess, onSaveFailure ) => ( dispatch, getState
 	dispatch( setFormMetaProperty( 'isSaving', true ) );
 
 	const request = {
-		method: submitMethod || 'PUT',
+		method: submitMethod || 'POST',
 		credentials: 'same-origin',
 		headers: {
 			'X-WP-Nonce': nonce,

--- a/client/lib/save-form/index.js
+++ b/client/lib/save-form/index.js
@@ -5,7 +5,7 @@ import { EMPTY_ERROR } from 'settings/state/selectors/errors';
 const saveForm = ( setIsSaving, setSuccess, setFieldsStatus, setError, url, nonce, submitMethod, formData ) => {
 	setIsSaving( true );
 	const request = {
-		method: submitMethod || 'PUT',
+		method: submitMethod || 'POST',
 		credentials: 'same-origin',
 		headers: {
 			'X-WP-Nonce': nonce,

--- a/client/packages/state/actions.js
+++ b/client/packages/state/actions.js
@@ -79,7 +79,7 @@ export const saveForm = ( onSaveSuccess, onSaveFailure ) => ( dispatch, getState
 	dispatch( setIsSaving( true ) );
 
 	const request = {
-		method: submitMethod || 'PUT',
+		method: submitMethod || 'POST',
 		credentials: 'same-origin',
 		headers: {
 			'X-WP-Nonce': nonce,


### PR DESCRIPTION
Fixes #930

Well, this was easier than expected. `mod_security` most common set of rules, OWASP rules, block by default `PUT` and `DELETE` requests to the server. [Here it is the default rule](https://github.com/SpiderLabs/owasp-modsecurity-crs/blob/v3.0/master/crs-setup.conf.example#L329).

I've changed all our REST endpoints that use `PUT` to use `POST` instead. We can't afford the luxury of REST semantics purity if it's gonna break in the wild wide world of web hosting configurations.

To test:
* Install `mod_security` with the `OWASP` set of rules. I've pointed to some instructions in #930, ping me if you get stuck.
* Try to update the USPS config. Without this PR, it should give an instantaneous `Unexpected Server Error`. With this PR, it should work.

This one is particularly difficult to test, I wouldn't blame any of you if you don't, and just check that it works with a vanilla Apache config.