### PR TITLE
Appearance and alignment tweaks in WC Settings

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -163,6 +163,7 @@
 			max-width: 100%;
 			display: flex;
 			padding-top: 24px;
+			padding-bottom: 24px;
 
 			@include breakpoint( '<660px' ) {
 				flex-wrap: wrap;

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -93,9 +93,9 @@
 		@include breakpoint( '<660px' ) {
 			width: 100%;
 		}
-	}
+		padding-right: 10px;
+		box-sizing: border-box;
 
-	.settings-group-header {
 		font-size: 16px;
 		font-weight: 600;
 		color: darken( $gray, 20% );
@@ -322,7 +322,12 @@
 	}
 
 	// Custom styles
-	max-width: 700px;
+	max-width: 720px;
+
+	&.wc-connect-packages,
+	&.wc-connect-account-settings {
+		margin-top: 6px;
+	}
 
 	// WP style conflict resets
 	.card {

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -49,7 +49,7 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 			}
 
 			$shipping_tabs[ 'package-settings' ] = __( 'Packages', 'woocommerce-services' );
-			$shipping_tabs[ 'label-settings'] = __( 'Shipping Labels', 'woocommerce-services' );
+			$shipping_tabs[ 'label-settings'] = __( 'Shipping labels', 'woocommerce-services' );
 			return $shipping_tabs;
 		}
 

--- a/client/components/checkbox/style.scss
+++ b/client/components/checkbox/style.scss
@@ -4,6 +4,7 @@
 	display: inline-flex;
 	align-items: center;
 	position: relative;
