### PR TITLE
Generalize save notifications for shipping label settings

### DIFF
--- a/client/apps/account-settings/view.js
+++ b/client/apps/account-settings/view.js
@@ -21,9 +21,9 @@ import * as NoticeActions from 'state/notices/actions';
 const AccountSettingsRootView = ( { formData, formMeta, actions, noticeActions, storeOptions } ) => {
 	const onSaveSuccess = () => {
 		actions.setFormMetaProperty( 'pristine', true );
-		noticeActions.successNotice( __( 'Your payment method has been updated.' ), { duration: 5000 } );
+		noticeActions.successNotice( __( 'Your shipping label settings have been saved.' ), { duration: 5000 } );
 	};
-	const onSaveFailure = () => noticeActions.errorNotice( __( 'Unable to update your payment method. Please try again.' ) );
+	const onSaveFailure = () => noticeActions.errorNotice( __( 'Unable to save your shipping label settings. Please try again.' ) );
 	const onSaveChanges = () => actions.submit( onSaveSuccess, onSaveFailure );
 
 	const buttons = [

--- a/client/apps/shipping-label/components/label-refund-modal/index.js
+++ b/client/apps/shipping-label/components/label-refund-modal/index.js
@@ -14,7 +14,7 @@ import FormSectionHeading from 'components/forms/form-section-heading';
 
 const RefundDialog = ( { refundDialog, labelActions, storeOptions, created, refundable_amount, label_id } ) => {
 	const getRefundableAmount = () => {
-		return storeOptions.currency_symbol + refundable_amount.toFixed( 2 );
+		return storeOptions.currency_symbol + Number( refundable_amount ).toFixed( 2 );
 	};
 
 	return (


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/1118 by generalizing the post-"save" notifications beyond "payment method", which is no longer the only available setting.

After changing "Paper size" to "Legal" and saving:
<img width="880" src="https://user-images.githubusercontent.com/1867547/29344506-484e6ea2-8206-11e7-9afd-44d17efb1361.png">