### PR TITLE
Fixed cancel button behaviour when the label is ready to print

### DIFF
--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -468,6 +468,9 @@ reducers[ PURCHASE_LABEL_RESPONSE ] = ( state, { response, error } ) => {
 	}
 
 	return { ...state,
+		form: { ...state.form,
+			isSubmitting: false,
+		},
 		labels: [
 			...response.map( ( label ) => ( { ...label,
 				statusUpdated: true,


### PR DESCRIPTION
Addresses a part of #976 

To test:
* use Firefox or similar browser
* purchase a label
* verify that clicking "Cancel" closes the modal
* reopening the modal should still show the "Print" button and allow to print the labels

 