### PR TITLE
dimmer div not rendered correctly

### DIFF
--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -87,7 +87,6 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				return;
 			}
 
-			add_action( 'admin_footer', array( $this, 'add_dimming_div' ) );
 			wp_enqueue_style( 'wp-pointer' );
 			wp_localize_script( 'wc_services_admin_pointers', 'wcSevicesAdminPointers', $valid_pointers );
 			wp_enqueue_script( 'wc_services_admin_pointers' );
@@ -106,10 +105,6 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				),
 			);
 			return $pointers;
-		}
-
-		public function add_dimming_div() {
-			echo '<div id="wcs-pointer-page-dimmer" class="wcs-pointer-page-dimmer"></div>';
 		}
 
 		public function is_new_labels_user() {

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -87,7 +87,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				return;
 			}
 
-			add_action( 'admin_footer', '<div id="wcs-pointer-page-dimmer" class="wcs-pointer-page-dimmer"></div>' );
+			add_action( 'admin_footer', array( $this, 'add_dimming_div' ) );
 			wp_enqueue_style( 'wp-pointer' );
 			wp_localize_script( 'wc_services_admin_pointers', 'wcSevicesAdminPointers', $valid_pointers );
 			wp_enqueue_script( 'wc_services_admin_pointers' );
@@ -106,6 +106,10 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				),
 			);
 			return $pointers;
+		}
+
+		public function add_dimming_div() {
+			echo '<div id="wcs-pointer-page-dimmer" class="wcs-pointer-page-dimmer"></div>';
 		}
 
 		public function is_new_labels_user() {

--- a/client/admin-pointers.js
+++ b/client/admin-pointers.js
@@ -40,6 +40,7 @@ jQuery( document ).ready( function( $ ) {
 		target.pointer( options ).pointer( 'open' );
 		if ( pointer.dim ) {
 			target.css( 'z-index', 9999 );
+			$( 'body' ).append( '<div id="wcs-pointer-page-dimmer" class="wcs-pointer-page-dimmer"></div>' );
 			$( '#wcs-pointer-page-dimmer' ).fadeIn( 500 );
 		}
 	}


### PR DESCRIPTION
Fixes #1047 

No, you can't pass a string to a WordPress hook. It must be a function.