### PR TITLE
PDF printing - Fixed a conflict with plugins that try to pass arrays to kses

### DIFF
--- a/classes/class-wc-rest-connect-shipping-label-print-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-print-controller.php
@@ -18,9 +18,9 @@ class WC_REST_Connect_Shipping_Label_Print_Controller extends WC_REST_Connect_Ba
 		$params[ 'paper_size' ] = $raw_params[ 'paper_size' ];
 		$this->settings_store->set_preferred_paper_size( $params[ 'paper_size' ] );
 
-		$label_ids = isset( $raw_params[ 'label_id_csv' ] ) && $raw_params[ 'label_id_csv' ] ? explode( ',', $raw_params[ 'label_id_csv' ] ) : array();
+		$label_ids = ! empty( $raw_params[ 'label_id_csv' ] ) ? explode( ',', $raw_params[ 'label_id_csv' ] ) : array();
 		$n_label_ids = count( $label_ids );
-		$captions = isset( $raw_params[ 'caption_csv' ] ) && $raw_params[ 'caption_csv' ] ? explode( ',', $raw_params[ 'caption_csv' ] ) : array();
+		$captions = ! empty( $raw_params[ 'caption_csv' ] ) ? explode( ',', $raw_params[ 'caption_csv' ] ) : array();
 		$n_captions = count( $captions );
 		// Either there are the same number of captions as labels, or no captions at all
 		if ( ! $n_label_ids || ( $n_captions && $n_captions !== $n_label_ids ) ) {

--- a/classes/class-wc-rest-connect-shipping-label-print-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-print-controller.php
@@ -18,8 +18,10 @@ class WC_REST_Connect_Shipping_Label_Print_Controller extends WC_REST_Connect_Ba
 		$params[ 'paper_size' ] = $raw_params[ 'paper_size' ];
 		$this->settings_store->set_preferred_paper_size( $params[ 'paper_size' ] );
 
-		$n_label_ids = isset( $raw_params[ 'label_ids' ] ) ? count( $raw_params[ 'label_ids' ] ) : 0;
-		$n_captions = isset( $raw_params[ 'captions' ] ) ? count( $raw_params[ 'captions' ] ) : 0;
+		$label_ids = isset( $raw_params[ 'label_id_csv' ] ) && $raw_params[ 'label_id_csv' ] ? explode( ',', $raw_params[ 'label_id_csv' ] ) : array();
+		$n_label_ids = count( $label_ids );
+		$captions = isset( $raw_params[ 'caption_csv' ] ) && $raw_params[ 'caption_csv' ] ? explode( ',', $raw_params[ 'caption_csv' ] ) : array();
+		$n_captions = count( $captions );
 		// Either there are the same number of captions as labels, or no captions at all
 		if ( ! $n_label_ids || ( $n_captions && $n_captions !== $n_label_ids ) ) {
 			$message = __( 'Invalid PDF request.', 'woocommerce-services' );
@@ -37,10 +39,10 @@ class WC_REST_Connect_Shipping_Label_Print_Controller extends WC_REST_Connect_Ba
 		$params[ 'labels' ] = array();
 		for ( $i = 0; $i < $n_label_ids; $i++ ) {
 			$params[ 'labels' ][ $i ] = array();
-			$params[ 'labels' ][ $i ][ 'label_id' ] = (int) $raw_params[ 'label_ids' ][ $i ];
+			$params[ 'labels' ][ $i ][ 'label_id' ] = (int) $label_ids[ $i ];
 
 			if ( $n_captions ) {
-				$params[ 'labels' ][ $i ][ 'caption' ] = $raw_params[ 'captions' ][ $i ];
+				$params[ 'labels' ][ $i ][ 'caption' ] = urldecode( $captions[ $i ] );
 			}
 		}
 

--- a/client/lib/pdf-label-utils/index.js
+++ b/client/lib/pdf-label-utils/index.js
@@ -42,8 +42,8 @@ const _getPDFURL = ( paperSize, labels, baseURL, nonce ) => {
 	const params = {
 		_wpnonce: nonce,
 		paper_size: paperSize,
-		'label_ids[]': _.filter( _.map( labels, 'labelId' ) ),
-		'captions[]': _.filter( _.map( labels, 'caption' ) ),
+		label_id_csv: _.filter( _.map( labels, 'labelId' ) ).join( ',' ),
+		caption_csv: _.filter( _.map( labels, ( l ) => ( l.caption ? encodeURIComponent( l.caption ) : null ) ) ).join( ',' ),
 	};
 	return baseURL + '?' + querystring.stringify( params );
 };

--- a/client/lib/pdf-label-utils/index.js
+++ b/client/lib/pdf-label-utils/index.js
@@ -42,6 +42,7 @@ const _getPDFURL = ( paperSize, labels, baseURL, nonce ) => {
 	const params = {
 		_wpnonce: nonce,
 		paper_size: paperSize,
+		//send params as a CSV to avoid conflicts with some plugins out there (#1111)
 		label_id_csv: _.filter( _.map( labels, 'labelId' ) ).join( ',' ),
 		caption_csv: _.filter( _.map( labels, ( l ) => ( l.caption ? encodeURIComponent( l.caption ) : null ) ) ).join( ',' ),
 	};


### PR DESCRIPTION
Fixes #1111 

This was caused by the label IDs and their captions being passed as arrays in GET string. Some plugins try to call `kses` on all query params. With Jetpack, this could produce a warning if one of the params has been already converted to an array.

To test:
* check that a single label can be printed
* check that multiple labels can be printed
* optional
  * Activate the `shortcode embeds` module at `/wp-admin/admin.php?page=jetpack_modules`
  * Install an offending plugin (see slack channel for details p1501775680572853-slack-hydra )
  * verify that everything still prints

@melindahelt @v18 