### PR TITLE
Show errors in rate step

### DIFF
--- a/assets/stylesheets/shipping-label.scss
+++ b/assets/stylesheets/shipping-label.scss
@@ -261,6 +261,25 @@
 			opacity: 0.5;
 		}
 	}
+
+	.wcc-metabox-rate__package-container {
+		margin-bottom: 2em;
+	}
+
+	.wcc-metabox-rate__package-container .form-server-error {
+		margin-left: -2px; // align with form-input-validation gridicon
+	}
+
+	.wcc-metabox-rate__package-container .form-fieldset ~ .form-server-error {
+		// when there is a rates drop-down
+		margin-top: -1em;
+	}
+
+	.wcc-metabox-rate__package-heading {
+		font-size: 14px;
+		font-weight: 600;
+		margin-bottom: 5px;
+	}
 }
 
 // Notice

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -115,6 +115,13 @@
 		}
 	}
 
+	.form-server-error {
+		.gridicon {
+			float: none;
+			vertical-align: middle;
+		}
+	}
+
 	.settings-form-row {
 		display: flex;
 

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -520,7 +520,9 @@ reducers[ SET_RATES ] = ( state, { rates } ) => {
 		form: { ...state.form,
 			rates: {
 				values: _.mapValues( rates, ( rate ) => {
-					const selected = rate.rates.find( ( r ) => r.is_selected );
+					const selected = _.get( rate, 'rates', [] )
+						.find( ( r ) => r.is_selected );
+
 					if ( selected ) {
 						return selected.service_id;
 					}

--- a/client/shipping-label/state/selectors/errors.js
+++ b/client/shipping-label/state/selectors/errors.js
@@ -58,10 +58,10 @@ const getPackagesErrors = ( values ) => _.mapValues( values, ( pckg ) => {
 	return errors;
 } );
 
-const getRatesErrors = ( { values: selectedRates, available: allRates } ) => {
+export const getRatesErrors = ( { values: selectedRates, available: allRates } ) => {
 	return {
 		server: _.mapValues( allRates, ( rate ) => {
-			if( ! rate.errors ) {
+			if ( ! rate.errors ) {
 				return;
 			}
 

--- a/client/shipping-label/state/selectors/errors.js
+++ b/client/shipping-label/state/selectors/errors.js
@@ -58,7 +58,22 @@ const getPackagesErrors = ( values ) => _.mapValues( values, ( pckg ) => {
 	return errors;
 } );
 
-const getRatesErrors = ( values ) => _.mapValues( values, ( ( rate ) => rate ? null : __( 'Please choose a rate' ) ) );
+const getRatesErrors = ( { values: selectedRates, available: allRates } ) => {
+	return {
+		server: _.mapValues( allRates, ( rate ) => {
+			if( ! rate.errors ) {
+				return;
+			}
+
+			return rate.errors.map( ( error ) =>
+				error.userMessage ||
+				error.message ||
+				__( "We couldn't get a rate for this package, please try again." )
+			);
+		} ),
+		form: _.mapValues( selectedRates, ( ( rate ) => rate ? null : __( 'Please choose a rate' ) ) ),
+	};
+};
 
 const getSidebarErrors = ( paperSize ) => {
 	const errors = {};
@@ -80,7 +95,7 @@ export default createSelector(
 			origin: getAddressErrors( form.origin, countriesData ),
 			destination: getAddressErrors( form.destination, countriesData ),
 			packages: getPackagesErrors( form.packages.selected ),
-			rates: getRatesErrors( form.rates.values ),
+			rates: getRatesErrors( form.rates ),
 			sidebar: getSidebarErrors( paperSize ),
 		};
 	}

--- a/client/shipping-label/state/selectors/test/errors.js
+++ b/client/shipping-label/state/selectors/test/errors.js
@@ -1,0 +1,284 @@
+/*
+ * Internal Dependencies
+ */
+import { getRatesErrors } from '../errors';
+
+describe( '#getRatesErrors', () => {
+	// when there are selected rates
+	// the values match `service_id` in the rate object
+	const firstBoxSelectedValues = {
+		box_1: 'Priority',
+	};
+	const secondBoxSelectedValues = {
+		box_2: 'Express',
+	};
+
+	// rates when there are no server errors, for each box
+	const firstBoxRatesWithNoServerErrors = {
+		box_1: {
+			shipment_id: 'shp_1',
+			rates: [
+				{
+					rate_id: 'rate_box_1_a',
+					service_id: 'Priority',
+					carrier_id: 'usps',
+					title: 'USPS - Priority Mail',
+					rate: 10,
+					is_selected: true,
+				},
+				{
+					rate_id: 'rate_box_1_b',
+					service_id: 'Express',
+					carrier_id: 'usps',
+					title: 'USPS - Express Mail',
+					rate: 11,
+					is_selected: false,
+				},
+			],
+			errors: [],
+		},
+	};
+	const secondBoxRatesWithNoServerErrors = {
+		box_2: {
+			shipment_id: 'shp_2',
+			rates: [
+				{
+					rate_id: 'rate_box_2_a',
+					service_id: 'Priority',
+					carrier_id: 'usps',
+					title: 'USPS - Priority Mail',
+					rate: 20,
+					is_selected: false,
+				},
+				{
+					rate_id: 'rate_box_2_b',
+					service_id: 'Express',
+					carrier_id: 'usps',
+					title: 'USPS - Express Mail',
+					rate: 21,
+					is_selected: true,
+				},
+			],
+			errors: [],
+		},
+	};
+
+	// rates when there are server errors
+	const firstBoxRatesWithError = {
+		box_1: {
+			rates: [],
+			errors: [ {
+				code: 'ERROR 1',
+				message: 'There was an error!',
+			} ],
+		},
+	};
+	const firstBoxRatesWithUserMessageError = {
+		box_1: {
+			rates: [],
+			errors: [ {
+				code: 'ERROR 1',
+				userMessage: 'This is a friendly error message!',
+			} ],
+		},
+	};
+	const firstBoxRatesWithErrorButNoErrorMessage = {
+		box_1: {
+			rates: [],
+			errors: [ {
+				code: 'ERROR 1',
+			} ],
+		},
+	};
+	const firstBoxRatesWithMultipleErrors = {
+		box_1: {
+			rates: [],
+			errors: [
+				{
+					code: 'ERROR A',
+					message: 'Error 1',
+				},
+				{
+					code: 'ERROR B',
+					message: 'Error 2',
+				},
+			],
+		},
+	};
+
+	describe( 'a box with server errors', () => {
+		// i.e. it has an errors array, and an empty rates array
+
+		// `rates` is form.rates in the state
+		// `values` is the currently-selected rate in the form
+		// an empty string means none is selected
+		// `available` is all the available rates for the package/box
+
+		// rates with a message prop in the error object
+		const rates = {
+			values: {
+				box_1: '',
+			},
+			available: firstBoxRatesWithError,
+		};
+		const result = getRatesErrors( rates );
+
+		it( 'should return the server error and a form error', () => {
+			expect( result ).to.eql( {
+				server: {
+					box_1: [ 'There was an error!' ],
+				},
+				form: {
+					box_1: 'Please choose a rate',
+				},
+			} );
+		} );
+
+		// rates with a userMessage prop in the error object
+		const ratesWithUserMessage = {
+			...rates,
+			available: firstBoxRatesWithUserMessageError,
+		};
+		const resultWithUserMessage = getRatesErrors( ratesWithUserMessage );
+
+		it( 'should return the `userMessage` if it exists', () => {
+			expect( resultWithUserMessage.server ).to.eql( {
+				box_1: [ 'This is a friendly error message!' ],
+			} );
+		} );
+
+		// rates with no message or userMessage prop in the error object
+		const ratesWithNoMessage = {
+			...rates,
+			available: firstBoxRatesWithErrorButNoErrorMessage,
+		};
+		const resultWithErrorAndNoMessage = getRatesErrors( ratesWithNoMessage );
+
+		it( 'should return the the default error message if no error message sent', () => {
+			expect( resultWithErrorAndNoMessage.server ).to.eql( {
+				box_1: [ "We couldn't get a rate for this package, please try again." ],
+			} );
+		} );
+
+		describe( 'multiple errors', () => {
+			const ratesWithMultipleErrors = {
+				values: {
+					box_1: '',
+				},
+				available: firstBoxRatesWithMultipleErrors,
+			};
+			const resultWithMultipleErrors = getRatesErrors( ratesWithMultipleErrors );
+
+			it( 'should return array with each server error', () => {
+				expect( resultWithMultipleErrors.server ).to.eql( {
+					box_1: [
+						'Error 1',
+						'Error 2',
+					],
+				} );
+			} );
+		} );
+	} );
+
+	describe( 'a box with no server errors', () => {
+		// i.e. it has a rates array, and an empty errors array
+
+		describe( 'rate is selected', () => {
+			const rates = {
+				values: Object.assign( {}, firstBoxSelectedValues ),
+				available: firstBoxRatesWithNoServerErrors,
+			};
+			const result = getRatesErrors( rates );
+
+			it( 'should return a null form error and no server errors', () => {
+				expect( result ).to.eql( {
+					server: {
+						box_1: [],
+					},
+					form: {
+						box_1: null,
+					},
+				} );
+			} );
+		} );
+
+		describe( 'rate is not selected', () => {
+			const rates = {
+				values: {
+					box_1: '',
+				},
+				available: firstBoxRatesWithNoServerErrors,
+			};
+			const result = getRatesErrors( rates );
+
+			it( 'should return a form error and no server errors', () => {
+				expect( result ).to.eql( {
+					server: {
+						box_1: [],
+					},
+					form: {
+						box_1: 'Please choose a rate',
+					},
+				} );
+			} );
+		} );
+	} );
+
+	describe( 'two boxes: box 1 with server errors, box 2 without', () => {
+		describe( 'rate is selected for box 2', () => {
+			const rates = {
+				values: {
+					box_1: '',
+					box_2: Object.assign( {}, secondBoxSelectedValues ),
+				},
+				available: Object.assign( {},
+					firstBoxRatesWithError,
+					secondBoxRatesWithNoServerErrors
+				),
+			};
+			const result = getRatesErrors( rates );
+
+			it( 'should return the server error for the first box', () => {
+				expect( result.server ).to.eql( {
+					box_1: [ 'There was an error!' ],
+					box_2: [],
+				} );
+			} );
+
+			it( 'should return the form error for the second box', () => {
+				expect( result.form ).to.eql( {
+					box_1: 'Please choose a rate',
+					box_2: null,
+				} );
+			} );
+		} );
+
+		describe( 'rate not selected for box 2', () => {
+			const rates = {
+				values: {
+					box_1: '',
+					box_2: '',
+				},
+				available: Object.assign( {},
+					firstBoxRatesWithError,
+					secondBoxRatesWithNoServerErrors
+				),
+			};
+			const result = getRatesErrors( rates );
+
+			it( 'should return the server error for the first box', () => {
+				expect( result.server ).to.eql( {
+					box_1: [ 'There was an error!' ],
+					box_2: [],
+				} );
+			} );
+
+			it( 'should return no error for the second box', () => {
+				expect( result.form ).to.eql( {
+					box_1: 'Please choose a rate',
+					box_2: 'Please choose a rate',
+				} );
+			} );
+		} );
+	} );
+} );

--- a/client/shipping-label/views/purchase/steps/rates/list.js
+++ b/client/shipping-label/views/purchase/steps/rates/list.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import FieldError from 'components/field-error';
 import Dropdown from 'components/dropdown';
 import Notice from 'components/notice';
 import getPackageDescriptions from '../packages/get-package-descriptions';
@@ -29,9 +30,11 @@ const ShippingRates = ( {
 		shouldShowRateNotice,
 	} ) => {
 	const packageNames = getPackageDescriptions( selectedPackages, allPackages, true );
+	const hasSinglePackage = ( 1 === Object.keys( selectedPackages ).length );
+	const hasMultiplePackages = ( 1 < Object.keys( selectedPackages ).length );
 
 	const getTitle = ( pckg, pckgId ) => {
-		if ( 1 === Object.keys( selectedPackages ).length ) {
+		if ( hasSinglePackage ) {
 			return __( 'Choose rate' );
 		}
 		return sprintf( __( 'Choose rate: %s' ), packageNames[ pckgId ] );
@@ -41,20 +44,35 @@ const ShippingRates = ( {
 		const selectedRate = selectedRates[ pckgId ] || '';
 		const packageRates = _.get( availableRates, [ pckgId, 'rates' ], [] );
 		const valuesMap = { '': __( 'Select one...' ) };
+		const serverErrors = errors.server && errors.server[ pckgId ];
+		const formError = errors.form && errors.form[ pckgId ];
 
 		packageRates.forEach( ( rateObject ) => {
 			valuesMap[ rateObject.service_id ] = rateObject.title + ' (' + currencySymbol + rateObject.rate.toFixed( 2 ) + ')';
 		} );
 
 		return (
-			<div key={ pckgId }>
-				<Dropdown
-					id={ id + '_' + pckgId }
-					valuesMap={ valuesMap }
-					title={ getTitle( pckg, pckgId ) }
-					value={ selectedRate }
-					updateValue={ ( value ) => updateRate( pckgId, value ) }
-					error={ errors[ pckgId ] } />
+			<div key={ pckgId } className="wcc-metabox-rate__package-container">
+				{ serverErrors &&
+					_.isEmpty( packageRates ) &&
+					hasMultiplePackages &&
+					<p className="wcc-metabox-rate__package-heading">{ packageNames[ pckgId ] }</p>
+				}
+				{ ! _.isEmpty( packageRates ) &&
+					<Dropdown
+						id={ id + '_' + pckgId }
+						valuesMap={ valuesMap }
+						title={ getTitle( pckg, pckgId ) }
+						value={ selectedRate }
+						updateValue={ ( value ) => updateRate( pckgId, value ) }
+						error={ formError } />
+				}
+				{ serverErrors && serverErrors.map( ( serverError, index ) => {
+					return <FieldError
+						type="server-error"
+						key={ index }
+						text={ serverError } />;
+				} ) }
 			</div>
 		);
 	};

--- a/client/shipping-label/views/purchase/steps/rates/test/list.js
+++ b/client/shipping-label/views/purchase/steps/rates/test/list.js
@@ -1,0 +1,369 @@
+/*
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { noop } from 'lodash';
+
+/*
+ * Internal Dependencies
+ */
+import ShippingRates from '../list';
+import Dropdown from 'components/dropdown';
+import FieldError from 'components/field-error';
+
+/*
+ * Useful data for testing
+ */
+const allPackages = {
+	small_flat_box: {
+		inner_dimensions: '8.63 x 5.38 x 1.63',
+		outer_dimensions: '8.63 x 5.38 x 1.63',
+		id: 'small_flat_box',
+		name: 'Small Flat Rate Box',
+		dimensions: [ {
+			inner: '8.63 x 5.38: x 1.63',
+			outer: '8.63 x 5.38 x 1.63',
+		} ],
+		box_weight: 0,
+		max_weight: 70,
+		is_letter: false,
+		is_flat_rate: true,
+		group_id: 'pri_flat_boxes',
+	},
+	medium_flat_box_top: {
+		inner_dimensions: '11 x 8.5 x 5.5',
+		outer_dimensions: '11.25 x 8.75 x 6',
+		id: 'medium_flat_box_top',
+		name: 'Medium Flat Rate Box 1, Top Loading',
+		dimensions: [ {
+			inner: '11 x 8.5 x 5.5',
+			outer: '11.25 x 8.75 x 6',
+		} ],
+		box_weight: 0,
+		max_weight: 70,
+		is_letter: false,
+		is_flat_rate: true,
+		group_id: 'pri_flat_boxes',
+	},
+};
+
+const package_1_rate = {
+	shipment_id: 'abcdef',
+	rates: [ {
+		title: 'USPS - Priority Mail translated',
+		rate_id: 'rate_123',
+		carrier_id: 'usps',
+		rate: 2.87,
+		service_id: 'priority',
+	} ],
+};
+
+const package_1_error = {
+	errors: [ 'There was a fedex error!' ],
+};
+
+const package_2_rate = {
+	shipment_id: 'abcdef',
+	rates: [ {
+		title: 'USPS - Priority Mail translated',
+		rate_id: 'rate_123',
+		carrier_id: 'usps',
+		rate: 2.87,
+		service_id: 'priority',
+	} ],
+};
+
+const package_2_error = {
+	errors: [ 'There was a fedex error!' ],
+};
+
+const selectedPackage_1 = {
+	weight_0_individual: {
+		id: 'weight_0_individual',
+		box_id: 'individual',
+		length: 1,
+		width: 2,
+		height: 3,
+		weight: 1,
+		items: [ {
+			product_id: 1,
+			length: 1,
+			width: 2,
+			height: 3,
+			weight: 1,
+			quantity: 1,
+			name: '#1 - Package 1 Name',
+			url: 'http://example.com/wp-admin/post.php?post=1&action=edit',
+		} ],
+		service_id: 'pri',
+	},
+};
+
+const selectedPackage_2 = {
+	weight_1_individual: {
+		id: 'weight_1_individual',
+		box_id: 'individual',
+		length: 2,
+		width: 2,
+		height: 1,
+		weight: 1,
+		items: [ {
+			product_id: 2,
+			length: 2,
+			width: 2,
+			height: 1,
+			weight: 1,
+			quantity: 1,
+			name: '#2 - Package 2 Name',
+			url: 'http://example.com/wp-admin/post.php?post=2&action=edit',
+		} ],
+		service_id: 'pri',
+	},
+};
+
+const server_error_1 = {
+	weight_0_individual: [ 'There was a fedex error!' ],
+};
+
+const server_error_2 = {
+	weight_1_individual: [ 'There was a fedex error!' ],
+};
+
+const form_error_1 = {
+	weight_0_individual: 'Please choose a rate 1',
+};
+
+const form_error_2 = {
+	weight_1_individual: 'Please choose a rate 2',
+};
+
+const props = {
+	id: 'rates',
+	updateRate: noop,
+	currencySymbol: '$',
+	showRateNotice: false,
+	allPackages: allPackages,
+	availableRates: {},
+	errors: {},
+};
+
+const singlePackageProps = Object.assign(
+	{},
+	props,
+	{
+		selectedRates: {
+			weight_0_individual: '',
+		},
+		selectedPackages: selectedPackage_1,
+	}
+);
+
+const multiPackageProps = Object.assign(
+	{},
+	props,
+	{
+		selectedRates: {
+			weight_0_individual: '',
+			weight_1_individual: '',
+		},
+		selectedPackages: Object.assign(
+			{},
+			selectedPackage_1,
+			selectedPackage_2
+		),
+		availableRates: {
+			weight_0_individual: Object.assign( {}, package_1_rate, package_1_error ),
+			weight_1_individual: Object.assign( {}, package_2_rate, package_2_error ),
+		},
+		errors: {
+			server: Object.assign(
+				{},
+				server_error_1,
+				server_error_2
+			),
+			form: Object.assign(
+				{},
+				form_error_1,
+				form_error_2,
+			),
+		},
+	},
+);
+
+describe( '<ShippingRates />', () => {
+	it( 'handles empty available rates', () => {
+		const wrapper = shallow(
+			<ShippingRates
+				{ ...singlePackageProps }
+				availableRates={ {} }
+			/>
+		);
+		expect( wrapper.exists() ).to.equal( true );
+	} );
+
+	describe( 'Individual package', () => {
+		describe( 'Rates only, no errors', () => {
+			const wrapper = shallow(
+				<ShippingRates
+					{ ...singlePackageProps }
+					availableRates={ {
+						weight_0_individual: package_1_rate,
+					} }
+					selectedRates={ {
+						weight_0_individual: '',
+					} }
+					errors={ {
+						server: {},
+						form: {},
+					} }
+				/>
+			);
+			it( 'should display rates dropdown', () => {
+				expect( wrapper.find( Dropdown ) ).to.have.length( 1 );
+			} );
+			it( 'should not display any errors', () => {
+				expect( wrapper.find( FieldError ) ).to.have.length( 0 );
+			} );
+			it( 'should not display extra heading for package title', () => {
+				// the package title is displayed using the dropdown legend
+				expect( wrapper.find( '.wcc-metabox-rate__package-heading' ) ).to.have.length( 0 );
+			} );
+		} );
+
+		describe( 'Errors only, no rates', () => {
+			const wrapper = shallow(
+				<ShippingRates
+					{ ...singlePackageProps }
+					availableRates={ {
+						weight_0_individual: package_1_error,
+					} }
+					selectedRates={ {
+						weight_0_individual: '',
+					} }
+					errors={ {
+						server: {
+							weight_0_individual: [ 'There was an error!' ],
+						},
+						form: {
+							weight_0_individual: null,
+						},
+					} }
+				/>
+			);
+			it( 'should not display rates dropdown', () => {
+				expect( wrapper.find( Dropdown ) ).to.have.length( 0 );
+			} );
+			it( 'should display error', () => {
+				const errorWrapper = wrapper.find( FieldError );
+				expect( errorWrapper ).to.have.length( 1 );
+				expect( errorWrapper.prop( 'text' ) ).to.equal( 'There was an error!' );
+			} );
+			it( 'should not display extra heading for package title', () => {
+				// the package title is displayed using the dropdown legend
+				expect( wrapper.find( '.wcc-metabox-rate__package-heading' ) ).to.have.length( 0 );
+			} );
+		} );
+
+		describe( 'Both rates and errors', () => {
+			const wrapper = shallow(
+				<ShippingRates
+					{ ...singlePackageProps }
+					availableRates={ {
+						weight_0_individual: Object.assign( {}, package_1_rate, package_1_error ),
+					} }
+					selectedRates={ {
+						weight_0_individual: '',
+					} }
+					errors={ {
+						server: {
+							weight_0_individual: [ 'There was an error!' ],
+						},
+						form: {
+							weight_0_individual: null,
+						},
+					} }
+				/>
+			);
+			it( 'should display rates drop down', () => {
+				expect( wrapper.find( Dropdown ) ).to.have.length( 1 );
+			} );
+			it( 'should display error', () => {
+				expect( wrapper.find( FieldError ) ).to.have.length( 1 );
+			} );
+			it( 'should not display extra heading for package title', () => {
+				// the package title is displayed using the dropdown legend
+				expect( wrapper.find( '.wcc-metabox-rate__package-heading' ) ).to.have.length( 0 );
+			} );
+		} );
+	} );
+
+	describe( 'Multiple packages', () => {
+		describe( 'Rates only for all packages', () => {
+			const wrapper = shallow(
+				<ShippingRates
+					{ ...multiPackageProps }
+					availableRates={ {
+						weight_0_individual: package_1_rate,
+						weight_1_individual: package_2_rate,
+					} }
+					errors={ {} }
+				/>
+			);
+			it( 'should display dropdown for each package', () => {
+				expect( wrapper.find( Dropdown ) ).to.have.length( 2 );
+			} );
+			it( 'should not display any errors', () => {
+				expect( wrapper.find( FieldError ) ).to.have.length( 0 );
+			} );
+			it( 'should not display extra heading for package title', () => {
+				// the package title is displayed using the dropdown legend
+				expect( wrapper.find( '.wcc-metabox-rate__package-heading' ) ).to.have.length( 0 );
+			} );
+		} );
+
+		describe( 'Errors only for all packages', () => {
+			const wrapper = shallow(
+				<ShippingRates
+					{ ...multiPackageProps }
+					availableRates={ {
+						weight_0_individual: package_1_error,
+						weight_1_individual: package_2_error,
+					} }
+				/>
+			);
+			it( 'should not display any dropdowns', () => {
+				expect( wrapper.find( Dropdown ) ).to.have.length( 0 );
+			} );
+			it( 'should display error for each package', () => {
+				expect( wrapper.find( FieldError ) ).to.have.length( 2 );
+			} );
+			it( 'should display extra heading for package title', () => {
+				const packageNames = wrapper.find( '.wcc-metabox-rate__package-heading' ).map( node => node.text() );
+				expect( packageNames ).to.have.length( 2 );
+				expect( packageNames ).to.eql( [ '#1 - Package 1 Name', '#2 - Package 2 Name' ] );
+			} );
+		} );
+
+		describe( 'Both rates and errors for all packages', () => {
+			// this case is not expected to come from the server
+			// but the client should be able to handle it without error just in case
+			const wrapper = shallow(
+				<ShippingRates
+					{ ...multiPackageProps }
+				/>
+			);
+			it( 'should display dropdowns for each package', () => {
+				expect( wrapper.find( Dropdown ) ).to.have.length( 2 );
+			} );
+			it( 'should display error for each package', () => {
+				expect( wrapper.find( FieldError ) ).to.have.length( 2 );
+			} );
+			it( 'should not display extra heading for package title', () => {
+				// the package title is displayed using the dropdown legend
+				expect( wrapper.find( '.wcc-metabox-rate__package-heading' ) ).to.have.length( 0 );
+			} );
+		} );
+	} );
+} );

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,6 +15,9 @@ module.exports = function( config ) {
 			captureConsole: true
 		},
 		reporters: [ 'mocha', 'coverage' ],
+		mochaReporter: {
+			showDiff: true,
+		},
 		coverageReporter: {
 			dir: 'coverage/',
 			includeAllSources: true,


### PR DESCRIPTION
# Changes in this PR
- check rates prop exists before using it in the shipping-label reducer
- add server errors to `getRatesErrors` selector
- if there's an error sent from the server for a package's rates, show a `FieldError`
- add Enzyme tests for `<ShippingRates />`

# Testing
Check out the [counterpart PR on the server](https://github.com/Automattic/woocommerce-connect-server/pull/802). Use the testing instructions there to simulate different responses to see the errors show up on the rates step. You can trigger a re-fresh of the rates by re-saving your packages on the modal :)

# What does it look like?

When there are no rates, only errors:

<img src="https://cloud.githubusercontent.com/assets/11487924/25467225/e964f988-2ada-11e7-971a-c911e3b56b4e.png" />

Where there is both a rate and an error (we don't currently support sending down both. if there are errors and rates we'll send only the rates - but there is good stylin' in just in case that situation ever happens):

<img src="https://cloud.githubusercontent.com/assets/11487924/25467257/103b86da-2adb-11e7-8d2b-cb557cd0aaef.png">

# Stacked PRs!
The following PRs are related and stacked:
https://github.com/Automattic/woocommerce-services/pull/997
https://github.com/Automattic/woocommerce-services/pull/998
https://github.com/Automattic/woocommerce-services/pull/999
https://github.com/Automattic/woocommerce-services/pull/1000