### PR TITLE
Added enabled flag to the account/label payments settings

### DIFF
--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -51,11 +51,13 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 */
 		public function get_account_settings() {
 			$default = array(
-				'selected_payment_method_id' => 0
+				'selected_payment_method_id' => 0,
+				'enabled' => true,
 			);
 
 			$result = WC_Connect_Options::get_option( 'account_settings', $default );
 			$result[ 'paper_size' ] = $this->get_preferred_paper_size();
+			$result = array_merge( $default, $result );
 
 			return $result;
 		}


### PR DESCRIPTION
This PR shouldn't affect any of the plugin's UI.

The `enabled` flag will be used in Calypso to control whether to show the label settings and potentially the label controls on the order page

To test:
* verify that you can open and save the label settings (payment method, paper size)