### PR TITLE
Add Stripe Create Deferred Account REST Endpoint

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -271,6 +271,15 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		/**
+		 * Create a deferred Stripe Standard Account
+		 * @param $request
+		 * @return object|WP_Error
+		 */
+		public function create_stripe_account( $request ) {
+			return $this->request( 'POST', '/stripe/account', $request );
+		}
+
+		/**
 		 * Sends a request to the WooCommerce Services Server
 		 *
 		 * @param $method

--- a/classes/class-wc-rest-connect-stripe-account-controller.php
+++ b/classes/class-wc-rest-connect-stripe-account-controller.php
@@ -1,0 +1,37 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( class_exists( 'WC_REST_Connect_Stripe_Account_Controller' ) ) {
+	return;
+}
+
+class WC_REST_Connect_Stripe_Account_Controller extends WC_REST_Connect_Base_Controller {
+	protected $rest_base = 'connect/stripe/account';
+
+	public function post( $request ) {
+		$data = $request->get_json_params();
+
+		// Whitelist the properties we want.
+		$body = array(
+			'email' => $data['email'],
+			'country' => $data['country'],
+		);
+
+		$response = $this->api_client->create_stripe_account( $body );
+
+		if ( is_wp_error( $response ) ) {
+			$this->logger->debug( $response, __CLASS__ );
+			return $response;
+		}
+
+		return new WP_REST_Response( array(
+			'success'         => true,
+			'account_id'      => $response->accountId,
+			'publishable_key' => $response->publishableKey,
+			'secret_key'      => $response->secretKey,
+		), 200 );
+	}
+}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -163,6 +163,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 */
 		protected $rest_tos_controller;
 
+		/**
+		 * @var WC_REST_Connect_Stripe_Account_Controller
+		 */
+		protected $rest_stripe_account_controller;
+
 		protected $services = array();
 
 		protected $service_object_cache = array();
@@ -351,6 +356,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->taxjar = $taxjar;
 		}
 
+		public function set_rest_stripe_account_controller( WC_REST_Connect_Stripe_Account_Controller $rest_stripe_account_controller ) {
+			$this->rest_stripe_account_controller = $rest_stripe_account_controller;
+		}
+
 		/**
 		 * Load our textdomain
 		 *
@@ -419,7 +428,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			require_once( plugin_basename( 'classes/class-wc-connect-help-view.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-shipping-label.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-nux.php' ) );
-
 
 			$logger                = new WC_Connect_Logger( new WC_Logger() );
 			$validator             = new WC_Connect_Service_Schemas_Validator();
@@ -586,6 +594,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$rest_address_normalization_controller = new WC_REST_Connect_Address_Normalization_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_address_normalization_controller( $rest_address_normalization_controller );
 			$rest_address_normalization_controller->register_routes();
+
+			require_once( plugin_basename( 'classes/class-wc-rest-connect-stripe-account-controller.php' ) );
+			$rest_stripe_account_controller = new WC_REST_Connect_Stripe_Account_Controller( $this->api_client, $settings_store, $logger );
+			$this->set_rest_stripe_account_controller( $rest_stripe_account_controller );
+			$rest_stripe_account_controller->register_routes();
 
 			add_filter( 'rest_request_before_callbacks', array( $this, 'log_rest_api_errors' ), 10, 3 );
 		}


### PR DESCRIPTION
This PR adds a new REST endpoint to merchant's site at `connect/stripe/account`, which creates a new deferred account under the user's email address on Stripe. It makes a POST request to our server at `connect/stripe/account` with a payload containing an email address and country.

# Responses

It expects in return either:
1. A successful response, with the new user's account info (details below)
2. An unsuccessful response (status code 409) when the email already has an account
3. An unsuccessful response if there's a parameter missing 
4. An unsuccessful response for unknown reasons (JS, PHP errors, Stripe API bad respones, timeout, etc)

``` js
1. Successful response, status 200
{
    account_id: "acct_1Aru57F8xp6h4d6q",
    publishable_key: "pk_test_QEavJXFa4FJlzpOIw1E2e1BJ"
    secret_key: "sk_test_4wzMns8rsEy1KJF329BjLDUX",
    success: true
}

2. Unsuccessful response: email already used
status 409 Conflict
{
	"code": "wcc_server_error_response",
	"message": "Error: The WooCommerce Services server returned: Conflict Account already exists. ( 409 )",
	"data": {
		"status": 409,
		"error_code": null
	}
}

3. Unsuccessful response: status 400, Bad Request
{
	"code": "wcc_server_error_response",
	"message": "Error: The WooCommerce Services server returned: Bad Request Failed to create account. ( 400 )",
	"data": {
		"status": 400,
		"error_code": null
	}
}
```
# Testing instructions

You can see these responses with the correct status code only by making adding this block of code in 'classes/class-wc-connect-api-client.php` on [line 369](https://github.com/Automattic/woocommerce-services/blob/master/classes/class-wc-connect-api-client.php#L369):

```
// Preserve the response http status code
// by adding it to the data array
$data[ 'status' ] = $response_code;

// Use the unique identifier sent for errors
$data[ 'error_code' ] = $response_body->errorCode;
```

You'll also want to check out @nabsul's related PR: https://github.com/Automattic/woocommerce-connect-server/pull/942

I tested this by replacing `api.url.addressNormalization()` with `wc/v1/connect/stripe/account` (and the related data object) in `client/apps/shipping-label/state/normalize-address.js`. I imagine there's a better way, and if so please let me know.