### PR TITLE
Update NUX flow logic for all scenarios

### DIFF
--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -256,6 +256,8 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					add_action( 'admin_notices', array( $this, 'show_banner_after_connection' ) );
 					break;
 				case 'tos_only_banner':
+					wp_enqueue_style( 'wc_connect_banner' );
+					add_action( 'admin_notices', array( $this, 'show_tos_banner' ) );
 					break;
 			}
 		}
@@ -335,6 +337,26 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				'button_text'    => __( 'Got it, thanks!', 'woocommerce-services' ),
 				'button_link'    => add_query_arg( array(
 					'wcs-nux-notice' => 'dismiss',
+				) ),
+				'image_url'      => plugins_url(
+					'images/nux-printer-laptop-illustration.png', dirname( __FILE__ )
+				),
+				'should_show_jp' => false,
+			) );
+		}
+
+		public function show_tos_banner() {
+			if ( isset( $_GET['wcs-nux-tos'] ) && 'accept' === $_GET['wcs-nux-tos'] ) {
+				WC_Connect_Options::update_option( 'tos_accepted', true );
+				wp_safe_redirect( remove_query_arg( 'wcs-nux-tos' ) );
+				exit;
+			}
+			$this->show_nux_banner( array(
+				'title'          => __( 'Setup complete! We need you to accept our TOS', 'woocommerce-services' ),
+				'description'    => __( 'Everything is ready to roll, we just need you to agree to our Terms of Service.', 'woocommerce-services' ),
+				'button_text'    => __( 'I accept the TOS!', 'woocommerce-services' ),
+				'button_link'    => add_query_arg( array(
+					'wcs-nux-tos' => 'accept',
 				) ),
 				'image_url'      => plugins_url(
 					'images/nux-printer-laptop-illustration.png', dirname( __FILE__ )

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -333,7 +333,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			WC_Connect_Options::update_option( 'tos_accepted', true );
 
 			$this->show_nux_banner( array(
-				'title'          => __( 'Setup complete! You can now access discounted shipping rates and printing services' ),
+				'title'          => __( 'Setup complete! You can now access discounted shipping rates and printing services', 'woocommerce-services' ),
 				'description'    => __( 'When you’re ready, you can purchase discounted labels from USPS, and print USPS labels at home.', 'woocommerce-services' ),
 				'button_text'    => __( 'Got it, thanks!', 'woocommerce-services' ),
 				'button_link'    => add_query_arg( array(

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -299,6 +299,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				'button_text'     => $button_text,
 				'image_url'       => $image_url,
 				'should_show_jp'  => true,
+				'should_show_terms' => true,
 			);
 
 			$base_location = wc_get_base_location();
@@ -345,6 +346,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					'images/nux-printer-laptop-illustration.png', dirname( __FILE__ )
 				),
 				'should_show_jp' => false,
+				'should_show_terms' => false,
 			) );
 		}
 
@@ -365,6 +367,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					'images/nux-printer-laptop-illustration.png', dirname( __FILE__ )
 				),
 				'should_show_jp' => false,
+				'should_show_terms' => false,
 			) );
 		}
 
@@ -379,7 +382,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					<p class="wcs-nux__notice-content-text">
 						<?php echo esc_html( $content['description'] ); ?>
 					</p>
-					<?php if ( $content['should_show_jp'] ) : ?>
+					<?php if ( isset( $content['should_show_terms'] ) && $content['should_show_terms'] ) : ?>
 						<p><?php
 						/* translators: %1$s example values include "Install Jetpack and CONNECT >", "Activate Jetpack and CONNECT >", "CONNECT >" */
 						printf(

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -311,9 +311,11 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 						'description'     => __( "WooCommerce Shipping is almost ready to go! Once you connect your store you'll be able to show your customers live shipping rates when they check out.", 'woocommerce-services' ),
 					);
 					break;
+				default:
+					$localized_content = array();
 			}
 
-			$this->show_nux_banner( wp_parse_args( $localized_content, $default_content ) );
+			$this->show_nux_banner( array_merge( $default_content, $localized_content ) );
 		}
 
 		public function show_banner_after_connection() {

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -326,6 +326,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				// No longer need to keep track of whether the before connection banner was displayed.
 				WC_Connect_Options::delete_option( self::SHOULD_SHOW_AFTER_CXN_BANNER );
 				wp_safe_redirect( remove_query_arg( 'wcs-nux-notice' ) );
+				exit;
 			}
 
 			// By going through the connection process, the user has accepted our TOS

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -326,6 +326,9 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				wp_safe_redirect( remove_query_arg( 'wcs-nux-notice' ) );
 			}
 
+			// By going through the connection process, the user has accepted our TOS
+			WC_Connect_Options::update_option( 'tos_accepted', true );
+
 			$this->show_nux_banner( array(
 				'title'          => __( 'Setup complete! You can now access discounted shipping rates and printing services' ),
 				'description'    => __( 'When you’re ready, you can purchase discounted labels from USPS, and print USPS labels at home.', 'woocommerce-services' ),

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -45,7 +45,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				'packages',
 				'predefined_packages',
 				'shipping_methods_migrated',
-				'after_jp_cxn_nux_success_banner_dismissed',
+				'should_display_nux_after_jp_cxn_banner',
 			);
 		}
 

