### PR TITLE
Fix test label printing on self help page

### DIFF
--- a/client/print-test-label/index.js
+++ b/client/print-test-label/index.js
@@ -25,6 +25,10 @@ export default ( { paperSize, storeOptions } ) => ( {
 		};
 	},
 
+	getStateKey() {
+		return 'wcs-print-test-label';
+	},
+
 	View: () => {
 		return <PrintTestLabelView />;
 	},


### PR DESCRIPTION
Fixes #1003.

Add expected method `getStateKey()` to label test print route class.

The lack of this method caused an error preventing the test label help section from rendering.

To test:
* Verify the test label print control renders on the self help page, and functions properly