### PR TITLE
Checking the Jetpack master user in account settings REST endpoint

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -437,7 +437,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				'last_heartbeat' => WC_Connect_Options::get_option( 'last_heartbeat', 0 ),
 				'last_rate_request' => WC_Connect_Options::get_option( 'last_rate_request', 0 ),
 				'active_services' => $this->wc_connect_loader->get_active_services(),
-				'disable_stats' => Jetpack::is_staging_site(),
+				'disable_stats' => WC_Connect_Jetpack::is_staging_site(),
 			) );
 
 			return $body;

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -90,11 +90,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			// Check that Jetpack is active
 			// Check that Jetpack is connected
 			include_once ( ABSPATH . 'wp-admin/includes/plugin.php' ); // required for is_plugin_active
-			if ( method_exists( 'Jetpack', 'is_development_mode' ) && method_exists( 'Jetpack', 'is_active' ) ) {
-				$is_connected = Jetpack::is_development_mode() ? true : Jetpack::is_active();
-			} else {
-				$is_connected = false;
-			}
+			$is_connected = WC_Connect_Jetpack::is_active() || WC_Connect_Jetpack::is_development_mode();
 			if ( ! is_plugin_active( 'jetpack/jetpack.php' ) ) {
 				$health_item = $this->build_indicator(
 					'jetpack_indicator',
@@ -126,7 +122,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 					__( 'Jetpack is not connected to WordPress.com. Make sure the Jetpack plugin is installed, activated, and connected.', 'woocommerce-services' ),
 					''
 				);
-			} else if ( Jetpack::is_staging_site() ) {
+			} else if ( WC_Connect_Jetpack::is_staging_site() ) {
 				$health_item = $this->build_indicator(
 					'jetpack_indicator',
 					'notice',

--- a/classes/class-wc-connect-jetpack.php
+++ b/classes/class-wc-connect-jetpack.php
@@ -1,0 +1,68 @@
+<?php
+
+if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
+	class WC_Connect_Jetpack {
+		/**
+		 * Helper method to get if Jetpack is in development mode
+		 * @return bool
+		 */
+		public static function is_development_mode() {
+			if ( method_exists( 'Jetpack', 'is_development_mode' ) ) {
+				return Jetpack::is_development_mode();
+			}
+
+			return false;
+		}
+
+		/**
+		 * Helper method to get if Jetpack is connected (aka active)
+		 * @return bool
+		 */
+		public static function is_active() {
+			if ( method_exists( 'Jetpack', 'is_active' ) ) {
+				return Jetpack::is_active();
+			}
+
+			return false;
+		}
+
+		/**
+		 * Helper method to get if the current Jetpack website is marked as staging
+		 * @return bool
+		 */
+		public static function is_staging_site() {
+			if ( method_exists( 'Jetpack', 'is_staging_site' ) ) {
+				return Jetpack::is_staging_site();
+			}
+
+			return false;
+		}
+
+		/**
+		 * Helper method to get the Jetpack master user, IF we are connected
+		 * @return WP_User | false
+		 */
+		public static function get_master_user() {
+			include_once ( ABSPATH . 'wp-admin/includes/plugin.php' );
+			if ( self::is_active() && method_exists( 'Jetpack_Options', 'get_option' ) ) {
+				$master_user_id = Jetpack_Options::get_option( 'master_user' );
+				return get_userdata( $master_user_id );
+			}
+
+			return false;
+		}
+
+		/**
+		 * Builds a connect url
+		 * @param $redirect_url
+		 * @return string
+		 */
+		public static function build_connect_url( $redirect_url ) {
+			return Jetpack::init()->build_connect_url(
+				true,
+				$redirect_url,
+				'woocommerce-services'
+			);
+		}
+	}
+}

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -588,11 +588,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				$redirect_url = esc_url_raw( wp_unslash( $_POST['redirect_url'] ) );
 			}
 
