### PR TITLE
Maintain fixed precision of weight values when moving items among packages

### DIFF
--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -60,7 +60,8 @@ const generateUniqueBoxId = ( keyBase, boxIds ) => {
 	}
 };
 
-const toFixed = ( n ) => +n.toFixed( 6 );
+/* Irons out floating point arithmetic artifacts */
+const round = ( n ) => _.round( n, 8 );
 
 const reducers = {};
 
@@ -248,7 +249,7 @@ reducers[ MOVE_ITEM ] = ( state, { originPackageId, movedItemIndex, targetPackag
 	newPackages[ originPackageId ] = {
 		...newPackages[ originPackageId ],
 		items: originItems,
-		weight: toFixed( newPackages[ originPackageId ].weight - movedItem.weight ),
+		weight: round( newPackages[ originPackageId ].weight - movedItem.weight ),
 	};
 
 	if ( 'individual' === targetPackageId ) {
@@ -279,7 +280,7 @@ reducers[ MOVE_ITEM ] = ( state, { originPackageId, movedItemIndex, targetPackag
 		newPackages[ targetPackageId ] = {
 			...newPackages[ targetPackageId ],
 			items: targetItems,
-			weight: toFixed( newPackages[ targetPackageId ].weight + movedItem.weight ),
+			weight: round( newPackages[ targetPackageId ].weight + movedItem.weight ),
 		};
 	}
 
@@ -438,7 +439,7 @@ reducers[ SET_PACKAGE_TYPE ] = ( state, { packageId, boxTypeId } ) => {
 		newPackages[ packageId ] = {
 			..._.omit( oldPackage, 'service_id' ),
 			height, length, width,
-			weight: toFixed( box.box_weight + _.sumBy( oldPackage.items, 'weight' ) ),
+			weight: round( box.box_weight + _.sumBy( oldPackage.items, 'weight' ) ),
 			box_id: boxTypeId,
 		};
 	}

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -60,6 +60,8 @@ const generateUniqueBoxId = ( keyBase, boxIds ) => {
 	}
 };
 
+const toFixed = ( n ) => +n.toFixed( 6 );
+
 const reducers = {};
 
 reducers[ OPEN_PRINTING_FLOW ] = ( state ) => {
@@ -246,7 +248,7 @@ reducers[ MOVE_ITEM ] = ( state, { originPackageId, movedItemIndex, targetPackag
 	newPackages[ originPackageId ] = {
 		...newPackages[ originPackageId ],
 		items: originItems,
-		weight: newPackages[ originPackageId ].weight - movedItem.weight,
+		weight: toFixed( newPackages[ originPackageId ].weight - movedItem.weight ),
 	};
 
 	if ( 'individual' === targetPackageId ) {
@@ -277,7 +279,7 @@ reducers[ MOVE_ITEM ] = ( state, { originPackageId, movedItemIndex, targetPackag
 		newPackages[ targetPackageId ] = {
 			...newPackages[ targetPackageId ],
 			items: targetItems,
-			weight: newPackages[ targetPackageId ].weight + movedItem.weight,
+			weight: toFixed( newPackages[ targetPackageId ].weight + movedItem.weight ),
 		};
 	}
 
@@ -436,7 +438,7 @@ reducers[ SET_PACKAGE_TYPE ] = ( state, { packageId, boxTypeId } ) => {
 		newPackages[ packageId ] = {
 			..._.omit( oldPackage, 'service_id' ),
 			height, length, width,
-			weight: box.box_weight + _.sumBy( oldPackage.items, 'weight' ),
+			weight: toFixed( box.box_weight + _.sumBy( oldPackage.items, 'weight' ) ),
 			box_id: boxTypeId,
 		};
 	}

--- a/client/shipping-label/state/test/reducer.js
+++ b/client/shipping-label/state/test/reducer.js
@@ -274,4 +274,42 @@ describe( 'Label purchase form reducer', () => {
 		// All labels in response should be in state, marked as "updated"
 		expect( state.labels ).to.deep.equal( [ { ...label, statusUpdated: true } ] );
 	} );
+
+	it( 'Maintains fixed precision upon adjusting total weight', () => {
+		const existingState = hoek.clone( initialState );
+		existingState.form.packages.all.customPackage1.box_weight = 1.33;
+		existingState.form.packages.selected.weight_0_custom1 = {
+			items: [
+				{
+					product_id: 123,
+					weight: 3,
+				},
+				{
+					product_id: 124,
+					weight: 0.3,
+				},
+			],
+			weight: 3.3,
+		};
+		existingState.form.packages.selected.weight_1_custom1 = {
+			items: [
+				{
+					product_id: 456,
+					weight: 1.44,
+				},
+			],
+			weight: 1.44,
+		};
+
+		const action = moveItem( 'weight_0_custom1', 0, 'weight_1_custom1' );
+		let state = reducer( existingState, action );
+
+		expect( state.form.packages.selected.weight_0_custom1.weight ).to.eql( 0.3 );
+		expect( state.form.packages.selected.weight_1_custom1.weight ).to.eql( 4.44 );
+
+		const packageTypeAction = setPackageType( 'weight_0_custom1', 'customPackage1' );
+		state = reducer( state, packageTypeAction );
+
+		expect( state.form.packages.selected.weight_0_custom1.weight ).to.eql( 1.63 );
+	} );
 } );


### PR DESCRIPTION
Avoids floating point arithmetic artifacts (such as `9.879999999999999`) being stored and displayed in the Total Weight value when moving items around in the shipping label dialog.

Before:
![precision-before](https://user-images.githubusercontent.com/1867547/28432928-e1a78ce6-6d57-11e7-8bba-cef4c8929f5d.gif)

After:
![precision-after](https://user-images.githubusercontent.com/1867547/28432940-e6d4d868-6d57-11e7-9ea0-c025e6cb6624.gif)
