### PR TITLE
Not loading admin dependencies before TOS has been accepted

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -426,8 +426,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->set_shipping_label( $shipping_label );
 			$this->set_nux( $nux );
 			$this->set_taxjar( $taxjar );
-
-			add_action( 'admin_init', array( $this, 'load_admin_dependencies' ) );
 		}
 
 		/**


### PR DESCRIPTION
Fixes #1101 

The removed line is a duplicate of a line that is hit after TOS has been accepted. I checked and `load_admin_dependencies()` didn't contain anything that would be necessary before the TOS.

To test:
* ensure the `tos_accepted` option is set to false in the database by editing `wc_connect_options` in `wp_options`
* the NUX notice should show
* verify that the WC Services menu entries are not visible on the shipping settings and status pages