### PR TITLE
Label Modal - using the api module instead of saveForm

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -473,15 +473,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		public function meta_box( $post ) {
 			$order = wc_get_order( $post );
 
-			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
-
 			$payload = $this->get_label_payload( $order );
 			if ( ! $payload ) {
 				return;
 			}
-
-			//pass order ID as the only constant in the context, everything else can be fetched dynamically
-			$payload[ 'orderId' ] = $order_id;
 
 			do_action( 'enqueue_wc_connect_script', 'wc-connect-create-shipping-label', $payload );
 		}

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -452,12 +452,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
 			$payload = array(
-				'purchaseURL'             => get_rest_url( null, '/wc/v1/connect/label/' . $order_id ),
-				'addressNormalizationURL' => get_rest_url( null, '/wc/v1/connect/normalize-address' ),
-				'getRatesURL'             => get_rest_url( null, '/wc/v1/connect/label/' . $order_id . '/rates' ),
-				'labelStatusURL'          => get_rest_url( null, '/wc/v1/connect/label/' . $order_id . '/%d' ),
-				'labelRefundURL'          => get_rest_url( null, '/wc/v1/connect/label/' . $order_id . '/%d/refund' ),
-				'labelsPrintURL'          => get_rest_url( null, '/wc/v1/connect/label/print' ),
 				'orderId'                 => $order_id,
 				'paperSize'               => $this->settings_store->get_preferred_paper_size(),
 				'formData'                => $this->get_form_data( $order ),
@@ -478,15 +472,11 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
 
-			do_action( 'enqueue_wc_connect_script', 'wc-connect-create-shipping-label', array(
-				'purchaseURL'             => get_rest_url( null, '/wc/v1/connect/label/' . $order_id ),
-				'addressNormalizationURL' => get_rest_url( null, '/wc/v1/connect/normalize-address' ),
-				'getRatesURL'             => get_rest_url( null, '/wc/v1/connect/label/' . $order_id . '/rates' ),
-				'labelStatusURL'          => get_rest_url( null, '/wc/v1/connect/label/' . $order_id . '/%d' ),
-				'labelRefundURL'          => get_rest_url( null, '/wc/v1/connect/label/' . $order_id . '/%d/refund' ),
-				'labelsPrintURL'          => get_rest_url( null, '/wc/v1/connect/label/print' ),
-				'orderId'                 => $order_id,
-			) );
+			$payload = $this->get_label_payload( $order );
+			//pass order ID as the only constant in the context, everything else can be fetched dynamically
+			$payload[ 'orderId' ] = $order_id;
+
+			do_action( 'enqueue_wc_connect_script', 'wc-connect-create-shipping-label', $payload );
 		}
 
 	}

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -447,8 +447,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return null;
 		}
 
