### PR TITLE
Fix broken TOS links

### DIFF
--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -440,10 +440,8 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 								),
 							) ),
 							esc_html( $content['button_text'] ),
-							'<a href="https://woocommerce.com/terms-conditions/">',
-							'</a>',
-							'<a href="https://woocommerce.com/terms-conditions/services-privacy/"/>',
-							'</a>'
+							'https://woocommerce.com/terms-conditions/',
+							'https://woocommerce.com/terms-conditions/services-privacy/'
 						); ?></p>
 					<?php endif; ?>
 					<?php if ( isset( $content['button_link'] ) ) : ?>

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -433,7 +433,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 						<p><?php
 						/* translators: %1$s example values include "Install Jetpack and CONNECT >", "Activate Jetpack and CONNECT >", "CONNECT >" */
 						printf(
-							wp_kses( __( 'By clicking "%1$s", you agree to the <a href="%2$s">Terms of Service</a> and understand that some of your data will be passed to external servers. You can find more information about how your data is handled <a href="%3$s">here</a>', 'woocommerce-services' ),
+							wp_kses( __( 'By clicking "%1$s", you agree to the <a href="%2$s">Terms of Service</a> and understand that some of your data will be passed to external servers. You can find more information about how your data is handled <a href="%3$s">here</a>.', 'woocommerce-services' ),
 								array(
 								'a' => array(
 									'href' => array(),


### PR DESCRIPTION
Fixes #1043 

- Fixes broken HTML from a bad rebase
- Adds a missing period at the end of a sentence. 

To Test:
- On a fully setup site, The message should pop up you simply deactivate the Jetpack plugin
