### PR TITLE
Support for async label purchases

### DIFF
--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -221,15 +221,20 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 *
 		 * @param $order_id
 		 * @param $new_label_data
+		 *
+		 * @return array updated label info
 		 */
 		public function update_label_order_meta_data( $order_id, $new_label_data ) {
+			$result = $new_label_data;
 			$labels_data = $this->get_label_order_meta_data( $order_id );
 			foreach( $labels_data as $index => $label_data ) {
 				if ( $label_data[ 'label_id' ] === $new_label_data->label_id ) {
-					$labels_data[ $index ] = array_merge( $label_data, (array) $new_label_data );
+					$result = array_merge( $label_data, (array) $new_label_data );
+					$labels_data[ $index ] = $result;
 				}
 			}
 			update_post_meta( $order_id, 'wc_connect_labels', $labels_data );
+			return $result;
 		}
 
 		/**

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -81,7 +81,6 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 				'carrier_id' => $label_data->label->carrier_id,
 				'service_name' => $service_names[ $index ],
 				'status' => $label_data->label->status,
-				'error' => $label_data->label->error,
 			);
 
 			$package = $settings[ 'packages' ][ $index ];

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -80,6 +80,8 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 				'created' => $label_data->label->created,
 				'carrier_id' => $label_data->label->carrier_id,
 				'service_name' => $service_names[ $index ],
+				'status' => $label_data->label->status,
+				'error' => $label_data->label->error,
 			);
 
 			$package = $settings[ 'packages' ][ $index ];

--- a/classes/class-wc-rest-connect-shipping-label-status-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-status-controller.php
@@ -24,11 +24,11 @@ class WC_REST_Connect_Shipping_Label_Status_Controller extends WC_REST_Connect_B
 			return $error;
 		}
 
-		$this->settings_store->update_label_order_meta_data( $request[ 'order_id' ], $response->label );
+		$label = $this->settings_store->update_label_order_meta_data( $request[ 'order_id' ], $response->label );
 
 		return array(
 			'success' => true,
-			'label' => $response->label,
+			'label' => $label,
 		);
 	}
 

--- a/client/apps/shipping-label/state/actions.js
+++ b/client/apps/shipping-label/state/actions.js
@@ -503,7 +503,7 @@ const pollForLabelsPurchase = ( dispatch, getState, orderId, labels, error, show
 			dispatch( exitPrintingFlow( true ) );
 		} else {
 			console.error( error );
-			dispatch( NoticeActions.errorNotice( error.toString() ) );
+			dispatch( NoticeActions.errorNotice( __( 'Some labels for this order didn\'t purchase. Please try again.' ) ) );
 			//re-request the rates on failure to avoid attempting repurchase of the same shipment id
 			dispatch( clearAvailableRates() );
 			getLabelRates( dispatch, getState, _.noop, { orderId } );

--- a/client/apps/shipping-label/state/actions.js
+++ b/client/apps/shipping-label/state/actions.js
@@ -511,7 +511,7 @@ const handleLabelPurchaseError = ( dispatch, getState, error, orderId ) => {
 const pollForLabelsPurchase = ( dispatch, getState, orderId, labels ) => {
 	const errorLabel = _.find( labels, { status: 'PURCHASE_ERROR' } );
 	if ( errorLabel ) {
-		handleLabelPurchaseError( dispatch, getState, errorLabel.error , orderId );
+		handleLabelPurchaseError( dispatch, getState, errorLabel.error, orderId );
 		return;
 	}
 

--- a/client/apps/shipping-label/state/actions.js
+++ b/client/apps/shipping-label/state/actions.js
@@ -511,9 +511,10 @@ const pollForLabelsPurchase = ( dispatch, getState, orderId, labels, error, show
 		return;
 	}
 
-	const errorLabel = _.find( labels, { status: 'ERROR' } );
+	const errorLabel = _.find( labels, { status: 'PURCHASE_ERROR' } );
 	if ( errorLabel ) {
 		pollForLabelsPurchase( dispatch, getState, orderId, null, errorLabel.error, showPrintDialog );
+		return;
 	}
 
 	if ( ! _.every( labels, { status: 'PURCHASED' } ) ) {

--- a/client/apps/shipping-label/style.scss
+++ b/client/apps/shipping-label/style.scss
@@ -93,5 +93,13 @@
 				color: $alert-red;
 			}
 		}
+
+		.shipping-label__purchase-error {
+			color: $alert-red;
+			cursor: help;
+			text-decoration: underline;
+			text-decoration-color: $alert-red;
+			text-decoration-style: dotted;
+		}
 	}
 }

--- a/client/apps/shipping-label/view.js
+++ b/client/apps/shipping-label/view.js
@@ -205,8 +205,23 @@ class ShippingLabelRootView extends Component {
 		);
 	};
 
+	renderError = ( label ) => {
+		const tooltipAnchor = (
+			<span className="shipping-label__purchase-error">
+				{ __( 'Purchase error' ) }
+			</span>
+		);
+		return (
+			<InfoTooltip anchor={ tooltipAnchor }>
+				<p>{ __( 'Label purchase failed with the following error: %s', { args: [ label.error ] } ) }</p>
+			</InfoTooltip>
+		);
+	};
+
 	renderLabel = ( label, index, labels ) => {
 		const purchased = timeAgo( label.created );
+		const isInProgress = 'PURCHASE_IN_PROGRESS' === label.status;
+		const isError = 'PURCHASE_ERROR' === label.status;
 
 		return (
 			<div key={ label.label_id } className="shipping-label__item" >
@@ -222,8 +237,10 @@ class ShippingLabelRootView extends Component {
 					{ __( 'Tracking #: {{trackingLink/}}', { components: { trackingLink: <TrackingLink { ...label } /> } } ) }
 				</p>
 				<p className="shipping-label__item-actions" >
-					{ this.renderRefund( label ) }
-					{ this.renderReprint( label ) }
+					{ isInProgress && <span>{ __( 'Purchase in progress' ) }</span> }
+					{ isError && this.renderError( label ) }
+					{ ! isInProgress && ! isError && this.renderRefund( label ) }
+					{ ! isInProgress && ! isError && this.renderReprint( label ) }
 				</p>
 			</div>
 		);

--- a/client/apps/shipping-label/view.js
+++ b/client/apps/shipping-label/view.js
@@ -231,6 +231,7 @@ class ShippingLabelRootView extends Component {
 	};
 
 	renderLabels = () => {
+		//filter by blacklist (rather than just checking for PURCHASED) to handle legacy labels without the status field
 		const labelsToRender = filter( this.props.shippingLabel.labels,
 			( label ) => 'PURCHASE_IN_PROGRESS' !== label.status && 'PURCHASE_ERROR' !== label.status );
 

--- a/client/apps/shipping-label/view.js
+++ b/client/apps/shipping-label/view.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Gridicon from 'gridicons';
 import { translate as __ } from 'i18n-calypso';
+import { filter } from 'lodash';
 
 /**
  * Internal dependencies
@@ -205,23 +206,8 @@ class ShippingLabelRootView extends Component {
 		);
 	};
 
-	renderError = ( label ) => {
-		const tooltipAnchor = (
-			<span className="shipping-label__purchase-error">
-				{ __( 'Purchase error' ) }
-			</span>
-		);
-		return (
-			<InfoTooltip anchor={ tooltipAnchor }>
-				<p>{ __( 'Label purchase failed with the following error: %s', { args: [ label.error ] } ) }</p>
-			</InfoTooltip>
-		);
-	};
-
 	renderLabel = ( label, index, labels ) => {
 		const purchased = timeAgo( label.created );
-		const isInProgress = 'PURCHASE_IN_PROGRESS' === label.status;
-		const isError = 'PURCHASE_ERROR' === label.status;
 
 		return (
 			<div key={ label.label_id } className="shipping-label__item" >
@@ -237,17 +223,18 @@ class ShippingLabelRootView extends Component {
 					{ __( 'Tracking #: {{trackingLink/}}', { components: { trackingLink: <TrackingLink { ...label } /> } } ) }
 				</p>
 				<p className="shipping-label__item-actions" >
-					{ isInProgress && <span>{ __( 'Purchase in progress' ) }</span> }
-					{ isError && this.renderError( label ) }
-					{ ! isInProgress && ! isError && this.renderRefund( label ) }
-					{ ! isInProgress && ! isError && this.renderReprint( label ) }
+					{ this.renderRefund( label ) }
+					{ this.renderReprint( label ) }
 				</p>
 			</div>
 		);
 	};
 
 	renderLabels = () => {
-		return this.props.shippingLabel.labels.map( this.renderLabel );
+		const labelsToRender = filter( this.props.shippingLabel.labels,
+			( label ) => 'PURCHASE_IN_PROGRESS' !== label.status && 'PURCHASE_ERROR' !== label.status );
+
+		return labelsToRender.map( this.renderLabel );
 	};
 
 	renderLoading() {


### PR DESCRIPTION
Fixes #1120 

To test:
* Checkout the server PR: Automattic/woocommerce-connect-server#959
* Purchase a single label
* Purchase multiple labels
* Hack the server by throwing an error at any step in `lib/shipping/handler.js` and verify that the errors are handled properly in the client
* ~~If the page is refreshed during the purchase or after an error, this should show in the label history~~ (will be handled in #1135)
