### PR TITLE
Update NUX banner mobile styles

### DIFF
--- a/assets/stylesheets/banner.scss
+++ b/assets/stylesheets/banner.scss
@@ -61,3 +61,35 @@
 		color: #82B1D2;
 	}
 }
+
+@media (max-width: 1000px) {
+	.notice.wcs-nux__notice {
+		flex-direction: column;
+
+		.wcs-nux__notice-logo {
+			display: none;
+		}
+
+		.wcs-nux__notice-content {
+			.wcs-nux__notice-content-button {
+				align-self: auto;
+				margin: 1.5em 0 1em 0;
+			}
+		}
+
+		.wcs-nux__notice-jetpack {
+			flex-direction: row;
+			padding: 0.5em;
+
+			img {
+				height: 2em;
+				width: 2em;
+				margin: 0 1em 0 0;
+			}
+
+			.wcs-nux__notice-jetpack-text {
+				margin: 0;
+			}
+		}
+	}
+}

--- a/assets/stylesheets/banner.scss
+++ b/assets/stylesheets/banner.scss
@@ -24,6 +24,16 @@
 		padding: 1em;
 		margin-left: 1em;
 
+		.wcs-nux__notice-content-tos {
+			font-size: 0.8em;
+			color: #cbd8e0;
+			margin-bottom: 1em;
+
+			a {
+					color: #49a8ce;
+			}
+		}
+
 		.wcs-nux__notice-content-button {
 			align-self: flex-start; // do not stretch the button across entire div
 		}
@@ -71,6 +81,10 @@
 		}
 
 		.wcs-nux__notice-content {
+			.wcs-nux__notice-content-tos {
+				margin: 0;
+			}
+
 			.wcs-nux__notice-content-button {
 				align-self: auto;
 				margin: 1.5em 0 1em 0;

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -430,7 +430,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 						<?php echo esc_html( $content['description'] ); ?>
 					</p>
 					<?php if ( isset( $content['should_show_terms'] ) && $content['should_show_terms'] ) : ?>
-						<p><?php
+						<p class="wcs-nux__notice-content-tos"><?php
 						/* translators: %1$s example values include "Install Jetpack and CONNECT >", "Activate Jetpack and CONNECT >", "CONNECT >" */
 						printf(
 							wp_kses( __( 'By clicking "%1$s", you agree to the <a href="%2$s">Terms of Service</a> and understand that some of your data will be passed to external servers. You can find more information about how your data is handled <a href="%3$s">here</a>', 'woocommerce-services' ),


### PR DESCRIPTION
Here are the designs from Ola I'm following:

![jitm-mobile-before-connection-existing-1](https://user-images.githubusercontent.com/11487924/27492653-f7e0c390-5814-11e7-9a45-a8345da8e490.jpg)

# Before connect banner large

<img width="1499" alt="screen shot 2017-06-23 at 1 03 42 pm" src="https://user-images.githubusercontent.com/11487924/27492624-db3d8836-5814-11e7-844b-956a5c8d7b75.png">

Close to the cutoff:
<img width="867" alt="screen shot 2017-06-23 at 1 03 47 pm" src="https://user-images.githubusercontent.com/11487924/27492615-d3f20598-5814-11e7-8b9c-cd02289d1d04.png">


# Before connect banner small

Smallest:
<img width="463" alt="screen shot 2017-06-23 at 1 03 55 pm" src="https://user-images.githubusercontent.com/11487924/27492594-c5d1b6fc-5814-11e7-8bd2-79c0c0acec5f.png">

A bit larger:
<img width="693" alt="screen shot 2017-06-23 at 1 03 51 pm" src="https://user-images.githubusercontent.com/11487924/27492605-cb0cdf8e-5814-11e7-958b-1ec9b3e64f14.png">

# After connect banner large

<img width="947" alt="screen shot 2017-06-23 at 1 02 59 pm" src="https://user-images.githubusercontent.com/11487924/27492647-f0356380-5814-11e7-96ea-684c88254143.png">


# After connect banner small

<img width="663" alt="screen shot 2017-06-23 at 1 02 52 pm" src="https://user-images.githubusercontent.com/11487924/27492648-f331e77a-5814-11e7-85b7-1827dc0846a9.png">


# TOS-only banner large

 
<img width="941" alt="screen shot 2017-06-23 at 1 03 21 pm" src="https://user-images.githubusercontent.com/11487924/27492644-ea5186ec-5814-11e7-92e0-804543d731cf.png">


# TOS-only banner small

<img width="548" alt="screen shot 2017-06-23 at 1 03 24 pm" src="https://user-images.githubusercontent.com/11487924/27492637-e5fbeb50-5814-11e7-9412-3f0c8f4903f1.png">


# Not done in this PR
- [ ] the full text styles (this is currently blocked - waiting for the final design decision to be made)