### PR TITLE
Restrict TOS acceptance to Jetpack master user

### DIFF
--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -207,6 +207,11 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					return 'before_jetpack_connection';
 				case self::JETPACK_CONNECTED:
 				case self::JETPACK_DEV:
+					// Has the user just gone through our NUX connection flow?
+					if ( isset( $status['should_display_after_cxn_banner'] ) && $status['should_display_after_cxn_banner'] ) {
+						return 'after_jetpack_connection';
+					}
+
 					// Has the user already accepted our TOS? Then do nothing.
 					// Note: TOS is accepted during the after_connection banner
 					if (
@@ -216,11 +221,6 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 						&& $status['can_accept_tos']
 					) {
 						return 'tos_only_banner';
-					}
-
-					// Has the user just gone through our NUX connection flow?
-					if ( isset( $status['should_display_after_cxn_banner'] ) && $status['should_display_after_cxn_banner'] ) {
-						return 'after_jetpack_connection';
 					}
 
 					return false;

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -165,9 +165,15 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		 * @return bool
 		 */
 		public function can_accept_tos() {
+			$jetpack_status = $this->get_jetpack_install_status();
+
 			// Developer case
-			if ( self::JETPACK_DEV === $this->get_jetpack_install_status() ) {
+			if ( self::JETPACK_DEV === $jetpack_status ) {
 				return true;
+			}
+
+			if ( self::JETPACK_INSTALLED_NOT_ACTIVATED === $jetpack_status ) {
+				return false;
 			}
 
 			$user_token = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -160,11 +160,13 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		 * Check that the current user is the owner of the Jetpack connection
 		 * - Only that person can accept the TOS
 		 *
+		 * @uses self::get_jetpack_install_status()
+		 *
 		 * @return bool
 		 */
 		public function can_accept_tos() {
 			// Developer case
-			if ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) {
+			if ( self::JETPACK_DEV === $this->get_jetpack_install_status() ) {
 				return true;
 			}
 

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -199,11 +199,6 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					return 'before_jetpack_connection';
 				case self::JETPACK_CONNECTED:
 				case self::JETPACK_DEV:
-					// Has the user just gone through our NUX connection flow?
-					if ( isset( $status['should_display_after_cxn_banner'] ) && $status['should_display_after_cxn_banner'] ) {
-						return 'after_jetpack_connection';
-					}
-
 					// Has the user already accepted our TOS? Then do nothing.
 					// Note: TOS is accepted during the after_connection banner
 					if (
@@ -213,6 +208,12 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					) {
 						return 'tos_only_banner';
 					}
+
+					// Has the user just gone through our NUX connection flow?
+					if ( isset( $status['should_display_after_cxn_banner'] ) && $status['should_display_after_cxn_banner'] ) {
+						return 'after_jetpack_connection';
+					}
+
 					return false;
 				default:
 					return false;

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -177,7 +177,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			return $can_accept;
 		}
 
-		public function get_banner_type_to_display( $status = array() ) {
+		public static function get_banner_type_to_display( $status = array() ) {
 			if ( ! isset( $status['jetpack_connection_status'] ) ) {
 				return false;
 			}
@@ -204,7 +204,8 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					if (
 						isset( $status['tos_accepted'] )
 						&& ! $status['tos_accepted']
-						&& $this->can_accept_tos()
+						&& isset( $status['can_accept_tos'] )
+						&& $status['can_accept_tos']
 					) {
 						return 'tos_only_banner';
 					}
@@ -314,9 +315,10 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			}
 
 			$jetpack_install_status = $this->get_jetpack_install_status();
-			$banner_to_display = $this->get_banner_type_to_display( array(
+			$banner_to_display = self::get_banner_type_to_display( array(
 				'jetpack_connection_status'       => $jetpack_install_status,
 				'tos_accepted'                    => WC_Connect_Options::get_option( 'tos_accepted' ),
+				'can_accept_tos'                  => $this->can_accept_tos(),
 				'should_display_after_cxn_banner' => WC_Connect_Options::get_option( self::SHOULD_SHOW_AFTER_CXN_BANNER ),
 			) );
 

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -167,13 +167,16 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		public function can_accept_tos() {
 			$jetpack_status = $this->get_jetpack_install_status();
 
+			if (
+				( self::JETPACK_NOT_INSTALLED === $jetpack_status ) ||
+				( self::JETPACK_INSTALLED_NOT_ACTIVATED === $jetpack_status )
+			) {
+				return false;
+			}
+
 			// Developer case
 			if ( self::JETPACK_DEV === $jetpack_status ) {
 				return true;
-			}
-
-			if ( self::JETPACK_INSTALLED_NOT_ACTIVATED === $jetpack_status ) {
-				return false;
 			}
 
 			$user_token = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );

--- a/tests/php/test_class_wc-connect-nux.php
+++ b/tests/php/test_class_wc-connect-nux.php
@@ -5,73 +5,58 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 	public static function setupBeforeClass() {
 		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-nux.php' );
 	}
-	
-	public function get_mock_nux( $can_accept_tos = false ) {
-		$nux = $this->getMockBuilder( 'WC_Connect_Nux' )
-			->disableOriginalConstructor()
-			->setMethods( array( 'can_accept_tos' ) )
-			->getMock();
-
-		$nux
-			->expects( $this->any() )
-			->method( 'can_accept_tos' )
-			->will( $this->returnValue( $can_accept_tos ) );
-		
-		return $nux;
-	}
 
 	public function test_get_banner_type_to_display_dev_jp() {
-		$nux = $this->get_mock_nux( false );
-
 		$this->assertEquals(
-			$nux->get_banner_type_to_display(
+			WC_Connect_Nux::get_banner_type_to_display(
 				array(
 					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_DEV,
 					'tos_accepted'                    => false,
+					'can_accept_tos'                  => false,
 					'should_display_after_cxn_banner' => false,
 				)
 			), false
 		);
 
 		$this->assertEquals(
-			$nux->get_banner_type_to_display(
+			WC_Connect_Nux::get_banner_type_to_display(
 				array(
 					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_DEV,
 					'tos_accepted'                    => true,
+					'can_accept_tos'                  => false,
 					'should_display_after_cxn_banner' => false,
 				)
 			), false
 		);
 
 		$this->assertEquals(
-			$nux->get_banner_type_to_display(
+			WC_Connect_Nux::get_banner_type_to_display(
 				array(
 					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_DEV,
 					'tos_accepted'                    => false,
+					'can_accept_tos'                  => false,
 					'should_display_after_cxn_banner' => true,
 				)
 			), 'after_jetpack_connection'
 		);
 
 		$this->assertEquals(
-			$nux->get_banner_type_to_display(
+			WC_Connect_Nux::get_banner_type_to_display(
 				array(
 					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_DEV,
 					'tos_accepted'                    => true,
+					'can_accept_tos'                  => false,
 					'should_display_after_cxn_banner' => true,
 				)
 			), 'after_jetpack_connection'
 		);
-	}
-
-	public function test_get_banner_type_to_display_dev_jp_can_accept_tos() {
-		$nux = $this->get_mock_nux( true );
 
 		$this->assertEquals(
-			$nux->get_banner_type_to_display(
+			WC_Connect_Nux::get_banner_type_to_display(
 				array(
 					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_DEV,
 					'tos_accepted'                    => false,
+					'can_accept_tos'                  => true,
 					'should_display_after_cxn_banner' => false,
 				)
 			), 'tos_only_banner'
@@ -79,84 +64,86 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 	}
 
 	public function test_get_banner_type_to_display_no_jp_cxn_without_tos_acceptance() {
-		$nux = $this->get_mock_nux( false );
-
 		// before going through connection
-		$this->assertEquals( $nux->get_banner_type_to_display( array(
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_NOT_INSTALLED,
 			'tos_accepted'                           => false,
+			'can_accept_tos'                         => false,
 			'should_display_after_cxn_banner'        => false,
 		) ), 'before_jetpack_connection' );
 
-		$this->assertEquals( $nux->get_banner_type_to_display( array(
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_INSTALLED_NOT_ACTIVATED,
 			'tos_accepted'                           => false,
+			'can_accept_tos'                         => false,
 			'should_display_after_cxn_banner'        => false,
 		) ), 'before_jetpack_connection' );
 
-		$this->assertEquals( $nux->get_banner_type_to_display( array(
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_ACTIVATED_NOT_CONNECTED,
 			'tos_accepted'                           => false,
+			'can_accept_tos'                         => false,
 			'should_display_after_cxn_banner'        => false,
 		) ), 'before_jetpack_connection' );
 
 		// after going through connection, TOS was never accepted
-		$this->assertEquals( $nux->get_banner_type_to_display( array(
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
 			'tos_accepted'                           => false,
+			'can_accept_tos'                         => false,
 			'should_display_after_cxn_banner'        => true,
 		) ), 'after_jetpack_connection' );
 	}
 
 	public function test_get_banner_type_to_display_no_jp_cxn_with_tos_acceptance() {
-		$nux = $this->get_mock_nux( true );
-
 		// before going through connection
-		$this->assertEquals( $nux->get_banner_type_to_display( array(
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_NOT_INSTALLED,
 			'tos_accepted'                           => true,
+			'can_accept_tos'                         => true,
 			'should_display_after_cxn_banner'        => false,
 		) ), 'before_jetpack_connection' );
 
-		$this->assertEquals( $nux->get_banner_type_to_display( array(
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_INSTALLED_NOT_ACTIVATED,
 			'tos_accepted'                           => true,
+			'can_accept_tos'                         => true,
 			'should_display_after_cxn_banner'        => false,
 		) ), 'before_jetpack_connection' );
 
-		$this->assertEquals( $nux->get_banner_type_to_display( array(
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_ACTIVATED_NOT_CONNECTED,
 			'tos_accepted'                           => true,
+			'can_accept_tos'                         => true,
 			'should_display_after_cxn_banner'        => false,
 		) ), 'before_jetpack_connection' );
 
 		// after going through connection, TOS was already previously accepted
-		$this->assertEquals( $nux->get_banner_type_to_display( array(
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
 			'tos_accepted'                           => true,
+			'can_accept_tos'                         => true,
 			'should_display_after_cxn_banner'        => true,
 		) ), 'after_jetpack_connection' );
 	}
 
 	public function test_get_banner_type_to_display_with_jp_cxn_without_tos_acceptance() {
-		$nux = $this->get_mock_nux( true );
-
 		// Jetpack is already connected, TOS was not yet accepted
-		$this->assertEquals( $nux->get_banner_type_to_display( array(
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
 			'tos_accepted'                           => false,
+			'can_accept_tos'                         => true,
 			'should_display_after_cxn_banner'        => false,
 		) ), 'tos_only_banner' );
 	}
 
 	public function test_get_banner_type_to_display_with_jp_cxn_with_tos_acceptance() {
-		$nux = $this->get_mock_nux( true );
-
 		// Jetpack is already connected, TOS is already accepted
 		// did not show before connection banner
-		$this->assertEquals( $nux->get_banner_type_to_display( array(
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
 			'tos_accepted'                           => true,
+			'can_accept_tos'                         => true,
 			'should_display_after_cxn_banner'        => false,
 		) ), false );
 	}

--- a/tests/php/test_class_wc-connect-nux.php
+++ b/tests/php/test_class_wc-connect-nux.php
@@ -5,19 +5,26 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 	public static function setupBeforeClass() {
 		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-nux.php' );
 	}
-
-	public function setUp() {
-		$this->nux = $this->getMockBuilder( 'WC_Connect_Nux' )
+	
+	public function get_mock_nux( $can_accept_tos = false ) {
+		$nux = $this->getMockBuilder( 'WC_Connect_Nux' )
 			->disableOriginalConstructor()
 			->setMethods( array( 'can_accept_tos' ) )
 			->getMock();
+
+		$nux
+			->expects( $this->any() )
+			->method( 'can_accept_tos' )
+			->will( $this->returnValue( $can_accept_tos ) );
+		
+		return $nux;
 	}
 
 	public function test_get_banner_type_to_display_dev_jp() {
-		$this->nux->method( 'can_accept_tos' )->willReturn( false );
+		$nux = $this->get_mock_nux( false );
 
 		$this->assertEquals(
-			$this->nux->get_banner_type_to_display(
+			$nux->get_banner_type_to_display(
 				array(
 					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_DEV,
 					'tos_accepted'                    => false,
@@ -27,7 +34,7 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 		);
 
 		$this->assertEquals(
-			$this->nux->get_banner_type_to_display(
+			$nux->get_banner_type_to_display(
 				array(
 					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_DEV,
 					'tos_accepted'                    => true,
@@ -37,7 +44,7 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 		);
 
 		$this->assertEquals(
-			$this->nux->get_banner_type_to_display(
+			$nux->get_banner_type_to_display(
 				array(
 					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_DEV,
 					'tos_accepted'                    => false,
@@ -47,7 +54,7 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 		);
 
 		$this->assertEquals(
-			$this->nux->get_banner_type_to_display(
+			$nux->get_banner_type_to_display(
 				array(
 					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_DEV,
 					'tos_accepted'                    => true,
@@ -58,10 +65,10 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 	}
 
 	public function test_get_banner_type_to_display_dev_jp_can_accept_tos() {
-		$this->nux->method( 'can_accept_tos' )->willReturn( true );
+		$nux = $this->get_mock_nux( true );
 
 		$this->assertEquals(
-			$this->nux->get_banner_type_to_display(
+			$nux->get_banner_type_to_display(
 				array(
 					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_DEV,
 					'tos_accepted'                    => false,
@@ -72,78 +79,85 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 	}
 
 	public function test_get_banner_type_to_display_no_jp_cxn_without_tos_acceptance() {
+		$nux = $this->get_mock_nux( false );
+
 		// before going through connection
-		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
+		$this->assertEquals( $nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_NOT_INSTALLED,
 			'tos_accepted'                           => false,
-			'should_display_after_cxn_banner'        =>  false,
+			'should_display_after_cxn_banner'        => false,
 		) ), 'before_jetpack_connection' );
 
-		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
+		$this->assertEquals( $nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_INSTALLED_NOT_ACTIVATED,
 			'tos_accepted'                           => false,
-			'should_display_after_cxn_banner'        =>  false,
+			'should_display_after_cxn_banner'        => false,
 		) ), 'before_jetpack_connection' );
 
-		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
+		$this->assertEquals( $nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_ACTIVATED_NOT_CONNECTED,
 			'tos_accepted'                           => false,
-			'should_display_after_cxn_banner'        =>  false,
+			'should_display_after_cxn_banner'        => false,
 		) ), 'before_jetpack_connection' );
 
 		// after going through connection, TOS was never accepted
-		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
+		$this->assertEquals( $nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
 			'tos_accepted'                           => false,
-			'should_display_after_cxn_banner'        =>  true,
+			'should_display_after_cxn_banner'        => true,
 		) ), 'after_jetpack_connection' );
 	}
 
 	public function test_get_banner_type_to_display_no_jp_cxn_with_tos_acceptance() {
+		$nux = $this->get_mock_nux( true );
+
 		// before going through connection
-		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
+		$this->assertEquals( $nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_NOT_INSTALLED,
 			'tos_accepted'                           => true,
-			'should_display_after_cxn_banner'        =>  false,
+			'should_display_after_cxn_banner'        => false,
 		) ), 'before_jetpack_connection' );
 
-		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
+		$this->assertEquals( $nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_INSTALLED_NOT_ACTIVATED,
 			'tos_accepted'                           => true,
-			'should_display_after_cxn_banner'        =>  false,
+			'should_display_after_cxn_banner'        => false,
 		) ), 'before_jetpack_connection' );
 
-		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
+		$this->assertEquals( $nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_ACTIVATED_NOT_CONNECTED,
 			'tos_accepted'                           => true,
-			'should_display_after_cxn_banner'        =>  false,
+			'should_display_after_cxn_banner'        => false,
 		) ), 'before_jetpack_connection' );
 
 		// after going through connection, TOS was already previously accepted
-		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
+		$this->assertEquals( $nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
 			'tos_accepted'                           => true,
-			'should_display_after_cxn_banner'        =>  true,
+			'should_display_after_cxn_banner'        => true,
 		) ), 'after_jetpack_connection' );
 	}
 
 	public function test_get_banner_type_to_display_with_jp_cxn_without_tos_acceptance() {
+		$nux = $this->get_mock_nux( true );
+
 		// Jetpack is already connected, TOS was not yet accepted
-		$this->nux->method( 'can_accept_tos' )->willReturn( true );
-		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
+		$this->assertEquals( $nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
 			'tos_accepted'                           => false,
-			'should_display_after_cxn_banner'        =>  false,
+			'should_display_after_cxn_banner'        => false,
 		) ), 'tos_only_banner' );
 	}
 
 	public function test_get_banner_type_to_display_with_jp_cxn_with_tos_acceptance() {
+		$nux = $this->get_mock_nux( true );
+
 		// Jetpack is already connected, TOS is already accepted
 		// did not show before connection banner
-		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
+		$this->assertEquals( $nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
 			'tos_accepted'                           => true,
-			'should_display_after_cxn_banner'        =>  false,
+			'should_display_after_cxn_banner'        => false,
 		) ), false );
 	}
 }

--- a/tests/php/test_class_wc-connect-nux.php
+++ b/tests/php/test_class_wc-connect-nux.php
@@ -135,6 +135,14 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 			'can_accept_tos'                         => true,
 			'should_display_after_cxn_banner'        => false,
 		) ), 'tos_only_banner' );
+
+		// Regression test for changing order of "tos accepted" and "should display after cxn banner"
+		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
+			'tos_accepted'                           => false,
+			'can_accept_tos'                         => true,
+			'should_display_after_cxn_banner'        => true,
+		) ), 'after_jetpack_connection' );
 	}
 
 	public function test_get_banner_type_to_display_with_jp_cxn_with_tos_acceptance() {

--- a/tests/php/test_class_wc-connect-nux.php
+++ b/tests/php/test_class_wc-connect-nux.php
@@ -6,54 +6,93 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-nux.php' );
 	}
 
+	public function setUp() {
+		$this->nux = $this->getMockBuilder( 'WC_Connect_Nux' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'can_accept_tos' ) )
+			->getMock();
+	}
+
 	public function test_get_banner_type_to_display_dev_jp() {
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
-			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_DEV,
-			'tos_accepted'                           => false,
-			'should_display_after_cxn_banner'        => false,
-		) ), false );
+		$this->nux->method( 'can_accept_tos' )->willReturn( false );
 
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
-			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_DEV,
-			'tos_accepted'                           => true,
-			'should_display_after_cxn_banner'        => false,
-		) ), false );
+		$this->assertEquals(
+			$this->nux->get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_DEV,
+					'tos_accepted'                    => false,
+					'should_display_after_cxn_banner' => false,
+				)
+			), false
+		);
 
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
-			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_DEV,
-			'tos_accepted'                           => false,
-			'should_display_after_cxn_banner'        =>  true,
-		) ), false );
+		$this->assertEquals(
+			$this->nux->get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_DEV,
+					'tos_accepted'                    => true,
+					'should_display_after_cxn_banner' => false,
+				)
+			), false
+		);
 
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
-			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_DEV,
-			'tos_accepted'                           => true,
-			'should_display_after_cxn_banner'        =>  true,
-		) ), false );
+		$this->assertEquals(
+			$this->nux->get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_DEV,
+					'tos_accepted'                    => false,
+					'should_display_after_cxn_banner' => true,
+				)
+			), 'after_jetpack_connection'
+		);
+
+		$this->assertEquals(
+			$this->nux->get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_DEV,
+					'tos_accepted'                    => true,
+					'should_display_after_cxn_banner' => true,
+				)
+			), 'after_jetpack_connection'
+		);
+	}
+
+	public function test_get_banner_type_to_display_dev_jp_can_accept_tos() {
+		$this->nux->method( 'can_accept_tos' )->willReturn( true );
+
+		$this->assertEquals(
+			$this->nux->get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_DEV,
+					'tos_accepted'                    => false,
+					'should_display_after_cxn_banner' => false,
+				)
+			), 'tos_only_banner'
+		);
 	}
 
 	public function test_get_banner_type_to_display_no_jp_cxn_without_tos_acceptance() {
 		// before going through connection
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_NOT_INSTALLED,
 			'tos_accepted'                           => false,
 			'should_display_after_cxn_banner'        =>  false,
 		) ), 'before_jetpack_connection' );
 
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_INSTALLED_NOT_ACTIVATED,
 			'tos_accepted'                           => false,
 			'should_display_after_cxn_banner'        =>  false,
 		) ), 'before_jetpack_connection' );
 
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_ACTIVATED_NOT_CONNECTED,
 			'tos_accepted'                           => false,
 			'should_display_after_cxn_banner'        =>  false,
 		) ), 'before_jetpack_connection' );
 
 		// after going through connection, TOS was never accepted
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
 			'tos_accepted'                           => false,
 			'should_display_after_cxn_banner'        =>  true,