-		public function get_label_payload( $post ) {
-			$order = wc_get_order( $post );
+		public function get_label_payload( $post_order_or_id ) {
+			$order = wc_get_order( $post_order_or_id );
 
 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
 			$payload = array(

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -449,6 +449,9 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 		public function get_label_payload( $post_order_or_id ) {
 			$order = wc_get_order( $post_order_or_id );
+			if ( ! $order ) {
+				return false;
+			}
 
 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
 			$payload = array(
@@ -473,6 +476,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
 
 			$payload = $this->get_label_payload( $order );
+			if ( ! $payload ) {
+				return;
+			}
+
 			//pass order ID as the only constant in the context, everything else can be fetched dynamically
 			$payload[ 'orderId' ] = $order_id;
 

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -447,7 +447,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return null;
 		}
 
-		public function meta_box( $post ) {
+		public function get_label_payload( $post ) {
 			$order = wc_get_order( $post );
 
 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
@@ -458,8 +458,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				'labelStatusURL'          => get_rest_url( null, '/wc/v1/connect/label/' . $order_id . '/%d' ),
 				'labelRefundURL'          => get_rest_url( null, '/wc/v1/connect/label/' . $order_id . '/%d/refund' ),
 				'labelsPrintURL'          => get_rest_url( null, '/wc/v1/connect/label/print' ),
+				'orderId'                 => $order_id,
 				'paperSize'               => $this->settings_store->get_preferred_paper_size(),
-				'nonce'                   => wp_create_nonce( 'wp_rest' ),
 				'formData'                => $this->get_form_data( $order ),
 				'paymentMethod'           => $this->get_selected_payment_method(),
 				'numPaymentMethods'       => count( $this->payment_methods_store->get_payment_methods() ),
@@ -470,7 +470,23 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			$store_options['countriesData'] = $this->get_states_map();
 			$payload['storeOptions'] = $store_options;
 
-			do_action( 'enqueue_wc_connect_script', 'wc-connect-create-shipping-label', $payload );
+			return $payload;
+		}
+
+		public function meta_box( $post ) {
+			$order = wc_get_order( $post );
+
+			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
+
+			do_action( 'enqueue_wc_connect_script', 'wc-connect-create-shipping-label', array(
+				'purchaseURL'             => get_rest_url( null, '/wc/v1/connect/label/' . $order_id ),
+				'addressNormalizationURL' => get_rest_url( null, '/wc/v1/connect/normalize-address' ),
+				'getRatesURL'             => get_rest_url( null, '/wc/v1/connect/label/' . $order_id . '/rates' ),
+				'labelStatusURL'          => get_rest_url( null, '/wc/v1/connect/label/' . $order_id . '/%d' ),
+				'labelRefundURL'          => get_rest_url( null, '/wc/v1/connect/label/' . $order_id . '/%d/refund' ),
+				'labelsPrintURL'          => get_rest_url( null, '/wc/v1/connect/label/print' ),
+				'orderId'                 => $order_id,
+			) );
 		}
 
 	}

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -43,7 +43,7 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 
 	public function post( $request ) {
 		if ( ! $this->can_user_manage_payment_methods() ) {
-			return new WP_Error( 403 );
+			return new WP_Error( 'forbidden', __( 'You are not allowed to do that' ), array( 'status' => 403 ) );
 		}
 
 		$settings = $request->get_json_params();

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -43,7 +43,7 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 
 	public function post( $request ) {
 		if ( ! $this->can_user_manage_payment_methods() ) {
-			return new WP_Error( 'forbidden', __( 'You are not allowed to do that' ), array( 'status' => 403 ) );
+			return new WP_Error( 'forbidden', __( 'You are not allowed to do that', 'woocommerce-services' ), array( 'status' => 403 ) );
 		}
 
 		$settings = $request->get_json_params();

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -11,6 +11,23 @@ if ( class_exists( 'WC_REST_Connect_Shipping_Label_Controller' ) ) {
 class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Controller {
 	protected $rest_base = 'connect/label/(?P<order_id>\d+)';
 
+	/*
+	 * @var WC_Connect_Shipping_Label
+	 */
+	protected $shipping_label;
+
+	public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Service_Settings_Store $settings_store, WC_Connect_Logger $logger, WC_Connect_Shipping_Label $shipping_label ) {
+		parent::__construct( $api_client, $settings_store, $logger );
+		$this->shipping_label = $shipping_label;
+	}
+
+	public function get( $request ) {
+		$order_id = $request[ 'order_id' ];
+		$payload = $this->shipping_label->get_label_payload( $order_id );
+		$payload[ 'success' ] = true;
+		return new WP_REST_Response( $payload, 200 );
+	}
+
 	public function post( $request ) {
 		$settings = $request->get_json_params();
 		$order_id = $request[ 'order_id' ];

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -25,7 +25,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 		$order_id = $request[ 'order_id' ];
 		$payload = $this->shipping_label->get_label_payload( $order_id );
 		if ( ! $payload ) {
-			return new WP_Error( 404 );
+			return new WP_Error( 'not_found', __( 'Order not found', 'woocommerce-services' ), array( 'status' => 404 ) );
 		}
 		$payload[ 'success' ] = true;
 		return new WP_REST_Response( $payload, 200 );

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -24,6 +24,9 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 	public function get( $request ) {
 		$order_id = $request[ 'order_id' ];
 		$payload = $this->shipping_label->get_label_payload( $order_id );
+		if ( ! $payload ) {
+			return new WP_Error( 404 );
+		}
 		$payload[ 'success' ] = true;
 		return new WP_REST_Response( $payload, 200 );
 	}

--- a/classes/class-wc-rest-connect-tos-controller.php
+++ b/classes/class-wc-rest-connect-tos-controller.php
@@ -23,7 +23,7 @@ class WC_REST_Connect_Tos_Controller extends WC_REST_Connect_Base_Controller {
 		$settings = $request->get_json_params();
 
 		if ( ! $settings || ! isset( $settings[ 'accepted' ] ) || ! $settings[ 'accepted' ] ) {
-			return new WP_Error( 400 );
+			return new WP_Error( 'bad_request', __( 'Bad request' ), array( 'status' => 400 ) );
 		}
 
 		WC_Connect_Options::update_option( 'tos_accepted', true );

--- a/classes/class-wc-rest-connect-tos-controller.php
+++ b/classes/class-wc-rest-connect-tos-controller.php
@@ -23,7 +23,7 @@ class WC_REST_Connect_Tos_Controller extends WC_REST_Connect_Base_Controller {
 		$settings = $request->get_json_params();
 
 		if ( ! $settings || ! isset( $settings[ 'accepted' ] ) || ! $settings[ 'accepted' ] ) {
-			return new WP_Error( 'bad_request', __( 'Bad request' ), array( 'status' => 400 ) );
+			return new WP_Error( 'bad_request', __( 'Bad request', 'woocommerce-services' ), array( 'status' => 400 ) );
 		}
 
 		WC_Connect_Options::update_option( 'tos_accepted', true );

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -16,3 +16,5 @@ const handleError = ( jsonError ) => {
 export const post = ( url, data ) => request.post( url, data ).catch( handleError );
 
 export const get = ( url ) => request.get( url ).catch( handleError );
+
+export const createGetUrlWithNonce = ( url, queryString ) => request.createGetUrlWithNonce( url, queryString );

--- a/client/api/request.js
+++ b/client/api/request.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { translate as __ } from 'i18n-calypso';
+import { startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -48,3 +49,17 @@ const _request = ( url, data, method ) => {
 export const post = ( url, data ) => _request( url, data, 'POST' );
 
 export const get = ( url ) => _request( url, null, 'GET' );
+
+export const createGetUrlWithNonce = ( url, queryString ) => {
+	if ( queryString ) {
+		if ( startsWith( queryString, '?' ) ) {
+			queryString = queryString.substring( 1 );
+		}
+
+		if ( ! startsWith( queryString, '&' ) ) {
+			queryString = '&' + queryString;
+		}
+	}
+
+	return `${ baseURL }${ url }?_wpnonce=${ nonce }${ queryString }`;
+};

--- a/client/api/url.js
+++ b/client/api/url.js
@@ -3,3 +3,15 @@ const namespace = 'wc/v1/connect/';
 export const accountSettings = () => namespace + 'account/settings';
 
 export const packages = () => namespace + 'packages';
+
+export const orderLabels = ( orderId ) => `${ namespace }label/${ orderId }`;
+
+export const getLabelRates = ( orderId ) => `${ namespace }label/${ orderId }/rates`;
+
+export const labelStatus = ( orderId, labelId ) => `${ namespace }label/${ orderId }/${ labelId }`;
+
+export const labelRefund = ( orderId, labelId ) => `${ namespace }label/${ orderId }/${ labelId }/refund`;
+
+export const labelsPrint = () => `${ namespace }label/print`;
+
+export const addressNormalization = () => `${ namespace }normalize-address`;

--- a/client/apps/print-test-label/state/actions.js
+++ b/client/apps/print-test-label/state/actions.js
@@ -17,7 +17,7 @@ export const updatePaperSize = ( paperSize ) => {
 	return { type: UPDATE_PAPER_SIZE, paperSize };
 };
 
-export const print = () => ( dispatch, getState, { labelsPreviewURL, nonce } ) => {
+export const print = () => ( dispatch, getState ) => {
 	dispatch( { type: PRINTING_IN_PROGRESS, inProgress: true } );
 	const { paperSize } = getState();
 
@@ -28,7 +28,7 @@ export const print = () => ( dispatch, getState, { labelsPreviewURL, nonce } ) =
 		labelData.push( { caption: __( 'TEST LABEL 2' ) } );
 	}
 
-	printDocument( getPreviewURL( paperSize, labelData, { labelsPreviewURL, nonce } ) )
+	printDocument( getPreviewURL( paperSize, labelData ) )
 		.then( () => {
 			dispatch( { type: PRINTING_IN_PROGRESS, inProgress: false } );
 		} )

--- a/client/apps/shipping-label/components/label-refund-modal/index.js
+++ b/client/apps/shipping-label/components/label-refund-modal/index.js
@@ -19,7 +19,7 @@ const RefundDialog = ( { refundDialog, labelActions, storeOptions, created, refu
 
 	return (
 		<Modal
-			isVisible={ refundDialog && refundDialog.labelId === label_id }
+			isVisible={ Boolean( refundDialog && refundDialog.labelId === label_id ) }
 			onClose={ labelActions.closeRefundDialog }
 			additionalClassNames="label-refund-modal">
 			<FormSectionHeading>

--- a/client/apps/shipping-label/index.js
+++ b/client/apps/shipping-label/index.js
@@ -2,18 +2,18 @@
  * External dependencies
  */
 import React from 'react';
-import _ from 'lodash';
 
 /**
  * Internal dependencies
  */
 import ShippingLabelRootView from './view';
 import shippingLabel from './state/reducer';
+import initializeLabelsState from 'lib/initialize-labels-state';
 // from calypso
 import notices from 'state/notices/reducer';
 import { combineReducers } from 'state/utils';
 
-export default ( { formData, labelsData, paperSize, storeOptions, paymentMethod, numPaymentMethods } ) => ( {
+export default ( { orderId, formData, labelsData, paperSize, storeOptions, paymentMethod, numPaymentMethods } ) => ( {
 	getReducer() {
 		return combineReducers( {
 			shippingLabel,
@@ -29,57 +29,8 @@ export default ( { formData, labelsData, paperSize, storeOptions, paymentMethod,
 	},
 
 	getInitialState() {
-		// The phone field is never prefilled, so if it's present it means the address is fully valid
-		const hasOriginAddress = Boolean( formData.origin.phone );
-		const hasDestinationAddress = Boolean( formData.destination.phone );
-
 		return {
-			shippingLabel: {
-				labels: labelsData || [],
-				paperSize,
-				paymentMethod,
-				numPaymentMethods,
-				form: {
-					orderId: formData.order_id,
-					origin: {
-						values: formData.origin,
-						isNormalized: hasOriginAddress,
-						normalized: hasOriginAddress ? formData.origin : null,
-						// If no origin address is stored, mark all fields as "ignore validation"
-						// so the UI doesn't immediately show errors
-						ignoreValidation: hasOriginAddress ? null : _.mapValues( formData.origin, () => true ),
-						selectNormalized: true,
-						normalizationInProgress: false,
-						allowChangeCountry: false,
-					},
-					destination: {
-						values: formData.destination,
-						isNormalized: Boolean( formData.destination_normalized ),
-						normalized: formData.destination_normalized ? formData.destination : null,
-						// If no destination address is stored, mark all fields as "ignore validation"
-						// so the UI doesn't immediately show errors
-						ignoreValidation: hasDestinationAddress ? null : _.mapValues( formData.destination, () => true ),
-						selectNormalized: true,
-						normalizationInProgress: false,
-						allowChangeCountry: false,
-					},
-					packages: {
-						all: formData.all_packages,
-						flatRateGroups: formData.flat_rate_groups,
-						selected: formData.selected_packages,
-						isPacked: formData.is_packed,
-						saved: true,
-					},
-					rates: {
-						values: _.isEmpty( formData.rates.selected )
-							? _.mapValues( formData.packages, () => '' )
-							: formData.rates.selected,
-						available: {},
-						retrievalInProgress: false,
-					},
-				},
-				openedPackageId: Object.keys( formData.selected_packages )[ 0 ] || '',
-			},
+			shippingLabel: initializeLabelsState( formData, labelsData, paperSize, storeOptions, paymentMethod, numPaymentMethods ),
 		};
 	},
 
@@ -88,11 +39,10 @@ export default ( { formData, labelsData, paperSize, storeOptions, paymentMethod,
 	},
 
 	getStateKey() {
-		return `wcs-label-${ formData.order_id }`;
+		return `wcs-label-${ orderId }`;
 	},
 
 	View: () => (
-		<ShippingLabelRootView
-			storeOptions={ storeOptions } />
+		<ShippingLabelRootView />
 	),
 } );

--- a/client/apps/shipping-label/state/actions.js
+++ b/client/apps/shipping-label/state/actions.js
@@ -525,7 +525,7 @@ export const purchaseLabel = () => ( dispatch, getState, context ) => {
 					labelId: label.label_id,
 				} ) );
 				const state = getState().shippingLabel;
-				const printUrl = getPrintURL( state.paperSize, labelsToPrint, context );
+				const printUrl = getPrintURL( state.paperSize, labelsToPrint );
 				if ( 'addon' === getPDFSupport() ) {
 					// If the browser has a PDF "addon", we need another user click to trigger opening it in a new tab
 					dispatch( { type: SHOW_PRINT_CONFIRMATION, printUrl } );
@@ -687,11 +687,11 @@ export const closeReprintDialog = () => {
 	return { type: CLOSE_REPRINT_DIALOG };
 };
 
-export const confirmReprint = () => ( dispatch, getState, context ) => {
+export const confirmReprint = () => ( dispatch, getState ) => {
 	dispatch( { type: CONFIRM_REPRINT } );
 	const state = getState().shippingLabel;
 	const labelId = state.reprintDialog.labelId;
-	printDocument( getPrintURL( getState().shippingLabel.paperSize, [ { labelId } ], context ) )
+	printDocument( getPrintURL( getState().shippingLabel.paperSize, [ { labelId } ] ) )
 		.catch( ( error ) => {
 			console.error( error );
 			dispatch( NoticeActions.errorNotice( error.toString() ) );

--- a/client/apps/shipping-label/state/actions.js
+++ b/client/apps/shipping-label/state/actions.js
@@ -492,8 +492,7 @@ export const updatePaperSize = ( value ) => {
 	};
 };
 
-export const purchaseLabel = () => ( dispatch, getState, context ) => {
-	const { orderId } = context;
+export const purchaseLabel = () => ( dispatch, getState, { orderId } ) => {
 	let error = null;
 	let response = null;
 
@@ -675,7 +674,7 @@ export const confirmRefund = () => ( dispatch, getState, { orderId } ) => {
 	setIsSaving( true );
 	api.post( api.url.labelRefund( orderId, labelId ) )
 		.then( setSuccess )
-        .catch( setError )
+		.catch( setError )
 		.then( () => setIsSaving( false ) );
 };
 

--- a/client/apps/shipping-label/state/get-rates.js
+++ b/client/apps/shipping-label/state/get-rates.js
@@ -1,12 +1,7 @@
 /**
- * External dependencies
- */
-import _ from 'lodash';
-
-/**
  * Internal dependencies
  */
-import saveForm from 'lib/save-form';
+import * as api from 'api';
 import {
 	RATES_RETRIEVAL_IN_PROGRESS,
 	SET_RATES,
@@ -14,18 +9,16 @@ import {
 	exitPrintingFlow,
 } from './actions';
 
-export default ( dispatch, origin, destination, packages, getRatesURL, nonce ) => {
+export default ( dispatch, origin, destination, packages, orderId ) => {
 	dispatch( { type: RATES_RETRIEVAL_IN_PROGRESS } );
 	return new Promise( ( resolve, reject ) => {
 		let error = null;
 		const setError = ( err ) => error = err;
-		const setSuccess = ( success, json ) => {
-			if ( success ) {
-				dispatch( {
-					type: SET_RATES,
-					rates: json.rates,
-				} );
-			}
+		const setSuccess = ( json ) => {
+			dispatch( {
+				type: SET_RATES,
+				rates: json.rates,
+			} );
 		};
 		const setIsSaving = ( saving ) => {
 			if ( ! saving ) {
@@ -41,6 +34,11 @@ export default ( dispatch, origin, destination, packages, getRatesURL, nonce ) =
 				}
 			}
 		};
-		saveForm( setIsSaving, setSuccess, _.noop, setError, getRatesURL, nonce, 'POST', { origin, destination, packages } );
+
+		setIsSaving( true );
+		api.post( api.url.getLabelRates( orderId ), { origin, destination, packages } )
+			.then( setSuccess )
+			.catch( setError )
+			.then( () => setIsSaving( false ) );
 	} );
 };

--- a/client/apps/shipping-label/state/reducer.js
+++ b/client/apps/shipping-label/state/reducer.js
@@ -8,6 +8,9 @@ import _ from 'lodash';
  * Internal dependencies
  */
 import {
+	INIT_LABELS,
+	SET_IS_FETCHING,
+	SET_FETCH_ERROR,
 	OPEN_PRINTING_FLOW,
 	EXIT_PRINTING_FLOW,
 	TOGGLE_STEP,
@@ -52,6 +55,7 @@ import {
 	ADD_ITEMS,
 } from './actions';
 import getBoxDimensions from 'lib/utils/get-box-dimensions';
+import initializeLabelsState from 'lib/initialize-labels-state';
 
 const generateUniqueBoxId = ( keyBase, boxIds ) => {
 	for ( let i = 0; i <= boxIds.length; i++ ) {
@@ -65,6 +69,27 @@ const generateUniqueBoxId = ( keyBase, boxIds ) => {
 const round = ( n ) => _.round( n, 8 );
 
 const reducers = {};
+
+reducers[ INIT_LABELS ] = ( state, { formData, labelsData, paperSize, storeOptions, paymentMethod, numPaymentMethods } ) => {
+	return {
+		...state,
+		...initializeLabelsState( formData, labelsData, paperSize, storeOptions, paymentMethod, numPaymentMethods ),
+	};
+};
+
+reducers[ SET_IS_FETCHING ] = ( state, { isFetching } ) => {
+	return {
+		...state,
+		isFetching,
+	};
+};
+
+reducers[ SET_FETCH_ERROR ] = ( state, { error } ) => {
+	return {
+		...state,
+		error,
+	};
+};
 
 reducers[ OPEN_PRINTING_FLOW ] = ( state ) => {
 	return { ...state,

--- a/client/apps/shipping-label/state/reducer.js
+++ b/client/apps/shipping-label/state/reducer.js
@@ -658,6 +658,7 @@ reducers[ LABEL_STATUS_RESPONSE ] = ( state, { labelId, response, error } ) => {
 
 	const newState = { ...state,
 		labels: [ ...state.labels ],
+		refreshedLabelStatus: true,
 	};
 	newState.labels[ labelIndex ] = labelData;
 	return newState;

--- a/client/apps/shipping-label/view.js
+++ b/client/apps/shipping-label/view.js
@@ -31,16 +31,6 @@ class ShippingLabelRootView extends Component {
 	constructor( props ) {
 		super( props );
 
-		this.renderLabel = this.renderLabel.bind( this );
-		this.renderLabels = this.renderLabels.bind( this );
-		this.renderLabelButton = this.renderLabelButton.bind( this );
-		this.renderPaymentInfo = this.renderPaymentInfo.bind( this );
-		this.renderPurchaseLabelFlow = this.renderPurchaseLabelFlow.bind( this );
-		this.renderRefundLink = this.renderRefundLink.bind( this );
-		this.renderRefund = this.renderRefund.bind( this );
-		this.renderReprint = this.renderReprint.bind( this );
-		this.renderLabelDetails = this.renderLabelDetails.bind( this );
-
 		this.state = {
 			needToFetchLabelsStatus: true,
 		};
@@ -62,7 +52,7 @@ class ShippingLabelRootView extends Component {
 		}
 	}
 
-	renderPaymentInfo() {
+	renderPaymentInfo = () => {
 		const numPaymentMethods = this.props.shippingLabel.numPaymentMethods;
 		const paymentMethod = this.props.shippingLabel.paymentMethod;
 
@@ -95,17 +85,17 @@ class ShippingLabelRootView extends Component {
 				<p><a href="admin.php?page=wc-settings&tab=shipping&section=label-settings">{ __( 'Add a credit card' ) }</a></p>
 			</Notice>
 		);
-	}
+	};
 
-	renderLabelButton() {
+	renderLabelButton = () => {
 		return (
 			<Button className="shipping-label__new-label-button" onClick={ this.props.labelActions.openPrintingFlow } >
 				{ __( 'Create new label' ) }
 			</Button>
 		);
-	}
+	};
 
-	renderPurchaseLabelFlow() {
+	renderPurchaseLabelFlow = () => {
 		const paymentMethod = this.props.shippingLabel.paymentMethod;
 
 		return (
@@ -117,9 +107,9 @@ class ShippingLabelRootView extends Component {
 				{ paymentMethod && this.renderLabelButton() }
 			</div>
 		);
-	}
+	};
 
-	renderRefundLink( label ) {
+	renderRefundLink = ( label ) => {
 		const today = new Date();
 		const thirtyDaysAgo = new Date().setDate( today.getDate() - 30 );
 		if ( ( label.used_date && label.used_date < today.getTime() ) || ( label.created_date && label.created_date < thirtyDaysAgo ) ) {
@@ -143,9 +133,9 @@ class ShippingLabelRootView extends Component {
 				</a>
 			</span>
 		);
-	}
+	};
 
-	renderRefund( label ) {
+	renderRefund = ( label ) => {
 		if ( ! label.refund ) {
 			return this.renderRefundLink( label );
 		}
@@ -177,9 +167,9 @@ class ShippingLabelRootView extends Component {
 		return (
 			<span className={ className } ><Gridicon icon="time" size={ 12 } />{ text }</span>
 		);
-	}
+	};
 
-	renderReprint( label ) {
+	renderReprint = ( label ) => {
 		const todayTime = new Date().getTime();
 		if ( label.refund ||
 			( label.used_date && label.used_date < todayTime ) ||
@@ -204,9 +194,9 @@ class ShippingLabelRootView extends Component {
 				</a>
 			</span>
 		);
-	}
+	};
 
-	renderLabelDetails( label, labelNum ) {
+	renderLabelDetails = ( label, labelNum ) => {
 		if ( ! label.package_name || ! label.product_names ) {
 			return null;
 		}
@@ -225,9 +215,9 @@ class ShippingLabelRootView extends Component {
 				</ul>
 			</InfoTooltip>
 		);
-	}
+	};
 
-	renderLabel( label, index, labels ) {
+	renderLabel = ( label, index, labels ) => {
 		const purchased = timeAgo( label.created );
 
 		return (
@@ -249,11 +239,11 @@ class ShippingLabelRootView extends Component {
 				</p>
 			</div>
 		);
-	}
+	};
 
-	renderLabels() {
+	renderLabels = () => {
 		return this.props.shippingLabel.labels.map( this.renderLabel );
-	}
+	};
 
 	renderLoading() {
 		return (

--- a/client/apps/shipping-label/view.js
+++ b/client/apps/shipping-label/view.js
@@ -12,6 +12,7 @@ import { translate as __ } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import PurchaseDialog from './components/label-purchase-modal';
+import QueryLabels from 'components/query-labels';
 import RefundDialog from './components/label-refund-modal';
 import ReprintDialog from './components/label-reprint-modal';
 import TrackingLink from './components/tracking-link';
@@ -45,7 +46,15 @@ class ShippingLabelRootView extends Component {
 	}
 
 	componentWillMount() {
-		if ( this.state.needToFetchLabelsStatus ) {
+		if ( this.props.loaded && this.state.needToFetchLabelsStatus ) {
+			// TODO: Use redux for this instead
+			this.setState( { needToFetchLabelsStatus: false } );
+			this.props.labelActions.fetchLabelsStatus();
+		}
+	}
+
+	componentWillReceiveProps( props ) {
+		if ( props.loaded && this.state.needToFetchLabelsStatus ) {
 			// TODO: Use redux for this instead
 			this.setState( { needToFetchLabelsStatus: false } );
 			this.props.labelActions.fetchLabelsStatus();
@@ -248,24 +257,31 @@ class ShippingLabelRootView extends Component {
 	render() {
 		return (
 			<div className="shipping-label__container">
+				<QueryLabels />
 				<GlobalNotices id="notices" notices={ notices.list } />
-				{ this.renderPurchaseLabelFlow() }
-				{ this.props.shippingLabel.labels.length ? this.renderLabels() : null }
+				{ this.props.loaded && this.renderPurchaseLabelFlow() }
+				{ this.props.loaded && this.props.shippingLabel.labels.length ? this.renderLabels() : null }
 			</div>
 		);
 	}
 }
 
 ShippingLabelRootView.propTypes = {
-	storeOptions: PropTypes.object.isRequired,
+	storeOptions: PropTypes.object,
 	shippingLabel: PropTypes.object.isRequired,
 };
 
-function mapStateToProps( state, { storeOptions } ) {
+function mapStateToProps( state ) {
+	const shippingLabel = state.shippingLabel;
+	const loaded = shippingLabel.loaded;
+	const storeOptions = loaded ? shippingLabel.storeOptions : {};
+
 	return {
-		shippingLabel: state.shippingLabel,
-		errors: getFormErrors( state, storeOptions ),
-		canPurchase: canPurchase( state, storeOptions ),
+		shippingLabel,
+		loaded,
+		storeOptions,
+		errors: loaded && getFormErrors( state, storeOptions ),
+		canPurchase: loaded && canPurchase( state, storeOptions ),
 	};
 }
 

--- a/client/apps/shipping-label/view.js
+++ b/client/apps/shipping-label/view.js
@@ -28,26 +28,14 @@ import canPurchase from './state/selectors/can-purchase';
 import Notice from 'components/notice';
 
 class ShippingLabelRootView extends Component {
-	constructor( props ) {
-		super( props );
-
-		this.state = {
-			needToFetchLabelsStatus: true,
-		};
-	}
-
 	componentWillMount() {
-		if ( this.props.loaded && this.state.needToFetchLabelsStatus ) {
-			// TODO: Use redux for this instead
-			this.setState( { needToFetchLabelsStatus: false } );
+		if ( this.props.needToFetchLabelStatus ) {
 			this.props.labelActions.fetchLabelsStatus();
 		}
 	}
 
 	componentWillReceiveProps( props ) {
-		if ( props.loaded && this.state.needToFetchLabelsStatus ) {
-			// TODO: Use redux for this instead
-			this.setState( { needToFetchLabelsStatus: false } );
+		if ( props.needToFetchLabelStatus ) {
 			this.props.labelActions.fetchLabelsStatus();
 		}
 	}
@@ -284,6 +272,7 @@ function mapStateToProps( state ) {
 		shippingLabel,
 		loaded,
 		storeOptions,
+		needToFetchLabelStatus: loaded && ! shippingLabel.refreshedLabelStatus,
 		errors: loaded && getFormErrors( state, storeOptions ),
 		canPurchase: loaded && canPurchase( state, storeOptions ),
 	};

--- a/client/apps/shipping-label/view.js
+++ b/client/apps/shipping-label/view.js
@@ -11,6 +11,7 @@ import { translate as __ } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
+import LoadingSpinner from 'components/loading-spinner';
 import PurchaseDialog from './components/label-purchase-modal';
 import QueryLabels from 'components/query-labels';
 import RefundDialog from './components/label-refund-modal';
@@ -254,20 +255,33 @@ class ShippingLabelRootView extends Component {
 		return this.props.shippingLabel.labels.map( this.renderLabel );
 	}
 
+	renderLoading() {
+		return (
+			<div>
+				<QueryLabels />
+				<LoadingSpinner />
+			</div>
+		);
+	}
+
 	render() {
+		if ( ! this.props.loaded ) {
+			return this.renderLoading();
+		}
+
 		return (
 			<div className="shipping-label__container">
 				<QueryLabels />
 				<GlobalNotices id="notices" notices={ notices.list } />
-				{ this.props.loaded && this.renderPurchaseLabelFlow() }
-				{ this.props.loaded && this.props.shippingLabel.labels.length ? this.renderLabels() : null }
+				{ this.renderPurchaseLabelFlow() }
+				{ this.props.shippingLabel.labels.length ? this.renderLabels() : null }
 			</div>
 		);
 	}
 }
 
 ShippingLabelRootView.propTypes = {
-	storeOptions: PropTypes.object,
+	storeOptions: PropTypes.object.isRequired,
 	shippingLabel: PropTypes.object.isRequired,
 };
 

--- a/client/components/query-labels/index.js
+++ b/client/components/query-labels/index.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import { fetchLabelsData } from '../../apps/shipping-label/state/actions';
+
+class QueryLabels extends Component {
+	fetch() {
+		this.props.fetchLabelsData();
+	}
+
+	componentWillMount() {
+		const { loaded, isFetching, error } = this.props;
+		if ( ! loaded && ! isFetching && ! error ) {
+			this.fetch();
+		}
+	}
+
+	componentWillReceiveProps( props ) {
+		const { loaded, isFetching, error } = props;
+		if ( ! loaded && ! isFetching && ! error ) {
+			this.fetch();
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	( state ) => ( {
+		loaded: state.shippingLabel.loaded,
+		isFetching: state.shippingLabel.isFetching,
+		error: state.shippingLabel.error,
+	} ),
+	( dispatch ) => bindActionCreators( {
+		fetchLabelsData,
+	}, dispatch )
+)( QueryLabels );

--- a/client/lib/initialize-labels-state/index.js
+++ b/client/lib/initialize-labels-state/index.js
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import { isEmpty, mapValues } from 'lodash';
+
+/**
+ * Parses the data passed from the backed into a Redux state to be used in the label purchase flow
+ * @param {Object} formData form data
+ * @param {Object} labelsData labels data
+ * @param {string} paperSize selected paper size
+ * @param {Object} storeOptions store options (weight/dimensions units etc)
+ * @param {Number} paymentMethod selected payment method
+ * @param {Number} numPaymentMethods number of payments methods stored with the jetpack master account
+ * @returns {Object} labels Redux state
+ */
+export default ( formData, labelsData, paperSize, storeOptions, paymentMethod, numPaymentMethods ) => {
+	if ( ! formData ) {
+		return {
+			loaded: false,
+			isFetching: false,
+			error: false,
+		};
+	}
+
+	// The phone field is never prefilled, so if it's present it means the address is fully valid
+	const hasOriginAddress = Boolean( formData.origin.phone );
+	const hasDestinationAddress = Boolean( formData.destination.phone );
+
+	return {
+		loaded: true,
+		isFetching: false,
+		error: false,
+		labels: labelsData || [],
+		paperSize,
+		paymentMethod,
+		numPaymentMethods,
+		storeOptions,
+		form: {
+			orderId: formData.order_id,
+			origin: {
+				values: formData.origin,
+				isNormalized: hasOriginAddress,
+				normalized: hasOriginAddress ? formData.origin : null,
+				// If no origin address is stored, mark all fields as "ignore validation"
+				// so the UI doesn't immediately show errors
+				ignoreValidation: hasOriginAddress ? null : mapValues( formData.origin, () => true ),
+				selectNormalized: true,
+				normalizationInProgress: false,
+				allowChangeCountry: false,
+			},
+			destination: {
+				values: formData.destination,
+				isNormalized: Boolean( formData.destination_normalized ),
+				normalized: formData.destination_normalized ? formData.destination : null,
+				// If no destination address is stored, mark all fields as "ignore validation"
+				// so the UI doesn't immediately show errors
+				ignoreValidation: hasDestinationAddress ? null : mapValues( formData.destination, () => true ),
+				selectNormalized: true,
+				normalizationInProgress: false,
+				allowChangeCountry: false,
+			},
+			packages: {
+				all: formData.all_packages,
+				flatRateGroups: formData.flat_rate_groups,
+				selected: formData.selected_packages,
+				isPacked: formData.is_packed,
+				saved: true,
+			},
+			rates: {
+				values: isEmpty( formData.rates.selected )
+					? mapValues( formData.packages, () => '' )
+					: formData.rates.selected,
+				available: {},
+				retrievalInProgress: false,
+			},
+		},
+		openedPackageId: Object.keys( formData.selected_packages )[ 0 ] || '',
+	};
+};

--- a/client/lib/initialize-labels-state/index.js
+++ b/client/lib/initialize-labels-state/index.js
@@ -30,6 +30,7 @@ export default ( formData, labelsData, paperSize, storeOptions, paymentMethod, n
 		loaded: true,
 		isFetching: false,
 		error: false,
+		refreshedLabelStatus: false,
 		labels: labelsData || [],
 		paperSize,
 		paymentMethod,

--- a/client/lib/pdf-label-utils/index.js
+++ b/client/lib/pdf-label-utils/index.js
@@ -8,6 +8,7 @@ import _ from 'lodash';
 /**
  * Internal dependencies
  */
+import * as api from 'api';
 import getPDFSupport from 'lib/utils/pdf-support';
 
 const PAPER_SIZES = {
@@ -35,24 +36,24 @@ export const getPaperSizes = ( country ) => (
 	}, {} )
 );
 
-const _getPDFURL = ( paperSize, labels, baseURL, nonce ) => {
+const _getPDFURL = ( paperSize, labels ) => {
 	if ( ! PAPER_SIZES[ paperSize ] ) {
 		throw new Error( `Invalid paper size: ${ paperSize }` );
 	}
 	const params = {
-		_wpnonce: nonce,
 		paper_size: paperSize,
 		//send params as a CSV to avoid conflicts with some plugins out there (#1111)
 		label_id_csv: _.filter( _.map( labels, 'labelId' ) ).join( ',' ),
 		caption_csv: _.filter( _.map( labels, ( l ) => ( l.caption ? encodeURIComponent( l.caption ) : null ) ) ).join( ',' ),
 	};
-	return baseURL + '?' + querystring.stringify( params );
+
+	return api.createGetUrlWithNonce( api.url.labelsPrint(), querystring.stringify( params ) );
 };
 
-export const getPrintURL = ( paperSize, labels, { labelsPrintURL, nonce } ) => {
-	return _getPDFURL( paperSize, labels, labelsPrintURL, nonce );
+export const getPrintURL = ( paperSize, labels ) => {
+	return _getPDFURL( paperSize, labels );
 };
 
-export const getPreviewURL = ( paperSize, labels, { labelsPreviewURL, nonce } ) => {
-	return getPDFSupport() ? _getPDFURL( paperSize, labels, labelsPreviewURL, nonce ) : null;
+export const getPreviewURL = ( paperSize, labels ) => {
+	return getPDFSupport() ? _getPDFURL( paperSize, labels ) : null;
 };

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -553,7 +553,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$rest_self_help_controller->register_routes();
 
 			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-label-controller.php' ) );
-			$rest_shipping_label_controller = new WC_REST_Connect_Shipping_Label_Controller( $this->api_client, $settings_store, $logger );
+			$rest_shipping_label_controller = new WC_REST_Connect_Shipping_Label_Controller( $this->api_client, $settings_store, $logger, $this->shipping_label );
 			$this->set_rest_shipping_label_controller( $rest_shipping_label_controller );
 			$rest_shipping_label_controller->register_routes();
 


### PR DESCRIPTION
Fixes #1103

This is a prerequisite to start moving the label modal component to Calypso. I also cleaned up some of the code in the last two commits.

To test:
* everything should work correctly:
  * address normalization
  * label rates request
  * label purchase and print
  * label refund
* to test the dynamic fetch, replace `$payload = $this->get_label_payload( $order );` with `$payload = array()` in `class-wc-connect-shipping-label.php`
  * a spinner should appear while the data is being requested
  * everything should work once the data has been loaded