### PR TITLE
Fix test label printing

### DIFF
--- a/classes/class-wc-rest-connect-shipping-label-preview-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-preview-controller.php
@@ -19,8 +19,10 @@ class WC_REST_Connect_Shipping_Label_Preview_Controller extends WC_REST_Connect_
 		$this->settings_store->set_preferred_paper_size( $params[ 'paper_size' ] );
 		$params[ 'carrier' ] = 'usps';
 		$params[ 'labels' ] = array();
-		foreach ( $raw_params[ 'captions' ] as $caption ) {
-			$params[ 'labels' ][] = array( 'caption' => $caption );
+		$captions = empty( $raw_params[ 'caption_csv' ] ) ? array() : explode( ',', $raw_params[ 'caption_csv' ] );
+
+		foreach ( $captions as $caption ) {
+			$params[ 'labels' ][] = array( 'caption' => urldecode( $caption ) );
 		}
 
 		$raw_response = $this->api_client->get_labels_preview_pdf( $params );

--- a/client/api/url.js
+++ b/client/api/url.js
@@ -14,4 +14,6 @@ export const labelRefund = ( orderId, labelId ) => `${ namespace }label/${ order
 
 export const labelsPrint = () => `${ namespace }label/print`;
 
+export const labelTestPrint = () => `${ namespace }label/preview`;
+
 export const addressNormalization = () => `${ namespace }normalize-address`;

--- a/client/lib/pdf-label-utils/index.js
+++ b/client/lib/pdf-label-utils/index.js
@@ -36,7 +36,7 @@ export const getPaperSizes = ( country ) => (
 	}, {} )
 );
 
-const _getPDFURL = ( paperSize, labels ) => {
+const _getPDFURL = ( paperSize, labels, test = false ) => {
 	if ( ! PAPER_SIZES[ paperSize ] ) {
 		throw new Error( `Invalid paper size: ${ paperSize }` );
 	}
@@ -46,8 +46,9 @@ const _getPDFURL = ( paperSize, labels ) => {
 		label_id_csv: _.filter( _.map( labels, 'labelId' ) ).join( ',' ),
 		caption_csv: _.filter( _.map( labels, ( l ) => ( l.caption ? encodeURIComponent( l.caption ) : null ) ) ).join( ',' ),
 	};
+	const urlBase = test ? api.url.labelTestPrint() : api.url.labelsPrint();
 
-	return api.createGetUrlWithNonce( api.url.labelsPrint(), querystring.stringify( params ) );
+	return api.createGetUrlWithNonce( urlBase, querystring.stringify( params ) );
 };
 
 export const getPrintURL = ( paperSize, labels ) => {
@@ -55,5 +56,5 @@ export const getPrintURL = ( paperSize, labels ) => {
 };
 
 export const getPreviewURL = ( paperSize, labels ) => {
-	return getPDFSupport() ? _getPDFURL( paperSize, labels ) : null;
+	return getPDFSupport() ? _getPDFURL( paperSize, labels, true ) : null;
 };


### PR DESCRIPTION
This is blocking the 1.7 release 😬 

https://github.com/Automattic/woocommerce-services/pull/1121 broke printing test labels from the WC status page.

This PR restores test label printing and updates the label preview controller to work with CSV captions introduced in https://github.com/Automattic/woocommerce-services/pull/1112.

To test:
* Verify that the test label print works
* Verify that reprinting a purchased label still works