@@ -62,26 +101,26 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 
 	public function test_get_banner_type_to_display_no_jp_cxn_with_tos_acceptance() {
 		// before going through connection
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_NOT_INSTALLED,
 			'tos_accepted'                           => true,
 			'should_display_after_cxn_banner'        =>  false,
 		) ), 'before_jetpack_connection' );
 
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_INSTALLED_NOT_ACTIVATED,
 			'tos_accepted'                           => true,
 			'should_display_after_cxn_banner'        =>  false,
 		) ), 'before_jetpack_connection' );
 
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_ACTIVATED_NOT_CONNECTED,
 			'tos_accepted'                           => true,
 			'should_display_after_cxn_banner'        =>  false,
 		) ), 'before_jetpack_connection' );
 
 		// after going through connection, TOS was already previously accepted
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
 			'tos_accepted'                           => true,
 			'should_display_after_cxn_banner'        =>  true,
@@ -90,7 +129,8 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 
 	public function test_get_banner_type_to_display_with_jp_cxn_without_tos_acceptance() {
 		// Jetpack is already connected, TOS was not yet accepted
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+		$this->nux->method( 'can_accept_tos' )->willReturn( true );
+		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
 			'tos_accepted'                           => false,
 			'should_display_after_cxn_banner'        =>  false,
@@ -100,7 +140,7 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 	public function test_get_banner_type_to_display_with_jp_cxn_with_tos_acceptance() {
 		// Jetpack is already connected, TOS is already accepted
 		// did not show before connection banner
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
+		$this->assertEquals( $this->nux->get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
 			'tos_accepted'                           => true,
 			'should_display_after_cxn_banner'        =>  false,

--- a/tests/php/test_class_wc-connect-nux.php
+++ b/tests/php/test_class_wc-connect-nux.php
@@ -23,7 +23,7 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 				array(
 					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_DEV,
 					'tos_accepted'                    => true,
-					'can_accept_tos'                  => false,
+					'can_accept_tos'                  => null, // irrelevant here, TOS is accepted (DEV)
 					'should_display_after_cxn_banner' => false,
 				)
 			), false
@@ -34,7 +34,7 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 				array(
 					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_DEV,
 					'tos_accepted'                    => false,
-					'can_accept_tos'                  => false,
+					'can_accept_tos'                  => null, // irrelevant here, TOS will be accepted in "after" banner
 					'should_display_after_cxn_banner' => true,
 				)
 			), 'after_jetpack_connection'
@@ -68,21 +68,21 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_NOT_INSTALLED,
 			'tos_accepted'                           => false,
-			'can_accept_tos'                         => false,
+			'can_accept_tos'                         => false, // no master user, not DEV
 			'should_display_after_cxn_banner'        => false,
 		) ), 'before_jetpack_connection' );
 
 		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_INSTALLED_NOT_ACTIVATED,
 			'tos_accepted'                           => false,
-			'can_accept_tos'                         => false,
+			'can_accept_tos'                         => false, // no master user, not DEV
 			'should_display_after_cxn_banner'        => false,
 		) ), 'before_jetpack_connection' );
 
 		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_ACTIVATED_NOT_CONNECTED,
 			'tos_accepted'                           => false,
-			'can_accept_tos'                         => false,
+			'can_accept_tos'                         => false, // no master user, not DEV
 			'should_display_after_cxn_banner'        => false,
 		) ), 'before_jetpack_connection' );
 
@@ -90,7 +90,7 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
 			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
 			'tos_accepted'                           => false,
-			'can_accept_tos'                         => false,
+			'can_accept_tos'                         => null, // irrelevant here, TOS will be accepted in "after" banner
 			'should_display_after_cxn_banner'        => true,
 		) ), 'after_jetpack_connection' );
 	}


### PR DESCRIPTION
Fixes #1058.

To test:
* Make sure TOS isn't accepted
* Log in with Jetpack master user
* Verify TOS banner displays
* Log in with different user (with `manage_woocommerce`, `install_plugins`, `activate_plugins` caps)
* Verify no TOS banner
* `define( 'JETPACK_DEV_DEBUG', true );`
* Verify TOS banner displays