--- a/tests/php/test_class_wc-connect-nux.php
+++ b/tests/php/test_class_wc-connect-nux.php
@@ -1,0 +1,109 @@
+<?php
+
+class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
+
+	public static function setupBeforeClass() {
+		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-nux.php' );
+	}
+
+	public function test_get_banner_type_to_display_dev_jp() {
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_DEV,
+			'tos_accepted'                           => false,
+			'should_display_after_cxn_banner'        => false,
+		) ), false );
+
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_DEV,
+			'tos_accepted'                           => true,
+			'should_display_after_cxn_banner'        => false,
+		) ), false );
+
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_DEV,
+			'tos_accepted'                           => false,
+			'should_display_after_cxn_banner'        =>  true,
+		) ), false );
+
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_DEV,
+			'tos_accepted'                           => true,
+			'should_display_after_cxn_banner'        =>  true,
+		) ), false );
+	}
+
+	public function test_get_banner_type_to_display_no_jp_cxn_without_tos_acceptance() {
+		// before going through connection
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_NOT_INSTALLED,
+			'tos_accepted'                           => false,
+			'should_display_after_cxn_banner'        =>  false,
+		) ), 'before_jetpack_connection' );
+
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_INSTALLED_NOT_ACTIVATED,
+			'tos_accepted'                           => false,
+			'should_display_after_cxn_banner'        =>  false,
+		) ), 'before_jetpack_connection' );
+
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_ACTIVATED_NOT_CONNECTED,
+			'tos_accepted'                           => false,
+			'should_display_after_cxn_banner'        =>  false,
+		) ), 'before_jetpack_connection' );
+
+		// after going through connection, TOS was never accepted
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
+			'tos_accepted'                           => false,
+			'should_display_after_cxn_banner'        =>  true,
+		) ), 'after_jetpack_connection' );
+	}
+
+	public function test_get_banner_type_to_display_no_jp_cxn_with_tos_acceptance() {
+		// before going through connection
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_NOT_INSTALLED,
+			'tos_accepted'                           => true,
+			'should_display_after_cxn_banner'        =>  false,
+		) ), 'before_jetpack_connection' );
+
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_INSTALLED_NOT_ACTIVATED,
+			'tos_accepted'                           => true,
+			'should_display_after_cxn_banner'        =>  false,
+		) ), 'before_jetpack_connection' );
+
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_ACTIVATED_NOT_CONNECTED,
+			'tos_accepted'                           => true,
+			'should_display_after_cxn_banner'        =>  false,
+		) ), 'before_jetpack_connection' );
+
+		// after going through connection, TOS was already previously accepted
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
+			'tos_accepted'                           => true,
+			'should_display_after_cxn_banner'        =>  true,
+		) ), 'after_jetpack_connection' );
+	}
+
+	public function test_get_banner_type_to_display_with_jp_cxn_without_tos_acceptance() {
+		// Jetpack is already connected, TOS was not yet accepted
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
+			'tos_accepted'                           => false,
+			'should_display_after_cxn_banner'        =>  false,
+		) ), 'tos_only_banner' );
+	}
+
+	public function test_get_banner_type_to_display_with_jp_cxn_with_tos_acceptance() {
+		// Jetpack is already connected, TOS is already accepted
+		// did not show before connection banner
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
+			'tos_accepted'                           => true,
+			'should_display_after_cxn_banner'        =>  false,
+		) ), false );
+	}
+}


### PR DESCRIPTION
These are the scenarios that need to be handled:

<table class="table table-bordered table-hover table-condensed">
<tbody><tr>
<td>Install type</td>
<td>JP cxned</td>
<td>TOS accepted</td>
<td>First banner</td>
<td>After cxn banner</td>
<td>After TOS banner</td>
</tr>
<tr>
<td>New </td>
<td>No</td>
<td>No</td>
<td>Original before</td>
<td>Original after</td>
<td>N/A</td>
</tr>
<tr>
<td>New </td>
<td>Yes</td>
<td>No</td>
<td>TOS (new)</td>
<td>N/A</td>
<td>Original after</td>
</tr>
<tr>
<td>Update</td>
<td>No</td>
<td>No</td>
<td>Original before</td>
<td>Original after</td>
<td>N/A</td>
</tr>
<tr>
<td>Update</td>
<td>Yes</td>
<td>No</td>
<td>TOS (new)</td>
<td>N/A</td>
<td>Original after</td>
</tr>
<tr>
<td>Update</td>
<td>No</td>
<td>Yes</td>
<td>Original before</td>
<td>Original after</td>
<td>N/A</td>
</tr>
<tr>
<td>Update</td>
<td>Yes</td>
<td>Yes</td>
<td>N/A</td>
<td>N/A</td>
<td>N/A</td>
</tr>
</tbody></table>

Original before = `show_banner_before_connection()`
Original after = `show_banner_after_connection`
TOS (new) = new TOS banner (does not yet exist)

# Testing instructions
1. Deactivate Jetpack, and delete all WCS options in the DB. Should see: the before connection banner before connecting to JP, the after connection banner after connecting to JP. You should be able to dismiss the after connection banner and not see it again. You should see the `tos_accepted` option saved.
2. Deactivate Jetpack. Keep `tos_activated` still saved in the DB. You should see the same as # 1 above: the before connection, and after connection banners.
3. Add logging on line [238](https://github.com/Automattic/woocommerce-services/pull/1038/files#diff-02948c6603eae6cf021f42bde08b17c8R238). Remove the `tos_accepted` option, and keep Jetpack connected. You should see the TOS-only logging you just added.
4. After you're both connected to Jetpack and have TOS enabled, and you've dismissed the after connection notice, you should see no more notices.
5. Run the php unit tests