### PR TITLE
Avoid rendering a Reprint dialog for each label

### DIFF
--- a/client/apps/shipping-label/components/label-reprint-modal/index.js
+++ b/client/apps/shipping-label/components/label-reprint-modal/index.js
@@ -17,10 +17,10 @@ import FormSectionHeading from 'components/forms/form-section-heading';
 import { closeReprintDialog, confirmReprint, updatePaperSize } from '../../state/actions';
 
 const ReprintDialog = ( props ) => {
-	const { reprintDialog, paperSize, storeOptions } = props;
+	const { reprintDialog, paperSize, storeOptions, label_id } = props;
 	return (
 		<Modal
-			isVisible={ Boolean( reprintDialog ) }
+			isVisible={ Boolean( reprintDialog && reprintDialog.labelId === label_id ) }
 			onClose={ props.closeReprintDialog }
 			additionalClassNames="label-reprint-modal">
 			<FormSectionHeading>


### PR DESCRIPTION
Makes sure to render only a single Reprint dialog at a time. Multiple dialogs are harmless but result in opaque overlay:

Before | After
-- | --
<img width="955" src="https://user-images.githubusercontent.com/1867547/29957761-24695ff6-8ebd-11e7-9d72-2dd95684b9c5.png"> | <img width="925" src="https://user-images.githubusercontent.com/1867547/29957633-87bb02cc-8ebc-11e7-92d0-ecaa86e1190e.png">
