### PR TITLE
Proxy TaxJar requests through the WCS Server

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -383,6 +383,33 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		/**
+		 * Proxy an HTTP request through the WCS Server
+		 *
+		 * @param $path Path of proxy route
+		 * @param $args WP_Http request args
+		 *
+		 * @return array|WP_Error
+		 */
+		public function proxy_request( $path, $args ) {
+			$proxy_url = trailingslashit( WOOCOMMERCE_CONNECT_SERVER_URL );
+			$proxy_url .= ltrim( $path, '/' );
+
+			$args['headers']['Authorization'] = $this->authorization_header();
+
+			$http_timeout = 60; // 1 minute
+
+			if ( function_exists( 'wc_set_time_limit' ) ) {
+				wc_set_time_limit( $http_timeout + 10 );
+			}
+
+			$args['timeout'] = $http_timeout;
+
+			$response = wp_remote_request( $proxy_url, $args );
+
+			return $response;
+		}
+
+		/**
 		 * Adds useful WP/WC/WCC information to request bodies
 		 *
 		 * @param array $initial_body

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -14,11 +14,24 @@ class WC_Connect_TaxJar_Integration {
 
 	const TAXJAR_URL = 'https://api.taxjar.com';
 	const PROXY_PATH = 'taxjar';
+	const FAKE_TOKEN = '[Managed by WooCommerce Services]';
 
 	public function __construct( WC_Connect_API_Client $api_client ) {
 		$this->api_client = $api_client;
 
 		add_filter( 'default_option_woocommerce_taxjar-integration_settings', array( $this, 'override_taxjar_settings' ) );
+		add_filter( 'option_woocommerce_taxjar-integration_settings', array( $this, 'check_taxjar_settings' ) );
+	}
+
+	public function check_taxjar_settings( $settings ) {
+		if (
+			isset( $settings['api_token'] ) &&
+			( $settings['api_token'] === strtolower( self::FAKE_TOKEN ) )
+		) {
+			return $this->override_taxjar_settings( $settings );
+		}
+
+		return $settings;
 	}
 
 	public function override_taxjar_settings( $settings ) {
@@ -30,7 +43,7 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		$settings = array_merge( $settings, array(
-			'api_token'  => '[Managed by WooCommerce Services]',
+			'api_token'  => self::FAKE_TOKEN,
 			'enabled'    => 'yes',
 			'store_city' => get_option( 'woocommerce_store_city' ),
 			'store_zip'  => get_option( 'woocommerce_store_postcode' ),

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -37,7 +37,15 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	public function override_taxjar_settings( $settings ) {
-		// Attach proxy filter, since we know that no TaxJar settings exist on this store.
+		$store_city     = get_option( 'woocommerce_store_city' );
+		$store_postcode = get_option( 'woocommerce_store_postcode' );
+
+		// Check for store address before hijacking requests.
+		if ( empty( $store_city ) || empty( $store_postcode ) ) {
+			return $settings;
+		}
+
+		// Attach proxy filter.
 		add_filter( 'pre_http_request', array( $this, 'proxy_taxjar_requests' ), 10, 3 );
 
 		if ( ! is_array( $settings ) ) {
@@ -47,8 +55,8 @@ class WC_Connect_TaxJar_Integration {
 		$settings = array_merge( $settings, array(
 			'api_token'  => self::FAKE_TOKEN,
 			'enabled'    => 'yes',
-			'store_city' => get_option( 'woocommerce_store_city' ),
-			'store_zip'  => get_option( 'woocommerce_store_postcode' ),
+			'store_city' => $store_city,
+			'store_zip'  => $store_postcode,
 		) );
 
 		return $settings;

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -18,11 +18,13 @@ class WC_Connect_TaxJar_Integration {
 	public function __construct( WC_Connect_API_Client $api_client ) {
 		$this->api_client = $api_client;
 
-		add_filter( 'option_woocommerce_taxjar-integration_settings', array( $this, 'override_taxjar_settings' ) );
-		add_filter( 'pre_http_request', array( $this, 'proxy_taxjar_requests' ), 10, 3 );
+		add_filter( 'default_option_woocommerce_taxjar-integration_settings', array( $this, 'override_taxjar_settings' ) );
 	}
 
 	public function override_taxjar_settings( $settings ) {
+		// Attach proxy filter, since we know that no TaxJar settings exist on this store.
+		add_filter( 'pre_http_request', array( $this, 'proxy_taxjar_requests' ), 10, 3 );
+
 		if ( ! is_array( $settings ) ) {
 			$settings = array();
 		}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -30,8 +30,8 @@ class WC_Connect_TaxJar_Integration {
 		$settings = array_merge( $settings, array(
 			'api_token'  => '[Managed by WooCommerce Services]',
 			'enabled'    => 'yes',
-			'store_city' => 'Park City', // TODO: get from new WC address data
-			'store_zip'  => '84060',     // TODO: get from new WC address data
+			'store_city' => get_option( 'woocommerce_store_city' ),
+			'store_zip'  => get_option( 'woocommerce_store_postcode' ),
 		) );
 
 		return $settings;

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1,0 +1,34 @@
+<?php
+
+class WC_Connect_TaxJar_Integration {
+
+	public function __construct( ) {
+		add_filter( 'option_woocommerce_taxjar-integration_settings', array( $this, 'override_taxjar_settings' ) );
+		add_filter( 'pre_http_request', array( $this, 'prevent_taxjar_status_check' ), 10, 3 );
+	}
+
+	public function override_taxjar_settings( $settings ) {
+		if ( ! is_array( $settings ) ) {
+			$settings = array();
+		}
+
+		$settings = array_merge( $settings, array(
+			'api_token' => '[Managed by WooCommerce Services]',
+		) );
+
+		return $settings;
+	}
+
+	public function prevent_taxjar_status_check( $pre, $r, $url ) {
+		if ( 'https://api.taxjar.com/v2/verify' === $url ) {
+			return array(
+				'response' => array(
+					'code' => 200,
+				),
+				'body' => '',
+			);
+		}
+
+		return $pre;
+	}
+}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -18,7 +18,9 @@ class WC_Connect_TaxJar_Integration {
 
 	public function __construct( WC_Connect_API_Client $api_client ) {
 		$this->api_client = $api_client;
+	}
 
+	public function init() {
 		add_filter( 'default_option_woocommerce_taxjar-integration_settings', array( $this, 'override_taxjar_settings' ) );
 		add_filter( 'option_woocommerce_taxjar-integration_settings', array( $this, 'check_taxjar_settings' ) );
 	}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -13,7 +13,10 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		$settings = array_merge( $settings, array(
-			'api_token' => '[Managed by WooCommerce Services]',
+			'api_token'  => '[Managed by WooCommerce Services]',
+			'enabled'    => 'yes',
+			'store_city' => 'Park City', // TODO: get from new WC address data
+			'store_zip'  => '84060',     // TODO: get from new WC address data
 		) );
 
 		return $settings;

--- a/tests/php/test_woocommerce-connect-client.php
+++ b/tests/php/test_woocommerce-connect-client.php
@@ -92,12 +92,12 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 	public function test_init_hook_attached_in_constructor() {
 
 		$loader = $this->getMockBuilder( 'WC_Connect_Loader' )
-			->setMethods( array( 'init' ) )
+			->setMethods( array( 'pre_wc_init' ) )
 			->getMock();
 
-		$attached = has_action( 'before_woocommerce_init', array( $loader, 'init' ) );
+		$attached = has_action( 'before_woocommerce_init', array( $loader, 'pre_wc_init' ) );
 
-		$this->assertNotFalse( $attached, 'WC_Connect_Loader::init() not attached to `before_woocommerce_init`.' );
+		$this->assertNotFalse( $attached, 'WC_Connect_Loader::pre_wc_init() not attached to `before_woocommerce_init`.' );
 
 	}
 

--- a/tests/php/test_woocommerce-connect-client.php
+++ b/tests/php/test_woocommerce-connect-client.php
@@ -95,9 +95,9 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 			->setMethods( array( 'init' ) )
 			->getMock();
 
-		$attached = has_action( 'woocommerce_init', array( $loader, 'init' ) );
+		$attached = has_action( 'before_woocommerce_init', array( $loader, 'init' ) );
 
-		$this->assertNotFalse( $attached, 'WC_Connect_Loader::init() not attached to `woocommerce_init`.' );
+		$this->assertNotFalse( $attached, 'WC_Connect_Loader::init() not attached to `before_woocommerce_init`.' );
 
 	}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -169,6 +169,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function __construct() {
 			$this->wc_connect_base_url = trailingslashit( defined( 'WOOCOMMERCE_CONNECT_DEV_SERVER_URL' ) ? WOOCOMMERCE_CONNECT_DEV_SERVER_URL : plugins_url( 'dist/', __FILE__ ) );
 			add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
+			add_action( 'before_woocommerce_init', array( $this, 'before_init' ) );
 			add_action( 'woocommerce_init', array( $this, 'init' ) );
 		}
 
@@ -339,6 +340,12 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 */
 		public function load_textdomain() {
 			load_plugin_textdomain( 'woocommerce-services', false, dirname( plugin_basename( __FILE__ ) ) . '/i18n/languages' );
+		}
+
+		public function before_init() {
+			require_once( plugin_basename( 'classes/class-wc-connect-taxjar-integration.php' ) );
+
+			$taxjar = new WC_Connect_TaxJar_Integration();
 		}
 
 		/**

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -343,9 +343,19 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		public function before_init() {
+			require_once( plugin_basename( 'classes/class-wc-connect-logger.php' ) );
+			require_once( plugin_basename( 'classes/class-wc-connect-api-client.php' ) );
+			require_once( plugin_basename( 'classes/class-wc-connect-service-schemas-validator.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-taxjar-integration.php' ) );
 
-			$taxjar = new WC_Connect_TaxJar_Integration();
+			$logger     = new WC_Connect_Logger( new WC_Logger() );
+			$validator  = new WC_Connect_Service_Schemas_Validator();
+			$api_client = new WC_Connect_API_Client( $validator, $this );
+			$taxjar     = new WC_Connect_TaxJar_Integration( $api_client );
+
+			$this->set_logger( $logger );
+			$this->set_api_client( $api_client );
+			$this->set_service_schemas_validator( $validator );
 		}
 
 		/**
@@ -379,9 +389,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function load_dependencies() {
 			require_once( plugin_basename( 'classes/class-wc-connect-error-notice.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-compatibility.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-logger.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-api-client.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-service-schemas-validator.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-shipping-method.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-service-schemas-store.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-service-settings-store.php' ) );
@@ -391,9 +398,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			require_once( plugin_basename( 'classes/class-wc-connect-shipping-label.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-nux.php' ) );
 
-			$logger                = new WC_Connect_Logger( new WC_Logger() );
-			$validator             = new WC_Connect_Service_Schemas_Validator();
-			$api_client            = new WC_Connect_API_Client( $validator, $this );
+			$logger                = $this->get_logger();
+			$api_client            = $this->get_api_client();
 			$schemas_store         = new WC_Connect_Service_Schemas_Store( $api_client, $logger );
 			$settings_store        = new WC_Connect_Service_Settings_Store( $schemas_store, $api_client, $logger );
 			$payment_methods_store = new WC_Connect_Payment_Methods_Store( $settings_store, $api_client, $logger );
@@ -401,9 +407,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$shipping_label        = new WC_Connect_Shipping_Label( $api_client, $settings_store, $schemas_store, $payment_methods_store );
 			$nux                   = new WC_Connect_Nux( $tracks, $shipping_label );
 
-			$this->set_logger( $logger );
-			$this->set_api_client( $api_client );
-			$this->set_service_schemas_validator( $validator );
 			$this->set_service_schemas_store( $schemas_store );
 			$this->set_service_settings_store( $settings_store );
 			$this->set_payment_methods_store( $payment_methods_store );


### PR DESCRIPTION
Fixes #1035.

**Note: this changes the WCS init hook from `woocommerce_init` to `before_woocommerce_init` in order to augment the TaxJar integration**

To test:
* Set up a local server with `add/taxjar-api-proxy` checked out
* Set values for `woocommerce_store_city` and `woocommerce_store_postcode` in `wp_options` table
* Enable tax calculation
* Install and activate the TaxJar plugin
* Verify that taxes are shown at checkout / in cart