### PR TITLE
Refactor shipping label code to use child containers

### DIFF
--- a/client/apps/shipping-label/components/label-item/index.js
+++ b/client/apps/shipping-label/components/label-item/index.js
@@ -1,0 +1,158 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import Gridicon from 'gridicons';
+import { translate as __ } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import RefundDialog from '../label-refund-modal';
+import ReprintDialog from '../label-reprint-modal';
+import TrackingLink from '../tracking-link';
+import InfoTooltip from 'components/info-tooltip';
+import formatDate from 'lib/utils/format-date';
+import timeAgo from 'lib/utils/time-ago';
+import { openRefundDialog, openReprintDialog } from '../../state/actions';
+
+class LabelItem extends Component {
+	renderRefundLink = ( label ) => {
+		const today = new Date();
+		const thirtyDaysAgo = new Date().setDate( today.getDate() - 30 );
+		if ( ( label.used_date && label.used_date < today.getTime() ) || ( label.created_date && label.created_date < thirtyDaysAgo ) ) {
+			return null;
+		}
+
+		const openDialog = ( e ) => {
+			e.preventDefault();
+			this.props.labelActions.openRefundDialog( label.label_id );
+		};
+
+		return (
+			<span>
+				<RefundDialog { ...label } />
+				<a href="#" onClick={ openDialog } >
+					<Gridicon icon="refund" size={ 12 } />{ __( 'Request refund' ) }
+				</a>
+			</span>
+		);
+	};
+
+	renderRefund = ( label ) => {
+		if ( ! label.refund ) {
+			return this.renderRefundLink( label );
+		}
+
+		let text = '';
+		let className = '';
+		switch ( label.refund.status ) {
+			case 'pending':
+				if ( label.statusUpdated ) {
+					className = 'is-refund-pending';
+					text = __( 'Refund pending' );
+				} else {
+					className = 'is-refund-checking';
+					text = __( 'Checking refund status' );
+				}
+				break;
+			case 'complete':
+				className = 'is-refund-complete';
+				text = __( 'Refunded on %(date)s', { args: { date: formatDate( label.refund.refund_date ) } } );
+				break;
+			case 'rejected':
+				className = 'is-refund-rejected';
+				text = __( 'Refund rejected' );
+				break;
+			default:
+				return this.renderRefundLink( label );
+		}
+
+		return (
+			<span className={ className } ><Gridicon icon="time" size={ 12 } />{ text }</span>
+		);
+	};
+
+	renderReprint = ( label ) => {
+		const todayTime = new Date().getTime();
+		if ( label.refund ||
+			( label.used_date && label.used_date < todayTime ) ||
+			( label.expiry_date && label.expiry_date < todayTime ) ) {
+			return null;
+		}
+
+		const openDialog = ( e ) => {
+			e.preventDefault();
+			this.props.labelActions.openReprintDialog( label.label_id );
+		};
+
+		return (
+			<span>
+				<ReprintDialog { ...label } />
+				<a href="#" onClick={ openDialog } >
+					<Gridicon icon="print" size={ 12 } />{ __( 'Reprint' ) }
+				</a>
+			</span>
+		);
+	};
+
+	renderLabelDetails = ( label ) => {
+		if ( ! label.package_name || ! label.product_names ) {
+			return null;
+		}
+
+		const tooltipAnchor = (
+			<span className="label-item__detail">
+				{ __( 'Label #%(labelNum)s', { args: { labelNum: this.props.labelNum } } ) }
+			</span>
+		);
+		return (
+			<InfoTooltip anchor={ tooltipAnchor }>
+				<h3>{ label.package_name }</h3>
+				<p>{ label.service_name }</p>
+				<ul>
+					{ label.product_names.map( ( productName, productIdx ) => <li key={ productIdx }>{ productName }</li> ) }
+				</ul>
+			</InfoTooltip>
+		);
+	};
+
+	render() {
+		const { label } = this.props;
+		const purchased = timeAgo( label.created );
+
+		return (
+			<div key={ label.label_id } className="label-item" >
+				<p className="label-item__created">
+					{ __( '{{labelDetails/}} purchased {{purchasedAt/}}', {
+						components: {
+							labelDetails: this.renderLabelDetails( label ),
+							purchasedAt: <span title={ formatDate( label.created ) }>{ purchased }</span>
+						}
+					} ) }
+				</p>
+				<p className="label-item__tracking">
+					{ __( 'Tracking #: {{trackingLink/}}', { components: { trackingLink: <TrackingLink { ...label } /> } } ) }
+				</p>
+				<p className="label-item__actions" >
+					{ this.renderRefund( label ) }
+					{ this.renderReprint( label ) }
+				</p>
+			</div>
+		);
+	}
+}
+
+LabelItem.propTypes = {
+	label: PropTypes.object.isRequired,
+};
+
+function mapDispatchToProps( dispatch ) {
+	return {
+		labelActions: bindActionCreators( { openRefundDialog, openReprintDialog }, dispatch ),
+	};
+}
+
+export default connect( null, mapDispatchToProps )( LabelItem );

