### PR TITLE
Fixed label repurchasing without page refresh

### DIFF
--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -197,8 +197,13 @@ export const openPrintingFlow = () => (
 	dispatch( { type: OPEN_PRINTING_FLOW } );
 };
 
-export const exitPrintingFlow = ( force ) => {
-	return { type: EXIT_PRINTING_FLOW, force };
+export const exitPrintingFlow = ( force ) => ( dispatch, getState ) => {
+	const form = getState().shippingLabel.form;
+	if ( form.needsPrintConfirmation ) {
+		dispatch( clearAvailableRates() );
+	}
+
+	dispatch( { type: EXIT_PRINTING_FLOW, force } );
 };
 
 export const updateAddressValue = ( group, name, value ) => {

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -110,6 +110,10 @@ const convertToApiPackage = ( pckg ) => {
 	return _.pick( pckg, [ 'id', 'box_id', 'service_id', 'length', 'width', 'height', 'weight' ] );
 };
 
+export const clearAvailableRates = () => {
+	return { type: CLEAR_AVAILABLE_RATES };
+};
+
 const getLabelRates = ( dispatch, getState, handleResponse, { getRatesURL, nonce } ) => {
 	const formState = getState().shippingLabel.form;
 	const {
@@ -506,7 +510,7 @@ export const purchaseLabel = () => ( dispatch, getState, context ) => {
 								: sprintf( __( 'Your %d shipping labels were purchased successfully' ), response.length );
 							dispatch( NoticeActions.successNotice( noticeText ) );
 							dispatch( exitPrintingFlow( true ) );
-							dispatch( { type: CLEAR_AVAILABLE_RATES } );
+							dispatch( clearAvailableRates() );
 						} )
 						.catch( ( err ) => {
 							console.error( err );
@@ -561,7 +565,7 @@ export const confirmPrintLabel = ( url ) => ( dispatch ) => {
 	printDocument( url )
 		.then( () => {
 			dispatch( exitPrintingFlow( true ) );
-			dispatch( { type: CLEAR_AVAILABLE_RATES } );
+			dispatch( clearAvailableRates() );
 		} )
 		.catch( ( error ) => dispatch( NoticeActions.errorNotice( error.toString() ) ) );
 };

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -198,12 +198,13 @@ export const openPrintingFlow = () => (
 };
 
 export const exitPrintingFlow = ( force ) => ( dispatch, getState ) => {
+	dispatch( { type: EXIT_PRINTING_FLOW, force } );
+
 	const form = getState().shippingLabel.form;
+
 	if ( form.needsPrintConfirmation ) {
 		dispatch( clearAvailableRates() );
 	}
-
-	dispatch( { type: EXIT_PRINTING_FLOW, force } );
 };
 
 export const updateAddressValue = ( group, name, value ) => {

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -30,6 +30,7 @@ export const SHOW_PRINT_CONFIRMATION = 'SHOW_PRINT_CONFIRMATION';
 export const RATES_RETRIEVAL_IN_PROGRESS = 'RATES_RETRIEVAL_IN_PROGRESS';
 export const SET_RATES = 'SET_RATES';
 export const RATES_RETRIEVAL_COMPLETED = 'RATES_RETRIEVAL_COMPLETED';
+export const CLEAR_AVAILABLE_RATES = 'CLEAR_AVAILABLE_RATES';
 export const OPEN_REFUND_DIALOG = 'OPEN_REFUND_DIALOG';
 export const CLOSE_REFUND_DIALOG = 'CLOSE_REFUND_DIALOG';
 export const LABEL_STATUS_RESPONSE = 'LABEL_STATUS_RESPONSE';
@@ -505,6 +506,7 @@ export const purchaseLabel = () => ( dispatch, getState, context ) => {
 								: sprintf( __( 'Your %d shipping labels were purchased successfully' ), response.length );
 							dispatch( NoticeActions.successNotice( noticeText ) );
 							dispatch( exitPrintingFlow( true ) );
+							dispatch( { type: CLEAR_AVAILABLE_RATES } );
 						} )
 						.catch( ( err ) => {
 							console.error( err );
@@ -557,7 +559,10 @@ export const purchaseLabel = () => ( dispatch, getState, context ) => {
 
 export const confirmPrintLabel = ( url ) => ( dispatch ) => {
 	printDocument( url )
-		.then( () => dispatch( exitPrintingFlow( true ) ) )
+		.then( () => {
+			dispatch( exitPrintingFlow( true ) );
+			dispatch( { type: CLEAR_AVAILABLE_RATES } );
+		} )
 		.catch( ( error ) => dispatch( NoticeActions.errorNotice( error.toString() ) ) );
 };
 

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -472,7 +472,7 @@ export const updatePaperSize = ( value ) => {
 };
 
 export const purchaseLabel = () => ( dispatch, getState, context ) => {
-	const { purchaseURL, addressNormalizationURL, nonce } = context;
+	const { purchaseURL, getRatesURL, addressNormalizationURL, nonce } = context;
 	let error = null;
 	let response = null;
 
@@ -492,6 +492,9 @@ export const purchaseLabel = () => ( dispatch, getState, context ) => {
 			} else if ( error ) {
 				console.error( error );
 				dispatch( NoticeActions.errorNotice( error.toString() ) );
+				//re-request the rates on failure to avoid attempting repurchase of the same shipment id
+				dispatch( clearAvailableRates() );
+				getLabelRates( dispatch, getState, _.noop, { getRatesURL, nonce } );
 			} else {
 				const labelsToPrint = response.map( ( label, index ) => ( {
 					caption: sprintf( __( 'PACKAGE %d (OF %d)' ), index + 1, response.length ),

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -19,6 +19,7 @@ import {
 	RATES_RETRIEVAL_IN_PROGRESS,
 	SET_RATES,
 	RATES_RETRIEVAL_COMPLETED,
+	CLEAR_AVAILABLE_RATES,
 	OPEN_REFUND_DIALOG,
 	CLOSE_REFUND_DIALOG,
 	LABEL_STATUS_RESPONSE,
@@ -276,6 +277,7 @@ reducers[ MOVE_ITEM ] = ( state, { openedPackageId, movedItemIndex, targetPackag
 		...state,
 		form: {
 			...state.form,
+			needsPrintConfirmation: false,
 			packages: {
 				...state.form.packages,
 				selected: newPackages,
@@ -357,6 +359,7 @@ reducers[ ADD_PACKAGE ] = ( state ) => {
 		addedPackageId,
 		form: {
 			...state.form,
+			needsPrintConfirmation: false,
 			packages: {
 				...state.form.packages,
 				selected: newPackages,
@@ -383,6 +386,7 @@ reducers[ REMOVE_PACKAGE ] = ( state, { packageId } ) => {
 		openedPackageId,
 		form: {
 			...state.form,
+			needsPrintConfirmation: false,
 			packages: {
 				...state.form.packages,
 				selected: newPackages,
@@ -415,6 +419,7 @@ reducers[ SET_PACKAGE_TYPE ] = ( state, { packageId, boxTypeId } ) => {
 		...state,
 		form: {
 			...state.form,
+			needsPrintConfirmation: false,
 			packages: {
 				...state.form.packages,
 				selected: newPackages,
@@ -533,6 +538,17 @@ reducers[ RATES_RETRIEVAL_COMPLETED ] = ( state ) => {
 		form: { ...state.form,
 			rates: { ...state.form.rates,
 				retrievalInProgress: false,
+			},
+		},
+	};
+};
+
+reducers[ CLEAR_AVAILABLE_RATES ] = ( state ) => {
+	return { ...state,
+		form: { ...state.form,
+			needsPrintConfirmation: false,
+			rates: { ...state.form.rates,
+				available: {},
 			},
 		},
 	};

--- a/client/shipping-label/state/test/reducer.js
+++ b/client/shipping-label/state/test/reducer.js
@@ -7,8 +7,7 @@ import {
 	savePackages,
 	removeIgnoreValidation,
 	updateAddressValue,
-
-	CLEAR_AVAILABLE_RATES,
+    clearAvailableRates,
 } from '../actions';
 import hoek from 'hoek';
 
@@ -290,7 +289,7 @@ describe( 'Label purchase form reducer', () => {
 	it( 'CLEAR_AVAILABLE_RATES clears the available rates and resets the print confirmation', () => {
 		const existingState = hoek.clone( initialState );
 
-		const action = { type: CLEAR_AVAILABLE_RATES };
+		const action = clearAvailableRates();
 		const state = reducer( existingState, action );
 
 		expect( state.form.rates.available ).to.eql( {} );

--- a/client/shipping-label/state/test/reducer.js
+++ b/client/shipping-label/state/test/reducer.js
@@ -7,6 +7,8 @@ import {
 	savePackages,
 	removeIgnoreValidation,
 	updateAddressValue,
+
+	CLEAR_AVAILABLE_RATES,
 } from '../actions';
 import hoek from 'hoek';
 
@@ -73,6 +75,7 @@ describe( 'Label purchase form reducer', () => {
 		expect( state.form.packages.selected.weight_1_custom1.items ).to.include( initialState.form.packages.selected.weight_0_custom1.items[ 0 ] );
 		expect( state.form.packages.saved ).to.eql( false );
 		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
+		expect( state.form.needsPrintConfirmation ).to.eql( false );
 		expect( state.form.rates.available ).to.eql( {} );
 	} );
 
@@ -87,6 +90,7 @@ describe( 'Label purchase form reducer', () => {
 		expect( state.form.packages.selected.client_individual_0.items ).to.include( initialState.form.packages.selected.weight_0_custom1.items[ 0 ] );
 		expect( state.form.packages.saved ).to.eql( false );
 		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
+		expect( state.form.needsPrintConfirmation ).to.eql( false );
 		expect( state.form.rates.available ).to.eql( {} );
 	} );
 
@@ -99,6 +103,7 @@ describe( 'Label purchase form reducer', () => {
 		expect( state.form.packages.unpacked ).to.include( initialState.form.packages.selected.weight_0_custom1.items[ 0 ] );
 		expect( state.form.packages.saved ).to.eql( false );
 		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
+		expect( state.form.needsPrintConfirmation ).to.eql( false );
 		expect( state.form.rates.available ).to.eql( {} );
 	} );
 
@@ -116,6 +121,7 @@ describe( 'Label purchase form reducer', () => {
 		expect( state.form.packages.selected.weight_0_custom1.items ).to.include( existingState.form.packages.unpacked[ 0 ] );
 		expect( state.form.packages.saved ).to.eql( false );
 		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
+		expect( state.form.needsPrintConfirmation ).to.eql( false );
 		expect( state.form.rates.available ).to.eql( {} );
 	} );
 
@@ -135,6 +141,7 @@ describe( 'Label purchase form reducer', () => {
 		expect( state.form.packages.selected.client_individual_0.items ).to.include( existingState.form.packages.unpacked[ 0 ] );
 		expect( state.form.packages.saved ).to.eql( false );
 		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
+		expect( state.form.needsPrintConfirmation ).to.eql( false );
 		expect( state.form.rates.available ).to.eql( {} );
 	} );
 
@@ -154,6 +161,7 @@ describe( 'Label purchase form reducer', () => {
 		expect( state.form.packages.selected.weight_0_custom1.items.length ).to.eql( 2 );
 		expect( state.form.packages.selected.weight_0_custom1.items ).to.include( existingState.form.packages.selected.client_individual_0.items[ 0 ] );
 		expect( state.form.packages.saved ).to.eql( false );
+		expect( state.form.needsPrintConfirmation ).to.eql( false );
 		expect( state.form.rates.available ).to.eql( {} );
 	} );
 
@@ -174,6 +182,7 @@ describe( 'Label purchase form reducer', () => {
 		expect( state.form.packages.unpacked ).to.include( existingState.form.packages.selected.client_individual_0.items[ 0 ] );
 		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
 		expect( state.form.packages.saved ).to.eql( false );
+		expect( state.form.needsPrintConfirmation ).to.eql( false );
 		expect( state.form.rates.available ).to.eql( {} );
 	} );
 
@@ -190,6 +199,7 @@ describe( 'Label purchase form reducer', () => {
 		expect( state.form.packages.selected.client_custom_0.weight ).to.eql( 3.5 );
 		expect( state.form.packages.saved ).to.eql( false );
 		expect( state.openedPackageId ).to.eql( 'client_custom_0' );
+		expect( state.form.needsPrintConfirmation ).to.eql( false );
 		expect( state.form.rates.available ).to.eql( {} );
 	} );
 
@@ -202,6 +212,7 @@ describe( 'Label purchase form reducer', () => {
 		expect( state.form.packages.unpacked ).to.include( initialState.form.packages.selected.weight_0_custom1.items[ 0 ] );
 		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
 		expect( state.form.packages.saved ).to.eql( false );
+		expect( state.form.needsPrintConfirmation ).to.eql( false );
 		expect( state.form.rates.available ).to.eql( {} );
 	} );
 
@@ -217,6 +228,7 @@ describe( 'Label purchase form reducer', () => {
 		expect( state.form.packages.selected.weight_0_custom1.weight ).to.eql( 4.7 );
 		expect( state.form.packages.saved ).to.eql( false );
 		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
+		expect( state.form.needsPrintConfirmation ).to.eql( false );
 		expect( state.form.rates.available ).to.eql( {} );
 	} );
 
@@ -273,5 +285,15 @@ describe( 'Label purchase form reducer', () => {
 
 		expect( state.form.origin.ignoreValidation.address ).to.be.false;
 		expect( state.form.origin.ignoreValidation.postcode ).to.be.true;
+	} );
+
+	it( 'CLEAR_AVAILABLE_RATES clears the available rates and resets the print confirmation', () => {
+		const existingState = hoek.clone( initialState );
+
+		const action = { type: CLEAR_AVAILABLE_RATES };
+		const state = reducer( existingState, action );
+
+		expect( state.form.rates.available ).to.eql( {} );
+		expect( state.form.needsPrintConfirmation ).to.eql( false );
 	} );
 } );


### PR DESCRIPTION
Fixes #944 

To test:
* purchase a label
* without refreshing the page, open the label modal again
* the rates should be re-requested
* purchase the label again
* verify there are no errors in the server log (there should be an error about repurchasing a shipment id in other branches)

This also fixes the flow in some of the browsers (such as Firefox):
* purchase a label, the button should change to "Print"
* it should now be possible to close the modal, and the button should still be "Print" on reopening (before it wouldn't be possible to close the modal)
* clicking print should close the modal and open a new tab with the label ready to print
* reopening the modal should trigger a new rates request and allow to repurchase a label, as outlined in the steps above