### PR TITLE
Handle corrupted or empty packaging metadata.

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -142,8 +142,14 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 		protected function get_packaging_metadata( WC_Order $order ) {
 			$shipping_methods = $order->get_shipping_methods();
-			$shipping_method = reset( $shipping_methods );
-			return $this->get_packaging_from_shipping_method( $shipping_method );
+			$shipping_method  = reset( $shipping_methods );
+			$packaging        = $this->get_packaging_from_shipping_method( $shipping_method );
+
+			if ( is_array( $packaging ) ) {
+				return array_filter( $packaging );
+			}
+
+			return array();
 		}
 
 		protected function get_name( WC_Product $product ) {

--- a/tests/php/test_class-wc-connect-shipping-label.php
+++ b/tests/php/test_class-wc-connect-shipping-label.php
@@ -346,6 +346,35 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		$this->assertEquals( $actual, $this->expected_selected_packages );
 	}
 
+	// WC 3.1.0 shipping rate meta_data save bug
+	// See: https://github.com/Automattic/woocommerce-services/issues/1075
+	public function test_get_selected_packages_null_in_array() {
+		$shipping_method = array(
+			array(
+				'wc_connect_packages' => array( null ), // Bug causes data to be `a:1:{i:0;N;}` in database
+			),
+		);
+
+		$expected = array(
+			'default_box' => array(
+				'id'     => 'default_box',
+				'box_id' => 'not_selected',
+				'height' => 0,
+				'length' => 0,
+				'weight' => 0,
+				'width'  => 0,
+				'items'  => array(),
+			),
+		);
+
+		$mock_order = $this->create_mock_order();
+		$mock_order->expects( $this->any() )->method( 'get_shipping_methods' )->will( $this->returnValue( $shipping_method ) );
+
+		$shipping_label = $this->get_shipping_label();
+		$actual = $shipping_label->get_selected_packages( $mock_order );
+		$this->assertEquals( $actual, $expected );
+	}
+
 	public function test_get_selected_rates_multiple_packages_regular_json() {
 		$json = json_encode( $this->wc_connect_packages_multiple );
 


### PR DESCRIPTION
Fixes #1075.

This is specifically meant to handle a WC 3.1.0 bug, but adds general resilience to shipping labels.

To test:
* Check out with a WCS-provided live rate using WC 3.1.0
- OR -
* Edit an existing order item metadata `wc_connect_packages` to be `a:1:{i:0;N;}`
* Go to order details page
* Verify that no PHP warnings are displayed / in error log
* Verify that label dialog can be opened