### PR TITLE
Add order page pointer to shipping labels

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -467,6 +467,18 @@
 	}
 }
 
+.wcs-pointer-page-dimmer {
+	display: none;
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	background-color: black;
+	top: 0;
+	left: 0;
+	z-index: 9998;
+	opacity: 0.5;
+}
+
 // Gridicons
 .gridicon {
 	fill: currentColor;

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -469,12 +469,12 @@
 
 .wcs-pointer-page-dimmer {
 	display: none;
-	position: absolute;
-	width: 100%;
-	height: 100%;
+	position: fixed;
 	background-color: black;
 	top: 0;
+	bottom: 0;
 	left: 0;
+	right: 0;
 	z-index: 9998;
 	opacity: 0.5;
 }

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -48,9 +48,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 
 		private function init_pointers() {
 			add_filter( 'wc_services_pointer_woocommerce_page_wc-settings', array( $this, 'register_add_service_to_zone_pointer' ) );
-			if ( $this->is_new_labels_user() ) {
-				add_filter( 'wc_services_pointer_post.php', array( $this, 'register_order_page_labels_pointer' ) );
-			}
+			add_filter( 'wc_services_pointer_post.php', array( $this, 'register_order_page_labels_pointer' ) );
 		}
 
 		public function show_pointers( $hook ) {
@@ -111,18 +109,21 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		}
 
 		public function register_order_page_labels_pointer( $pointers ) {
-			$pointers[] = array(
-				'id' => 'wc_services_labels_metabox',
-				'target' => '#woocommerce-order-label',
-				'options' => array(
-					'content' => sprintf( '<h3>%s</h3><p>%s</p>',
-						__( 'Discounted Shipping Labels' ,'woocommerce-services' ),
-						__( 'When you\'re ready, purchase and print discounted labels from USPS right here.', 'woocommerce-services' )
+			if ( $this->is_new_labels_user() ) {
+				$pointers[] = array(
+					'id' => 'wc_services_labels_metabox',
+					'target' => '#woocommerce-order-label',
+					'options' => array(
+						'content' => sprintf( '<h3>%s</h3><p>%s</p>',
+							__( 'Discounted Shipping Labels' ,'woocommerce-services' ),
+							__( 'When you\'re ready, purchase and print discounted labels from USPS right here.', 'woocommerce-services' )
+						),
+						'position' => array( 'edge' => 'right', 'align' => 'left' ),
 					),
-					'position' => array( 'edge' => 'right', 'align' => 'left' ),
-				),
-				'dim' => true,
-			);
+					'dim' => true,
+				);
+			}
+
 			return $pointers;
 		}
 

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -393,10 +393,11 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 								),
 							) ),
 							esc_html( $content['button_text'] ),
-							'https://woocommerce.com/terms-conditions/',
-							'https://woocommerce.com/terms-conditions/services-privacy/'
-						);
-						?></p>
+							'<a href="https://woocommerce.com/terms-conditions/">',
+							'</a>',
+							'<a href="https://woocommerce.com/terms-conditions/services-privacy/"/>',
+							'</a>'
+						); ?></p>
 					<?php endif; ?>
 					<?php if ( isset( $content['button_link'] ) ) : ?>
 						<a

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -12,7 +12,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		const JETPACK_DEV = 'dev';
 		const JETPACK_CONNECTED = 'connected';
 
