### PR TITLE
Fix typo in prop type for ErrorNotice

### DIFF
--- a/client/components/error-notice/index.js
+++ b/client/components/error-notice/index.js
@@ -20,7 +20,7 @@ const ErrorNotice = ( { children, isWarning } ) => {
 };
 
 ErrorNotice.propTypes = {
-	isWarning: PropTypes.boolean,
+	isWarning: PropTypes.bool,
 };
 
 export default ErrorNotice;


### PR DESCRIPTION
Small change fixing a React console warning.

<img width="863" alt="screen shot 2017-08-30 at 7 28 41 am" src="https://user-images.githubusercontent.com/11487924/29855490-e463d742-8d54-11e7-98a2-2a0a7648bb3f.png">

To test:

1. Go to Edit Order page
2. Open label purchase modal
3. Open dev console
4. Use an address that'll show a suggested change
5. See error
6. Check out this branch, follow steps 1-4 and see no error