### PR TITLE
disable plugin features if no tos

### DIFF
--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -193,14 +193,17 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		}
 
 		public function get_jetpack_install_status() {
+			// check if jetpack is installed
+			if ( 0 !== validate_plugin( 'jetpack/jetpack.php' ) ) {
+				return self::JETPACK_NOT_INSTALLED;
+			}
+
 			// check if Jetpack is activated
 			if ( ! class_exists( 'Jetpack_Data' ) ) {
-				// not activated, check if installed
-				if ( 0 === validate_plugin( 'jetpack/jetpack.php' ) ) {
-					return self::JETPACK_INSTALLED_NOT_ACTIVATED;
-				}
-				return self::JETPACK_NOT_INSTALLED;
-			} else if ( defined( 'JETPACK_DEV_DEBUG' ) && true === JETPACK_DEV_DEBUG ) {
+				return self::JETPACK_INSTALLED_NOT_ACTIVATED;
+			}
+
+			if ( defined( 'JETPACK_DEV_DEBUG' ) && true === JETPACK_DEV_DEBUG ) {
 				// installed, activated, and dev mode on
 				return self::JETPACK_DEV;
 			}
@@ -208,11 +211,11 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			// installed, activated, dev mode off
 			// check if connected
 			$user_token = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
-			if ( isset( $user_token->external_user_id ) ) { // always an int
-				return self::JETPACK_CONNECTED;
+			if ( ! isset( $user_token->external_user_id ) ) { // always an int
+				return self::JETPACK_ACTIVATED_NOT_CONNECTED;
 			}
 
-			return self::JETPACK_ACTIVATED_NOT_CONNECTED;
+			return self::JETPACK_CONNECTED;
 		}
 
 		public function should_display_nux_notice_on_screen( $screen ) {

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -158,7 +158,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 
 		public static function get_banner_type_to_display( $status = array() ) {
 			if ( ! isset( $status['jetpack_connection_status'] ) ) {
-				return;
+				return false;
 			}
 
 			/* The NUX Flow:
@@ -186,6 +186,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					if ( isset( $status['tos_accepted'] ) && ! $status['tos_accepted'] ) {
 						return 'tos_only_banner';
 					}
+					return false;
 				default:
 					return false;
 			}

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -193,6 +193,9 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		}
 
 		public function get_jetpack_install_status() {
+			// we need to use validate_plugin to check that Jetpack is installed
+			include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+
 			// check if jetpack is installed
 			if ( 0 !== validate_plugin( 'jetpack/jetpack.php' ) ) {
 				return self::JETPACK_NOT_INSTALLED;

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -366,7 +366,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			// if the TOS has not bee accepted or Jetpack is not Connected do nothing else.
 			$jetpack_status = $this->nux->get_jetpack_install_status();
 			$is_jetpack_connected = WC_Connect_Nux::JETPACK_CONNECTED === $jetpack_status || WC_Connect_Nux::JETPACK_DEV === $jetpack_status;
-			if ( true !== WC_Connect_Options::get_option( 'tos_accepted' ) && $is_jetpack_connected ) {
+			if ( true !== WC_Connect_Options::get_option( 'tos_accepted' ) || ! $is_jetpack_connected ) {
 				return;
 			}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -364,10 +364,12 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'admin_init', array( $this, 'admin_enqueue_scripts' ) );
 			add_action( 'admin_init', array( $this->nux, 'set_up_nux_notices' ) );
 
-			// if the TOS has not been accepted or Jetpack is not Connected do nothing else.
+			// Plugin should be enabled if dev mode or connected + TOS
 			$jetpack_status = $this->nux->get_jetpack_install_status();
-			$is_jetpack_connected = WC_Connect_Nux::JETPACK_CONNECTED === $jetpack_status || WC_Connect_Nux::JETPACK_DEV === $jetpack_status;
-			if ( true !== WC_Connect_Options::get_option( 'tos_accepted' ) || ! $is_jetpack_connected ) {
+			$is_jetpack_connected = WC_Connect_Nux::JETPACK_CONNECTED === $jetpack_status;
+			$is_jetpack_dev_mode = WC_Connect_Nux::JETPACK_DEV === $jetpack_status;
+			$tos_accepted = WC_Connect_Options::get_option( 'tos_accepted' );
+			if (  ! ( $is_jetpack_dev_mode || ( $is_jetpack_connected && $tos_accepted ) ) ) {
 				return;
 			}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -361,7 +361,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function init() {
 			$this->load_dependencies();
 
-			add_action( 'admin_init', array( $this, 'load_admin_dependencies' ) );
 			add_action( 'admin_init', array( $this, 'admin_enqueue_scripts' ) );
 			add_action( 'admin_init', array( $this->nux, 'set_up_nux_notices' ) );
 
@@ -402,7 +401,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$settings_store        = new WC_Connect_Service_Settings_Store( $schemas_store, $api_client, $logger );
 			$payment_methods_store = new WC_Connect_Payment_Methods_Store( $settings_store, $api_client, $logger );
 			$tracks                = new WC_Connect_Tracks( $logger );
-			$help_view             = new WC_Connect_Help_View( $schemas_store, $settings_store, $logger );
 			$shipping_label        = new WC_Connect_Shipping_Label( $api_client, $settings_store, $schemas_store, $payment_methods_store );
 			$nux                   = new WC_Connect_Nux( $shipping_label );
 
@@ -413,7 +411,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->set_service_settings_store( $settings_store );
 			$this->set_payment_methods_store( $payment_methods_store );
 			$this->set_tracks( $tracks );
-			$this->set_help_view( $help_view );
 			$this->set_shipping_label( $shipping_label );
 			$this->set_nux( $nux );
 		}
@@ -429,6 +426,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$settings_pages = new WC_Connect_Settings_Pages( $this->payment_methods_store, $this->service_settings_store, $this->service_schemas_store );
 			$this->set_settings_pages( $settings_pages );
 
+			$schema = $this->get_service_schemas_store();
+			$settings = $this->get_service_settings_store();
+			$logger = $this->get_logger();
+			$this->set_help_view( new WC_Connect_Help_View( $schema, $settings, $logger ) );
 			add_action( 'admin_notices', array( WC_Connect_Error_Notice::instance(), 'render_notice' ) );
 		}
 
@@ -462,6 +463,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'admin_enqueue_scripts', array( $this->nux, 'show_pointers' ) );
 			add_filter( 'plugin_action_links_' . plugin_basename(__FILE__), array( $this, 'add_plugin_action_links' ) );
 			add_action( 'enqueue_wc_connect_script', array( $this, 'enqueue_wc_connect_script' ), 10, 2 );
+			add_action( 'admin_init', array( $this, 'load_admin_dependencies' ) );
 		}
 
 		/**

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -360,10 +360,12 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 */
 		public function init() {
 			$this->load_dependencies();
+
+			add_action( 'admin_init', array( $this, 'load_admin_dependencies' ) );
 			add_action( 'admin_init', array( $this, 'admin_enqueue_scripts' ) );
 			add_action( 'admin_init', array( $this->nux, 'set_up_nux_notices' ) );
 
-			// if the TOS has not bee accepted or Jetpack is not Connected do nothing else.
+			// if the TOS has not been accepted or Jetpack is not Connected do nothing else.
 			$jetpack_status = $this->nux->get_jetpack_install_status();
 			$is_jetpack_connected = WC_Connect_Nux::JETPACK_CONNECTED === $jetpack_status || WC_Connect_Nux::JETPACK_DEV === $jetpack_status;
 			if ( true !== WC_Connect_Options::get_option( 'tos_accepted' ) || ! $is_jetpack_connected ) {
@@ -379,6 +381,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * Load all plugin dependencies.
 		 */
 		public function load_dependencies() {
+			// we need to use validate_plugin to check that Jetpack is installed
+			include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+
 			require_once( plugin_basename( 'classes/class-wc-connect-error-notice.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-compatibility.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-logger.php' ) );
@@ -414,8 +419,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->set_help_view( $help_view );
 			$this->set_shipping_label( $shipping_label );
 			$this->set_nux( $nux );
-
-			add_action( 'admin_init', array( $this, 'load_admin_dependencies' ) );
 		}
 
 		/**

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -381,9 +381,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * Load all plugin dependencies.
 		 */
 		public function load_dependencies() {
-			// we need to use validate_plugin to check that Jetpack is installed
-			include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-
 			require_once( plugin_basename( 'classes/class-wc-connect-error-notice.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-compatibility.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-logger.php' ) );

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -369,7 +369,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$is_jetpack_connected = WC_Connect_Nux::JETPACK_CONNECTED === $jetpack_status;
 			$is_jetpack_dev_mode = WC_Connect_Nux::JETPACK_DEV === $jetpack_status;
 			$tos_accepted = WC_Connect_Options::get_option( 'tos_accepted' );
-			if (  ! ( $is_jetpack_dev_mode || ( $is_jetpack_connected && $tos_accepted ) ) ) {
+			if (  ! ( $tos_accepted && ( $is_jetpack_connected || $is_jetpack_dev_mode ) ) ) {
 				return;
 			}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -363,6 +363,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'admin_init', array( $this, 'admin_enqueue_scripts' ) );
 			add_action( 'admin_init', array( $this->nux, 'set_up_nux_notices' ) );
 
+			// if the TOS has not bee accepted, do nothing else.
+			if ( true !== WC_Connect_Options::get_option( 'tos_accepted' ) ) {
+				return;
+			}
+
 			$this->schedule_service_schemas_fetch();
 			$this->service_settings_store->migrate_legacy_services();
 			$this->attach_hooks();

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -363,8 +363,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'admin_init', array( $this, 'admin_enqueue_scripts' ) );
 			add_action( 'admin_init', array( $this->nux, 'set_up_nux_notices' ) );
 
-			// if the TOS has not bee accepted, do nothing else.
-			if ( true !== WC_Connect_Options::get_option( 'tos_accepted' ) ) {
+			// if the TOS has not bee accepted or Jetpack is not Connected do nothing else.
+			$jetpack_status = $this->nux->get_jetpack_install_status();
+			$is_jetpack_connected = WC_Connect_Nux::JETPACK_CONNECTED === $jetpack_status || WC_Connect_Nux::JETPACK_DEV === $jetpack_status;
+			if ( true !== WC_Connect_Options::get_option( 'tos_accepted' ) && $is_jetpack_connected ) {
 				return;
 			}
 


### PR DESCRIPTION
This makes sure we don't do things like enabling our features or talk to the server until the TOS has been accepted.

To Test:
- If you have TOS accepted already you can either disconnect jetpack or remove dev mode and plugin features like the labels metabox should disappear.