+	vertical-align: text-bottom;
 
 	input {
 		margin: 0;

--- a/client/packages/state/reducer.js
+++ b/client/packages/state/reducer.js
@@ -35,11 +35,12 @@ reducers[ ADD_PACKAGE ] = ( state ) => {
 	const newState = Object.assign( {}, state, {
 		showModal: true,
 		mode: 'add',
-		showOuterDimensions: false,
 	} );
 
-	if ( 'edit' === state.mode || ! newState.packageData ) {
+	if ( 'edit' === state.mode || ! newState.packageData ||
+			_.last( _.get( state, [ 'packages', 'custom' ] ) ) === newState.packageData ) {
 		newState.packageData = { is_user_defined: true };
+		newState.showOuterDimensions = false;
 	}
 
 	return newState;
@@ -107,6 +108,7 @@ reducers[ SAVE_PACKAGE ] = ( state, action ) => {
 	return {
 		...state,
 		showModal: false,
+		packageData,
 		packages: {
 			...state.packages,
 			custom,

--- a/client/packages/state/reducer.js
+++ b/client/packages/state/reducer.js
@@ -35,6 +35,10 @@ reducers[ ADD_PACKAGE ] = ( state ) => {
 	const newState = Object.assign( {}, state, {
 		showModal: true,
 		mode: 'add',
+		packageData: {
+			is_user_defined: true,
+		},
+		showOuterDimensions: false,
 	} );
 
 	if ( 'edit' === state.mode || ! newState.packageData ) {
@@ -58,7 +62,6 @@ reducers[ DISMISS_MODAL ] = ( state ) => {
 	return Object.assign( {}, state, {
 		modalErrors: {},
 		showModal: false,
-		showOuterDimensions: false,
 	} );
 };
 
@@ -107,15 +110,10 @@ reducers[ SAVE_PACKAGE ] = ( state, action ) => {
 	return {
 		...state,
 		showModal: false,
-		mode: 'add',
-		packageData: {
-			is_user_defined: true,
-		},
 		packages: {
 			...state.packages,
 			custom,
 		},
-		showOuterDimensions: false,
 		selectedPreset: null,
 		pristine: false,
 	};

--- a/client/packages/state/reducer.js
+++ b/client/packages/state/reducer.js
@@ -35,9 +35,6 @@ reducers[ ADD_PACKAGE ] = ( state ) => {
 	const newState = Object.assign( {}, state, {
 		showModal: true,
 		mode: 'add',
-		packageData: {
-			is_user_defined: true,
-		},
 		showOuterDimensions: false,
 	} );
 

--- a/client/packages/state/test/reducer.js
+++ b/client/packages/state/test/reducer.js
@@ -45,7 +45,8 @@ describe( 'Packages form reducer', () => {
 		const existingAddState = {
 			showModal: false,
 			mode: 'add',
-			showOuterDimensions: false,
+			showOuterDimensions: true,
+			selectedPreset: 'default_envelope',
 			packageData: {
 				name: 'Package name here',
 			},
@@ -56,7 +57,8 @@ describe( 'Packages form reducer', () => {
 		expect( state ).to.eql( {
 			showModal: true,
 			mode: 'add',
-			showOuterDimensions: false,
+			showOuterDimensions: true,
+			selectedPreset: 'default_envelope',
 			packageData: existingAddState.packageData,
 		} );
 	} );

--- a/client/packages/state/test/reducer.js
+++ b/client/packages/state/test/reducer.js
@@ -45,6 +45,7 @@ describe( 'Packages form reducer', () => {
 		const existingAddState = {
 			showModal: false,
 			mode: 'add',
+			showOuterDimensions: false,
 			packageData: {
 				name: 'Package name here',
 			},
@@ -55,6 +56,7 @@ describe( 'Packages form reducer', () => {
 		expect( state ).to.eql( {
 			showModal: true,
 			mode: 'add',
+			showOuterDimensions: false,
 			packageData: existingAddState.packageData,
 		} );
 	} );
@@ -63,6 +65,7 @@ describe( 'Packages form reducer', () => {
 		const existingEditState = {
 			showModal: false,
 			mode: 'edit',
+			showOuterDimensions: true,
 			packageData: {
 				index: 1,
 				name: 'Package name here',
@@ -74,6 +77,7 @@ describe( 'Packages form reducer', () => {
 		expect( state ).to.eql( {
 			showModal: true,
 			mode: 'add',
+			showOuterDimensions: false,
 			packageData: { is_user_defined: true },
 		} );
 	} );
@@ -110,7 +114,6 @@ describe( 'Packages form reducer', () => {
 		expect( state ).to.eql( {
 			modalErrors: {},
 			showModal: false,
-			showOuterDimensions: false,
 		} );
 	} );
 
@@ -229,15 +232,10 @@ describe( 'Packages form reducer', () => {
 		const state = reducer( initialSavePackageState, action );
 
 		expect( state.showModal ).to.eql( false );
-		expect( state.packageData ).to.eql( {
-			is_user_defined: true,
-		} );
-		expect( state.mode ).to.eql( 'add' );
 		expect( state.packages.custom[ 1 ] ).to.eql( {
 			is_user_defined: true,
 			name: 'Test Box',
 		} );
-		expect( state.showOuterDimensions ).to.eql( false );
 		expect( state.selectedPreset ).to.eql( null );
 		expect( state.pristine ).to.eql( false );
 	} );

--- a/client/packages/views/add-package.js
+++ b/client/packages/views/add-package.js
@@ -63,6 +63,7 @@ const AddPackageDialog = ( props ) => {
 		packages,
 		packageSchema,
 		predefinedSchema,
+		selectedPreset,
 		packageData,
 		showOuterDimensions,
 	} = form;
@@ -132,7 +133,7 @@ const AddPackageDialog = ( props ) => {
 			<FormSectionHeading>
 				{ ( 'edit' === mode ) ? __( 'Edit package' ) : __( 'Add a package' ) }
 			</FormSectionHeading>
-			{ ( 'add' === mode ) ? <AddPackagePresets { ...props } /> : null }
+			{ ( 'add' === mode ) ? <AddPackagePresets { ...props } selectedPreset={ selectedPreset } /> : null }
 			<FormFieldset>
 				<FormLabel htmlFor="name">{ __( 'Package name' ) }</FormLabel>
 				<FormTextInput

--- a/client/packages/views/packages-list.js
+++ b/client/packages/views/packages-list.js
@@ -68,7 +68,9 @@ const PackagesList = ( { packages, dimensionUnit, editable, selected, serviceId,
 				<FormLegend className="package-type">{ __( 'Type' ) }</FormLegend>
 				<FormLegend className="package-name">{ __( 'Name' ) }</FormLegend>
 				<FormLegend className="package-dimensions">
-					{ __( 'Dimensions (L x W x H)' ).replace( /\(.+\)/g, ( d ) => d.replace( / /g, '\u00a0' ) ) }
+					<span className="package-dimensions-title">{ __( 'Dimensions' ) }</span>
+					{ ' ' }
+					<span className="package-dimensions-format">{ __( '(L x W x H)' ) }</span>
 				</FormLegend>
 				{ editable ? <FormLegend className="package-actions" /> : null }
 			</div>

--- a/client/packages/views/packages-list.js
+++ b/client/packages/views/packages-list.js
@@ -64,10 +64,13 @@ const PackagesList = ( { packages, dimensionUnit, editable, selected, serviceId,
 	return (
 		<FormFieldset className="wcc-shipping-packages-list">
 			<div className="wcc-shipping-packages-list-header">
-				<FormLegend className="package-actions" />
+				{ editable ? null : <FormLegend className="package-actions" /> }
 				<FormLegend className="package-type">{ __( 'Type' ) }</FormLegend>
 				<FormLegend className="package-name">{ __( 'Name' ) }</FormLegend>
-				<FormLegend className="package-dimensions">{ __( 'Dimensions (L x W x H)' ) }</FormLegend>
+				<FormLegend className="package-dimensions">
+					{ __( 'Dimensions (L x W x H)' ).replace( /\(.+\)/g, ( d ) => d.replace( / /g, '\u00a0' ) ) }
+				</FormLegend>
+				{ editable ? <FormLegend className="package-actions" /> : null }
 			</div>
 			{ renderList() }
 		</FormFieldset>

--- a/client/packages/views/style.scss
+++ b/client/packages/views/style.scss
@@ -17,10 +17,10 @@
 			width: 11%;
 		}
 
-	.package-type-icon {
-		fill: $gray;
+		.package-type-icon {
+			fill: $gray;
+		}
 	}
-}
 
 	.package-name {
 		width: 46%;
@@ -51,6 +51,14 @@
 		text-align: right;
 		@include breakpoint( '<660px' ) {
 			width: 8%;
+		}
+
+		button {
+			padding-top: 4px;
+		}
+
+		.form-checkbox {
+			margin-top: 1px;
 		}
 	}
 
@@ -101,6 +109,11 @@
 			margin-left: -1px;
 		}
 	}
+
+	a {
+		display: inline-block;
+	}
+
 }
 
 .wcc-shipping-add-package-weight {

--- a/client/packages/views/style.scss
+++ b/client/packages/views/style.scss
@@ -72,8 +72,15 @@
 
 .wcc-shipping-packages-list-header {
 	display: flex;
-	height: 26px;
+	padding-bottom: 2px;
 	border-bottom: 1px solid lighten( $gray, 30% );
+	margin-bottom: 12px;
+
+	.package-type {
+		@include breakpoint( '<660px' ) {
+			visibility: hidden;
+		}
+	}
 }
 
 .wcc-shipping-packages-list-item,

--- a/client/packages/views/style.scss
+++ b/client/packages/views/style.scss
@@ -177,9 +177,13 @@
 	}
 }
 
-.add-package-button-field .button {
-	float: left;
-	margin-left: 0;
+.add-package-button-field {
+	margin-bottom: 0;
+
+	.button {
+		float: left;
+		margin-left: 0;
+	}
 }
 
 .form-text-input.flat-rate-package__inner-dimensions__read-only:disabled,

--- a/client/packages/views/style.scss
+++ b/client/packages/views/style.scss
@@ -44,6 +44,10 @@
 		@include breakpoint( '<660px' ) {
 			width: 37%;
 		}
+
+		.package-dimensions-format {
+			white-space: nowrap;
+		}
 	}
 
 	.package-actions {


### PR DESCRIPTION
- Slightly increase maximum width of `.wcc-root` to match Calypso form width
- Change 'Shipping Labels' to 'Shipping labels' for consistency
- Increase margin above packages and labels settings forms
- Add margin to form section header in Packages settings
- Improve alignment and wrapping of 'Custom packages' table headers (should fix https://github.com/Automattic/woocommerce-services/issues/936)

Before | After
-- | --
<img width="288" alt="screen shot 2017-07-18 at 9 25 51 pm" src="https://user-images.githubusercontent.com/1867547/28346579-d49a9b8c-6bff-11e7-956c-dad4e4f60375.png"> | <img width="286" alt="screen shot 2017-07-18 at 9 26 28 pm" src="https://user-images.githubusercontent.com/1867547/28346580-d5dcd78a-6bff-11e7-85a4-761a4750d355.png">

- Improve alignment of checkboxes to text
- Avoid 'Edit package' dialog flickering to 'Add a package' dialog upon closing

Before:
![packages-before](https://user-images.githubusercontent.com/1867547/28346427-1d920e2a-6bff-11e7-8d85-efdc23c66287.gif)

After:
![packages-after](https://user-images.githubusercontent.com/1867547/28346431-1ed9b59e-6bff-11e7-9522-3ff4af4f73c2.gif)