### PR TITLE
Update NumberInput to use a JS class

### DIFF
--- a/client/components/number-field/number-input.js
+++ b/client/components/number-field/number-input.js
@@ -1,44 +1,38 @@
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import FormTextInput from 'components/forms/form-text-input';
 
-export default React.createClass( {
-	displayName: 'NumberInput',
-
-	propTypes: {
+export default class NumberInput extends Component {
+	static propTypes = {
 		onChange: PropTypes.func,
-	},
+	};
 
-	getDefaultProps() {
-		return {
-			onChange: () => {},
-		};
-	},
+	static defaultProps = {
+		onChange: () => {},
+	};
 
-	getInitialState() {
-		return {
-			focused: false,
-			text: this.props.value,
-		};
-	},
+	state = {
+		focused: false,
+		text: this.props.value,
+	};
 
 	componentWillReceiveProps( nextProps ) {
 		if ( ! this.state.focused && nextProps.value !== this.props.value ) {
 			this.setState( { text: nextProps.value } );
 		}
-	},
+	}
 
-	handleChange( event ) {
+	handleChange = ( event ) => {
 		this.setState( { text: event.target.value } );
 		this.props.onChange( event );
-	},
+	}
 
-	handleBlur( event ) {
+	handleBlur = ( event ) => {
 		this.setState( {
 			focused: false,
 			text: this.props.value,
 		} );
 		this.props.onChange( event );
-	},
+	}
 
 	render() {
 		return (
@@ -50,5 +44,5 @@ export default React.createClass( {
 				onFocus={ () => this.setState( { focused: true } ) }
 			/>
 		);
-	},
-} );
+	}
+}


### PR DESCRIPTION
# The Changes
React.createClass will be deprecated in React 16. This change updated `<NumberInput />` to use a js class instead.

# How to test

Check that `<NumberField />` and `<NumberInput /`> are working as intended in these cases:

### `<ShippingServiceEntry />` and `<SettingsItem />`
*in client/settings/views/services/entry.js* 
and *client/settings/views/wcc-settings-form/settings-item.js*
1. Go to WooCommerce (sidebar) > Settings (sidebar) > Shipping (top tab)
2. Click on a  WCS Shipping Method (link)
3. In the Rates section, open the Services to see the price adjustments
4. See the fallback rate

### `<PackageInfo />`
In *client/shipping-label/views/purchase/steps/packages/package-info.js*
1. Go to an order package and open the printing modal
2. Add a package - see the total weight input