### PR TITLE
Cast refundable_amount to address "toFixed is not a function" bug

### DIFF
--- a/client/apps/shipping-label/components/label-purchase-modal/rates-step/list.js
+++ b/client/apps/shipping-label/components/label-purchase-modal/rates-step/list.js
@@ -54,7 +54,7 @@ const ShippingRates = ( {
 		const formError = errors.form && errors.form[ pckgId ];
 
 		packageRates.forEach( ( rateObject ) => {
-			valuesMap[ rateObject.service_id ] = rateObject.title + ' (' + currencySymbol + rateObject.rate.toFixed( 2 ) + ')';
+			valuesMap[ rateObject.service_id ] = rateObject.title + ' (' + currencySymbol + Number( rateObject.rate ).toFixed( 2 ) + ')';
 		} );
 
 		const onRateUpdate = ( value ) => updateRate( pckgId, value );

--- a/client/apps/shipping-label/components/label-refund-modal/index.js
+++ b/client/apps/shipping-label/components/label-refund-modal/index.js
@@ -14,7 +14,7 @@ import FormSectionHeading from 'components/forms/form-section-heading';
 
 const RefundDialog = ( { refundDialog, labelActions, storeOptions, created, refundable_amount, label_id } ) => {
 	const getRefundableAmount = () => {
-		return storeOptions.currency_symbol + refundable_amount.toFixed( 2 );
+		return storeOptions.currency_symbol + Number( refundable_amount ).toFixed( 2 );
 	};
 
 	return (

--- a/client/apps/shipping-label/state/selectors/rates.js
+++ b/client/apps/shipping-label/state/selectors/rates.js
@@ -19,6 +19,6 @@ export const getRatesTotal = createSelector(
 			return 0;
 		} );
 
-		return _.sum( ratesCost ).toFixed( 2 );
+		return Number( _.sum( ratesCost ) ).toFixed( 2 );
 	}
 );


### PR DESCRIPTION
Likely patches https://github.com/Automattic/woocommerce-services/issues/1078 superficially, though there may well be a more substantial fix available upon understanding why `refundable_amount` might be something other than a `Number` since it is likely indicative of a broader failure case.

Don't know how to reproduce the issue at this point. I identified the suspect primarily because it's the only piece of code in the repository fitting the reported pattern (i.e. `variable.toFixed(2)`). Can either ship this patch or modify the PR with a different solution based on feedback.