### PR TITLE
Fixed React warnings on the label print page

### DIFF
--- a/client/apps/shipping-label/components/label-purchase-modal/address-step/index.js
+++ b/client/apps/shipping-label/components/label-purchase-modal/address-step/index.js
@@ -61,10 +61,12 @@ const getNormalizationStatus = ( { normalizationInProgress, errors, isNormalized
 
 const AddressStep = ( props ) => {
 	const toggleStepHandler = () => props.toggleStep( props.type );
+	const { form, storeOptions, error, showCountryInSummary } = props;
+
 	return (
 		<StepContainer
 			title={ props.title }
-			summary={ props.summary }
+			summary={ renderSummary( { ...form, storeOptions, errors: error }, showCountryInSummary ) }
 			expanded={ props.expanded }
 			toggleStep={ toggleStepHandler }
 			{ ...props.normalizationStatus } >
@@ -74,10 +76,13 @@ const AddressStep = ( props ) => {
 };
 
 AddressStep.propTypes = {
-	values: PropTypes.object.isRequired,
-	isNormalized: PropTypes.bool.isRequired,
-	normalized: PropTypes.object,
-	normalizationInProgress: PropTypes.bool.isRequired,
+	form: PropTypes.shape( {
+		values: PropTypes.object.isRequired,
+		isNormalized: PropTypes.bool.isRequired,
+		normalized: PropTypes.object,
+		normalizationInProgress: PropTypes.bool.isRequired,
+	} ).isRequired,
+	storeOptions: PropTypes.object.isRequired,
 	errors: PropTypes.oneOfType( [
 		PropTypes.object,
 		PropTypes.bool,
@@ -97,8 +102,10 @@ const mapStateToProps = ( state, ownProps ) => {
 
 	return {
 		errors,
+		form,
+		storeOptions,
+		showCountryInSummary,
 		expanded: form.expanded,
-		summary: renderSummary( { ...form, storeOptions, errors }, showCountryInSummary ),
 		normalizationStatus: getNormalizationStatus( { ...form, errors } ),
 	};
 };

--- a/client/apps/shipping-label/components/label-purchase-modal/packages-step/package-info.js
+++ b/client/apps/shipping-label/components/label-purchase-modal/packages-step/package-info.js
@@ -25,9 +25,13 @@ import {
 } from '../../../state/actions';
 
 const renderPackageDimensions = ( dimensions, dimensionUnit ) => {
-	return `${ dimensions.length } ${ dimensionUnit } x
-			${ dimensions.width } ${ dimensionUnit } x
-			${ dimensions.height } ${ dimensionUnit }`;
+	return [
+		dimensions.length,
+		dimensions.width,
+		dimensions.height,
+	]
+	.map( ( dimension ) => `${ dimension } ${ dimensionUnit }` )
+	.join( ' x ' );
 };
 
 const PackageInfo = ( props ) => {

--- a/client/apps/shipping-label/components/label-purchase-modal/packages-step/package-info.js
+++ b/client/apps/shipping-label/components/label-purchase-modal/packages-step/package-info.js
@@ -18,15 +18,15 @@ import Button from 'components/button';
 import getBoxDimensions from 'lib/utils/get-box-dimensions';
 import getFormErrors from '../../../state/selectors/errors';
 import {
-	updateWeight,
+	updatePackageWeight,
 	removePackage,
 	setPackageType,
 	openAddItem,
 } from '../../../state/actions';
 
 const renderPackageDimensions = ( dimensions, dimensionUnit ) => {
-	return `${ dimensions.length } ${ dimensionUnit } x 
-			${ dimensions.width } ${ dimensionUnit } x 
+	return `${ dimensions.length } ${ dimensionUnit } x
+			${ dimensions.width } ${ dimensionUnit } x
 			${ dimensions.height } ${ dimensionUnit }`;
 };
 
@@ -145,7 +145,7 @@ const PackageInfo = ( props ) => {
 		);
 	};
 
-	const onWeightChange = ( value ) => props.updateWeight( packageId, value );
+	const onWeightChange = ( value ) => props.updatePackageWeight( packageId, value );
 
 	return (
 		<div className="packages-step__package">
@@ -177,7 +177,7 @@ PackageInfo.propTypes = {
 	selected: PropTypes.object.isRequired,
 	all: PropTypes.object.isRequired,
 	flatRateGroups: PropTypes.object.isRequired,
-	updateWeight: PropTypes.func.isRequired,
+	updatePackageWeight: PropTypes.func.isRequired,
 	dimensionUnit: PropTypes.string.isRequired,
 	weightUnit: PropTypes.string.isRequired,
 	errors: PropTypes.object.isRequired,
@@ -202,7 +202,7 @@ const mapStateToProps = ( state ) => {
 
 const mapDispatchToProps = ( dispatch ) => {
 	return bindActionCreators( {
-		updateWeight,
+		updatePackageWeight,
 		removePackage,
 		setPackageType,
 		openAddItem,

--- a/client/apps/shipping-label/view.js
+++ b/client/apps/shipping-label/view.js
@@ -130,7 +130,7 @@ ShippingLabelRootView.propTypes = {
 	loaded: PropTypes.bool.isRequired,
 	needToFetchLabelStatus: PropTypes.bool.isRequired,
 	numPaymentMethods: PropTypes.number.isRequired,
-	paymentMethod: PropTypes.number.isRequired,
+	paymentMethod: PropTypes.string.isRequired,
 	labels: PropTypes.array.isRequired,
 	fetchLabelsStatus: PropTypes.func.isRequired,
 	openPrintingFlow: PropTypes.func.isRequired,


### PR DESCRIPTION
Fixed some problems that were missed in #1144 

To test:
* the order page should show no react warnings on load
* the label modal should show no react warnings
* everything in the modal should render and work properly (esp. package weight change)