### PR TITLE
Fix missing order items in purchase label dialog

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -42,7 +42,9 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		}
 
 		protected function get_items_as_individual_packages( WC_Order $order ) {
-			$packages = array();
+			$packages   = array();
+			$item_count = 0;
+
 			foreach( $order->get_items() as $item ) {
 				$product = WC_Connect_Compatibility::instance()->get_item_product( $order, $item );
 				if ( ! $product || ! $product->needs_shipping() ) {
@@ -60,7 +62,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				}
 
 				for ( $i = 0; $i < $item[ 'qty' ]; $i++ ) {
-					$id = "weight_{$i}_individual";
+					$id = 'weight_' . $item_count++ . '_individual';
 					$product_data = array(
 						'height'     => ( float ) $height,
 						'product_id' => $item[ 'product_id' ],


### PR DESCRIPTION
Orders with no packaging metadata had package ID collisions, which caused order items to be missing from the purchase label dialog.

To test:
* Manually create an order ("Add order") with two different products that will require shipping
* Verify that only one product shows in the Packages step of the label flow
* Check out this branch, refresh order
* Verify that both products show as in "original packaging" in the Packages step