### PR TITLE
Adjust the label payload to respect whether shipping labels are enabled

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -453,6 +453,11 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				return false;
 			}
 
+			$account_settings = $this->settings_store->get_account_settings();
+			if ( ! $account_settings[ 'enabled' ] ) {
+				return array( 'enabled' => false );
+			}
+
 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
 			$payload = array(
 				'orderId'                 => $order_id,
@@ -461,6 +466,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				'paymentMethod'           => $this->get_selected_payment_method(),
 				'numPaymentMethods'       => count( $this->payment_methods_store->get_payment_methods() ),
 				'labelsData'              => $this->settings_store->get_label_order_meta_data( $order_id ),
+				'enabled'                 => true,
 			);
 
 			$store_options = $this->settings_store->get_store_options();

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -453,6 +453,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				return false;
 			}
 
+			$account_settings = $this->settings_store->get_account_settings();
+
 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
 			$payload = array(
 				'orderId'                 => $order_id,
@@ -461,7 +463,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				'paymentMethod'           => $this->get_selected_payment_method(),
 				'numPaymentMethods'       => count( $this->payment_methods_store->get_payment_methods() ),
 				'labelsData'              => $this->settings_store->get_label_order_meta_data( $order_id ),
-				'enabled'                 => $this->settings_store->get_account_settings()[ 'enabled' ],
+				'enabled'                 => $account_settings[ 'enabled' ],
 			);
 
 			$store_options = $this->settings_store->get_store_options();

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -453,11 +453,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				return false;
 			}
 
-			$account_settings = $this->settings_store->get_account_settings();
-			if ( ! $account_settings[ 'enabled' ] ) {
-				return array( 'enabled' => false );
-			}
-
 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
 			$payload = array(
 				'orderId'                 => $order_id,
@@ -466,7 +461,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				'paymentMethod'           => $this->get_selected_payment_method(),
 				'numPaymentMethods'       => count( $this->payment_methods_store->get_payment_methods() ),
 				'labelsData'              => $this->settings_store->get_label_order_meta_data( $order_id ),
-				'enabled'                 => true,
+				'enabled'                 => $this->settings_store->get_account_settings()[ 'enabled' ],
 			);
 
 			$store_options = $this->settings_store->get_store_options();


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/1142 by adding the `enabled` flag to the shipping label payload. Also returns no other data if not `enabled`.