### PR TITLE
Take into account current package weight when setting package type

### DIFF
--- a/client/apps/shipping-label/state/reducer.js
+++ b/client/apps/shipping-label/state/reducer.js
@@ -208,6 +208,7 @@ reducers[ UPDATE_PACKAGE_WEIGHT ] = ( state, { packageId, value } ) => {
 	newPackages[ packageId ] = {
 		...newPackages[ packageId ],
 		weight: parseFloat( value ),
+		is_user_specified_weight: true,
 	};
 
 	return { ...state,
@@ -445,11 +446,10 @@ reducers[ SET_PACKAGE_TYPE ] = ( state, { packageId, boxTypeId } ) => {
 	const newPackages = { ...state.form.packages.selected };
 	const oldPackage = newPackages[ packageId ];
 
-	const oldBox = state.form.packages.all[ oldPackage.box_id ];
-	const newBox = state.form.packages.all[ boxTypeId ];
+	const box = state.form.packages.all[ boxTypeId ];
 	const weight = round(
-		( newBox ? newBox.box_weight : 0 ) - ( oldBox ? oldBox.box_weight : 0 ) +
-			( oldPackage.weight != null ? oldPackage.weight : _.sumBy( oldPackage.items, 'weight' ) )
+		oldPackage.is_user_specified_weight ? oldPackage.weight
+			: ( box ? box.box_weight : 0 ) + _.sumBy( oldPackage.items, 'weight' )
 	);
 
 	if ( 'not_selected' === boxTypeId ) {
@@ -463,7 +463,7 @@ reducers[ SET_PACKAGE_TYPE ] = ( state, { packageId, boxTypeId } ) => {
 			box_id: boxTypeId,
 		};
 	} else {
-		const { length, width, height } = getBoxDimensions( newBox );
+		const { length, width, height } = getBoxDimensions( box );
 		newPackages[ packageId ] = {
 			..._.omit( oldPackage, 'service_id' ),
 			height,

--- a/client/apps/shipping-label/state/reducer.js
+++ b/client/apps/shipping-label/state/reducer.js
@@ -445,21 +445,25 @@ reducers[ SET_PACKAGE_TYPE ] = ( state, { packageId, boxTypeId } ) => {
 	const newPackages = { ...state.form.packages.selected };
 	const oldPackage = newPackages[ packageId ];
 
+	const oldBox = state.form.packages.all[ oldPackage.box_id ];
+	const newBox = state.form.packages.all[ boxTypeId ];
+	const weight = round(
+		(newBox != null ? newBox.box_weight : 0) - ( oldBox != null ? oldBox.box_weight : 0 ) +
+			( oldPackage.weight != null ? oldPackage.weight : _.sumBy( oldPackage.items, 'weight' ) )
+	);
+
 	if ( 'not_selected' === boxTypeId ) {
 		// This is when no box is selected
 		newPackages[ packageId ] = {
 			..._.omit( oldPackage, 'service_id' ),
-			height: 0, length: 0, width: 0,
-			weight: 0 + _.sumBy( oldPackage.items, 'weight' ),
+			height: 0, length: 0, width: 0, weight,
 			box_id: boxTypeId,
 		};
 	} else {
-		const box = state.form.packages.all[ boxTypeId ];
-		const { length, width, height } = getBoxDimensions( box );
+		const { length, width, height } = getBoxDimensions( newBox );
 		newPackages[ packageId ] = {
 			..._.omit( oldPackage, 'service_id' ),
-			height, length, width,
-			weight: round( box.box_weight + _.sumBy( oldPackage.items, 'weight' ) ),
+			height, length, width, weight,
 			box_id: boxTypeId,
 		};
 	}

--- a/client/apps/shipping-label/state/reducer.js
+++ b/client/apps/shipping-label/state/reducer.js
@@ -208,7 +208,7 @@ reducers[ UPDATE_PACKAGE_WEIGHT ] = ( state, { packageId, value } ) => {
 	newPackages[ packageId ] = {
 		...newPackages[ packageId ],
 		weight: parseFloat( value ),
-		is_user_specified_weight: true,
+		isUserSpecifiedWeight: true,
 	};
 
 	return { ...state,
@@ -448,7 +448,7 @@ reducers[ SET_PACKAGE_TYPE ] = ( state, { packageId, boxTypeId } ) => {
 
 	const box = state.form.packages.all[ boxTypeId ];
 	const weight = round(
-		oldPackage.is_user_specified_weight ? oldPackage.weight
+		oldPackage.isUserSpecifiedWeight ? oldPackage.weight
 			: ( box ? box.box_weight : 0 ) + _.sumBy( oldPackage.items, 'weight' )
 	);
 

--- a/client/apps/shipping-label/state/reducer.js
+++ b/client/apps/shipping-label/state/reducer.js
@@ -448,7 +448,7 @@ reducers[ SET_PACKAGE_TYPE ] = ( state, { packageId, boxTypeId } ) => {
 	const oldBox = state.form.packages.all[ oldPackage.box_id ];
 	const newBox = state.form.packages.all[ boxTypeId ];
 	const weight = round(
-		( newBox != null ? newBox.box_weight : 0 ) - ( oldBox != null ? oldBox.box_weight : 0 ) +
+		( newBox ? newBox.box_weight : 0 ) - ( oldBox ? oldBox.box_weight : 0 ) +
 			( oldPackage.weight != null ? oldPackage.weight : _.sumBy( oldPackage.items, 'weight' ) )
 	);
 
@@ -456,14 +456,20 @@ reducers[ SET_PACKAGE_TYPE ] = ( state, { packageId, boxTypeId } ) => {
 		// This is when no box is selected
 		newPackages[ packageId ] = {
 			..._.omit( oldPackage, 'service_id' ),
-			height: 0, length: 0, width: 0, weight,
+			height: 0,
+			length: 0,
+			width: 0,
+			weight,
 			box_id: boxTypeId,
 		};
 	} else {
 		const { length, width, height } = getBoxDimensions( newBox );
 		newPackages[ packageId ] = {
 			..._.omit( oldPackage, 'service_id' ),
-			height, length, width, weight,
+			height,
+			length,
+			width,
+			weight,
 			box_id: boxTypeId,
 		};
 	}

--- a/client/apps/shipping-label/state/reducer.js
+++ b/client/apps/shipping-label/state/reducer.js
@@ -448,7 +448,7 @@ reducers[ SET_PACKAGE_TYPE ] = ( state, { packageId, boxTypeId } ) => {
 	const oldBox = state.form.packages.all[ oldPackage.box_id ];
 	const newBox = state.form.packages.all[ boxTypeId ];
 	const weight = round(
-		(newBox != null ? newBox.box_weight : 0) - ( oldBox != null ? oldBox.box_weight : 0 ) +
+		( newBox != null ? newBox.box_weight : 0 ) - ( oldBox != null ? oldBox.box_weight : 0 ) +
 			( oldPackage.weight != null ? oldPackage.weight : _.sumBy( oldPackage.items, 'weight' ) )
 	);
 

--- a/client/apps/shipping-label/state/test/reducer.js
+++ b/client/apps/shipping-label/state/test/reducer.js
@@ -16,6 +16,7 @@ import {
 	addPackage,
 	removePackage,
 	setPackageType,
+	updatePackageWeight,
 	savePackages,
 	removeIgnoreValidation,
 	updateAddressValue,
@@ -216,6 +217,17 @@ describe( 'Label purchase form reducer', () => {
 		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
 		expect( state.form.needsPrintConfirmation ).to.eql( false );
 		expect( state.form.rates.available ).to.eql( {} );
+	} );
+
+	it( 'SET_PACKAGE_TYPE maintains user-specified weight after changing an existing package', () => {
+		const priorAction = updatePackageWeight( 'weight_0_custom1', 5.8 );
+		const existingState = reducer( initialState, priorAction );
+
+		const action = setPackageType( 'weight_0_custom1', 'customPackage1' );
+		const state = reducer( existingState, action );
+
+		expect( state.form.packages.selected.weight_0_custom1.box_id ).to.eql( 'customPackage1' );
+		expect( state.form.packages.selected.weight_0_custom1.weight ).to.eql( 5.8 );
 	} );
 
 	it( 'SAVE_PACKAGES changes the saved state', () => {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/1071. If you modify the weight and then change the package type, it'll keep (or adjust, depending on box weights) the weight you entered.

![fix-1071](https://user-images.githubusercontent.com/1867547/28146003-a1ef327a-6744-11e7-8f31-7ba00c71af57.gif)
