### PR TITLE
Add proper spacing to label "purchased" text by translating whole phrase

### DIFF
--- a/client/shipping-label/views/index.js
+++ b/client/shipping-label/views/index.js
@@ -244,10 +244,9 @@ class ShippingLabelRootView extends Component {
 		return (
 			<div key={ label.label_id } className="wcc-metabox-label-item" >
 				<p className="wcc-metabox-label-item__created">
-					{ this.renderLabelDetails( label, labels.length - index, index ) }
-					{ ' ' }
-					{ __( 'purchased {{purchasedAt/}}', {
+					{ __( '{{labelDetails/}} purchased {{purchasedAt/}}', {
 						components: {
+							labelDetails: this.renderLabelDetails( label, labels.length - index, index ),
 							purchasedAt: <span title={ formatDate( label.created ) }>{ purchased }</span>
 						}
 					} ) }

--- a/client/shipping-label/views/index.js
+++ b/client/shipping-label/views/index.js
@@ -244,8 +244,13 @@ class ShippingLabelRootView extends Component {
 		return (
 			<div key={ label.label_id } className="wcc-metabox-label-item" >
 				<p className="wcc-metabox-label-item__created">
-					{ this.renderLabelDetails( label, labels.length - index, index ) } { __( 'purchased' ) }
-					<span title={ formatDate( label.created ) }>{ purchased }</span>
+					{ this.renderLabelDetails( label, labels.length - index, index ) }
+					{ ' ' }
+					{ __( 'purchased {{purchasedAt/}}', {
+						components: {
+							purchasedAt: <span title={ formatDate( label.created ) }>{ purchased }</span>
+						}
+					} ) }
 				</p>
 				<p className="wcc-metabox-label-item__tracking">
 					{ __( 'Tracking #: {{trackingLink/}}', { components: { trackingLink: <TrackingLink { ...label } /> } } ) }


### PR DESCRIPTION
Fix for https://github.com/Automattic/woocommerce-services/issues/1080.

Before:
![screen shot 2017-07-07 at 12 23 02 pm](https://user-images.githubusercontent.com/1867547/27966943-1f4a8650-630f-11e7-9d2f-98919cd2cb6f.png)

After:
![screen shot 2017-07-07 at 12 23 25 pm](https://user-images.githubusercontent.com/1867547/27966953-267c1984-630f-11e7-87ab-7c402b73fb1e.png)

Expanded i18n string can now support RTL and verb-final languages (thanks @jeffstieler).