### PR TITLE
Add custom error type to FieldError

### DIFF
--- a/client/components/field-error/index.js
+++ b/client/components/field-error/index.js
@@ -1,10 +1,14 @@
 import React, { PropTypes } from 'react';
 import sanitizeHTML from 'lib/utils/sanitize-html';
 import Gridicon from 'gridicons';
+import classNames from 'classnames';
 
-const FieldError = ( { text } ) => {
+const FieldError = ( { text, type = 'input-validation' } ) => {
 	return (
-		<div className="form-input-validation is-error">
+		<div className={ classNames(
+			'is-error',
+			`form-${ type }`
+		) }>
 			<Gridicon size={ 24 } icon="notice-outline" /> <span dangerouslySetInnerHTML={ sanitizeHTML( text ) } />
 		</div>
 	);
@@ -12,6 +16,7 @@ const FieldError = ( { text } ) => {
 
 FieldError.propTypes = {
 	text: PropTypes.string,
+	type: PropTypes.string,
 };
 
 export default FieldError;


### PR DESCRIPTION
This change allows a user to specify an error type as a prop passed to `< FieldError />`.  The default error type is left as `input-validation`. The type is used to add the right CSS class.