### PR TITLE
Track plugin activation, deactivation, and uninstallation instead of "opt out".

### DIFF
--- a/classes/class-wc-connect-tracks.php
+++ b/classes/class-wc-connect-tracks.php
@@ -27,8 +27,16 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 			$this->record_user_event( 'opted_in' );
 		}
 
-		public function opted_out() {
-			$this->record_user_event( 'opted_out' );
+		public function plugin_activated() {
+			$this->record_user_event( 'plugin_activated' );
+		}
+
+		public function plugin_deactivated() {
+			$this->record_user_event( 'plugin_deactivated' );
+		}
+
+		public function plugin_uninstalled() {
+			$this->record_user_event( 'plugin_uninstalled' );
 		}
 
 		public function shipping_zone_method_added( $instance_id, $service_id ) {

--- a/tests/php/test_woocommerce-connect-tracks.php
+++ b/tests/php/test_woocommerce-connect-tracks.php
@@ -28,7 +28,7 @@ class WP_Test_WC_Connect_Tracks_No_Jetpack extends WP_Test_WC_Connect_Tracks {
 				$this->stringContains( 'Error' ),
 				$this->anything()
 		);
-		$record = $this->tracks->opted_out();
+		$record = $this->tracks->plugin_deactivated();
 		$this->assertNull( $record );
 	}
 
@@ -95,22 +95,22 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		$this->assertArrayHasKey( 'wp_version', $record[2] );
 	}
 
-	public function test_opted_out() {
+	public function test_plugin_deactivated() {
 		global $mock_recorded_tracks_events;
 		$mock_recorded_tracks_events = array();
 
 		$this->logger->expects( $this->once() )
 			->method( 'debug' )
 			->with(
-				$this->stringContains( 'woocommerceconnect_opted_out' ),
+				$this->stringContains( 'woocommerceconnect_plugin_deactivated' ),
 				$this->anything()
 			);
 
 		// $record will contain the args received by jetpack_tracks_record_event
-		$this->tracks->opted_out();
+		$this->tracks->plugin_deactivated();
 		$record = $mock_recorded_tracks_events[0];
 		$this->assertInstanceOf( 'WP_User', $record[0] );
-		$this->assertEquals( 'woocommerceconnect_opted_out', $record[1] );
+		$this->assertEquals( 'woocommerceconnect_plugin_deactivated', $record[1] );
 		$this->assertInternalType( 'array', $record[2] );
 		$this->assertArrayHasKey( '_via_ua', $record[2] );
 		$this->assertArrayHasKey( '_via_ip', $record[2] );

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -168,13 +168,28 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			return new WC_Connect_Tracks( $logger );
 		}
 
+		static function plugin_activation() {
+			if ( WC_Connect_Options::get_option( 'tos_accepted' ) ) {
+				$tracks = self::load_tracks_for_activation_hooks();
+				$tracks->plugin_activated();
+			}
+		}
+
 		static function plugin_deactivation() {
-			$tracks = self::load_tracks_for_activation_hooks();
-			$tracks->opted_out();
+			if ( WC_Connect_Options::get_option( 'tos_accepted' ) ) {
+				$tracks = self::load_tracks_for_activation_hooks();
+				$tracks->plugin_deactivated();
+			}
+
 			wp_clear_scheduled_hook( 'wc_connect_fetch_service_schemas' );
 		}
 
 		static function plugin_uninstall() {
+			if ( WC_Connect_Options::get_option( 'tos_accepted' ) ) {
+				$tracks = self::load_tracks_for_activation_hooks();
+				$tracks->plugin_uninstalled();
+			}
+
 			WC_Connect_Options::delete_all_options();
 		}
 
@@ -1024,5 +1039,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 	}
 }
 
+register_activation_hook( __FILE__, array( 'WC_Connect_Loader', 'plugin_activation' ) );
 register_deactivation_hook( __FILE__, array( 'WC_Connect_Loader', 'plugin_deactivation' ) );
 register_uninstall_hook( __FILE__, array( 'WC_Connect_Loader', 'plugin_uninstall' ) );


### PR DESCRIPTION
Fixes #994.

Remove “opt out” tracks event in favor of “plugin activated”, “plugin deactivated”, and “plugin uninstalled”. Ensure that the TOS has been accepted before sending.

**Note:** still marked "in progress" because events are firing twice.