### PR TITLE
Enhance "Add Item" dialog by allowing multiple items to be checked

### DIFF
--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -381,11 +381,12 @@ export const closeAddItem = () => {
 	};
 };
 
-export const setAddedItem = ( sourcePackageId, movedItemIndex ) => {
+export const setAddedItem = ( sourcePackageId, movedItemIndex, added ) => {
 	return {
 		type: SET_ADDED_ITEM,
 		sourcePackageId,
 		movedItemIndex,
+		added,
 	};
 };
 

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -59,6 +59,7 @@ export const SAVE_PACKAGES = 'SAVE_PACKAGES';
 export const OPEN_ADD_ITEM = 'OPEN_ADD_ITEM';
 export const CLOSE_ADD_ITEM = 'CLOSE_ADD_ITEM';
 export const SET_ADDED_ITEM = 'SET_ADDED_ITEM';
+export const ADD_ITEMS = 'ADD_ITEMS';
 
 const FORM_STEPS = [ 'origin', 'destination', 'packages', 'rates' ];
 
@@ -387,6 +388,13 @@ export const setAddedItem = ( sourcePackageId, movedItemIndex, added ) => {
 		sourcePackageId,
 		movedItemIndex,
 		added,
+	};
+};
+
+export const addItems = ( targetPackageId ) => {
+	return {
+		type: ADD_ITEMS,
+		targetPackageId,
 	};
 };
 

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -341,14 +341,17 @@ reducers[ CLOSE_ADD_ITEM ] = ( state ) => {
 };
 
 reducers[ SET_ADDED_ITEM ] = ( state, { sourcePackageId, movedItemIndex, added } ) => {
-	const itemIndices = state.addedItems[ sourcePackageId ] || []
+	let newItemIndices;
+	if ( added ) {
+		const itemIndices = state.addedItems[ sourcePackageId ] || [];
+		newItemIndices = _.includes( itemIndices, movedItemIndex ) ? itemIndices : [ ...itemIndices, movedItemIndex ];
+	} else {
+		newItemIndices = _.without( state.addedItems[ sourcePackageId ], movedItemIndex );
+	}
+
 	return {
 		...state,
-		addedItems: { ...state.addedItems,
-			[ sourcePackageId ]: ! added
-				? _.without( itemIndices, movedItemIndex )
-				: _.includes( itemIndices, movedItemIndex ) ? itemIndices : [ ...itemIndices, movedItemIndex ]
-		},
+		addedItems: { ...state.addedItems, [ sourcePackageId ]: newItemIndices },
 	};
 };
 

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -334,16 +334,19 @@ reducers[ OPEN_ADD_ITEM ] = ( state ) => {
 reducers[ CLOSE_ADD_ITEM ] = ( state ) => {
 	return {
 		...state,
-		movedItemIndex: -1,
+		addedItems: null,
 		showAddItemDialog: false,
 	};
 };
 
-reducers[ SET_ADDED_ITEM ] = ( state, { sourcePackageId, movedItemIndex } ) => {
+reducers[ SET_ADDED_ITEM ] = ( state, { sourcePackageId, movedItemIndex, added } ) => {
 	return {
 		...state,
-		sourcePackageId,
-		movedItemIndex,
+		addedItems: { ...state.addedItems,
+			[ sourcePackageId ]: { ...( state.addedItems || {} )[ sourcePackageId ],
+				[ movedItemIndex ]: added,
+			}
+		},
 	};
 };
 

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -341,21 +341,23 @@ reducers[ CLOSE_ADD_ITEM ] = ( state ) => {
 };
 
 reducers[ SET_ADDED_ITEM ] = ( state, { sourcePackageId, movedItemIndex, added } ) => {
+	const itemIndices = state.addedItems[ sourcePackageId ] || []
 	return {
 		...state,
 		addedItems: { ...state.addedItems,
-			[ sourcePackageId ]: added
-				? { ...state.addedItems[ sourcePackageId ], [ movedItemIndex ]: true }
-				: _.omit( state.addedItems[ sourcePackageId ], movedItemIndex )
+			[ sourcePackageId ]: ! added
+				? _.without( itemIndices, movedItemIndex )
+				: _.includes( itemIndices, movedItemIndex ) ? itemIndices : [ ...itemIndices, movedItemIndex ]
 		},
 	};
 };
 
 reducers[ ADD_ITEMS ] = ( state, { targetPackageId } ) => {
 	// For each origin package
-	_.each( state.addedItems, ( inPackage, originPackageId ) => {
-		// Move items in reverse order of index, to maintain validity as items are removed
-		_.sortBy( Object.keys( inPackage ), ( d ) => -d ).forEach( ( movedItemIndex ) => {
+	_.each( state.addedItems, ( itemIndices, originPackageId ) => {
+		// Move items in reverse order of index, to maintain validity as items are removed.
+		// e.g. when index 0 is removed from the package, index 1 would become index 0
+		_.sortBy( itemIndices, ( i ) => -i ).forEach( ( movedItemIndex ) => {
 			state = reducers[ MOVE_ITEM ]( state, { originPackageId, movedItemIndex, targetPackageId } );
 		} );
 	} );

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -49,6 +49,7 @@ import {
 	OPEN_ADD_ITEM,
 	CLOSE_ADD_ITEM,
 	SET_ADDED_ITEM,
+	ADD_ITEMS,
 } from './actions';
 import getBoxDimensions from 'lib/utils/get-box-dimensions';
 
@@ -328,13 +329,13 @@ reducers[ OPEN_ADD_ITEM ] = ( state ) => {
 	return {
 		...state,
 		showAddItemDialog: true,
+		addedItems: {},
 	};
 };
 
 reducers[ CLOSE_ADD_ITEM ] = ( state ) => {
 	return {
 		...state,
-		addedItems: null,
 		showAddItemDialog: false,
 	};
 };
@@ -343,11 +344,24 @@ reducers[ SET_ADDED_ITEM ] = ( state, { sourcePackageId, movedItemIndex, added }
 	return {
 		...state,
 		addedItems: { ...state.addedItems,
-			[ sourcePackageId ]: { ...( state.addedItems || {} )[ sourcePackageId ],
+			[ sourcePackageId ]: { ...state.addedItems[ sourcePackageId ],
 				[ movedItemIndex ]: added,
 			}
 		},
 	};
+};
+
+reducers[ ADD_ITEMS ] = ( state, { targetPackageId } ) => {
+	return _.reduce( state.addedItems, ( prevState, inPackage, originPackageId ) => {
+		const movedItemIndices = _.toPairs( inPackage )
+			.filter( ( [ , added ] ) => added )
+			.map( ( [ movedItemIndex ] ) => +movedItemIndex );
+		return _.sortBy( movedItemIndices ).reverse().reduce( ( prevPrevState, movedItemIndex ) => {
+			return reducers[ MOVE_ITEM ]( prevPrevState, { originPackageId, movedItemIndex, targetPackageId } );
+		}, prevState );
+	}, { ...state,
+		showAddItemDialog: false,
+	} );
 };
 
 reducers[ ADD_PACKAGE ] = ( state ) => {

--- a/client/shipping-label/state/test/reducer.js
+++ b/client/shipping-label/state/test/reducer.js
@@ -10,6 +10,8 @@ import hoek from 'hoek';
 import reducer from '../reducer';
 import {
 	moveItem,
+	setAddedItem,
+	addItems,
 	addPackage,
 	removePackage,
 	setPackageType,
@@ -59,6 +61,7 @@ const initialState = {
 	},
 	openedPackageId: 'weight_0_custom1',
 	labels: [],
+	addedItems: {},
 };
 
 describe( 'Label purchase form reducer', () => {
@@ -123,6 +126,41 @@ describe( 'Label purchase form reducer', () => {
 		expect( state.form.packages.saved ).to.eql( false );
 		expect( state.form.needsPrintConfirmation ).to.eql( false );
 		expect( state.form.rates.available ).to.eql( {} );
+	} );
+
+	it( 'ADD_ITEMS moves a set of items from their original packaging to selected package', () => {
+		let existingState = hoek.clone( initialState );
+		existingState.form.packages.selected.weight_2_custom1 = {
+			items: [
+				{
+					product_id: 789,
+					weight: 4.5,
+				},
+			],
+		};
+		existingState.form.packages.selected.weight_1_custom1.items[ 1 ] = {
+			product_id: 457,
+			weight: 3.4,
+		};
+
+		existingState = [
+			setAddedItem( 'weight_0_custom1', 0, true ),
+			setAddedItem( 'weight_1_custom1', 0, true ),
+			setAddedItem( 'weight_1_custom1', 1, true ),
+		].reduce( reducer, existingState );
+
+		const action = addItems( 'weight_2_custom1' );
+		const state = reducer( existingState, action );
+
+		expect( state.form.packages.selected.weight_0_custom1 ).to.not.exist;
+		expect( state.form.packages.selected.weight_1_custom1 ).to.not.exist;
+		expect( state.form.packages.selected.weight_2_custom1.items.length ).to.eql( 4 );
+		expect( state.form.packages.selected.weight_2_custom1.items )
+			.to.include( existingState.form.packages.selected.weight_0_custom1.items[ 0 ] );
+		expect( state.form.packages.selected.weight_2_custom1.items )
+			.to.include( existingState.form.packages.selected.weight_1_custom1.items[ 0 ] );
+		expect( state.form.packages.selected.weight_2_custom1.items )
+			.to.include( existingState.form.packages.selected.weight_1_custom1.items[ 1 ] );
 	} );
 
 	it( 'ADD_PACKAGE adds a new package', () => {

--- a/client/shipping-label/state/test/reducer.js
+++ b/client/shipping-label/state/test/reducer.js
@@ -10,6 +10,7 @@ import hoek from 'hoek';
 import reducer from '../reducer';
 import {
 	moveItem,
+	openAddItem,
 	setAddedItem,
 	addItems,
 	addPackage,
@@ -61,7 +62,6 @@ const initialState = {
 	},
 	openedPackageId: 'weight_0_custom1',
 	labels: [],
-	addedItems: {},
 };
 
 describe( 'Label purchase form reducer', () => {
@@ -129,7 +129,7 @@ describe( 'Label purchase form reducer', () => {
 	} );
 
 	it( 'ADD_ITEMS moves a set of items from their original packaging to selected package', () => {
-		let existingState = hoek.clone( initialState );
+		const existingState = hoek.clone( initialState );
 		existingState.form.packages.selected.weight_2_custom1 = {
 			items: [
 				{
@@ -143,14 +143,20 @@ describe( 'Label purchase form reducer', () => {
 			weight: 3.4,
 		};
 
-		existingState = [
+		let state = reducer( existingState, openAddItem() );
+		expect( state.addedItems ).to.eql( {} );
+
+		state = [
 			setAddedItem( 'weight_0_custom1', 0, true ),
 			setAddedItem( 'weight_1_custom1', 0, true ),
 			setAddedItem( 'weight_1_custom1', 1, true ),
-		].reduce( reducer, existingState );
+		].reduce( reducer, state );
 
-		const action = addItems( 'weight_2_custom1' );
-		const state = reducer( existingState, action );
+		expect( state.addedItems.weight_0_custom1 ).to.eql( [ 0 ] );
+		expect( state.addedItems.weight_1_custom1 ).to.include( 0 );
+		expect( state.addedItems.weight_1_custom1 ).to.include( 1 );
+
+		state = reducer( state, addItems( 'weight_2_custom1' ) );
 
 		expect( state.form.packages.selected.weight_0_custom1 ).to.not.exist;
 		expect( state.form.packages.selected.weight_1_custom1 ).to.not.exist;

--- a/client/shipping-label/views/purchase/steps/packages/add-item.js
+++ b/client/shipping-label/views/purchase/steps/packages/add-item.js
@@ -3,6 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import { translate as __ } from 'i18n-calypso';
+import _ from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,7 +22,7 @@ const AddItemDialog = ( {
 	all,
 	closeAddItem,
 	setAddedItem,
-	moveItem } ) => {
+	addItems } ) => {
 	if ( ! showAddItemDialog ) {
 		return null;
 	}
@@ -41,7 +42,7 @@ const AddItemDialog = ( {
 			<FormLabel
 				key={ `${ pckgId }-${ itemIdx }` }
 				className="wcc-move-item-dialog__package-option">
-				<FormCheckbox checked={ ! ! ( ( addedItems || {} )[ pckgId ] || {} )[ itemIdx ] }
+				<FormCheckbox checked={ _.get( addedItems, [ pckgId, itemIdx ], false ) }
 						onChange={ onChange } />
 				<span>{ itemLabel }</span>
 			</FormLabel>
@@ -83,21 +84,8 @@ const AddItemDialog = ( {
 					{
 						label: __( 'Add' ),
 						isPrimary: true,
-						isDisabled: ! Object.keys( addedItems || {} ).filter( ( sourcePackageId ) =>
-							Object.keys( addedItems[ sourcePackageId ] || {} ).filter( ( movedItemIndex ) =>
-								addedItems[ sourcePackageId ][ movedItemIndex ]
-							).length
-						).length,
-						onClick: () => {
-							Object.keys( addedItems || {} ).forEach( ( sourcePackageId ) => {
-								Object.keys( addedItems[ sourcePackageId ] || {} ).forEach( ( movedItemIndex ) => {
-									if ( addedItems[ sourcePackageId ][ movedItemIndex ] ) {
-										moveItem( sourcePackageId, movedItemIndex, openedPackageId );
-									}
-								} );
-							} );
-							closeAddItem();
-						},
+						isDisabled: ! _.some( addedItems, _.some ),
+						onClick: () => addItems( openedPackageId ),
 					},
 					{ label: __( 'Close' ), onClick: closeAddItem },
 				] } />
@@ -114,7 +102,7 @@ AddItemDialog.propTypes = {
 	all: PropTypes.object.isRequired,
 	closeAddItem: PropTypes.func.isRequired,
 	setAddedItem: PropTypes.func.isRequired,
-	moveItem: PropTypes.func.isRequired,
+	addItems: PropTypes.func.isRequired,
 };
 
 export default AddItemDialog;

--- a/client/shipping-label/views/purchase/steps/packages/add-item.js
+++ b/client/shipping-label/views/purchase/steps/packages/add-item.js
@@ -80,16 +80,25 @@ const AddItemDialog = ( {
 					{ itemOptions }
 				</div>
 				<ActionButtons buttons={ [
-					{ label: __( 'Add' ), isPrimary: true, onClick: () => {
-						Object.keys( addedItems || {} ).forEach( ( sourcePackageId ) => {
-							Object.keys( addedItems[ sourcePackageId ] || {} ).forEach( ( movedItemIndex ) => {
-								if ( addedItems[ sourcePackageId ][ movedItemIndex ] ) {
-									moveItem( sourcePackageId, movedItemIndex, openedPackageId );
-								}
+					{
+						label: __( 'Add' ),
+						isPrimary: true,
+						isDisabled: ! Object.keys( addedItems || {} ).filter( ( sourcePackageId ) =>
+							Object.keys( addedItems[ sourcePackageId ] || {} ).filter( ( movedItemIndex ) =>
+								addedItems[ sourcePackageId ][ movedItemIndex ]
+							).length
+						).length,
+						onClick: () => {
+							Object.keys( addedItems || {} ).forEach( ( sourcePackageId ) => {
+								Object.keys( addedItems[ sourcePackageId ] || {} ).forEach( ( movedItemIndex ) => {
+									if ( addedItems[ sourcePackageId ][ movedItemIndex ] ) {
+										moveItem( sourcePackageId, movedItemIndex, openedPackageId );
+									}
+								} );
 							} );
-						} );
-						closeAddItem();
-					} },
+							closeAddItem();
+						},
+					},
 					{ label: __( 'Close' ), onClick: closeAddItem },
 				] } />
 			</div>

--- a/client/shipping-label/views/purchase/steps/packages/add-item.js
+++ b/client/shipping-label/views/purchase/steps/packages/add-item.js
@@ -42,7 +42,7 @@ const AddItemDialog = ( {
 			<FormLabel
 				key={ `${ pckgId }-${ itemIdx }` }
 				className="wcc-move-item-dialog__package-option">
-				<FormCheckbox checked={ _.get( addedItems, [ pckgId, itemIdx ], false ) }
+				<FormCheckbox checked={ _.includes( addedItems[ pckgId ], itemIdx ) }
 						onChange={ onChange } />
 				<span>{ itemLabel }</span>
 			</FormLabel>
@@ -84,7 +84,7 @@ const AddItemDialog = ( {
 					{
 						label: __( 'Add' ),
 						isPrimary: true,
-						isDisabled: ! _.some( addedItems, _.some ),
+						isDisabled: ! _.some( addedItems, _.size ),
 						onClick: () => addItems( openedPackageId ),
 					},
 					{ label: __( 'Close' ), onClick: closeAddItem },

--- a/client/shipping-label/views/purchase/steps/packages/index.js
+++ b/client/shipping-label/views/purchase/steps/packages/index.js
@@ -195,7 +195,7 @@ const PackagesStep = ( props ) => {
 				all={ all }
 				closeAddItem={ labelActions.closeAddItem }
 				setAddedItem={ labelActions.setAddedItem }
-				moveItem={ labelActions.moveItem } />
+				addItems={ labelActions.addItems } />
 		</StepContainer>
 	);
 };

--- a/client/shipping-label/views/purchase/steps/packages/index.js
+++ b/client/shipping-label/views/purchase/steps/packages/index.js
@@ -30,7 +30,7 @@ const PackagesStep = ( props ) => {
 		movedItemIndex,
 		targetPackageId,
 		showAddItemDialog,
-		sourcePackageId,
+		addedItems,
 	} = props;
 
 	const packageIds = Object.keys( selected );
@@ -189,14 +189,12 @@ const PackagesStep = ( props ) => {
 				moveItem={ labelActions.moveItem } />
 			<AddItemDialog
 				showAddItemDialog={ showAddItemDialog || false }
-				movedItemIndex={ movedItemIndex }
-				sourcePackageId={ sourcePackageId }
+				addedItems={ addedItems }
 				openedPackageId={ openedPackageId }
 				selected={ selected }
 				all={ all }
 				closeAddItem={ labelActions.closeAddItem }
 				setAddedItem={ labelActions.setAddedItem }
-				confirmAddItem={ labelActions.confirmAddItem }
 				moveItem={ labelActions.moveItem } />
 		</StepContainer>
 	);

--- a/client/shipping-label/views/purchase/steps/packages/move-item.js
+++ b/client/shipping-label/views/purchase/steps/packages/move-item.js
@@ -105,7 +105,12 @@ const MoveItemDialog = ( {
 					{ renderIndividualOption() }
 				</div>
 				<ActionButtons buttons={ [
-					{ label: __( 'Move' ), isPrimary: true, onClick: () => moveItem( openedPackageId, movedItemIndex, targetPackageId ) },
+					{
+						label: __( 'Move' ),
+						isPrimary: true,
+						isDisabled: targetPackageId === openedPackageId,
+						onClick: () => moveItem( openedPackageId, movedItemIndex, targetPackageId ),
+					},
 					{ label: __( 'Cancel' ), onClick: closeItemMove },
 				] } />
 			</div>

--- a/client/shipping-label/views/purchase/steps/packages/move-item.js
+++ b/client/shipping-label/views/purchase/steps/packages/move-item.js
@@ -108,7 +108,7 @@ const MoveItemDialog = ( {
 					{
 						label: __( 'Move' ),
 						isPrimary: true,
-						isDisabled: targetPackageId === openedPackageId,
+						isDisabled: targetPackageId === openedPackageId,  // Result of targetPackageId initialization
 						onClick: () => moveItem( openedPackageId, movedItemIndex, targetPackageId ),
 					},
 					{ label: __( 'Cancel' ), onClick: closeItemMove },


### PR DESCRIPTION
Fixes: https://github.com/Automattic/woocommerce-services/issues/1033

Allows adding one _or more_ items to a package at once by using checkbox controls instead of radio buttons.

Before:
![add-items-before](https://user-images.githubusercontent.com/1867547/28231967-365d9258-68bc-11e7-8123-3c50c1c4bd2c.gif)

After:
![add-items](https://user-images.githubusercontent.com/1867547/28231853-a2b363c0-68bb-11e7-86ff-85ca362aeccb.gif)

Also disables the primary action button (for this dialog and the "Move" dialog) if no selection is made, indicating that no consequential action has been selected.