### PR TITLE
Fix issues in `can_accept_tos()`

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -788,7 +788,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * @return bool
 		 */
 		private function can_accept_tos() {
-			if ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) {
+			if ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG && current_user_can( 'manage_options' ) ) {
 				return true;
 			}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -365,7 +365,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			if ( ! $this->check_jetpack_install() ) {
 				add_action( 'admin_init', array( $this, 'admin_jetpack_notice' ) );
 				return;
-			} else if ( ! WC_Connect_Options::get_option( 'tos_accepted', false ) ) {
+			}
+
+			if ( ! WC_Connect_Options::get_option( 'tos_accepted', false ) ) {
 				add_action( 'admin_init', array( $this, 'admin_tos_notice' ) );
 				return;
 			}
@@ -792,12 +794,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				return true;
 			}
 
-			if ( ! class_exists( 'Jetpack_Data' ) ) {
-				return false;
-			}
-
 			$user_token = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
-			return is_object( $user_token ) && isset( $user_token->external_user_id) && get_current_user_id() === $user_token->external_user_id;
+			return isset( $user_token->external_user_id ) && get_current_user_id() === $user_token->external_user_id;
 		}
 
 		public function show_tos_notice() {
@@ -837,16 +835,13 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		public function check_jetpack_install() {
-			if ( defined( 'JETPACK_DEV_DEBUG' ) ) {
-				return true;
-			}
-
 			if ( ! class_exists( 'Jetpack_Data' ) ) {
 				return false;
 			}
 
 			$user_token = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
 			return $user_token && is_object( $user_token ) && isset( $user_token->external_user_id );
+
 		}
 
 		public function admin_jetpack_notice() {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -788,8 +788,16 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * @return bool
 		 */
 		private function can_accept_tos() {
+			if ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) {
+				return true;
+			}
+
+			if ( ! class_exists( 'Jetpack_Data' ) ) {
+				return false;
+			}
+
 			$user_token = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
-			return get_current_user_id() === $user_token->external_user_id;
+			return is_object( $user_token ) && isset( $user_token->external_user_id) && get_current_user_id() === $user_token->external_user_id;
 		}
 
 		public function show_tos_notice() {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -839,6 +839,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				return false;
 			}
 
+			if ( defined( 'JETPACK_DEV_DEBUG' ) ) {
+				return true;
+			}
+
 			$user_token = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
 			return $user_token && is_object( $user_token ) && isset( $user_token->external_user_id );
 


### PR DESCRIPTION
Fixes #1020 
Fixes #1021 

Adds more checks to `can_accept_tos()` that resolve several issues:

- Check that `Jetpack_Data` class exists before attempting to access it
- Account for the possibility of `Jetpack_Data::get_access_token()` returning a non-object
- Allow any admin to accept TOS if in Jetpack Dev Mode

To Test:
- Start out with a fresh unconfigured install of Jetpack and WooCommerce Services
- Deactivate Jetpack (in master this will cause a crash, in this PR it won't)
- Activate Jetpack and set it to dev mode with `define('JETPACK_DEV_DEBUG', true);`
- Observer that TOS now appears

@jeffstieler @DanReyLop @marcinbot @v18 