### PR TITLE
Logging individual rates instance errors

### DIFF
--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -317,6 +317,11 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			$instances = $response_body->rates;
 
 			foreach ( (array) $instances as $instance ) {
+				if ( property_exists( $instance, 'error' ) ) {
+					$this->error( $instance->error, __FUNCTION__ );
+					$this->set_last_request_failed();
+				}
+
 				if ( ! property_exists( $instance, 'rates' ) ) {
 					continue;
 				}

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -371,10 +371,11 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 			if ( 0 === count( $this->rates ) ) {
 				$this->add_fallback_rate( $service_settings );
+			} else {
+				$this->set_last_request_failed( 0 );
 			}
 
 			$this->update_last_rate_request_timestamp();
-			$this->set_last_request_failed( 0 );
 		}
 
 		public function update_last_rate_request_timestamp() {


### PR DESCRIPTION
When looking at Automattic/woocommerce-connect-server#857 I noticed the following issue:
* use Canada Post instance
* try to request rates for a product with one of the dimensions set to 0 and weight set correctly
* server returns HTTP 200 with body like `{"rates":[{"id":"canada_post","instance":9,"error":"Error: Weight, length, width and height must be greater than zero but were: 0.45, 29.2, 0, 1.9"}]}`
* see no rates on the checkout page (or a fallback rate if configured)
* there's no `An error occurred in WooCommerce Services` notice in the admin panel
* nothing logged on the service status page

This PR fixes the issue. If the server returns HTTP 200 with errors for any individual instance (currently we always request one instance anyway), they will be logged and presented to the admins, similar to what is happening in case of missing weight.