--- a/client/apps/shipping-label/components/label-item/index.js
+++ b/client/apps/shipping-label/components/label-item/index.js
@@ -28,7 +28,7 @@ class LabelItem extends Component {
 
 		const openDialog = ( e ) => {
 			e.preventDefault();
-			this.props.labelActions.openRefundDialog( label.label_id );
+			this.props.openRefundDialog( label.label_id );
 		};
 
 		return (
@@ -85,7 +85,7 @@ class LabelItem extends Component {
 
 		const openDialog = ( e ) => {
 			e.preventDefault();
-			this.props.labelActions.openReprintDialog( label.label_id );
+			this.props.openReprintDialog( label.label_id );
 		};
 
 		return (
@@ -147,12 +147,12 @@ class LabelItem extends Component {
 
 LabelItem.propTypes = {
 	label: PropTypes.object.isRequired,
+	openRefundDialog: PropTypes.func.isRequired,
+	openReprintDialog: PropTypes.func.isRequired,
 };
 
-function mapDispatchToProps( dispatch ) {
-	return {
-		labelActions: bindActionCreators( { openRefundDialog, openReprintDialog }, dispatch ),
-	};
-}
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( { openRefundDialog, openReprintDialog }, dispatch );
+};
 
 export default connect( null, mapDispatchToProps )( LabelItem );

--- a/client/apps/shipping-label/components/label-purchase-modal/address-step/fields.js
+++ b/client/apps/shipping-label/components/label-purchase-modal/address-step/fields.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { translate as __ } from 'i18n-calypso';
 import _ from 'lodash';
 
@@ -15,8 +17,17 @@ import StateDropdown from 'components/state-dropdown';
 import { hasNonEmptyLeaves } from 'lib/utils/tree';
 import AddressSuggestion from './suggestion';
 import { getPlainPhoneNumber, formatPhoneForDisplay } from 'lib/utils/phone-format';
+import getFormErrors from '../../../state/selectors/errors';
+import {
+	selectNormalizedAddress,
+	confirmAddressSuggestion,
+	editAddress,
+	updateAddressValue,
+	submitAddressForNormalization,
+} from '../../../state/actions';
 
-const AddressFields = ( {
+const AddressFields = ( props ) => {
+	const {
 		values,
 		isNormalized,
 		normalized,
@@ -24,22 +35,22 @@ const AddressFields = ( {
 		normalizationInProgress,
 		allowChangeCountry,
 		group,
-		labelActions,
 		storeOptions,
 		errors,
-	} ) => {
+	} = props;
+
 	if ( isNormalized && normalized && ! _.isEqual( normalized, values ) ) {
-		const selectNormalizedAddress = ( select ) => labelActions.selectNormalizedAddress( group, select );
-		const confirmAddressSuggestion = () => labelActions.confirmAddressSuggestion( group );
-		const editAddress = () => labelActions.editAddress( group );
+		const selectNormalizedAddressHandler = ( select ) => props.selectNormalizedAddress( group, select );
+		const confirmAddressSuggestionHandler = () => props.confirmAddressSuggestion( group );
+		const editAddressHandler = () => props.editAddress( group );
 		return (
 			<AddressSuggestion
 				values={ values }
 				normalized={ normalized }
 				selectNormalized={ selectNormalized }
-				selectNormalizedAddress={ selectNormalizedAddress }
-				confirmAddressSuggestion={ confirmAddressSuggestion }
-				editAddress={ editAddress }
+				selectNormalizedAddress={ selectNormalizedAddressHandler }
+				confirmAddressSuggestion={ confirmAddressSuggestionHandler }
+				editAddress={ editAddressHandler }
 				countriesData={ storeOptions.countriesData } />
 		);
 	}
@@ -47,10 +58,10 @@ const AddressFields = ( {
 	const fieldErrors = _.isObject( errors ) ? errors : {};
 	const getId = ( fieldName ) => group + '_' + fieldName;
 	const getValue = ( fieldName ) => values[ fieldName ] || '';
-	const updateValue = ( fieldName ) => ( newValue ) => labelActions.updateAddressValue( group, fieldName, newValue );
+	const updateValue = ( fieldName ) => ( newValue ) => props.updateAddressValue( group, fieldName, newValue );
 	const getPhoneNumber = ( value ) => getPlainPhoneNumber( value, getValue( 'country' ) );
-	const updatePhoneValue = ( value ) => labelActions.updateAddressValue( group, 'phone', getPhoneNumber( value ) );
-	const submitAddressForNormalization = () => labelActions.submitAddressForNormalization( group );
+	const updatePhoneValue = ( value ) => props.updateAddressValue( group, 'phone', getPhoneNumber( value ) );
+	const submitAddressForNormalizationHandler = () => props.submitAddressForNormalization( group );
 
 	return (
 		<div>
@@ -123,7 +134,7 @@ const AddressFields = ( {
 				error={ fieldErrors.country } />
 			<StepConfirmationButton
 				disabled={ hasNonEmptyLeaves( errors ) || normalizationInProgress }
-				onClick={ submitAddressForNormalization } >
+				onClick={ submitAddressForNormalizationHandler } >
 					{ __( 'Use this address' ) }
 			</StepConfirmationButton>
 		</div>
@@ -136,12 +147,32 @@ AddressFields.propTypes = {
 	normalized: PropTypes.object,
 	selectNormalized: PropTypes.bool.isRequired,
 	allowChangeCountry: PropTypes.bool.isRequired,
-	labelActions: PropTypes.object.isRequired,
 	storeOptions: PropTypes.object.isRequired,
 	errors: PropTypes.oneOfType( [
 		PropTypes.object,
 		PropTypes.bool,
 	] ).isRequired,
+	group: PropTypes.string.isRequired,
 };
 
-export default AddressFields;
+const mapStateToProps = ( state, ownProps ) => {
+	const loaded = state.shippingLabel.loaded;
+	const storeOptions = loaded ? state.shippingLabel.storeOptions : {};
+	return {
+		...state.shippingLabel.form[ ownProps.group ],
+		errors: loaded && getFormErrors( state, storeOptions )[ ownProps.group ],
+		storeOptions,
+	};
+};
+
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( {
+		selectNormalizedAddress,
+		confirmAddressSuggestion,
+		editAddress,
+		updateAddressValue,
+		submitAddressForNormalization,
+	}, dispatch );
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( AddressFields );

--- a/client/apps/shipping-label/components/label-purchase-modal/index.js
+++ b/client/apps/shipping-label/components/label-purchase-modal/index.js
@@ -60,9 +60,9 @@ const PurchaseDialog = ( props ) => {
 
 	const getPurchaseButtonAction = () => {
 		if ( props.form.needsPrintConfirmation ) {
-			return () => props.labelActions.confirmPrintLabel( props.form.printUrl );
+			return () => props.confirmPrintLabel( props.form.printUrl );
 		}
-		return props.labelActions.purchaseLabel;
+		return props.purchaseLabel;
 	};
 
 	const buttons = [
@@ -74,7 +74,7 @@ const PurchaseDialog = ( props ) => {
 		},
 	];
 
-	const closeModal = () => props.labelActions.exitPrintingFlow( false );
+	const closeModal = () => props.exitPrintingFlow( false );
 
 	if ( ! props.form.needsPrintConfirmation ) {
 		buttons.push( {
@@ -120,7 +120,7 @@ const PurchaseDialog = ( props ) => {
 	);
 };
 
-function mapStateToProps( state ) {
+const mapStateToProps = ( state ) => {
 	const shippingLabel = state.shippingLabel;
 	const loaded = shippingLabel.loaded;
 	const storeOptions = loaded ? shippingLabel.storeOptions : {};
@@ -131,12 +131,10 @@ function mapStateToProps( state ) {
 		errors: loaded && getFormErrors( state, storeOptions ),
 		canPurchase: loaded && canPurchase( state, storeOptions ),
 	};
-}
+};
 
-function mapDispatchToProps( dispatch ) {
-	return {
-		labelActions: bindActionCreators( { confirmPrintLabel, purchaseLabel, exitPrintingFlow }, dispatch ),
-	};
-}
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( { confirmPrintLabel, purchaseLabel, exitPrintingFlow }, dispatch );
+};
 
 export default connect( mapStateToProps, mapDispatchToProps )( PurchaseDialog );

--- a/client/apps/shipping-label/components/label-purchase-modal/index.js
+++ b/client/apps/shipping-label/components/label-purchase-modal/index.js
@@ -41,7 +41,7 @@ const PurchaseDialog = ( props ) => {
 		const noNativePDFSupport = ( 'addon' === getPDFSupport() );
 
 		if ( props.canPurchase ) {
-			const currencySymbol = props.storeOptions.currency_symbol;
+			const currencySymbol = props.currency_symbol;
 			const ratesTotal = getRatesTotal( props.form.rates );
 
 			if ( noNativePDFSupport ) {
@@ -93,26 +93,12 @@ const PurchaseDialog = ( props ) => {
 				</FormSectionHeading>
 				<div className="label-purchase-modal__body">
 					<div className="label-purchase-modal__main-section">
-						<AddressStep.Origin
-							{ ...props }
-							{ ...props.form.origin }
-							errors={ props.errors.origin } />
-						<AddressStep.Destination
-							{ ...props }
-							{ ...props.form.destination }
-							errors={ props.errors.destination } />
-						<PackagesStep
-							{ ...props }
-							{ ...props.form.packages }
-							errors={ props.errors.packages } />
-						<RatesStep
-							{ ...props }
-							{ ...props.form.rates }
-							errors={ props.errors.rates } />
+						<AddressStep type="origin" title={ __( 'Origin address' ) } />
+						<AddressStep type="destination" title={ __( 'Destination address' ) } />
+						<PackagesStep />
+						<RatesStep />
 					</div>
-					<Sidebar
-						{ ...props }
-						errors={ props.errors.rates } />
+					<Sidebar />
 				</div>
 				<ActionButtons buttons={ buttons } />
 			</div>
@@ -121,13 +107,12 @@ const PurchaseDialog = ( props ) => {
 };
 
 const mapStateToProps = ( state ) => {
-	const shippingLabel = state.shippingLabel;
-	const loaded = shippingLabel.loaded;
-	const storeOptions = loaded ? shippingLabel.storeOptions : {};
-
+	const loaded = state.shippingLabel.loaded;
+	const storeOptions = loaded ? state.shippingLabel.storeOptions : {};
 	return {
-		...shippingLabel,
-		storeOptions,
+		form: state.shippingLabel.form,
+		showPurchaseDialog: state.shippingLabel.showPurchaseDialog,
+		currency_symbol: storeOptions.currency_symbol,
 		errors: loaded && getFormErrors( state, storeOptions ),
 		canPurchase: loaded && canPurchase( state, storeOptions ),
 	};

--- a/client/apps/shipping-label/components/label-purchase-modal/packages-step/add-item.js
+++ b/client/apps/shipping-label/components/label-purchase-modal/packages-step/add-item.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { translate as __ } from 'i18n-calypso';
 import _ from 'lodash';
 
@@ -14,16 +16,17 @@ import FormLabel from 'components/forms/form-label';
 import ActionButtons from 'components/action-buttons';
 import getPackageDescriptions from './get-package-descriptions';
 import FormSectionHeading from 'components/forms/form-section-heading';
+import { closeAddItem, setAddedItem, addItems } from '../../../state/actions';
 
-const AddItemDialog = ( {
-	showAddItemDialog,
-	addedItems,
-	openedPackageId,
-	selected,
-	all,
-	closeAddItem,
-	setAddedItem,
-	addItems } ) => {
+const AddItemDialog = ( props ) => {
+	const {
+		showAddItemDialog,
+		addedItems,
+		openedPackageId,
+		selected,
+		all,
+	} = props;
+
 	if ( ! showAddItemDialog ) {
 		return null;
 	}
@@ -38,7 +41,7 @@ const AddItemDialog = ( {
 			? __( '%(item)s from {{pckg/}}', { args: { item: item.name }, components: { pckg: getPackageNameElement( pckgId ) } } )
 			: item;
 
-		const onChange = ( event ) => setAddedItem( pckgId, itemIdx, event.target.checked );
+		const onChange = ( event ) => props.setAddedItem( pckgId, itemIdx, event.target.checked );
 		return (
 			<FormLabel
 				key={ `${ pckgId }-${ itemIdx }` }
@@ -66,8 +69,8 @@ const AddItemDialog = ( {
 	return (
 		<Dialog isVisible={ showAddItemDialog }
 				isFullScreen={ false }
-				onClickOutside={ closeAddItem }
-				onClose={ closeAddItem }
+				onClickOutside={ props.closeAddItem }
+				onClose={ props.closeAddItem }
 				additionalClassNames="wcc-root packages-step__dialog" >
 			<FormSectionHeading>{ __( 'Add item' ) }</FormSectionHeading>
 			<div className="packages-step__dialog-body">
@@ -85,9 +88,9 @@ const AddItemDialog = ( {
 					label: __( 'Add' ),
 					isPrimary: true,
 					isDisabled: ! _.some( addedItems, _.size ),
-					onClick: () => addItems( openedPackageId ),
+					onClick: () => props.addItems( openedPackageId ),
 				},
-				{ label: __( 'Close' ), onClick: closeAddItem },
+				{ label: __( 'Close' ), onClick: props.closeAddItem },
 			] } />
 		</Dialog>
 	);
@@ -104,4 +107,18 @@ AddItemDialog.propTypes = {
 	addItems: PropTypes.func.isRequired,
 };
 
-export default AddItemDialog;
+const mapStateToProps = ( state ) => {
+	return {
+		showAddItemDialog: state.shippingLabel.showAddItemDialog || false,
+		addedItems: state.shippingLabel.addedItems,
+		openedPackageId: state.shippingLabel.openedPackageId,
+		selected: state.shippingLabel.form.packages.selected,
+		all: state.shippingLabel.form.packages.all,
+	};
+};
+
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( { closeAddItem, setAddedItem, addItems }, dispatch );
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( AddItemDialog );

--- a/client/apps/shipping-label/components/label-purchase-modal/packages-step/item-info.js
+++ b/client/apps/shipping-label/components/label-purchase-modal/packages-step/item-info.js
@@ -2,15 +2,19 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
+import { openItemMove, removeItem } from '../../../state/actions';
 
-const ItemInfo = ( { item, itemIndex, openItemMove } ) => {
-	const onMoveClick = () => openItemMove( itemIndex );
+const ItemInfo = ( props ) => {
+	const { item, itemIndex } = props;
+	const onMoveClick = () => props.openItemMove( itemIndex );
 
 	const renderMoveToPackage = () => {
 		return (
@@ -44,4 +48,11 @@ ItemInfo.propTypes = {
 	openItemMove: PropTypes.func.isRequired,
 };
 
-export default ItemInfo;
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( {
+		openItemMove,
+		removeItem,
+	}, dispatch );
+};
+
+export default connect( null, mapDispatchToProps )( ItemInfo );

--- a/client/apps/shipping-label/components/label-purchase-modal/packages-step/list.js
+++ b/client/apps/shipping-label/components/label-purchase-modal/packages-step/list.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { translate as __ } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import classNames from 'classnames';
@@ -10,8 +12,12 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import getPackageDescriptions from './get-package-descriptions';
+import getFormErrors from '../../../state/selectors/errors';
+import { openPackage } from '../../../state/actions';
 
-const PackageList = ( { selected, all, errors, packageId, openPackage } ) => {
+const PackageList = ( props ) => {
+	const { selected, all, errors, packageId } = props;
+
 	const renderCountOrError = ( isError, count ) => {
 		if ( isError ) {
 			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
@@ -27,7 +33,7 @@ const PackageList = ( { selected, all, errors, packageId, openPackage } ) => {
 
 	const renderPackageListItem = ( pckgId, name, count ) => {
 		const isError = 0 < Object.keys( errors[ pckgId ] || {} ).length;
-		const onOpenClick = () => openPackage( pckgId );
+		const onOpenClick = () => props.openPackage( pckgId );
 		return (
 			<div className="packages-step__list-item" key={ pckgId }>
 				<div
@@ -78,4 +84,20 @@ PackageList.propTypes = {
 	openPackage: PropTypes.func.isRequired,
 };
 
-export default PackageList;
+const mapStateToProps = ( state ) => {
+	const loaded = state.shippingLabel.loaded;
+	const storeOptions = loaded ? state.shippingLabel.storeOptions : {};
+	const errors = loaded && getFormErrors( state, storeOptions ).packages;
+	return {
+		errors,
+		packageId: state.shippingLabel.openedPackageId,
+		selected: state.shippingLabel.form.packages.selected,
+		all: state.shippingLabel.form.packages.all,
+	};
+};
+
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( { openPackage }, dispatch );
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( PackageList );

--- a/client/apps/shipping-label/components/label-purchase-modal/packages-step/move-item.js
+++ b/client/apps/shipping-label/components/label-purchase-modal/packages-step/move-item.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { translate as __ } from 'i18n-calypso';
 
 /**
@@ -13,23 +15,24 @@ import FormLabel from 'components/forms/form-label';
 import ActionButtons from 'components/action-buttons';
 import getPackageDescriptions from './get-package-descriptions';
 import FormSectionHeading from 'components/forms/form-section-heading';
+import { closeItemMove, setTargetPackage, moveItem } from '../../../state/actions';
 
-const MoveItemDialog = ( {
-	showItemMoveDialog,
-	movedItemIndex,
-	targetPackageId,
-	openedPackageId,
-	selected,
-	all,
-	closeItemMove,
-	setTargetPackage,
-	moveItem } ) => {
+const MoveItemDialog = ( props ) => {
+	const {
+		showItemMoveDialog,
+		movedItemIndex,
+		targetPackageId,
+		openedPackageId,
+		selected,
+		all,
+	} = props;
+
 	if ( -1 === movedItemIndex || ! showItemMoveDialog ) {
 		return null;
 	}
 
 	const renderRadioButton = ( pckgId, label ) => {
-		const onChange = () => setTargetPackage( pckgId );
+		const onChange = () => props.setTargetPackage( pckgId );
 		return (
 			<FormLabel
 				key={ pckgId }
@@ -93,8 +96,8 @@ const MoveItemDialog = ( {
 	return (
 		<Dialog isVisible={ showItemMoveDialog }
 				isFullScreen={ false }
-				onClickOutside={ closeItemMove }
-				onClose={ closeItemMove }
+				onClickOutside={ props.closeItemMove }
+				onClose={ props.closeItemMove }
 				additionalClassNames="wcc-root packages-step__dialog" >
 			<FormSectionHeading>{ __( 'Move item' ) }</FormSectionHeading>
 			<div className="packages-step__dialog-body">
@@ -109,9 +112,9 @@ const MoveItemDialog = ( {
 					label: __( 'Move' ),
 					isPrimary: true,
 					isDisabled: targetPackageId === openedPackageId,  // Result of targetPackageId initialization
-					onClick: () => moveItem( openedPackageId, movedItemIndex, targetPackageId ),
+					onClick: () => props.moveItem( openedPackageId, movedItemIndex, targetPackageId ),
 				},
-				{ label: __( 'Cancel' ), onClick: closeItemMove },
+				{ label: __( 'Cancel' ), onClick: props.closeItemMove },
 			] } />
 		</Dialog>
 	);
@@ -127,4 +130,19 @@ MoveItemDialog.propTypes = {
 	moveItem: PropTypes.func.isRequired,
 };
 
-export default MoveItemDialog;
+const mapStateToProps = ( state ) => {
+	return {
+		showItemMoveDialog: state.shippingLabel.showItemMoveDialog || false,
+		movedItemIndex: isNaN( state.shippingLabel.movedItemIndex ) ? -1 : state.shippingLabel.movedItemIndex,
+		targetPackageId: state.shippingLabel.targetPackageId,
+		openedPackageId: state.shippingLabel.openedPackageId,
+		selected: state.shippingLabel.form.packages.selected,
+		all: state.shippingLabel.form.packages.all,
+	};
+};
+
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( { closeItemMove, setTargetPackage, moveItem }, dispatch );
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( MoveItemDialog );

--- a/client/apps/shipping-label/components/label-purchase-modal/packages-step/package-info.js
+++ b/client/apps/shipping-label/components/label-purchase-modal/packages-step/package-info.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { translate as __ } from 'i18n-calypso';
 import _ from 'lodash';
 
@@ -14,6 +16,13 @@ import FormLegend from 'components/forms/form-legend';
 import FormSelect from 'components/forms/form-select';
 import Button from 'components/button';
 import getBoxDimensions from 'lib/utils/get-box-dimensions';
+import getFormErrors from '../../../state/selectors/errors';
+import {
+	updateWeight,
+	removePackage,
+	setPackageType,
+	openAddItem,
+} from '../../../state/actions';
 
 const renderPackageDimensions = ( dimensions, dimensionUnit ) => {
 	return `${ dimensions.length } ${ dimensionUnit } x 
@@ -21,7 +30,8 @@ const renderPackageDimensions = ( dimensions, dimensionUnit ) => {
 			${ dimensions.height } ${ dimensionUnit }`;
 };
 
-const PackageInfo = ( {
+const PackageInfo = ( props ) => {
+	const {
 		packageId,
 		selected,
 		all,
@@ -29,12 +39,8 @@ const PackageInfo = ( {
 		dimensionUnit,
 		weightUnit,
 		errors,
-		updateWeight,
-		openItemMove,
-		removeItem,
-		setPackageType,
-		openAddItem,
-	} ) => {
+	} = props;
+
 	const pckgErrors = errors[ packageId ] || {};
 	if ( ! packageId ) {
 		return null;
@@ -50,8 +56,6 @@ const PackageInfo = ( {
 					itemIndex={ itemIndex }
 					packageId={ packageId }
 					showRemove
-					openItemMove={ openItemMove }
-					removeItem={ removeItem }
 					isIndividualPackage={ isIndividualPackage } />
 		);
 	};
@@ -66,11 +70,11 @@ const PackageInfo = ( {
 			return null;
 		}
 
-		return ( <Button className="packages-step__add-item-btn" compact onClick={ openAddItem }>{ __( 'Add items' ) }</Button> );
+		return ( <Button className="packages-step__add-item-btn" compact onClick={ props.openAddItem }>{ __( 'Add items' ) }</Button> );
 	};
 
 	const packageOptionChange = ( e ) => {
-		setPackageType( packageId, e.target.value );
+		props.setPackageType( packageId, e.target.value );
 	};
 
 	const renderItems = () => {
@@ -141,7 +145,7 @@ const PackageInfo = ( {
 		);
 	};
 
-	const onWeightChange = ( value ) => updateWeight( packageId, value );
+	const onWeightChange = ( value ) => props.updateWeight( packageId, value );
 
 	return (
 		<div className="packages-step__package">
@@ -177,10 +181,32 @@ PackageInfo.propTypes = {
 	dimensionUnit: PropTypes.string.isRequired,
 	weightUnit: PropTypes.string.isRequired,
 	errors: PropTypes.object.isRequired,
-	openItemMove: PropTypes.func.isRequired,
-	removeItem: PropTypes.func.isRequired,
 	setPackageType: PropTypes.func.isRequired,
 	openAddItem: PropTypes.func.isRequired,
 };
 
-export default PackageInfo;
+const mapStateToProps = ( state ) => {
+	const loaded = state.shippingLabel.loaded;
+	const storeOptions = loaded ? state.shippingLabel.storeOptions : {};
+	const errors = loaded && getFormErrors( state, storeOptions ).packages;
+	return {
+		errors,
+		packageId: state.shippingLabel.openedPackageId,
+		selected: state.shippingLabel.form.packages.selected,
+		all: state.shippingLabel.form.packages.all,
+		flatRateGroups: state.shippingLabel.form.packages.flatRateGroups,
+		dimensionUnit: storeOptions.dimension_unit,
+		weightUnit: storeOptions.weight_unit,
+	};
+};
+
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( {
+		updateWeight,
+		removePackage,
+		setPackageType,
+		openAddItem,
+	}, dispatch );
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( PackageInfo );

--- a/client/apps/shipping-label/components/label-purchase-modal/packages-step/style.scss
+++ b/client/apps/shipping-label/components/label-purchase-modal/packages-step/style.scss
@@ -25,7 +25,7 @@
 	}
 }
 
-.packages-step {
+.packages-step__contents {
 	display: flex;
 	padding-bottom: 24px;
 }

--- a/client/apps/shipping-label/components/label-purchase-modal/sidebar.js
+++ b/client/apps/shipping-label/components/label-purchase-modal/sidebar.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { translate as __ } from 'i18n-calypso';
 
 /**
@@ -9,8 +11,11 @@ import { translate as __ } from 'i18n-calypso';
  */
 import { getPaperSizes } from 'lib/pdf-label-utils';
 import Dropdown from 'components/dropdown';
+import getFormErrors from '../../state/selectors/errors';
+import { updatePaperSize } from '../../state/actions';
 
-const Sidebar = ( { form, errors, labelActions, paperSize } ) => {
+const Sidebar = ( props ) => {
+	const { form, errors, paperSize } = props;
 	return (
 		<div className="label-purchase-modal__sidebar">
 			<Dropdown
@@ -18,7 +23,7 @@ const Sidebar = ( { form, errors, labelActions, paperSize } ) => {
 				valuesMap={ getPaperSizes( form.origin.values.country ) }
 				title={ __( 'Paper size' ) }
 				value={ paperSize }
-				updateValue={ labelActions.updatePaperSize }
+				updateValue={ props.updatePaperSize }
 				error={ errors.paperSize } />
 		</div>
 	);
@@ -28,7 +33,21 @@ Sidebar.propTypes = {
 	paperSize: PropTypes.string.isRequired,
 	errors: PropTypes.object.isRequired,
 	form: PropTypes.object.isRequired,
-	labelActions: PropTypes.object.isRequired,
+	updatePaperSize: PropTypes.func.isRequired,
 };
 
-export default Sidebar;
+const mapStateToProps = ( state ) => {
+	const loaded = state.shippingLabel.loaded;
+	const storeOptions = loaded ? state.shippingLabel.storeOptions : {};
+	return {
+		paperSize: state.shippingLabel.paperSize,
+		form: state.shippingLabel.form,
+		errors: loaded && getFormErrors( state, storeOptions ).sidebar,
+	};
+};
+
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( { updatePaperSize }, dispatch );
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( Sidebar );

--- a/client/apps/shipping-label/components/label-refund-modal/index.js
+++ b/client/apps/shipping-label/components/label-refund-modal/index.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { translate as __ } from 'i18n-calypso';
 
 /**
@@ -11,6 +13,7 @@ import Modal from 'components/modal';
 import ActionButtons from 'components/action-buttons';
 import formatDate from 'lib/utils/format-date';
 import FormSectionHeading from 'components/forms/form-section-heading';
+import { closeRefundDialog, confirmRefund } from '../../state/actions';
 
 const RefundDialog = ( { refundDialog, labelActions, storeOptions, created, refundable_amount, label_id } ) => {
 	const getRefundableAmount = () => {
@@ -62,4 +65,19 @@ RefundDialog.propTypes = {
 	label_id: PropTypes.number,
 };
 
-export default RefundDialog;
+function mapStateToProps( state ) {
+	const shippingLabel = state.shippingLabel;
+	const loaded = shippingLabel.loaded;
+	return {
+		refundDialog: loaded ? shippingLabel.refundDialog : {},
+		storeOptions: loaded ? shippingLabel.storeOptions : {},
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return {
+		labelActions: bindActionCreators( { closeRefundDialog, confirmRefund }, dispatch ),
+	};
+}
+
+export default connect( mapStateToProps, mapDispatchToProps )( RefundDialog );

--- a/client/apps/shipping-label/components/label-refund-modal/index.js
+++ b/client/apps/shipping-label/components/label-refund-modal/index.js
@@ -15,7 +15,9 @@ import formatDate from 'lib/utils/format-date';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import { closeRefundDialog, confirmRefund } from '../../state/actions';
 
-const RefundDialog = ( { refundDialog, labelActions, storeOptions, created, refundable_amount, label_id } ) => {
+const RefundDialog = ( props ) => {
+	const { refundDialog, storeOptions, created, refundable_amount, label_id } = props;
+
 	const getRefundableAmount = () => {
 		return storeOptions.currency_symbol + Number( refundable_amount ).toFixed( 2 );
 	};
@@ -23,7 +25,7 @@ const RefundDialog = ( { refundDialog, labelActions, storeOptions, created, refu
 	return (
 		<Modal
 			isVisible={ Boolean( refundDialog && refundDialog.labelId === label_id ) }
-			onClose={ labelActions.closeRefundDialog }
+			onClose={ props.closeRefundDialog }
 			additionalClassNames="label-refund-modal">
 			<FormSectionHeading>
 				{ __( 'Request a refund' ) }
@@ -42,13 +44,13 @@ const RefundDialog = ( { refundDialog, labelActions, storeOptions, created, refu
 			</dl>
 			<ActionButtons buttons={ [
 				{
-					onClick: labelActions.confirmRefund,
+					onClick: props.confirmRefund,
 					isPrimary: true,
 					isDisabled: refundDialog && refundDialog.isSubmitting,
 					label: __( 'Refund label (-%(amount)s)', { args: { amount: getRefundableAmount() } } ),
 				},
 				{
-					onClick: labelActions.closeRefundDialog,
+					onClick: props.closeRefundDialog,
 					label: __( 'Cancel' ),
 				},
 			] } />
@@ -58,26 +60,25 @@ const RefundDialog = ( { refundDialog, labelActions, storeOptions, created, refu
 
 RefundDialog.propTypes = {
 	refundDialog: PropTypes.object,
-	labelActions: PropTypes.object.isRequired,
 	storeOptions: PropTypes.object.isRequired,
 	created: PropTypes.number,
 	refundable_amount: PropTypes.number,
 	label_id: PropTypes.number,
+	closeRefundDialog: PropTypes.func.isRequired,
+	confirmRefund: PropTypes.func.isRequired,
 };
 
-function mapStateToProps( state ) {
+const mapStateToProps = ( state ) => {
 	const shippingLabel = state.shippingLabel;
 	const loaded = shippingLabel.loaded;
 	return {
 		refundDialog: loaded ? shippingLabel.refundDialog : {},
 		storeOptions: loaded ? shippingLabel.storeOptions : {},
 	};
-}
+};
 
-function mapDispatchToProps( dispatch ) {
-	return {
-		labelActions: bindActionCreators( { closeRefundDialog, confirmRefund }, dispatch ),
-	};
-}
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( { closeRefundDialog, confirmRefund }, dispatch );
+};
 
 export default connect( mapStateToProps, mapDispatchToProps )( RefundDialog );

--- a/client/apps/shipping-label/components/label-reprint-modal/index.js
+++ b/client/apps/shipping-label/components/label-reprint-modal/index.js
@@ -16,11 +16,12 @@ import { getPaperSizes } from 'lib/pdf-label-utils';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import { closeReprintDialog, confirmReprint, updatePaperSize } from '../../state/actions';
 
-const ReprintDialog = ( { reprintDialog, labelActions, paperSize, storeOptions } ) => {
+const ReprintDialog = ( props ) => {
+	const { reprintDialog, paperSize, storeOptions } = props;
 	return (
 		<Modal
 			isVisible={ Boolean( reprintDialog ) }
-			onClose={ labelActions.closeReprintDialog }
+			onClose={ props.closeReprintDialog }
 			additionalClassNames="label-reprint-modal">
 			<FormSectionHeading>
 				{ __( 'Reprint shipping label' ) }
@@ -37,16 +38,16 @@ const ReprintDialog = ( { reprintDialog, labelActions, paperSize, storeOptions }
 				valuesMap={ getPaperSizes( storeOptions.origin_country ) }
 				title={ __( 'Paper size' ) }
 				value={ paperSize }
-				updateValue={ labelActions.updatePaperSize } />
+				updateValue={ props.updatePaperSize } />
 			<ActionButtons buttons={ [
 				{
-					onClick: labelActions.confirmReprint,
+					onClick: props.confirmReprint,
 					isPrimary: true,
 					isDisabled: reprintDialog && reprintDialog.isFetching,
 					label: __( 'Print' ),
 				},
 				{
-					onClick: labelActions.closeReprintDialog,
+					onClick: props.closeReprintDialog,
 					label: __( 'Cancel' ),
 				},
 			] } />
@@ -56,12 +57,14 @@ const ReprintDialog = ( { reprintDialog, labelActions, paperSize, storeOptions }
 
 ReprintDialog.propTypes = {
 	reprintDialog: PropTypes.object,
-	labelActions: PropTypes.object.isRequired,
 	paperSize: PropTypes.string.isRequired,
 	storeOptions: PropTypes.object.isRequired,
+	closeReprintDialog: PropTypes.func.isRequired,
+	confirmReprint: PropTypes.func.isRequired,
+	updatePaperSize: PropTypes.func.isRequired,
 };
 
-function mapStateToProps( state ) {
+const mapStateToProps = ( state ) => {
 	const shippingLabel = state.shippingLabel;
 	const loaded = shippingLabel.loaded;
 	return {
@@ -69,12 +72,10 @@ function mapStateToProps( state ) {
 		paperSize: shippingLabel.paperSize,
 		storeOptions: loaded ? shippingLabel.storeOptions : {},
 	};
-}
+};
 
-function mapDispatchToProps( dispatch ) {
-	return {
-		labelActions: bindActionCreators( { closeReprintDialog, confirmReprint, updatePaperSize }, dispatch ),
-	};
-}
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( { closeReprintDialog, confirmReprint, updatePaperSize }, dispatch );
+};
 
 export default connect( mapStateToProps, mapDispatchToProps )( ReprintDialog );

--- a/client/apps/shipping-label/components/label-reprint-modal/index.js
+++ b/client/apps/shipping-label/components/label-reprint-modal/index.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { translate as __ } from 'i18n-calypso';
 
 /**
@@ -12,6 +14,7 @@ import ActionButtons from 'components/action-buttons';
 import Dropdown from 'components/dropdown';
 import { getPaperSizes } from 'lib/pdf-label-utils';
 import FormSectionHeading from 'components/forms/form-section-heading';
+import { closeReprintDialog, confirmReprint, updatePaperSize } from '../../state/actions';
 
 const ReprintDialog = ( { reprintDialog, labelActions, paperSize, storeOptions } ) => {
 	return (
@@ -58,4 +61,20 @@ ReprintDialog.propTypes = {
 	storeOptions: PropTypes.object.isRequired,
 };
 
-export default ReprintDialog;
+function mapStateToProps( state ) {
+	const shippingLabel = state.shippingLabel;
+	const loaded = shippingLabel.loaded;
+	return {
+		reprintDialog: loaded ? shippingLabel.reprintDialog : {},
+		paperSize: shippingLabel.paperSize,
+		storeOptions: loaded ? shippingLabel.storeOptions : {},
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return {
+		labelActions: bindActionCreators( { closeReprintDialog, confirmReprint, updatePaperSize }, dispatch ),
+	};
+}
+
+export default connect( mapStateToProps, mapDispatchToProps )( ReprintDialog );

--- a/client/apps/shipping-label/style.scss
+++ b/client/apps/shipping-label/style.scss
@@ -12,11 +12,11 @@
 		margin-top: 8px;
 	}
 
-	.shipping-label__item {
+	.shipping-label__item, .label-item {
 		padding: 16px;
 		border-bottom: 1px solid #eee;
 
-		.shipping-label__item-created {
+		.label-item__created {
 			color: $gray;
 			font-size: 12px;
 		}
@@ -29,7 +29,7 @@
 			margin-bottom: 3px;
 			text-align: left;
 
-			&.shipping-label__item-tracking {
+			&.label-item__tracking {
 				margin-bottom: 16px;
 				font-size: 12px;
 
@@ -39,7 +39,7 @@
 				}
 			}
 
-			& .shipping-label__item-detail {
+			& .label-item__detail {
 				font-weight: bold;
 				font-size: 14px;
 				color: $gray-dark;
@@ -55,7 +55,7 @@
 			margin-top: 16px;
 		}
 
-		.shipping-label__item-actions {
+		.label-item__actions {
 			display: flex;
 			justify-content: space-between;
 			font-size: 12px;

--- a/client/apps/shipping-label/view.js
+++ b/client/apps/shipping-label/view.js
@@ -23,13 +23,13 @@ import Notice from 'components/notice';
 class ShippingLabelRootView extends Component {
 	componentWillMount() {
 		if ( this.props.needToFetchLabelStatus ) {
-			this.props.labelActions.fetchLabelsStatus();
+			this.props.fetchLabelsStatus();
 		}
 	}
 
 	componentWillReceiveProps( props ) {
 		if ( props.needToFetchLabelStatus ) {
-			this.props.labelActions.fetchLabelsStatus();
+			this.props.fetchLabelsStatus();
 		}
 	}
 
@@ -70,7 +70,7 @@ class ShippingLabelRootView extends Component {
 
 	renderLabelButton = () => {
 		return (
-			<Button className="shipping-label__new-label-button" onClick={ this.props.labelActions.openPrintingFlow } >
+			<Button className="shipping-label__new-label-button" onClick={ this.props.openPrintingFlow } >
 				{ __( 'Create new label' ) }
 			</Button>
 		);
@@ -93,13 +93,15 @@ class ShippingLabelRootView extends Component {
 		const labelsToRender = filter( this.props.shippingLabel.labels,
 			( label ) => 'PURCHASE_IN_PROGRESS' !== label.status && 'PURCHASE_ERROR' !== label.status );
 
-		return labelsToRender.map( ( label, index ) =>
-			<LabelItem
-				key={ label.label_id }
-				label={ label }
-				labelNum={ labelsToRender.length - index }
-			/>
-		);
+		return labelsToRender.map( ( label, index ) => {
+			return (
+				<LabelItem
+					key={ label.label_id }
+					label={ label }
+					labelNum={ labelsToRender.length - index }
+				/>
+			);
+		} );
 	};
 
 	renderLoading() {
@@ -129,23 +131,24 @@ class ShippingLabelRootView extends Component {
 
 ShippingLabelRootView.propTypes = {
 	shippingLabel: PropTypes.object.isRequired,
+	loaded: PropTypes.bool.isRequired,
+	needToFetchLabelStatus: PropTypes.bool.isRequired,
+	fetchLabelsStatus: PropTypes.func.isRequired,
+	openPrintingFlow: PropTypes.func.isRequired,
 };
 
-function mapStateToProps( state ) {
+const mapStateToProps = ( state ) => {
 	const shippingLabel = state.shippingLabel;
 	const loaded = shippingLabel.loaded;
-
 	return {
 		shippingLabel,
 		loaded,
 		needToFetchLabelStatus: loaded && ! shippingLabel.refreshedLabelStatus,
 	};
-}
+};
 
-function mapDispatchToProps( dispatch ) {
-	return {
-		labelActions: bindActionCreators( { fetchLabelsStatus, openPrintingFlow }, dispatch ),
-	};
-}
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( { fetchLabelsStatus, openPrintingFlow }, dispatch );
+};
 
 export default connect( mapStateToProps, mapDispatchToProps )( ShippingLabelRootView );

--- a/client/apps/shipping-label/view.js
+++ b/client/apps/shipping-label/view.js
@@ -4,7 +4,6 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import Gridicon from 'gridicons';
 import { translate as __ } from 'i18n-calypso';
 import { filter } from 'lodash';
 
@@ -15,17 +14,10 @@ import Button from 'components/button';
 import LoadingSpinner from 'components/loading-spinner';
 import PurchaseDialog from './components/label-purchase-modal';
 import QueryLabels from 'components/query-labels';
-import RefundDialog from './components/label-refund-modal';
-import ReprintDialog from './components/label-reprint-modal';
-import TrackingLink from './components/tracking-link';
-import InfoTooltip from 'components/info-tooltip';
-import formatDate from 'lib/utils/format-date';
-import timeAgo from 'lib/utils/time-ago';
-import * as ShippingLabelActions from './state/actions';
+import LabelItem from './components/label-item';
+import { fetchLabelsStatus, openPrintingFlow } from './state/actions';
 import notices from 'notices';
 import GlobalNotices from 'components/global-notices';
-import getFormErrors from './state/selectors/errors';
-import canPurchase from './state/selectors/can-purchase';
 import Notice from 'components/notice';
 
 class ShippingLabelRootView extends Component {
@@ -89,143 +81,9 @@ class ShippingLabelRootView extends Component {
 
 		return (
 			<div className="shipping-label__item" >
-				<PurchaseDialog
-					{ ...this.props.shippingLabel }
-					{ ...this.props } />
+				<PurchaseDialog />
 				{ this.renderPaymentInfo( paymentMethod ) }
 				{ paymentMethod && this.renderLabelButton() }
-			</div>
-		);
-	};
-
-	renderRefundLink = ( label ) => {
-		const today = new Date();
-		const thirtyDaysAgo = new Date().setDate( today.getDate() - 30 );
-		if ( ( label.used_date && label.used_date < today.getTime() ) || ( label.created_date && label.created_date < thirtyDaysAgo ) ) {
-			return null;
-		}
-
-		const openRefundDialog = ( e ) => {
-			e.preventDefault();
-			this.props.labelActions.openRefundDialog( label.label_id );
-		};
-
-		return (
-			<span>
-				<RefundDialog
-					refundDialog={ this.props.shippingLabel.refundDialog }
-					{ ...this.props.shippingLabel }
-					{ ...this.props }
-					{ ...label } />
-				<a href="#" onClick={ openRefundDialog } >
-					<Gridicon icon="refund" size={ 12 } />{ __( 'Request refund' ) }
-				</a>
-			</span>
-		);
-	};
-
-	renderRefund = ( label ) => {
-		if ( ! label.refund ) {
-			return this.renderRefundLink( label );
-		}
-
-		let text = '';
-		let className = '';
-		switch ( label.refund.status ) {
-			case 'pending':
-				if ( label.statusUpdated ) {
-					className = 'is-refund-pending';
-					text = __( 'Refund pending' );
-				} else {
-					className = 'is-refund-checking';
-					text = __( 'Checking refund status' );
-				}
-				break;
-			case 'complete':
-				className = 'is-refund-complete';
-				text = __( 'Refunded on %(date)s', { args: { date: formatDate( label.refund.refund_date ) } } );
-				break;
-			case 'rejected':
-				className = 'is-refund-rejected';
-				text = __( 'Refund rejected' );
-				break;
-			default:
-				return this.renderRefundLink( label );
-		}
-
-		return (
-			<span className={ className } ><Gridicon icon="time" size={ 12 } />{ text }</span>
-		);
-	};
-
-	renderReprint = ( label ) => {
-		const todayTime = new Date().getTime();
-		if ( label.refund ||
-			( label.used_date && label.used_date < todayTime ) ||
-			( label.expiry_date && label.expiry_date < todayTime ) ) {
-			return null;
-		}
-
-		const openReprintDialog = ( e ) => {
-			e.preventDefault();
-			this.props.labelActions.openReprintDialog( label.label_id );
-		};
-
-		return (
-			<span>
-				<ReprintDialog
-					reprintDialog={ this.props.shippingLabel.reprintDialog }
-					{ ...this.props.shippingLabel }
-					{ ...this.props }
-					{ ...label } />
-				<a href="#" onClick={ openReprintDialog } >
-					<Gridicon icon="print" size={ 12 } />{ __( 'Reprint' ) }
-				</a>
-			</span>
-		);
-	};
-
-	renderLabelDetails = ( label, labelNum ) => {
-		if ( ! label.package_name || ! label.product_names ) {
-			return null;
-		}
-
-		const tooltipAnchor = (
-			<span className="shipping-label__item-detail">
-				{ __( 'Label #%(labelNum)s', { args: { labelNum } } ) }
-			</span>
-		);
-		return (
-			<InfoTooltip anchor={ tooltipAnchor }>
-				<h3>{ label.package_name }</h3>
-				<p>{ label.service_name }</p>
-				<ul>
-					{ label.product_names.map( ( productName, productIdx ) => <li key={ productIdx }>{ productName }</li> ) }
-				</ul>
-			</InfoTooltip>
-		);
-	};
-
-	renderLabel = ( label, index, labels ) => {
-		const purchased = timeAgo( label.created );
-
-		return (
-			<div key={ label.label_id } className="shipping-label__item" >
-				<p className="shipping-label__item-created">
-					{ __( '{{labelDetails/}} purchased {{purchasedAt/}}', {
-						components: {
-							labelDetails: this.renderLabelDetails( label, labels.length - index, index ),
-							purchasedAt: <span title={ formatDate( label.created ) }>{ purchased }</span>
-						}
-					} ) }
-				</p>
-				<p className="shipping-label__item-tracking">
-					{ __( 'Tracking #: {{trackingLink/}}', { components: { trackingLink: <TrackingLink { ...label } /> } } ) }
-				</p>
-				<p className="shipping-label__item-actions" >
-					{ this.renderRefund( label ) }
-					{ this.renderReprint( label ) }
-				</p>
 			</div>
 		);
 	};
@@ -235,7 +93,13 @@ class ShippingLabelRootView extends Component {
 		const labelsToRender = filter( this.props.shippingLabel.labels,
 			( label ) => 'PURCHASE_IN_PROGRESS' !== label.status && 'PURCHASE_ERROR' !== label.status );
 
-		return labelsToRender.map( this.renderLabel );
+		return labelsToRender.map( ( label, index ) =>
+			<LabelItem
+				key={ label.label_id }
+				label={ label }
+				labelNum={ labelsToRender.length - index }
+			/>
+		);
 	};
 
 	renderLoading() {
@@ -264,32 +128,24 @@ class ShippingLabelRootView extends Component {
 }
 
 ShippingLabelRootView.propTypes = {
-	storeOptions: PropTypes.object.isRequired,
 	shippingLabel: PropTypes.object.isRequired,
 };
 
 function mapStateToProps( state ) {
 	const shippingLabel = state.shippingLabel;
 	const loaded = shippingLabel.loaded;
-	const storeOptions = loaded ? shippingLabel.storeOptions : {};
 
 	return {
 		shippingLabel,
 		loaded,
-		storeOptions,
 		needToFetchLabelStatus: loaded && ! shippingLabel.refreshedLabelStatus,
-		errors: loaded && getFormErrors( state, storeOptions ),
-		canPurchase: loaded && canPurchase( state, storeOptions ),
 	};
 }
 
 function mapDispatchToProps( dispatch ) {
 	return {
-		labelActions: bindActionCreators( ShippingLabelActions, dispatch ),
+		labelActions: bindActionCreators( { fetchLabelsStatus, openPrintingFlow }, dispatch ),
 	};
 }
 
-export default connect(
-	mapStateToProps,
-	mapDispatchToProps
-)( ShippingLabelRootView );
+export default connect( mapStateToProps, mapDispatchToProps )( ShippingLabelRootView );

--- a/client/apps/shipping-label/view.js
+++ b/client/apps/shipping-label/view.js
@@ -34,8 +34,7 @@ class ShippingLabelRootView extends Component {
 	}
 
 	renderPaymentInfo = () => {
-		const numPaymentMethods = this.props.shippingLabel.numPaymentMethods;
-		const paymentMethod = this.props.shippingLabel.paymentMethod;
+		const { numPaymentMethods, paymentMethod } = this.props;
 
 		if ( numPaymentMethods > 0 && paymentMethod ) {
 			return (
@@ -77,20 +76,18 @@ class ShippingLabelRootView extends Component {
 	};
 
 	renderPurchaseLabelFlow = () => {
-		const paymentMethod = this.props.shippingLabel.paymentMethod;
-
 		return (
 			<div className="shipping-label__item" >
 				<PurchaseDialog />
-				{ this.renderPaymentInfo( paymentMethod ) }
-				{ paymentMethod && this.renderLabelButton() }
+				{ this.renderPaymentInfo() }
+				{ this.props.paymentMethod && this.renderLabelButton() }
 			</div>
 		);
 	};
 
 	renderLabels = () => {
 		//filter by blacklist (rather than just checking for PURCHASED) to handle legacy labels without the status field
-		const labelsToRender = filter( this.props.shippingLabel.labels,
+		const labelsToRender = filter( this.props.labels,
 			( label ) => 'PURCHASE_IN_PROGRESS' !== label.status && 'PURCHASE_ERROR' !== label.status );
 
 		return labelsToRender.map( ( label, index ) => {
@@ -123,27 +120,30 @@ class ShippingLabelRootView extends Component {
 				<QueryLabels />
 				<GlobalNotices id="notices" notices={ notices.list } />
 				{ this.renderPurchaseLabelFlow() }
-				{ this.props.shippingLabel.labels.length ? this.renderLabels() : null }
+				{ this.props.labels.length ? this.renderLabels() : null }
 			</div>
 		);
 	}
 }
 
 ShippingLabelRootView.propTypes = {
-	shippingLabel: PropTypes.object.isRequired,
 	loaded: PropTypes.bool.isRequired,
 	needToFetchLabelStatus: PropTypes.bool.isRequired,
+	numPaymentMethods: PropTypes.number.isRequired,
+	paymentMethod: PropTypes.number.isRequired,
+	labels: PropTypes.array.isRequired,
 	fetchLabelsStatus: PropTypes.func.isRequired,
 	openPrintingFlow: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = ( state ) => {
-	const shippingLabel = state.shippingLabel;
-	const loaded = shippingLabel.loaded;
+	const loaded = state.shippingLabel.loaded;
 	return {
-		shippingLabel,
 		loaded,
-		needToFetchLabelStatus: loaded && ! shippingLabel.refreshedLabelStatus,
+		needToFetchLabelStatus: loaded && ! state.shippingLabel.refreshedLabelStatus,
+		numPaymentMethods: state.shippingLabel.numPaymentMethods,
+		paymentMethod: state.shippingLabel.paymentMethod,
+		labels: state.shippingLabel.labels,
 	};
 };
 


### PR DESCRIPTION
Encapsulates `shipping-label/view` code that pertains to a single label item into a `LabelItem` component, and connects subcomponents to the state tree instead of passing everything as props from the top-level container.

cc @v18