### PR TITLE
Hide the wc_connect_destination_normalized post meta key

### DIFF
--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -138,7 +138,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			unset( $new_address[ 'address' ], $new_address[ 'name' ] );
 
 			$order->set_address( $new_address, 'shipping' );
-			update_post_meta( $order->id, 'wc_connect_destination_normalized', true );
+			update_post_meta( $order->id, '_wc_connect_destination_normalized', true );
 		}
 
 		protected function sort_services( $a, $b ) {

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -242,7 +242,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				$destination[ 'country' ] = $origin[ 'country' ];
 			}
 
-			$destination_normalized = ( bool ) get_post_meta( $order->id, 'wc_connect_destination_normalized', true );
+			$destination_normalized = ( bool ) get_post_meta( $order->id, '_wc_connect_destination_normalized', true );
 
 			$form_data = compact( 'is_packed', 'selected_packages', 'all_packages', 'flat_rate_groups', 'origin', 'destination', 'destination_normalized' );
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -858,7 +858,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		function hide_wc_connect_order_meta_data( $protected, $meta_key, $meta_type ) {
-			if ( 'wc_connect_labels' === $meta_key ) {
+			if ( in_array( $meta_key, array( 'wc_connect_labels', 'wc_connect_destination_normalized' ) ) ) {
 				$protected = true;
 			}
 


### PR DESCRIPTION
This fixes the following error:
1. on an order page, open the label modal
2. wait until the address is normalized and rates are requested
3. refresh the page
4. scroll down and see the following fields: 
![screen shot 2017-03-27 at 15 37 22](https://cloud.githubusercontent.com/assets/800604/24362003/5b682644-1303-11e7-9d45-0ea3351a2ced.png)

To test:
* follow the steps 1-3 from above
* the field should be hidden now

Backwards compatibility:
I prefixed the key with `_`, which should hide it automatically. I also added the unprefixed key to the hidden keys filter. Because of the former reopening old orders will trigger the normalization again, but it will only happen once and then the plugin will start using the prefixed key.
