### PR TITLE
Add labels metabox to the dismissed pointers list if the user is not new

### DIFF
--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -122,12 +122,24 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		}
 
 		public function register_order_page_labels_pointer( $pointers ) {
-			$dismissed_pointers = explode( ',', (string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true ) );
+			$user_id = get_current_user_id();
+			$dismissed_data = (string) get_user_meta( $user_id, 'dismissed_wp_pointers', true );
+			$dismissed_pointers = explode( ',', $dismissed_data );
 			if ( $dismissed_pointers && in_array( 'wc_services_labels_metabox', $dismissed_pointers ) ) {
 				return $pointers;
 			}
 
-			if ( $this->is_new_labels_user() && $this->shipping_label->should_show_meta_box() ) {
+			// If the user is not new to labels, we should just dismiss this pointer
+			if ( ! $this->is_new_labels_user() ) {
+				if ( strlen( $dismissed_data ) ) {
+					$dismissed_data .= ',';
+				}
+				$dismissed_data .= 'wc_services_labels_metabox';
+				update_user_meta( $user_id, 'dismissed_wp_pointers', $dismissed_data );
+				return $pointers;
+			}
+
+			if ( $this->shipping_label->should_show_meta_box() ) {
 				$pointers[] = array(
 					'id' => 'wc_services_labels_metabox',
 					'target' => '#woocommerce-order-label',

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -131,7 +131,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 
 		public function register_order_page_labels_pointer( $pointers ) {
 			$dismissed_pointers = $this->get_dismissed_pointers();
-			if ( $dismissed_pointers && in_array( 'wc_services_labels_metabox', $dismissed_pointers ) ) {
+			if ( in_array( 'wc_services_labels_metabox', $dismissed_pointers ) ) {
 				return $pointers;
 			}
 

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -73,14 +73,10 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			$dismissed_pointers = $this->get_dismissed_pointers();
 			$valid_pointers = array();
 
-			if( isset( $dismissed_pointers ) ) {
-				foreach ( $pointers as $pointer ) {
-					if ( ! in_array( $pointer['id'], $dismissed_pointers, true ) ) {
-						$valid_pointers[] =  $pointer;
-					}
+			foreach ( $pointers as $pointer ) {
+				if ( ! in_array( $pointer['id'], $dismissed_pointers, true ) ) {
+					$valid_pointers[] =  $pointer;
 				}
-			} else {
-				$valid_pointers = $pointers;
 			}
 
 			if ( empty( $valid_pointers ) ) {
@@ -131,7 +127,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 
 		public function register_order_page_labels_pointer( $pointers ) {
 			$dismissed_pointers = $this->get_dismissed_pointers();
-			if ( in_array( 'wc_services_labels_metabox', $dismissed_pointers ) ) {
+			if ( in_array( 'wc_services_labels_metabox', $dismissed_pointers, true ) ) {
 				return $pointers;
 			}
 


### PR DESCRIPTION
Fixes #1045 

This will help avoid checking the database in the future.