### PR TITLE
Added support to the plugin actions links

### DIFF
--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -430,11 +430,11 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 
 			$doc_link = sprintf(
 				wp_kses(
-					__( 'Our team is here for you. View our <a href="%1$s">support docs</a> or <a href="%2$s">report a bug</a>.', 'woocommerce-services' ),
+					__( 'Our team is here for you. View our <a href="%1$s">support docs</a> or <a href="%2$s">open a support ticket</a>.', 'woocommerce-services' ),
 					array(  'a' => array( 'href' => array() ) )
 				),
 				esc_url( 'https://docs.woocommerce.com/document/woocommerce-services/' ),
-				esc_url( 'https://wordpress.org/support/plugin/woocommerce-services' )
+				esc_url( 'https://woocommerce.com/my-account/create-a-ticket/' )
 			);
 
 			$support_items[] = (object) array(

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -454,6 +454,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'woocommerce_admin_shipping_fields', array( $this, 'add_shipping_phone_to_order_fields' ) );
 			add_filter( 'woocommerce_get_order_address', array( $this, 'get_shipping_phone_from_order' ), 10, 3 );
 			add_action( 'admin_enqueue_scripts', array( $this->nux, 'show_pointers' ) );
+			add_filter( 'plugin_action_links_' . plugin_basename(__FILE__), array( $this, 'add_plugin_action_links' ) );
 		}
 
 		/**
@@ -895,6 +896,17 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				$fields[ 'phone' ] =  $shipping_phone;
 			}
 			return $fields;
+		}
+
+		function add_plugin_action_links( $links ) {
+			$links[] = sprintf(
+				wp_kses(
+					__( '<a href="%s">Support</a>', 'woocommerce-services' ),
+					array(  'a' => array( 'href' => array() ) )
+				),
+				esc_url( 'https://woocommerce.com/my-account/create-a-ticket/' )
+			);
+			return $links;
 		}
 	}
 


### PR DESCRIPTION
Fixes #941 and #972 

* Added link to https://woocommerce.com/my-account/create-a-ticket/ to the plugins page, showing under our plugin
* Replaced "report a bug" link on the System Status page with "open a support ticket" linking to https://woocommerce.com/my-account/create-a-ticket/ as well