### PR TITLE
Add support for asynchronous requests

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -302,7 +302,12 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 
 			// Add useful system information to requests that contain bodies
 			if ( in_array( $method, array( 'POST', 'PUT' ) ) ) {
-				$body = $this->request_body( $body );
+				if ( isset( $body[ 'async_token' ] ) ) {
+					// If this is a polling request, only send the "async_token" field
+					$body = array( 'async_token' => $body[ 'async_token' ] );
+				} else {
+					$body = $this->request_body( $body );
+				}
 				$body = wp_json_encode( apply_filters( 'wc_connect_api_client_body', $body ) );
 
 				if ( ! $body ) {

--- a/classes/class-wc-rest-connect-base-controller.php
+++ b/classes/class-wc-rest-connect-base-controller.php
@@ -8,6 +8,14 @@ if ( class_exists( 'WC_REST_Connect_Base_Controller' ) ) {
 	return;
 }
 
+class WC_Connect_Api_Exception extends Exception {
+	public $response;
+	public function __construct( $response ) {
+		$this->response = $response;
+		parent::__construct();
+	}
+}
+
 abstract class WC_REST_Connect_Base_Controller extends WP_REST_Controller {
 
 	/**
@@ -63,14 +71,44 @@ abstract class WC_REST_Connect_Base_Controller extends WP_REST_Controller {
 		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
 			define( 'DONOTCACHEPAGE', true ); // Play nice with WP-Super-Cache
 		}
-		return $this->get( $request );
+		try {
+			return $this->get( $request );
+		} catch ( WCC_Api_Exception $error ) {
+			return $error->response;
+		}
 	}
 
 	public function post_internal( $request ) {
 		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
 			define( 'DONOTCACHEPAGE', true ); // Play nice with WP-Super-Cache
 		}
-		return $this->post( $request );
+		try {
+			return $this->post( $request );
+		} catch ( WC_Connect_Api_Exception $ex ) {
+			return $ex->response;
+		}
+	}
+
+	protected function api_request( $method /*, ...$args */ ) {
+		$args = array_slice( func_get_args(), 1 );
+		$response = call_user_func_array( array( $this->api_client, $method ), $args );
+
+		if ( is_wp_error( $response ) ) {
+			$error = new WP_Error(
+				$response->get_error_code(),
+				$response->get_error_message(),
+				array( 'message' => $response->get_error_message() )
+			);
+			$this->logger->debug( $error, get_class( $this ) );
+			throw new WC_Connect_Api_Exception( $error );
+		}
+
+		if ( isset( $response->async_token ) || isset( $response->async_status ) ) {
+			// Not an error per-se, but we want to interrupt further processing of the response at this point
+			throw new WC_Connect_Api_Exception( $response );
+		}
+
+		return $response;
 	}
 
 	/**

--- a/classes/class-wc-rest-connect-base-controller.php
+++ b/classes/class-wc-rest-connect-base-controller.php
@@ -73,7 +73,7 @@ abstract class WC_REST_Connect_Base_Controller extends WP_REST_Controller {
 		}
 		try {
 			return $this->get( $request );
-		} catch ( WCC_Api_Exception $error ) {
+		} catch ( WC_Connect_Api_Exception $error ) {
 			return $error->response;
 		}
 	}

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -53,17 +53,8 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 			);
 		}
 
-		$response = $this->api_client->send_shipping_label_request( $settings );
-
-		if ( is_wp_error( $response ) ) {
-			$error = new WP_Error(
-				$response->get_error_code(),
-				$response->get_error_message(),
-				array( 'message' => $response->get_error_message() )
-			);
-			$this->logger->debug( $error, __CLASS__ );
-			return $error;
-		}
+		$settings[ 'async' ] = true; // TODO: only make it async if the request comes from the Jetpack proxy?
+		$response = $this->api_request( 'send_shipping_label_request', $settings );
 
 		foreach ( $response->labels as $index => $label_data ) {
 			if ( isset( $label_data->error ) ) {

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -19,11 +19,38 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 		$settings[ 'ship_date' ] = date( 'Y-m-d', time() + 86400 ); // tomorrow
 		$settings[ 'order_id' ] = $order_id;
 
-		$service_names = array();
+		$labels_meta = array();
+		$package_lookup = $this->settings_store->get_package_lookup();
 		foreach ( $settings[ 'packages' ] as $index => $package ) {
-			$service_names[] = $package[ 'service_name' ];
+			$service_name = $package[ 'service_name' ];
 			unset( $package[ 'service_name' ] );
 			$settings[ 'packages' ][ $index ] = $package;
+
+			$product_names = array();
+			foreach ( $package[ 'products' ] as $product_id ) {
+				$product = wc_get_product( $product_id );
+				if ( $product ) {
+					$product_names[] = $product->get_title();
+				} else {
+					$order = wc_get_order( $order_id );
+					$product_names[] = WC_Connect_Compatibility::instance()->get_product_name_from_order( $product_id, $order );
+				}
+			}
+
+			$box_id = $package[ 'box_id' ];
+			if ( 'individual' === $box_id ) {
+				$package_name = __( 'Individual packaging', 'woocommerce-services' );
+			} else if ( isset( $package_lookup[ $box_id ] ) ) {
+				$package_name = $package_lookup[ $box_id ][ 'name' ];
+			} else {
+				$package_name = __( 'Unknown package', 'woocommerce-services' );
+			}
+
+			$labels_meta[] = array(
+				'service_name' => $service_name,
+				'product_names' => $product_names,
+				'package_name' => $package_name,
+			);
 		}
 
 		$response = $this->api_client->send_shipping_label_request( $settings );
@@ -38,9 +65,6 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 			return $error;
 		}
 
-		$label_ids = array();
-		$purchased_labels_meta = array();
-		$package_lookup = $this->settings_store->get_package_lookup();
 		foreach ( $response->labels as $index => $label_data ) {
 			if ( isset( $label_data->error ) ) {
 				$error = new WP_Error(
@@ -51,48 +75,20 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 				$this->logger->debug( $error, __CLASS__ );
 				return $error;
 			}
-			$label_ids[] = $label_data->label->label_id;
 
-			$label_meta = array(
+			$labels_meta[ $index ] = array_merge( $labels_meta[ $index ], array(
 				'label_id' => $label_data->label->label_id,
 				'tracking' => $label_data->label->tracking_id,
 				'refundable_amount' => $label_data->label->refundable_amount,
 				'created' => $label_data->label->created,
 				'carrier_id' => $label_data->label->carrier_id,
-				'service_name' => $service_names[ $index ],
-			);
-
-			$package = $settings[ 'packages' ][ $index ];
-			$box_id = $package[ 'box_id' ];
-			if ( 'individual' === $box_id ) {
-				$label_meta[ 'package_name' ] = __( 'Individual packaging', 'woocommerce-services' );
-			} else if ( isset( $package_lookup[ $box_id ] ) ) {
-				$label_meta[ 'package_name' ] = $package_lookup[ $box_id ][ 'name' ];
-			} else {
-				$label_meta[ 'package_name' ] = __( 'Unknown package', 'woocommerce-services' );
-			}
-
-			$product_names = array();
-			foreach ( $package[ 'products' ] as $product_id ) {
-				$product = wc_get_product( $product_id );
-
-				if ( $product ) {
-					$product_names[] = $product->get_title();
-				} else {
-					$order = wc_get_order( $order_id );
-					$product_names[] = WC_Connect_Compatibility::instance()->get_product_name_from_order( $product_id, $order );
-				}
-			}
-
-			$label_meta[ 'product_names' ] = $product_names;
-
-			array_unshift( $purchased_labels_meta, $label_meta );
+			 ) );
 		}
 
-		$this->settings_store->add_labels_to_order( $order_id, $purchased_labels_meta );
+		$this->settings_store->add_labels_to_order( $order_id, $labels_meta );
 
 		return array(
-			'labels' => $purchased_labels_meta,
+			'labels' => $labels_meta,
 			'success' => true,
 		);
 	}

--- a/client/api/request.js
+++ b/client/api/request.js
@@ -44,7 +44,7 @@ const _request = ( url, data, method ) => {
 					case 'IN_PROGRESS':
 						return poll( performRequest );
 					case 'NOT_FOUND':
-						throw { code: 'async_token_not_found', message: __( 'The request expired' ) }; // TODO: How to phrase this error?
+						throw { code: 'async_token_not_found', message: __( 'The request failed, please try again.' ) };
 				}
 
 				if ( json.success ) {

--- a/client/api/request.js
+++ b/client/api/request.js
@@ -14,6 +14,8 @@ export const setNonce = ( _nonce ) => nonce = _nonce;
 let baseURL;
 export const setBaseURL = ( _baseURL ) => baseURL = _baseURL;
 
+const ASYNC_POLLING_INTERVAL = 3 * 1000;
+
 const _request = ( url, data, method ) => {
 	const request = {
 		method,
@@ -27,22 +29,39 @@ const _request = ( url, data, method ) => {
 		request.body = JSON.stringify( data );
 	}
 
-	return fetch( baseURL + url, request ).then( ( response ) => {
-		return parseJson( response ).then( ( json ) => {
-			if ( json.success ) {
-				return json;
-			}
-
-			if ( 'rest_cookie_invalid_nonce' === json.code ) {
-				window.persistState = true;
-				alert( __( 'There was a problem saving your settings. Please try again after the page is reloaded.' ) );
-				location.reload();
-				return;
-			}
-
-			throw json;
-		} );
+	const poll = ( func ) => new Promise( ( resolve, reject ) => {
+		setTimeout( () => func().then( resolve ).catch( reject ), ASYNC_POLLING_INTERVAL );
 	} );
+
+	return ( function performRequest() {
+		return fetch( baseURL + url, request ).then( ( response ) => {
+			return parseJson( response ).then( ( json ) => {
+				if ( json.async_token ) {
+					request.body = JSON.stringify( { ...( data || {} ), async_token: json.async_token } );
+					return poll( performRequest );
+				}
+				switch ( json.async_status ) {
+					case 'IN_PROGRESS':
+						return poll( performRequest );
+					case 'NOT_FOUND':
+						throw { code: 'async_token_not_found', message: __( 'The request expired' ) }; // TODO: How to phrase this error?
+				}
+
+				if ( json.success ) {
+					return json;
+				}
+
+				if ( 'rest_cookie_invalid_nonce' === json.code ) {
+					window.persistState = true;
+					alert( __( 'There was a problem saving your settings. Please try again after the page is reloaded.' ) );
+					location.reload();
+					return;
+				}
+
+				throw json;
+			} );
+		} );
+	} )();
 };
 
 export const post = ( url, data ) => _request( url, data, 'POST' );

--- a/client/api/url.js
+++ b/client/api/url.js
@@ -3,3 +3,5 @@ const namespace = 'wc/v1/connect/';
 export const accountSettings = () => namespace + 'account/settings';
 
 export const packages = () => namespace + 'packages';
+
+export const purchaseLabel = ( orderId ) => namespace + 'label/' + orderId;

--- a/client/lib/before-unload/index.js
+++ b/client/lib/before-unload/index.js
@@ -1,0 +1,25 @@
+const handlers = [];
+
+const attachMainHandler = () => {
+	window.onbeforeunload = ( event ) => {
+		const messages = handlers.map( ( handler ) => handler() ).filter( Boolean );
+		if ( ! messages.length ) {
+			return;
+		}
+		const text = messages.join( '\n' );
+		( event || window.event ).returnValue = text;
+		return text;
+	};
+};
+
+/**
+ * Adds a handler to be executed before the page will be unloaded (due to the user closing it, navigating away or reloading).
+ * @param {Function} handler Function to be executed. Needs to return a string to be displayed in a confirmation dialog,
+ * or a "false-y" value if the page can be unloaded safely without losing data.
+ */
+export default ( handler ) => {
+	if ( ! window.onbeforeunload ) {
+		attachMainHandler();
+	}
+	handlers.push( handler );
+};

--- a/client/main.js
+++ b/client/main.js
@@ -22,6 +22,7 @@ import AccountSettings from './account-settings';
 import PrintTestLabel from './print-test-label';
 import Packages from './packages';
 import { setNonce, setBaseURL } from 'api/request';
+import addOnBeforeUnloadHandler from 'lib/before-unload';
 
 if ( global.wcConnectData ) {
 	setNonce( global.wcConnectData.nonce );
@@ -75,7 +76,7 @@ Array.from( document.getElementsByClassName( 'wcc-root' ) ).forEach( ( container
 		store.dispatch( Route.getInitialAction() );
 	}
 
-	window.addEventListener( 'beforeunload', ( event ) => {
+	addOnBeforeUnloadHandler( () => {
 		const state = store.getState();
 
 		if ( window.persistState ) {
@@ -86,9 +87,7 @@ Array.from( document.getElementsByClassName( 'wcc-root' ) ).forEach( ( container
 		if ( ! state.form || ( state.form.meta && state.form.meta.pristine ) || _.every( state.form.pristine ) ) {
 			return;
 		}
-		const text = __( 'You have unsaved changes.' );
-		( event || window.event ).returnValue = text;
-		return text;
+		return __( 'You have unsaved changes.' );
 	} );
 
 	let render = () => {

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -17,6 +17,7 @@ import { hasNonEmptyLeaves } from 'lib/utils/tree';
 import normalizeAddress from './normalize-address';
 import getRates from './get-rates';
 import { getPrintURL } from 'lib/pdf-label-utils';
+import * as api from 'api';
 
 export const OPEN_PRINTING_FLOW = 'OPEN_PRINTING_FLOW';
 export const EXIT_PRINTING_FLOW = 'EXIT_PRINTING_FLOW';
@@ -454,68 +455,55 @@ export const updatePaperSize = ( value ) => {
 };
 
 export const purchaseLabel = () => ( dispatch, getState, context ) => {
-	const { purchaseURL, getRatesURL, addressNormalizationURL, nonce } = context;
-	let error = null;
-	let response = null;
+	const { getRatesURL, addressNormalizationURL, nonce } = context;
 
-	const setError = ( err ) => error = err;
-	const setSuccess = ( success, json ) => {
-		if ( success ) {
-			response = json.labels;
+	const onPurchaseSuccess = ( { labels } ) => {
+		dispatch( { type: PURCHASE_LABEL_RESPONSE, response: labels } );
+		const labelsToPrint = labels.map( ( label, index ) => ( {
+			caption: __( 'PACKAGE %(num)d (OF %(total)d)', {
+				args: {
+					num: index + 1,
+					total: labels.length,
+				},
+			} ),
+			labelId: label.label_id,
+		} ) );
+		const state = getState().shippingLabel;
+		const printUrl = getPrintURL( state.paperSize, labelsToPrint, context );
+		if ( 'addon' === getPDFSupport() ) {
+			// If the browser has a PDF "addon", we need another user click to trigger opening it in a new tab
+			dispatch( { type: SHOW_PRINT_CONFIRMATION, printUrl } );
+		} else {
+			printDocument( printUrl )
+				.then( () => {
+					const noticeText = __(
+						'Your shipping label was purchased successfully',
+						'Your %(count)d shipping labels were purchased successfully',
+						{
+							count: labels.length,
+							args: { count: labels.length },
+						}
+					);
+					dispatch( NoticeActions.successNotice( noticeText ) );
+				} )
+				.catch( ( err ) => {
+					console.error( err );
+					dispatch( NoticeActions.errorNotice( err.toString() ) );
+				} )
+				.then( () => {
+					dispatch( exitPrintingFlow( true ) );
+					dispatch( clearAvailableRates() );
+				} );
 		}
 	};
-	const setIsSaving = ( saving ) => {
-		if ( saving ) {
-			dispatch( { type: PURCHASE_LABEL_REQUEST } );
-		} else {
-			dispatch( { type: PURCHASE_LABEL_RESPONSE, response, error } );
-			if ( 'rest_cookie_invalid_nonce' === error ) {
-				dispatch( exitPrintingFlow( true ) );
-			} else if ( error ) {
-				console.error( error );
-				dispatch( NoticeActions.errorNotice( error.toString() ) );
-				//re-request the rates on failure to avoid attempting repurchase of the same shipment id
-				dispatch( clearAvailableRates() );
-				getLabelRates( dispatch, getState, _.noop, { getRatesURL, nonce } );
-			} else {
-				const labelsToPrint = response.map( ( label, index ) => ( {
-					caption: __( 'PACKAGE %(num)d (OF %(total)d)', {
-						args: {
-							num: index + 1,
-							total: response.length,
-						},
-					} ),
-					labelId: label.label_id,
-				} ) );
-				const state = getState().shippingLabel;
-				const printUrl = getPrintURL( state.paperSize, labelsToPrint, context );
-				if ( 'addon' === getPDFSupport() ) {
-					// If the browser has a PDF "addon", we need another user click to trigger opening it in a new tab
-					dispatch( { type: SHOW_PRINT_CONFIRMATION, printUrl } );
-				} else {
-					printDocument( printUrl )
-						.then( () => {
-							const noticeText = __(
-								'Your shipping label was purchased successfully',
-								'Your %(count)d shipping labels were purchased successfully',
-								{
-									count: response.length,
-									args: { count: response.length },
-								}
-							);
-							dispatch( NoticeActions.successNotice( noticeText ) );
-						} )
-						.catch( ( err ) => {
-							console.error( err );
-							dispatch( NoticeActions.errorNotice( err.toString() ) );
-						} )
-						.then( () => {
-							dispatch( exitPrintingFlow( true ) );
-							dispatch( clearAvailableRates() );
-						} );
-				}
-			}
-		}
+
+	const onPurchaseFailure = ( err ) => {
+		console.error( err );
+		dispatch( { type: PURCHASE_LABEL_RESPONSE, error: err } );
+		dispatch( NoticeActions.errorNotice( err.toString() ) );
+		//re-request the rates on failure to avoid attempting repurchase of the same shipment id
+		dispatch( clearAvailableRates() );
+		getLabelRates( dispatch, getState, _.noop, { getRatesURL, nonce } );
 	};
 
 	let form = getState().shippingLabel.form;
@@ -552,7 +540,10 @@ export const purchaseLabel = () => ( dispatch, getState, context ) => {
 			} ),
 		};
 
-		saveForm( setIsSaving, setSuccess, _.noop, setError, purchaseURL, nonce, 'POST', formData );
+		dispatch( { type: PURCHASE_LABEL_REQUEST } );
+		api.post( api.url.purchaseLabel( form.orderId ), formData )
+			.then( onPurchaseSuccess )
+			.catch( onPurchaseFailure );
 	} ).catch( ( err ) => {
 		console.error( err );
 		dispatch( NoticeActions.errorNotice( err.toString() ) );


### PR DESCRIPTION
To test this, you'll need to checkout the `add/async-requests` branch in the server.

In this PR:
* Refactored the `Purchase Label` PHP endpoint to make the transition a bit clearer.
* Refactored the `Purchase Label` JS Redux action so it uses the new `api` module instead of the hacky `saveForm`.
* Add support in PHP to interpret when a REST response is `async`, implementing the whole flow described in the server-side PR.
* Add polling behaviour to the `api` module so the result is transparent to the rest of the JS code.

To test, just buy a label with the Chrome `Network` tab open. The HTTP requests & responses that happen during the `Purchase` action will speak from themselves (check out how the `async` flow works in the server-side PR first, to understand it more easily). The UI should behave exactly as before.