### PR TITLE
Re-word description for credit card settings to emphasize purpose

### DIFF
--- a/client/apps/account-settings/components/label-settings/index.js
+++ b/client/apps/account-settings/components/label-settings/index.js
@@ -52,7 +52,7 @@ const ShippingLabels = ( { isLoading, paymentMethods, setFormDataValue, selected
 					{ translate( 'Credit card' ) }
 				</FormLabel>
 				<p className="label-settings__credit-card-description">
-					{ translate( 'Use your credit card on file to pay for the labels you print or add a new one.' ) }
+					{ translate( 'To purchase shipping labels, use your credit card on file or add a new one.' ) }
 				</p>
 				{ paymentMethods.map( renderPaymentMethod ) }
 				<Button href="https://wordpress.com/me/billing" target="_blank" compact>


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/1116 by adjusting existing description for credit card label settings so that the reason for it is harder to miss.

<img width="743" src="https://user-images.githubusercontent.com/1867547/29856613-114d2b1a-8d22-11e7-9447-2202fba60b30.png">
