### PR TITLE
Don't break when printing a label for a non-existent product or variation

### DIFF
--- a/classes/class-wc-connect-compatibility-wc26.php
+++ b/classes/class-wc-connect-compatibility-wc26.php
@@ -83,12 +83,15 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC26' ) ) {
 		 * @return string The product (or variation) name, ready to print
 		 */
 		public function get_product_name_from_order( $product_id, $order ) {
-			foreach( $order->get_items() as $line_item ) {
+			foreach ( $order->get_items() as $line_item ) {
 				if ( (int) $line_item[ 'product_id' ] === $product_id || (int) $line_item[ 'variation_id' ] === $product_id ) {
-					return sprintf( '#%s - %s', $product_id, $line_item[ 'name' ] );
+					/* translators: %1$d: Product ID, %2$s: Product Name */
+					return sprintf( __( '#%1$d - %2$s', 'woocommerce-services' ), $product_id, $line_item[ 'name' ] );
 				}
 			}
-			return sprintf( __( '#%s - [Deleted product]', 'woocommerce-services' ), $product_id );
+
+			/* translators: %d: Deleted Product ID */
+			return sprintf( __( '#%d - [Deleted product]', 'woocommerce-services' ), $product_id );
 		}
 	}
 }

--- a/classes/class-wc-connect-compatibility-wc26.php
+++ b/classes/class-wc-connect-compatibility-wc26.php
@@ -72,5 +72,23 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC26' ) ) {
 		public function get_parent_product_id( WC_Product $product ) {
 			return ( $product->is_type( 'variation' ) ) ? $product->parent->get_id() : $product->get_id();
 		}
+
+		/**
+		 * For a given product ID, it tries to find its name inside an order's line items.
+		 * This is useful when an order has a product which was later deleted from the
+		 * store.
+		 *
+		 * @param int $product_id Product ID or variation ID
+		 * @param WC_Order $order
+		 * @return string The product (or variation) name, ready to print
+		 */
+		public function get_product_name_from_order( $product_id, $order ) {
+			foreach( $order->get_items() as $line_item ) {
+				if ( (int) $line_item[ 'product_id' ] === $product_id || (int) $line_item[ 'variation_id' ] === $product_id ) {
+					return sprintf( '#%s - %s', $product_id, $line_item[ 'name' ] );
+				}
+			}
+			return sprintf( __( '#%s - [Deleted product]', 'woocommerce-services' ), $product_id );
+		}
 	}
 }

--- a/classes/class-wc-connect-compatibility-wc30.php
+++ b/classes/class-wc-connect-compatibility-wc30.php
@@ -75,6 +75,32 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC30' ) ) {
 		public function get_parent_product_id( WC_Product $product ) {
 			return ( $product->is_type( 'variation' ) ) ? $product->get_parent_id() : $product->get_id();
 		}
+
+		/**
+		 * For a given product ID, it tries to find its name inside an order's line items.
+		 * This is useful when an order has a product which was later deleted from the
+		 * store.
+		 *
+		 * @param int $product_id Product ID or variation ID
+		 * @param WC_Order $order
+		 * @return string The product (or variation) name, ready to print
+		 */
+		public function get_product_name_from_order( $product_id, $order ) {
+			foreach( $order->get_items() as $line_item ) {
+				$line_product_id = $line_item->get_product_id();
+				if ( ! $line_product_id ) {
+					$line_product_id = (int) get_metadata( 'order_item', $line_item->get_id(), '_product_id', true );
+				}
+				$line_variation_id = $line_item->get_variation_id();
+				if ( ! $line_variation_id ) {
+					$line_variation_id = (int) get_metadata( 'order_item', $line_item->get_id(), '_variation_id', true );
+				}
+				if ( $line_product_id === $product_id || $line_variation_id === $product_id ) {
+					return sprintf( '#%s - %s', $product_id, $line_item->get_name() );
+				}
+			}
+			return sprintf( __( '#%s - [Deleted product]', 'woocommerce-services' ), $product_id );
+		}
 	}
 
 }

