### PR TITLE
Fix tracking of TOS acceptance

### DIFF
--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -21,12 +21,19 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		const SHOULD_SHOW_AFTER_CXN_BANNER = 'should_display_nux_after_jp_cxn_banner';
 
 		/**
+		 * @var WC_Connect_Tracks
+		 */
+		protected $tracks;
+
+		/**
 		 * @var WC_Connect_Shipping_Label
 		 */
 		private $shipping_label;
 
-		function __construct( WC_Connect_Shipping_Label $shipping_label ) {
+		function __construct( WC_Connect_Tracks $tracks, WC_Connect_Shipping_Label $shipping_label ) {
+			$this->tracks = $tracks;
 			$this->shipping_label = $shipping_label;
+
 			$this->init_pointers();
 		}
 
@@ -400,6 +407,8 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			// By going through the connection process, the user has accepted our TOS
 			WC_Connect_Options::update_option( 'tos_accepted', true );
 
+			$this->tracks->opted_in( 'connection_banner' );
+
 			$this->show_nux_banner( array(
 				'title'          => __( 'Setup complete! You can now access discounted shipping rates and printing services', 'woocommerce-services' ),
 				'description'    => __( 'When you’re ready, you can purchase discounted labels from USPS, and print USPS labels at home.', 'woocommerce-services' ),
@@ -418,9 +427,13 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		public function show_tos_banner() {
 			if ( isset( $_GET['wcs-nux-tos'] ) && 'accept' === $_GET['wcs-nux-tos'] ) {
 				WC_Connect_Options::update_option( 'tos_accepted', true );
+
+				$this->tracks->opted_in( 'tos_banner' );
+
 				wp_safe_redirect( remove_query_arg( 'wcs-nux-tos' ) );
 				exit;
 			}
+
 			$this->show_nux_banner( array(
 				'title'          => __( 'Setup complete! We need you to accept our TOS', 'woocommerce-services' ),
 				'description'    => __( 'Everything is ready to roll, we just need you to agree to our Terms of Service.', 'woocommerce-services' ),

--- a/classes/class-wc-connect-tracks.php
+++ b/classes/class-wc-connect-tracks.php
@@ -15,8 +15,9 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 		 */
 		protected $logger;
 
-		public function __construct( WC_Connect_Logger $logger = null ) {
+		public function __construct( WC_Connect_Logger $logger, $plugin_file ) {
 			$this->logger = $logger;
+			$this->plugin_file = $plugin_file;
 		}
 
 		public function init() {
@@ -24,6 +25,7 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 			add_action( 'wc_connect_shipping_zone_method_deleted', array( $this, 'shipping_zone_method_deleted' ), 10, 3 );
 			add_action( 'wc_connect_shipping_zone_method_status_toggled', array( $this, 'shipping_zone_method_status_toggled' ), 10, 4 );
 			add_action( 'wc_connect_saved_service_settings', array( $this, 'saved_service_settings' ), 10, 3 );
+			register_deactivation_hook( $this->plugin_file, array( $this, 'opted_out' ) );
 		}
 
 		public function opted_in( $source = null ) {

--- a/classes/class-wc-connect-tracks.php
+++ b/classes/class-wc-connect-tracks.php
@@ -17,6 +17,9 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 
 		public function __construct( WC_Connect_Logger $logger = null ) {
 			$this->logger = $logger;
+		}
+
+		public function init() {
 			add_action( 'wc_connect_shipping_zone_method_added', array( $this, 'shipping_zone_method_added' ), 10, 3 );
 			add_action( 'wc_connect_shipping_zone_method_deleted', array( $this, 'shipping_zone_method_deleted' ), 10, 3 );
 			add_action( 'wc_connect_shipping_zone_method_status_toggled', array( $this, 'shipping_zone_method_status_toggled' ), 10, 4 );

--- a/classes/class-wc-connect-tracks.php
+++ b/classes/class-wc-connect-tracks.php
@@ -23,8 +23,12 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 			add_action( 'wc_connect_saved_service_settings', array( $this, 'saved_service_settings' ), 10, 3 );
 		}
 
-		public function opted_in() {
-			$this->record_user_event( 'opted_in' );
+		public function opted_in( $source = null ) {
+			if ( is_null( $source ) ) {
+				$this->record_user_event( 'opted_in' );
+			} else {
+				$this->record_user_event( 'opted_in', compact( 'source' ) );
+			}
 		}
 
 		public function opted_out() {
@@ -80,6 +84,10 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 			$jetpack_blog_id = -1;
 			if ( class_exists( 'Jetpack_Options' ) && method_exists( 'Jetpack_Options', 'get_option' ) ) {
 				$jetpack_blog_id = Jetpack_Options::get_option( 'id' );
+			}
+
+			if ( ! is_array( $data ) ) {
+				$data = array();
 			}
 
 			$data['_via_ua'] = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';

--- a/tests/php/test_woocommerce-connect-tracks.php
+++ b/tests/php/test_woocommerce-connect-tracks.php
@@ -15,7 +15,7 @@ abstract class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 			->setMethods( array( 'debug' ) )
 			->getMock();
 
-		$this->tracks = new WC_Connect_Tracks( $this->logger );
+		$this->tracks = new WC_Connect_Tracks( $this->logger, __FILE__ );
 		$this->tracks->init();
 	}
 }

--- a/tests/php/test_woocommerce-connect-tracks.php
+++ b/tests/php/test_woocommerce-connect-tracks.php
@@ -16,6 +16,7 @@ abstract class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 			->getMock();
 
 		$this->tracks = new WC_Connect_Tracks( $this->logger );
+		$this->tracks->init();
 	}
 }
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -158,19 +158,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		protected $wc_connect_base_url;
 
-		static function load_tracks_for_activation_hooks() {
-			require_once( plugin_basename( 'classes/class-wc-connect-logger.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-tracks.php' ) );
-			$logger = null;
-			if ( class_exists( 'WC_Logger' ) ) {
-				$logger = new WC_Connect_Logger( new WC_Logger() );
-			}
-			return new WC_Connect_Tracks( $logger );
-		}
-
 		static function plugin_deactivation() {
-			$tracks = self::load_tracks_for_activation_hooks();
-			$tracks->opted_out();
 			wp_clear_scheduled_hook( 'wc_connect_fetch_service_schemas' );
 		}
 
@@ -402,7 +390,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$schemas_store         = new WC_Connect_Service_Schemas_Store( $api_client, $logger );
 			$settings_store        = new WC_Connect_Service_Settings_Store( $schemas_store, $api_client, $logger );
 			$payment_methods_store = new WC_Connect_Payment_Methods_Store( $settings_store, $api_client, $logger );
-			$tracks                = new WC_Connect_Tracks( $logger );
+			$tracks                = new WC_Connect_Tracks( $logger, __FILE__ );
 			$shipping_label        = new WC_Connect_Shipping_Label( $api_client, $settings_store, $schemas_store, $payment_methods_store );
 			$nux                   = new WC_Connect_Nux( $tracks, $shipping_label );
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -404,7 +404,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$payment_methods_store = new WC_Connect_Payment_Methods_Store( $settings_store, $api_client, $logger );
 			$tracks                = new WC_Connect_Tracks( $logger );
 			$shipping_label        = new WC_Connect_Shipping_Label( $api_client, $settings_store, $schemas_store, $payment_methods_store );
-			$nux                   = new WC_Connect_Nux( $shipping_label );
+			$nux                   = new WC_Connect_Nux( $tracks, $shipping_label );
 
 			$this->set_logger( $logger );
 			$this->set_api_client( $api_client );

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -466,6 +466,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_filter( 'plugin_action_links_' . plugin_basename(__FILE__), array( $this, 'add_plugin_action_links' ) );
 			add_action( 'enqueue_wc_connect_script', array( $this, 'enqueue_wc_connect_script' ), 10, 2 );
 			add_action( 'admin_init', array( $this, 'load_admin_dependencies' ) );
+
+			$tracks = $this->get_tracks();
+			$tracks->init();
 		}
 
 		/**


### PR DESCRIPTION
Fixes #1057.

This PR seeks to reestablish tracking of TOS acceptance. In addition to that goal, it:
* Adds an optional "source" parameter to the `opted_in()` helper method
* Attaches shipping method related tracks hooks explicitly, rather than on instantiation
* Tracks TOS accept from "TOS only" banner and "connect" banner separately