-		const SHOW_LABEL_METABOX_POINTER_OPTION = 'show_label_metabox_pointer';
+		const TRANSIENT_IS_NEW_LABEL_USER = 'wcc_is_new_label_user';
 
 		/**
 		 * Option name for dismissing success banner
@@ -102,10 +102,17 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		}
 
 		private function is_new_labels_user() {
-			global $wpdb;
-			$query = "SELECT meta_key FROM {$wpdb->postmeta} WHERE meta_key = 'wc_connect_labels' LIMIT 1";
-			$results = $wpdb->get_results( $query );
-			return 0 === count( $results );
+			$is_new_user = get_transient( self::TRANSIENT_IS_NEW_LABEL_USER );
+			if ( ! is_string( $is_new_user )) {
+				error_log( 'calculating if the user is new' );
+				global $wpdb;
+				$query = "SELECT meta_key FROM {$wpdb->postmeta} WHERE meta_key = 'wc_connect_labels' LIMIT 1";
+				$results = $wpdb->get_results( $query );
+				$is_new_user  = 0 === count( $results ) ? 'yes' : 'no';
+				set_transient( self::TRANSIENT_IS_NEW_LABEL_USER, $is_new_user );
+			}
+
+			return 'yes' === $is_new_user;
 		}
 
 		public function register_order_page_labels_pointer( $pointers ) {

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -46,6 +46,9 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 
 		private function init_pointers() {
 			add_filter( 'wc_services_pointer_woocommerce_page_wc-settings', array( $this, 'register_add_service_to_zone_pointer' ) );
+			if ( $this->should_show_labels_pointer() ) {
+				add_filter( 'wc_services_pointer_post.php', array( $this, 'register_order_page_labels_pointer' ) );
+			}
 		}
 
 		public function show_pointers( $hook ) {
@@ -78,6 +81,8 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				return;
 			}
 
+			error_log( json_encode($valid_pointers) );
+
 			wp_enqueue_style( 'wp-pointer' );
 			wp_localize_script( 'wc_services_admin_pointers', 'wcSevicesAdminPointers', $valid_pointers );
 			wp_enqueue_script( 'wc_services_admin_pointers' );
@@ -93,7 +98,39 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 						__( 'To ship products to customers using USPS or Canada Post, you will need to add them as a shipping method to an applicable zone. If you don\'t have any zones, add one first.', 'woocommerce-services' )
 					),
 					'position' => array( 'edge' => 'right', 'align' => 'left' ),
-				)
+				),
+			);
+			return $pointers;
+		}
+
+		private function should_show_labels_pointer() {
+			return true;
+		}
+
+		private function has_payments_configured() {
+			return true;
+		}
+
+		public function register_order_page_labels_pointer( $pointers ) {
+			if ( $this->has_payments_configured() ) {
+				$contents = sprintf( '<h3>%s</h3><p>%s</p>',
+					__( 'Discounted Shipping Labels' ,'woocommerce-services' ),
+					__( 'You can now purchase and print discounted labels from USPS directly from your customer\'s order. Select "Create new Label" to get started.', 'woocommerce-services' )
+				);
+			} else {
+				$contents = sprintf( '<h3>%s</h3><p>%s</p>',
+					__( 'Discounted Shipping Labels' ,'woocommerce-services' ),
+					__( 'Add a payment method to purchase and print discounted labels from USPS directly from your customer\'s order. Select "Create new Label" to get started.', 'woocommerce-services' )
+				);
+			}
+			$pointers[] = array(
+				'id' => 'wc_services_labels_metabox',
+				'target' => '#woocommerce-order-label',
+				'options' => array(
+					'content' => $contents,
+					'position' => array( 'edge' => 'right', 'align' => 'left' ),
+				),
+				'dim' => true,
 			);
 			return $pointers;
 		}

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -99,7 +99,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				'options' => array(
 					'content' => sprintf( '<h3>%s</h3><p>%s</p>',
 						__( 'Add a WooCommerce shipping service to a Zone' ,'woocommerce-services' ),
-						__( 'To ship products to customers using USPS or Canada Post, you will need to add them as a shipping method to an applicable zone. If you don\'t have any zones, add one first.', 'woocommerce-services' )
+						__( "To ship products to customers using USPS or Canada Post, you will need to add them as a shipping method to an applicable zone. If you don't have any zones, add one first.", 'woocommerce-services' )
 					),
 					'position' => array( 'edge' => 'right', 'align' => 'left' ),
 				),
@@ -107,10 +107,9 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			return $pointers;
 		}
 
-		private function is_new_labels_user() {
+		public function is_new_labels_user() {
 			$is_new_user = get_transient( self::TRANSIENT_IS_NEW_LABEL_USER );
-			if ( ! is_string( $is_new_user )) {
-				error_log( 'calculating if the user is new' );
+			if ( ! is_string( $is_new_user ) ) {
 				global $wpdb;
 				$query = "SELECT meta_key FROM {$wpdb->postmeta} WHERE meta_key = 'wc_connect_labels' LIMIT 1";
 				$results = $wpdb->get_results( $query );
@@ -129,7 +128,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					'options' => array(
 						'content' => sprintf( '<h3>%s</h3><p>%s</p>',
 							__( 'Discounted Shipping Labels' ,'woocommerce-services' ),
-							__( 'When you\'re ready, purchase and print discounted labels from USPS right here.', 'woocommerce-services' )
+							__( "When you're ready, purchase and print discounted labels from USPS right here.", 'woocommerce-services' )
 						),
 						'position' => array( 'edge' => 'right', 'align' => 'left' ),
 					),

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -105,27 +105,15 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			return true;
 		}
 
-		private function has_payments_configured() {
-			return true;
-		}
-
 		public function register_order_page_labels_pointer( $pointers ) {
-			if ( $this->has_payments_configured() ) {
-				$contents = sprintf( '<h3>%s</h3><p>%s</p>',
-					__( 'Discounted Shipping Labels' ,'woocommerce-services' ),
-					__( 'You can now purchase and print discounted labels from USPS directly from your customer\'s order. Select "Create new Label" to get started.', 'woocommerce-services' )
-				);
-			} else {
-				$contents = sprintf( '<h3>%s</h3><p>%s</p>',
-					__( 'Discounted Shipping Labels' ,'woocommerce-services' ),
-					__( 'Add a payment method to purchase and print discounted labels from USPS directly from your customer\'s order. Select "Create new Label" to get started.', 'woocommerce-services' )
-				);
-			}
 			$pointers[] = array(
 				'id' => 'wc_services_labels_metabox',
 				'target' => '#woocommerce-order-label',
 				'options' => array(
-					'content' => $contents,
+					'content' => sprintf( '<h3>%s</h3><p>%s</p>',
+						__( 'Discounted Shipping Labels' ,'woocommerce-services' ),
+						__( 'You can now purchase and print discounted labels from USPS directly from your customer\'s order. Select "Create new Label" to get started.', 'woocommerce-services' )
+					),
 					'position' => array( 'edge' => 'right', 'align' => 'left' ),
 				),
 				'dim' => true,

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -12,6 +12,8 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		const JETPACK_DEV = 'dev';
 		const JETPACK_CONNECTED = 'connected';
 
+		const SHOW_LABEL_METABOX_POINTER_OPTION = 'show_label_metabox_pointer';
+
 		/**
 		 * Option name for dismissing success banner
 		 * after the JP connection flow
@@ -46,7 +48,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 
 		private function init_pointers() {
 			add_filter( 'wc_services_pointer_woocommerce_page_wc-settings', array( $this, 'register_add_service_to_zone_pointer' ) );
-			if ( $this->should_show_labels_pointer() ) {
+			if ( $this->is_new_labels_user() ) {
 				add_filter( 'wc_services_pointer_post.php', array( $this, 'register_order_page_labels_pointer' ) );
 			}
 		}
@@ -101,8 +103,11 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			return $pointers;
 		}
 
-		private function should_show_labels_pointer() {
-			return true;
+		private function is_new_labels_user() {
+			global $wpdb;
+			$query = "SELECT meta_key FROM {$wpdb->postmeta} WHERE meta_key = 'wc_connect_labels' LIMIT 1";
+			$results = $wpdb->get_results( $query );
+			return 0 === count( $results );
 		}
 
 		public function register_order_page_labels_pointer( $pointers ) {

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -81,8 +81,6 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				return;
 			}
 
-			error_log( json_encode($valid_pointers) );
-
 			wp_enqueue_style( 'wp-pointer' );
 			wp_localize_script( 'wc_services_admin_pointers', 'wcSevicesAdminPointers', $valid_pointers );
 			wp_enqueue_script( 'wc_services_admin_pointers' );

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -112,7 +112,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				'options' => array(
 					'content' => sprintf( '<h3>%s</h3><p>%s</p>',
 						__( 'Discounted Shipping Labels' ,'woocommerce-services' ),
-						__( 'You can now purchase and print discounted labels from USPS directly from your customer\'s order. Select "Create new Label" to get started.', 'woocommerce-services' )
+						__( 'When you\'re ready, purchase and print discounted labels from USPS right here.', 'woocommerce-services' )
 					),
 					'position' => array( 'edge' => 'right', 'align' => 'left' ),
 				),

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -20,7 +20,13 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		 */
 		const SHOULD_SHOW_AFTER_CXN_BANNER = 'should_display_nux_after_jp_cxn_banner';
 
