### PR TITLE
Changing the purchase button label depending on browser pdf support

### DIFF
--- a/client/shipping-label/views/purchase/index.js
+++ b/client/shipping-label/views/purchase/index.js
@@ -33,10 +33,10 @@ const PrintLabelDialog = ( props ) => {
 			const ratesTotal = getRatesTotal( props.form.rates );
 
 			if ( noNativePDFSupport ) {
-				return sprintf( __( 'Buy (%1$s%2$.2f)' ), currencySymbol, ratesTotal );
+				return sprintf( __( 'Buy (%(currencySymbol)s%(ratesTotal).2f)' ), { currencySymbol, ratesTotal } );
 			}
 
-			return sprintf( __( 'Buy & Print (%1$s%2$.2f)' ), currencySymbol, ratesTotal );
+			return sprintf( __( 'Buy & Print (%(currencySymbol)s%(ratesTotal).2f)' ), { currencySymbol, ratesTotal } );
 		}
 
 		if ( noNativePDFSupport ) {

--- a/client/shipping-label/views/purchase/index.js
+++ b/client/shipping-label/views/purchase/index.js
@@ -12,12 +12,11 @@ import { sprintf } from 'sprintf-js';
 import { getRatesTotal } from 'shipping-label/state/selectors/rates';
 
 const PrintLabelDialog = ( props ) => {
-	const currencySymbol = props.storeOptions.currency_symbol;
-
 	const getPurchaseButtonLabel = () => {
 		if ( props.form.needsPrintConfirmation ) {
 			return __( 'Print' );
 		}
+
 		if ( props.form.isSubmitting ) {
 			return (
 				<div>
@@ -26,15 +25,25 @@ const PrintLabelDialog = ( props ) => {
 				</div>
 			);
 		}
-		let label = 'addon' === getPDFSupport() ? __( 'Buy' ) : __( 'Buy & Print' );
-		const nPackages = props.form.packages.selected.length;
-		if ( nPackages ) {
-			label += ' ' + ( 1 === nPackages ? __( '1 Label' ) : sprintf( __( '%d Labels' ), nPackages ) );
-		}
+
+		const noNativePDFSupport = ( 'addon' === getPDFSupport() );
+
 		if ( props.canPurchase ) {
-			label += ' (' + currencySymbol + getRatesTotal( props.form.rates ) + ')';
+			const currencySymbol = props.storeOptions.currency_symbol;
+			const ratesTotal = getRatesTotal( props.form.rates );
+
+			if ( noNativePDFSupport ) {
+				return sprintf( __( 'Buy (%1$s%2$.2f)' ), currencySymbol, ratesTotal );
+			}
+
+			return sprintf( __( 'Buy & Print (%1$s%2$.2f)' ), currencySymbol, ratesTotal );
 		}
-		return label;
+
+		if ( noNativePDFSupport ) {
+			return __( 'Buy' );
+		}
+
+		return __( 'Buy & Print' );
 	};
 
 	const getPurchaseButtonAction = () => {

--- a/client/shipping-label/views/purchase/index.js
+++ b/client/shipping-label/views/purchase/index.js
@@ -3,6 +3,7 @@ import Modal from 'components/modal';
 import ActionButtons from 'components/action-buttons';
 import Spinner from 'components/spinner';
 import { translate as __ } from 'lib/mixins/i18n';
+import getPDFSupport from 'lib/utils/pdf-support';
 import AddressStep from './steps/address';
 import PackagesStep from './steps/packages';
 import RatesStep from './steps/rates';
@@ -25,7 +26,7 @@ const PrintLabelDialog = ( props ) => {
 				</div>
 			);
 		}
-		let label = __( 'Buy & Print' );
+		let label = 'addon' === getPDFSupport() ? __( 'Buy' ) : __( 'Buy & Print' );
 		const nPackages = props.form.packages.selected.length;
 		if ( nPackages ) {
 			label += ' ' + ( 1 === nPackages ? __( '1 Label' ) : sprintf( __( '%d Labels' ), nPackages ) );
@@ -42,6 +43,22 @@ const PrintLabelDialog = ( props ) => {
 		}
 		return props.labelActions.purchaseLabel;
 	};
+
+	const buttons = [
+		{
+			isDisabled: ! props.form.needsPrintConfirmation && ( ! props.canPurchase || props.form.isSubmitting ),
+			onClick: getPurchaseButtonAction(),
+			isPrimary: true,
+			label: getPurchaseButtonLabel(),
+		},
+	];
+
+	if ( ! props.form.needsPrintConfirmation ) {
+		buttons.push( {
+			onClick: () => props.labelActions.exitPrintingFlow( false ),
+			label: __( 'Cancel' ),
+		} );
+	}
 
 	return (
 		<Modal
@@ -74,18 +91,7 @@ const PrintLabelDialog = ( props ) => {
 						{ ...props }
 						errors={ props.errors.rates } />
 				</div>
-				<ActionButtons buttons={ [
-					{
-						isDisabled: ! props.form.needsPrintConfirmation && ( ! props.canPurchase || props.form.isSubmitting ),
-						onClick: getPurchaseButtonAction(),
-						isPrimary: true,
-						label: getPurchaseButtonLabel(),
-					},
-					{
-						onClick: () => props.labelActions.exitPrintingFlow( false ),
-						label: __( 'Cancel' ),
-					},
-				] } />
+				<ActionButtons buttons={ buttons } />
 			</div>
 		</Modal>
 	);


### PR DESCRIPTION
Fixes #976 

To test:
* on firefox open the label modal
* the purchase button label should be "Buy"
* purchase a label
* cancel button should disappear and the button label should change to "Print"

The resetting of available rates after closing will be handled in #974 