### PR TITLE
Version 1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-services",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "scripts": {
     "start": "cross-env NODE_ENV=development webpack-dev-server --hot --inline --watch --content-base dist --port 8085",
     "dist": "cross-env NODE_ENV=production webpack",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes, allendav, kellychoffman, jkudish, jeffstiel
 Tags: canada-post, shipping, stamps, usps, woocommerce
 Requires at least: 4.6
 Tested up to: 4.7.2
-Stable tag: 1.3.0
+Stable tag: 1.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,6 +78,10 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 8. Checking on the health of WooCommerce Services
 
 == Changelog ==
+
+= 1.3.2 =
+* Hide destination address normalized order meta
+* Log rate retrieval failures as errors with admin notice
 
 = 1.3.1 =
 * Fix compatibility bug with `mod_security`

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -5,7 +5,7 @@
  * Description: WooCommerce Services: Hosted services for WooCommerce, including free real-time USPS and Canada Post rates and discounted USPS shipping labels.
  * Author: Automattic
  * Author URI: http://woocommerce.com/
- * Version: 1.3.1
+ * Version: 1.3.2
  *
  * Copyright (c) 2017 Automattic
  *


### PR DESCRIPTION
Update plugin version to 1.3.2 and add change log entries

* Hide destination address normalized order meta
* Log rate retrieval failures as errors with admin notice