### PR TITLE
Allow auto-authorizing Jetpack connections

### DIFF
--- a/classes/class-wc-connect-jetpack.php
+++ b/classes/class-wc-connect-jetpack.php
@@ -75,7 +75,7 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 			return Jetpack::init()->build_connect_url(
 				true,
 				$redirect_url,
-				'woocommerce-services'
+				'woocommerce-services-auto-authorize'
 			);
 		}
 	}


### PR DESCRIPTION
This PR allows us to auto-authenticate users going through the Jetpack connection flow with these two changes:

1. New 'from' GET parameter value so that Calypso can decide when a user can be auto-authorized when connecting to Jetpack.
2. The Jetpack connection banner to show a new URL describing the data that Jetpack collects when it's connected.

Here's a video showing what it looks like:

https://cloudup.com/cpZ-fOFL7yV

Background info: p7bbVw-1Rl-p2

# Testing Instructions
1. Install Jetpack on your site, and deactivate it
2. In the file `class.jetpack.php`, find the function `build_connect_url` and add this line to it right above `return $raw ? $url : esc_url( $url );`:  `$url = add_query_arg( 'calypso_env', 'development', $url );`
3. Check out the branch `update/wcs-jp-flow` in Calypso - https://github.com/Automattic/wp-calypso/pull/16937
4. Go to the plugins page on your site, and click the WooCommerce Services connect button to see the new flow

cc @jeffstieler @jennyzhu 