### PR TITLE
Fixed a crash when booting calypso with non-existent locale JSON

### DIFF
--- a/client/lib/calypso-boot/index.js
+++ b/client/lib/calypso-boot/index.js
@@ -10,7 +10,7 @@ export default function boot() {
 	}
 
 	const i18nLocaleStringsObject = JSON.parse( window.i18nLocale.json );
-	if ( ! i18nLocaleStringsObject ) {
+	if ( ! i18nLocaleStringsObject || ! i18nLocaleStringsObject[ '' ] ) {
 		return;
 	}
 


### PR DESCRIPTION
#1017 introduced a bug where setting the site language to anything other than Spanish or French would crash JS rendering and the following error would be logged in the console:

```
Uncaught TypeError: Cannot set property 'localeSlug' of undefined
```

This PR fixes it.

To test:
* load any of the WCS pages in English