-		function __construct() {
+		/**
+		 * @var WC_Connect_Shipping_Label
+		 */
+		private $shipping_label;
+
+		function __construct( WC_Connect_Shipping_Label $shipping_label ) {
+			$this->shipping_label = $shipping_label;
 			$this->init_pointers();
 		}
 
@@ -116,7 +122,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		}
 
 		public function register_order_page_labels_pointer( $pointers ) {
-			if ( $this->is_new_labels_user() ) {
+			if ( $this->is_new_labels_user() && $this->shipping_label->should_show_meta_box() ) {
 				$pointers[] = array(
 					'id' => 'wc_services_labels_metabox',
 					'target' => '#woocommerce-order-label',

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -446,6 +446,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				'nonce'                   => wp_create_nonce( 'wp_rest' ),
 				'formData'                => $this->get_form_data( $order ),
 				'paymentMethod'           => $this->get_selected_payment_method(),
+				'numPaymentMethods'       => count( $this->payment_methods_store->get_payment_methods() ),
 				'labelsData'              => $this->settings_store->get_label_order_meta_data( $order_id ),
 			);
 

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -29,6 +29,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		 */
 		private $unsupported_states = array( 'AA', 'AE', 'AP' );
 
+		private $show_metabox = null;
+
 		public function __construct(
 			WC_Connect_API_Client $api_client,
 			WC_Connect_Service_Settings_Store $settings_store,
@@ -362,6 +364,14 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		}
 
 		public function should_show_meta_box() {
+			if ( null === $this->show_metabox ) {
+				$this->show_metabox = $this->calculate_should_show_meta_box();
+			}
+
+			return $this->show_metabox;
+		}
+
+		private function calculate_should_show_meta_box() {
 			$order = wc_get_order();
 
 			if ( ! $order ) {

--- a/client/admin-pointers.js
+++ b/client/admin-pointers.js
@@ -6,9 +6,7 @@ import jQuery from 'jquery';
 
 jQuery( document ).ready( function( $ ) {
 	function show_pointer( pointers, i ) {
-		if ( ! Array.isArray( pointers ) ||
-			! pointers[ i ]
-		) {
+		if ( ! ( Array.isArray( pointers ) && pointers[ i ] ) ) {
 			return;
 		}
 
@@ -22,17 +20,29 @@ jQuery( document ).ready( function( $ ) {
 			return;
 		}
 
+		const target = $( pointer.target );
+
 		const options = $.extend( pointer.options, {
 			close: function() {
 				$.post( ajaxurl, {
 					pointer: pointer.id,
 					action: 'dismiss-wp-pointer',
 				} );
+
+				if ( pointer.dim ) {
+					$( '#wcs-pointer-page-dimmer' ).fadeOut( 500 );
+				}
+
 				show_pointer( pointers, i + 1 );
 			},
 		} );
 
-		$( pointer.target ).pointer( options ).pointer( 'open' );
+		target.pointer( options ).pointer( 'open' );
+		if ( pointer.dim ) {
+			target.css( 'z-index', 9999 );
+			$( 'body' ).append( '<div id="wcs-pointer-page-dimmer" class="wcs-pointer-page-dimmer"></div>' );
+			$( '#wcs-pointer-page-dimmer' ).fadeIn( 500 );
+		}
 	}
 	show_pointer( wcSevicesAdminPointers, 0 );
 } );

--- a/client/admin-pointers.js
+++ b/client/admin-pointers.js
@@ -40,7 +40,6 @@ jQuery( document ).ready( function( $ ) {
 		target.pointer( options ).pointer( 'open' );
 		if ( pointer.dim ) {
 			target.css( 'z-index', 9999 );
-			$( 'body' ).append( '<div id="wcs-pointer-page-dimmer" class="wcs-pointer-page-dimmer"></div>' );
 			$( '#wcs-pointer-page-dimmer' ).fadeIn( 500 );
 		}
 	}

--- a/client/shipping-label/index.js
+++ b/client/shipping-label/index.js
@@ -13,7 +13,7 @@ import shippingLabel from './state/reducer';
 // from calypso
 import notices from 'state/notices/reducer';
 
-export default ( { formData, labelsData, paperSize, storeOptions, paymentMethod } ) => ( {
+export default ( { formData, labelsData, paperSize, storeOptions, paymentMethod, numPaymentMethods } ) => ( {
 	getReducer() {
 		return combineReducers( {
 			shippingLabel,
@@ -38,6 +38,7 @@ export default ( { formData, labelsData, paperSize, storeOptions, paymentMethod 
 				labels: labelsData || [],
 				paperSize,
 				paymentMethod,
+				numPaymentMethods,
 				form: {
 					orderId: formData.order_id,
 					origin: {

--- a/client/shipping-label/views/index.js
+++ b/client/shipping-label/views/index.js
@@ -59,9 +59,10 @@ class ShippingLabelRootView extends Component {
 	}
 
 	renderPaymentInfo() {
+		const numPaymentMethods = this.props.shippingLabel.numPaymentMethods;
 		const paymentMethod = this.props.shippingLabel.paymentMethod;
 
-		if ( paymentMethod ) {
+		if ( numPaymentMethods > 0 && paymentMethod ) {
 			return (
 				<Notice isCompact={ true } showDismiss={ false } className="wcc-metabox-label-payment inline">
 					<p>
@@ -71,6 +72,15 @@ class ShippingLabelRootView extends Component {
 						} ) }
 					</p>
 					<p><a href="admin.php?page=wc-settings&tab=shipping&section=label-settings">{ __( 'Manage cards' ) }</a></p>
+				</Notice>
+			);
+		}
+
+		if ( numPaymentMethods > 0 ) {
+			return (
+				<Notice isCompact={ true } showDismiss={ false } className="wcc-metabox-label-payment inline">
+					<p>{ __( 'To purchase shipping labels, you will first need to select a credit card.' ) }</p>
+					<p><a href="admin.php?page=wc-settings&tab=shipping&section=label-settings">{ __( 'Select a credit card' ) }</a></p>
 				</Notice>
 			);
 		}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -394,8 +394,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$payment_methods_store = new WC_Connect_Payment_Methods_Store( $settings_store, $api_client, $logger );
 			$tracks                = new WC_Connect_Tracks( $logger );
 			$help_view             = new WC_Connect_Help_View( $schemas_store, $settings_store, $logger );
-			$nux                   = new WC_Connect_Nux();
 			$shipping_label        = new WC_Connect_Shipping_Label( $api_client, $settings_store, $schemas_store, $payment_methods_store );
+			$nux                   = new WC_Connect_Nux( $shipping_label );
 
 			$this->set_logger( $logger );
 			$this->set_api_client( $api_client );


### PR DESCRIPTION
This PR adds a pointer that highlights the shipping labels metabox. Details of features implemented:

- Added a new pointer to the labels metabox
- Added divs, css and jQuery for dimming everything but the metabox and pointer on the orders page
- Metabox now displays different text depending on if the user has any payment methods
- Added a numPaymentMethods field to redux init data for the above feature
- Implemented MySQL query to detect if the store has already created labels and therefore doesn't need to see the pointer.

Other questions:
- Did I add the CSS in the right place?
- I felt that a direct `show()` was abrupt so I faded the dimming in and out. @olaolusoga ?

To Test:
- For the user you're testing, make sure you've deleted `dismissed_wp_pointers` from usermeta
- Either have a clean site with no printed labels, or delete the `wc_connect_labels` metadata in your postmeta table.
- Open an order to see the pointer
- Note that as long as Jetpack isn't connected, the pointer should not show 
- Note that the pointer shows up after you've successfully connected jetpack
- Try reloading the page and dismissing
- The pointer on the shipping zones page should not do any dimming