--- a/classes/class-wc-connect-compatibility-wc30.php
+++ b/classes/class-wc-connect-compatibility-wc30.php
@@ -86,20 +86,26 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC30' ) ) {
 		 * @return string The product (or variation) name, ready to print
 		 */
 		public function get_product_name_from_order( $product_id, $order ) {
-			foreach( $order->get_items() as $line_item ) {
+			foreach ( $order->get_items() as $line_item ) {
 				$line_product_id = $line_item->get_product_id();
+				$line_variation_id = $line_item->get_variation_id();
+
 				if ( ! $line_product_id ) {
 					$line_product_id = (int) get_metadata( 'order_item', $line_item->get_id(), '_product_id', true );
 				}
-				$line_variation_id = $line_item->get_variation_id();
+
 				if ( ! $line_variation_id ) {
 					$line_variation_id = (int) get_metadata( 'order_item', $line_item->get_id(), '_variation_id', true );
 				}
+
 				if ( $line_product_id === $product_id || $line_variation_id === $product_id ) {
-					return sprintf( '#%s - %s', $product_id, $line_item->get_name() );
+					/* translators: %1$d: Product ID, %2$s: Product Name */
+					return sprintf( __( '#%1$d - %2$s', 'woocommerce-services' ), $product_id, $line_item->get_name() );
 				}
 			}
-			return sprintf( __( '#%s - [Deleted product]', 'woocommerce-services' ), $product_id );
+
+			/* translators: %d: Deleted Product ID */
+			return sprintf( __( '#%d - [Deleted product]', 'woocommerce-services' ), $product_id );
 		}
 	}
 

--- a/classes/class-wc-connect-compatibility.php
+++ b/classes/class-wc-connect-compatibility.php
@@ -99,6 +99,17 @@ if ( ! class_exists( 'WC_Connect_Compatibility' ) ) {
 		 * @return int
 		 */
 		abstract public function get_parent_product_id( WC_Product $product );
+
+		/**
+		 * For a given product ID, it tries to find its name inside an order's line items.
+		 * This is useful when an order has a product which was later deleted from the
+		 * store.
+		 *
+		 * @param int $product_id Product ID or variation ID
+		 * @param WC_Order $order
+		 * @return string The product (or variation) name, ready to print
+		 */
+		abstract public function get_product_name_from_order( $product_id, $order );
 	}
 
 }

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -124,18 +124,20 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				$formatted_packages[ $package_id ] = $package;
 
 				foreach( $package[ 'items' ] as $item_index => $item ) {
+					$product_data = $package[ 'items' ][ $item_index ];
 					$product = WC_Connect_Compatibility::instance()->get_item_product( $order, $item );
-					if ( ! $product ) {
-						continue;
+
+					if ( $product ) {
+						$product_data[ 'name' ] = $this->get_name( $product );
+						$product_data[ 'url' ] = get_edit_post_link( WC_Connect_Compatibility::instance()->get_parent_product_id( $product ), null );
+						if ( $product->is_type( 'variation' ) ) {
+							$formatted = WC_Connect_Compatibility::instance()->get_formatted_variation( $product, true );
+							$product_data[ 'attributes' ] = $formatted;
+						}
+					} else {
+						$product_data[ 'name' ] = sprintf( __( '#%s - [Deleted product]', 'woocommerce-services' ), $item[ 'product_id' ] );
 					}
 
-					$product_data = $package[ 'items' ][ $item_index ];
-					$product_data[ 'name' ] = $this->get_name( $product );
-					$product_data[ 'url' ] = get_edit_post_link( WC_Connect_Compatibility::instance()->get_parent_product_id( $product ), null );
-					if ( $product->is_type( 'variation' ) ) {
-						$formatted = WC_Connect_Compatibility::instance()->get_formatted_variation( $product, true );
-						$product_data[ 'attributes' ] = $formatted;
-					}
 					$formatted_packages[ $package_id ][ 'items' ][ $item_index ] = $product_data;
 				}
 			}

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -294,8 +294,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				return false;
 			}
 
-			// TODO: return true if the order has already label meta-data
+			// If the order already has purchased labels, show the meta-box no matter what
+			if ( get_post_meta( WC_Connect_Compatibility::instance()->get_order_id( $order ), 'wc_connect_labels', true ) ) {
+				return true;
+			}
 
+			// Restrict showing the meta-box to supported origin and destinations: US domestic, for now
 			$base_location = wc_get_base_location();
 			if ( 'US' !== $base_location[ 'country' ] ) {
 				return false;
@@ -307,6 +311,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				return false;
 			}
 
