### PR TITLE
Fix retrieving predefine package definitions from the user's preferences

### DIFF
--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -286,7 +286,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			);
 
 			$custom_boxes = $this->service_settings_store->get_packages();
-			$predefined_boxes = $this->service_settings_store->get_predefined_packages_for_service( $this->id );
+			$predefined_boxes = $this->service_settings_store->get_predefined_packages_for_service( $this->service_schema->id );
 			$predefined_boxes = array_values( array_filter( $predefined_boxes, array( $this, 'filter_preset_boxes' ) ) );
 
 			$response_body = $this->api_client->get_shipping_rates( $services, $package, $custom_boxes, $predefined_boxes );


### PR DESCRIPTION
Before:
* Predefined packages options (i.e which packages are enabled) were being stored with `usps` / `canada_post` as a key.
* For a checkout rates request, predefined packages options for the given method (`wc_services_usps` / `wc_services_canada_post`) were being fetched instead. Obviously, that always produced an empty list.

Fix: Use the `usps/canada_post` ID to fetch the predefined packages options from the user settings.

To test:
* Check that USPS predefined packages didn't work at all in `master`.
* Ccheck that now they work.