### PR TITLE
Show TOS-only banner if connect button not clicked

### DIFF
--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -388,8 +388,10 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				remove_action( 'admin_notices', array( $jetpack_banner, 'render_connect_prompt_full_screen' ) );
 			}
 
-			// Make sure we always disply the after-connection banner after this banner
-			WC_Connect_Options::update_option( self::SHOULD_SHOW_AFTER_CXN_BANNER, true );
+			// Make sure that we wait until the button is clicked before displaying
+			// the after_connection banner
+			// so that we don't accept the TOS pre-maturely
+			WC_Connect_Options::delete_option( self::SHOULD_SHOW_AFTER_CXN_BANNER );
 
 			$jetpack_status = $this->get_jetpack_install_status();
 
@@ -591,6 +593,10 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				$redirect_url,
 				'woocommerce-services'
 			);
+
+			// Make sure we always display the after-connection banner
+			// after the before_connection button is clicked
+			WC_Connect_Options::update_option( self::SHOULD_SHOW_AFTER_CXN_BANNER, true );
 
 			echo esc_url_raw( $connect_url );
 			wp_die();


### PR DESCRIPTION
Fixed #1068

Steps to repro:

To see the bug: 
1. Start with `q2-nux`
2. Remove the `tos_accepted` option
3. Deactivate Jetpack
4. See before banner
5. Go to the Jetpack admin page and connect to Jetpack the Jetpack process, not the WCS process
6. See the after-connection banner and `tos_accepted` set to true (if it wasn't before)

To see the fix:
1. Checkout this branch
2. Remove the `tos_accepted` option
3. Deactivate Jetpack
4. See before banner
5. Go to the Jetpack admin page and connect to Jetpack the Jetpack process, not the WCS process
6. See the TOS banner when you get back

Other tests: make sure that the usual connection process works:
1. TOS-only banner should work
2. Before + after connection banner should work as usual