+			// If the order was created using WCS checkout rates, show the meta-box regardless of the products' state
+			if ( $this->get_packaging_metadata( $order ) ) {
+				return true;
+			}
+
+			// At this point (no packaging data), only show if there's at least one existing and shippable product
 			foreach( $order->get_items() as $item ) {
 				$product = WC_Connect_Compatibility::instance()->get_item_product( $order, $item );
 				if ( $product && $product->needs_shipping() ) {

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -135,7 +135,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 							$product_data[ 'attributes' ] = $formatted;
 						}
 					} else {
-						$product_data[ 'name' ] = sprintf( __( '#%s - [Deleted product]', 'woocommerce-services' ), $item[ 'product_id' ] );
+						$product_data[ 'name' ] = WC_Connect_Compatibility::instance()->get_product_name_from_order( $item[ 'product_id' ], $order );
 					}
 
 					$formatted_packages[ $package_id ][ 'items' ][ $item_index ] = $product_data;

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -81,7 +81,13 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 			$product_names = array();
 			foreach ( $package[ 'products' ] as $product_id ) {
 				$product = wc_get_product( $product_id );
-				$product_names[] = $product ? $product->get_title() : WC_Connect_Compatibility::instance()->get_product_name_from_order( $product_id, wc_get_order( $order_id ) );
+
+				if ( $product ) {
+					$product_names[] = $product->get_title();
+				} else {
+					$order = wc_get_order( $order_id );
+					$product_names[] = WC_Connect_Compatibility::instance()->get_product_name_from_order( $product_id, $order );
+				}
 			}
 
 			$label_meta[ 'product_names' ] = $product_names;

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -81,7 +81,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 			$product_names = array();
 			foreach ( $package[ 'products' ] as $product_id ) {
 				$product = wc_get_product( $product_id );
-				$product_names[] = $product ? $product->get_title() : sprintf( __( '#%s - [Deleted product]', 'woocommerce-services' ), $product_id );
+				$product_names[] = $product ? $product->get_title() : WC_Connect_Compatibility::instance()->get_product_name_from_order( $product_id, wc_get_order( $order_id ) );
 			}
 
 			$label_meta[ 'product_names' ] = $product_names;

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -80,12 +80,8 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 
 			$product_names = array();
 			foreach ( $package[ 'products' ] as $product_id ) {
-				$product =  wc_get_product( $product_id );
-				if ( ! isset( $product ) ) {
-					continue;
-				}
-
-				$product_names[] = $product->get_title();
+				$product = wc_get_product( $product_id );
+				$product_names[] = $product ? $product->get_title() : sprintf( __( '#%s - [Deleted product]', 'woocommerce-services' ), $product_id );
 			}
 
 			$label_meta[ 'product_names' ] = $product_names;

--- a/client/shipping-label/views/purchase/steps/packages/item-info.js
+++ b/client/shipping-label/views/purchase/steps/packages/item-info.js
@@ -20,7 +20,10 @@ const ItemInfo = ( { item, itemIndex, packageId, showRemove, openItemMove, remov
 		<div key={ itemIndex } className="wcc-package-item">
 			<div className="wcc-package-item__name">
 					<span className="wcc-package-item__title">
-						<a href={ item.url } target="_blank">{ item.name }</a>
+						{ item.url
+							? <a href={ item.url } target="_blank">{ item.name }</a>
+							: item.name
+						}
 					</span>
 				{ item.attributes && <p>{ item.attributes }</p> }
 			</div>

--- a/tests/php/test_woocommerce-services-compatibility.php
+++ b/tests/php/test_woocommerce-services-compatibility.php
@@ -79,4 +79,22 @@ class WP_Test_WC_Services_Compatibility extends WC_Unit_Test_Case {
 		$this->assertEquals( self::get_id( $product ), $parent_id );
 		$this->assertEquals( self::get_id( $product ), $variation_id );
 	}
+
+	public function get_product_name_from_order() {
+		$compat = WC_Connect_Compatibility::instance();
+		$order = WC_Helper_Order::create_order();
+		$order_id = self::get_id( $order );
+
+		// The order is auto-populated with a product. Delete that product from the database, but not from the order
+		$items = $order->get_items();
+		$item_values = array_values( $items );
+		$item = $item_values[ 0 ];
+		$product = $compat->get_item_product( $order, $item );
+		$product_id = self::get_id( $product );
+		$product_name = $product->get_title();
+		WC_Helper_Product::delete_product( $product_id );
+
+		$order = wc_get_order( $order_id );
+		$this->assertContains( $product_name, $compat->get_product_name_from_order( $product_id, $order ) );
+	}
 }


### PR DESCRIPTION
Fixes #982 

To test:
* As a user, buy a product, and checkout using WCS-provided rates.
* As an admin, delete said product entirely (not just "Trash").
* Go to the `Edit Order` page, try to buy a label.

You can also try purchasing / deleting a variation instead of a whole product, it's the same case.

In `master`: The item won't have a name in the `Packages` step, and after correctly purchasing a label for it, the PHP server will crash. That means that the merchant loses money and doesn't get a label.

With this PR: The item will have a (non-clickable) name in the `Packages` step, it will be `#123 - [Deleted product]`. The label purchase can get through without any problem. After that, in the `Labels` list, hovering over the label ID you will be able to see the same "name" in the package contents: `#123 - [Deleted product]`.

I'm sure there's an esoteric way of getting the product name, such as parsing the order lines, but this is a case so rare that I'm perfectly fine just preventing a crash and providing a reasonable fallback.