### PR TITLE
Labels - Fixed rendering of "Saved for later" items when adding to a package

### DIFF
--- a/client/shipping-label/views/purchase/steps/packages/add-item.js
+++ b/client/shipping-label/views/purchase/steps/packages/add-item.js
@@ -27,12 +27,16 @@ const AddItemDialog = ( {
 	};
 
 	const renderRadioButton = ( pckgId, itemIdx, item ) => {
+		const itemLabel = packageLabels[ pckgId ]
+			? __( '%(item)s from {{pckg/}}', { args: { item: item.name }, components: { pckg: getPackageNameElement( pckgId ) } } )
+			: item;
+
 		return (
 			<FormLabel
 				key={ `${ pckgId }-${ itemIdx }` }
 				className="wcc-move-item-dialog__package-option">
 				<FormRadio checked={ pckgId === sourcePackageId && itemIdx === movedItemIndex } onChange={ () => ( setAddedItem( pckgId, itemIdx ) ) } />
-				<span> { __( '%(item)s from {{pckg/}}', { args: { item: item.name }, components: { pckg: getPackageNameElement( pckgId ) } } ) } </span>
+				<span>{ itemLabel }</span>
 			</FormLabel>
 		);
 	};


### PR DESCRIPTION
Fixes #1025 

To test:
* open the labels modal
* remove an item from a package
* click "Add item" in a package
* confirm that the removed item is listed correctly