### PR TITLE
Render shipping label list ahead of refund status update

### DIFF
--- a/assets/stylesheets/shipping-label.scss
+++ b/assets/stylesheets/shipping-label.scss
@@ -73,6 +73,11 @@
 
 			.wcc-metabox-label-item__refund-pending {
 				color: $alert-yellow;
+
+				.spinner {
+					margin-left: 2px;
+					margin-bottom: 1px;
+				}
 			}
 
 			.wcc-metabox-label-item__refund-complete {

--- a/assets/stylesheets/shipping-label.scss
+++ b/assets/stylesheets/shipping-label.scss
@@ -73,11 +73,11 @@
 
 			.wcc-metabox-label-item__refund-pending {
 				color: $alert-yellow;
-
-				.spinner {
-					margin-left: 2px;
-					margin-bottom: 1px;
-				}
+			}
+			
+			.wcc-metabox-label-item__refund-checking {
+				@extend .wcc-metabox-label-item__refund-pending;
+				animation: loading-fade 1.6s ease-in-out infinite;
 			}
 
 			.wcc-metabox-label-item__refund-complete {

--- a/client/shipping-label/views/index.js
+++ b/client/shipping-label/views/index.js
@@ -15,7 +15,6 @@ import PrintLabelDialog from './purchase';
 import RefundDialog from './refund';
 import ReprintDialog from './reprint';
 import TrackingLink from './tracking-link';
-import Spinner from 'components/spinner';
 import Tooltip from 'components/tooltip';
 import formatDate from 'lib/utils/format-date';
 import timeAgo from 'lib/utils/time-ago';
@@ -155,10 +154,13 @@ class ShippingLabelRootView extends Component {
 		let className = '';
 		switch ( label.refund.status ) {
 			case 'pending':
-				className = 'wcc-metabox-label-item__refund-pending';
-				text = label.statusUpdated
-					? __( 'Refund pending' )
-					: <span>{ __( 'Checking refund status' ) } <Spinner size={ 12 } /></span>;
+				if ( label.statusUpdated ) {
+					className = 'wcc-metabox-label-item__refund-pending';
+					text = __( 'Refund pending' );
+				} else {
+					className = 'wcc-metabox-label-item__refund-checking';
+					text = __( 'Checking refund status' );
+				}
 				break;
 			case 'complete':
 				className = 'wcc-metabox-label-item__refund-complete';

--- a/client/shipping-label/views/index.js
+++ b/client/shipping-label/views/index.js
@@ -4,7 +4,6 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import _ from 'lodash';
 import Gridicon from 'gridicons';
 import { translate as __ } from 'i18n-calypso';
 
@@ -157,7 +156,9 @@ class ShippingLabelRootView extends Component {
 		switch ( label.refund.status ) {
 			case 'pending':
 				className = 'wcc-metabox-label-item__refund-pending';
-				text = __( 'Refund pending' );
+				text = label.statusUpdated
+					? __( 'Refund pending' )
+					: <span>{ __( 'Checking refund status' ) } <Spinner size={ 12 } /></span>;
 				break;
 			case 'complete':
 				className = 'wcc-metabox-label-item__refund-complete';
@@ -266,9 +267,6 @@ class ShippingLabelRootView extends Component {
 		if ( this.needToFetchLabelsStatus ) {
 			this.needToFetchLabelsStatus = false;
 			this.props.labelActions.fetchLabelsStatus();
-		}
-		if ( ! _.every( this.props.shippingLabel.labels, 'statusUpdated' ) ) {
-			return <Spinner size={ 24 } />;
 		}
 		return this.props.shippingLabel.labels.map( this.renderLabel );
 	}


### PR DESCRIPTION
Currently, label data is available on first render of the shipping label view, but none is being displayed until all of the labels' data is individually updated from the server. `statusUpdated` is the property being checked for, referring to the refund status as I understand.

Under the general assumption that the cached data will tend to be up to date, and the specific assumption that a carrier refund completion is the only unexceptional case where it could be out of date — let me know if either of these is unfounded — I've replaced showing a spinner with rendering the labels straight away, with the exception of the refund status value of "pending".

### Before
![labels-before](https://user-images.githubusercontent.com/1867547/28418712-b884b4f6-6d2a-11e7-9561-1553b15cb7db.gif)

### After
![labels-after](https://user-images.githubusercontent.com/1867547/28418772-f072f2ba-6d2a-11e7-8222-172efb435c18.gif)