-			$connect_url = Jetpack::init()->build_connect_url(
-				true,
-				$redirect_url,
-				'woocommerce-services'
-			);
+			$connect_url = WC_Connect_Jetpack::build_connect_url( $redirect_url );
 
 			// Make sure we always display the after-connection banner
 			// after the before_connection button is clicked

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -54,44 +54,6 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 		}
 
 		/**
-		 * Helper method to get if Jetpack is in development mode
-		 * @return bool
-		 */
-		protected function is_jetpack_dev_mode() {
-			if ( method_exists( 'Jetpack', 'is_development_mode' ) ) {
-				return Jetpack::is_development_mode();
-			}
-
-			return false;
-		}
-
-		/**
-		 * Helper method to get if Jetpack is connected (aka active)
-		 * @return bool
-		 */
-		protected function is_jetpack_connected() {
-			if ( method_exists( 'Jetpack', 'is_active' ) ) {
-				return Jetpack::is_active();
-			}
-
-			return false;
-		}
-
-		/**
-		 * Helper method to get the Jetpack master user, IF we are connected
-		 * @return WP_User | false
-		 */
-		protected function get_master_user() {
-			include_once ( ABSPATH . 'wp-admin/includes/plugin.php' );
-			if ( $this->is_jetpack_connected() && method_exists( 'Jetpack_Options', 'get_option' ) ) {
-				$master_user_id = Jetpack_Options::get_option( 'master_user' );
-				return get_userdata( $master_user_id );
-			}
-
-			return false;
-		}
-
-		/**
 		 * Output the settings.
 		 */
 		public function output_settings_screen() {
@@ -103,8 +65,8 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 					$this->output_packages_screen();
 					break;
 				case 'label-settings':
-					$master_user = $this->get_master_user();
-					if ( $this->is_jetpack_dev_mode() || ( is_a( $master_user, 'WP_User' ) && $current_user->ID == $master_user->ID ) ) {
+					$master_user = WC_Connect_Jetpack::get_master_user();
+					if ( WC_Connect_Jetpack::is_development_mode() || ( is_a( $master_user, 'WP_User' ) && $current_user->ID == $master_user->ID ) ) {
 						$this->output_account_screen();
 					} else {
 						$this->output_no_priv_account_screen();
@@ -121,8 +83,8 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 			global $hide_save_button;
 			$hide_save_button = true;
 
-			if ( $this->is_jetpack_dev_mode() ) {
-				if ( $this->is_jetpack_connected() ) {
+			if ( WC_Connect_Jetpack::is_development_mode() ) {
+				if ( WC_Connect_Jetpack::is_active() ) {
 					$message = __( 'Note: Jetpack is connected, but development mode is also enabled on this site. Please disable development mode.', 'woocommerce-services' );
 				} else {
 					$message = __( 'Note: Jetpack development mode is enabled on this site. This site will not be able to obtain payment methods from WooCommerce Services production servers.', 'woocommerce-services' );
@@ -155,7 +117,7 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 
 			wp_enqueue_style( 'wc_connect_admin' );
 
-			$master_user = $this->get_master_user();
+			$master_user = WC_Connect_Jetpack::get_master_user();
 			if ( is_a( $master_user, 'WP_User' ) ) {
 				$message = sprintf(
 					__( 'Only the primary Jetpack user can manage shipping label payment methods. Please login as %1$s (%2$s) to manage payment methods.', 'woocommerce-services' ),

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -66,7 +66,7 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 					break;
 				case 'label-settings':
 					$master_user = WC_Connect_Jetpack::get_master_user();
-					if ( WC_Connect_Jetpack::is_development_mode() || ( is_a( $master_user, 'WP_User' ) && $current_user->ID == $master_user->ID ) ) {
+					if ( WC_Connect_Jetpack::is_development_mode() || ( is_a( $master_user, 'WP_User' ) && $current_user->ID === $master_user->ID ) ) {
 						$this->output_account_screen();
 					} else {
 						$this->output_no_priv_account_screen();

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -71,6 +71,6 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 		global $current_user;
 		$master_user = WC_Connect_Jetpack::get_master_user();
 		return WC_Connect_Jetpack::is_development_mode() ||
-			( is_a( $master_user, 'WP_User' ) && $current_user->ID == $master_user->ID );
+			( is_a( $master_user, 'WP_User' ) && $current_user->ID === $master_user->ID );
 	}
 }

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -30,6 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once( plugin_basename( 'classes/class-wc-connect-options.php' ) );
+require_once( plugin_basename( 'classes/class-wc-connect-jetpack.php' ) );
 
 if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 


### PR DESCRIPTION
This is part of the work on automattic/wp-calypso#16958

I made the following changes in this PR:
* moved all Jetpack utils to a single static class `WC_Connect_Jetpack`
* in `class-wc-rest-connect-account-settings-controller.php` I perform the same checks as when the account settings page is rendered to verify if the current user is a master user and if they can manage payments

To test:
* everything should work as before, especially on the accounts page
* in dev mode, Jetpack will not return a master user
* I tested the API changes by uploading the updated version of the plugin to my AT site. I got the following in the response when logged in as non-master: `"can_manage_payments":false,"master_user_name":"botmarcin","master_user_login":"botmarcin"`, which is as expected