### PR TITLE
Added support for labels to PR and VI

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -310,24 +310,23 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		protected function get_states_map() {
 			$result = array();
 			$all_countries = WC()->countries->get_countries();
-			$all_states = WC()->countries->get_states();
 			$allowed_countries = array( 'US', 'PR' );
 
-			foreach ( $allowed_countries as $code ) {
-				$country_data = array( 'name' => html_entity_decode( $all_countries[ $code ] ) );
+			foreach ( $allowed_countries as $country_code ) {
+				$country_data = array( 'name' => html_entity_decode( $all_countries[ $country_code ] ) );
+				$states = WC()->countries->get_states( $country_code );
 
-				if ( array_key_exists( $code, $all_states ) ) {
-					$states = $all_states[ $code ];
+				if ( $states ) {
 					$country_data['states'] = array();
 					foreach ( $states as $state_code => $name ) {
-						if ( 'US' === $code && in_array( $state_code, $this->unsupported_states ) ) {
+						if ( 'US' === $country_code && in_array( $state_code, $this->unsupported_states ) ) {
 						  continue;
 						}
 						$country_data['states'][ $state_code ] = html_entity_decode( $name );
 					}
 				}
 
-				$result[ $code ] = $country_data;
+				$result[ $country_code ] = $country_data;
 			}
 
 			return $result;

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -309,19 +309,27 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 		protected function get_states_map() {
 			$result = array();
-			foreach ( WC()->countries->get_countries() as $code => $name ) {
-				$result[ $code ] = array( 'name' => html_entity_decode( $name ) );
-			}
-			foreach ( WC()->countries->get_states() as $country => $states ) {
-				$result[ $country ]['states'] = array();
-				foreach ( $states as $code => $name ) {
-					if ( 'US' === $country && in_array( $code, $this->unsupported_states ) ) {
-						continue;
-					}
+			$all_countries = WC()->countries->get_countries();
+			$all_states = WC()->countries->get_states();
+			$allowed_countries = array( 'US', 'PR' );
 
-					$result[ $country ]['states'][ $code ] = html_entity_decode( $name );
+			foreach ( $allowed_countries as $code ) {
+				$country_data = array( 'name' => html_entity_decode( $all_countries[ $code ] ) );
+
+				if ( array_key_exists( $code, $all_states ) ) {
+					$states = $all_states[ $code ];
+					$country_data['states'] = array();
+					foreach ( $states as $state_code => $name ) {
+						if ( 'US' === $code && in_array( $state_code, $this->unsupported_states ) ) {
+						  continue;
+						}
+						$country_data['states'][ $state_code ] = html_entity_decode( $name );
+					}
 				}
+
+				$result[ $code ] = $country_data;
 			}
+
 			return $result;
 		}
 

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -353,8 +353,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 			$dest_address = $order->get_address( 'shipping' );
 			if ( ( $dest_address['country'] && 'US' !== $dest_address['country']
-				//special case - include PR and VI since it's treated as domestic
-				&& 'PR' !== $dest_address['country'] && 'VI' !== $dest_address['country'] )
+				//special case - include PR since it's treated as domestic
+				&& 'PR' !== $dest_address['country'] )
 				|| in_array( $dest_address['state'], $this->unsupported_states ) ) {
 				return false;
 			}

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -352,7 +352,9 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			}
 
 			$dest_address = $order->get_address( 'shipping' );
-			if ( ( $dest_address['country'] && 'US' !== $dest_address['country'] )
+			if ( ( $dest_address['country'] && 'US' !== $dest_address['country']
+				//special case - include PR and VI since it's treated as domestic
+				&& 'PR' !== $dest_address['country'] && 'VI' !== $dest_address['country'] )
 				|| in_array( $dest_address['state'], $this->unsupported_states ) ) {
 				return false;
 			}

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -41,13 +41,11 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		public function __construct(
 			WC_Connect_API_Client $api_client,
 			WC_Connect_Service_Settings_Store $settings_store,
-			WC_Connect_Service_Schemas_Store $service_schemas_store,
-			WC_Connect_Payment_Methods_Store $payment_methods_store
+			WC_Connect_Service_Schemas_Store $service_schemas_store
 		) {
 			$this->api_client = $api_client;
 			$this->settings_store = $settings_store;
 			$this->service_schemas_store = $service_schemas_store;
-			$this->payment_methods_store = $payment_methods_store;
 		}
 
 		public function get_item_data( WC_Order $order, $item ) {
@@ -421,12 +419,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
 			$payload = array(
-				'orderId'                 => $order_id,
-				'paperSize'               => $this->settings_store->get_preferred_paper_size(),
-				'formData'                => $this->get_form_data( $order ),
-				'numPaymentMethods'       => count( $this->payment_methods_store->get_payment_methods() ),
-				'labelsData'              => $this->settings_store->get_label_order_meta_data( $order_id ),
-				'enabled'                 => $account_settings[ 'enabled' ],
+				'orderId'            => $order_id,
+				'paperSize'          => $this->settings_store->get_preferred_paper_size(),
+				'formData'           => $this->get_form_data( $order ),
+				'labelsData'         => $this->settings_store->get_label_order_meta_data( $order_id ),
+				//for backwards compatibility, still disable the country dropdown for calypso users with older plugin versions
+				'canChangeCountries' => true,
 			);
 
 			$store_options = $this->settings_store->get_store_options();

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-services",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "dependencies": {
     "abab": {
       "version": "1.0.4",
@@ -876,7 +876,7 @@
     },
     "binary-extensions": {
       "version": "1.11.0",
-      "from": "binary-extensions@>=1.0.0 <2.0.0",
+      "from": "binary-extensions@^1.0.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
       "dev": true
     },
@@ -1085,15 +1085,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000766",
-      "from": "caniuse-db@^1.0.30000634",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000766.tgz",
+      "version": "1.0.30000769",
+      "from": "caniuse-db@>=1.0.30000634 <2.0.0",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000769.tgz",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000766",
-      "from": "caniuse-lite@^1.0.30000760",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000766.tgz"
+      "version": "1.0.30000769",
+      "from": "caniuse-lite@>=1.0.30000760 <2.0.0",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000769.tgz"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -2649,9 +2649,9 @@
       "dev": true,
       "dependencies": {
         "ajv": {
-          "version": "5.3.0",
-          "from": "ajv@^5.1.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+          "version": "5.4.0",
+          "from": "ajv@>=5.1.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.4.0.tgz",
           "dev": true
         }
       }
@@ -2844,9 +2844,9 @@
       "dev": true
     },
     "i18n-calypso": {
-      "version": "1.8.3",
+      "version": "1.8.4",
       "from": "i18n-calypso@>=1.7.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/i18n-calypso/-/i18n-calypso-1.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/i18n-calypso/-/i18n-calypso-1.8.4.tgz",
       "dependencies": {
         "babylon": {
           "version": "6.8.4",
@@ -2985,9 +2985,9 @@
       "dev": true
     },
     "interpolate-components": {
-      "version": "1.1.0",
-      "from": "interpolate-components@1.1.0",
-      "resolved": "https://registry.npmjs.org/interpolate-components/-/interpolate-components-1.1.0.tgz"
+      "version": "1.1.1",
+      "from": "interpolate-components@1.1.1",
+      "resolved": "https://registry.npmjs.org/interpolate-components/-/interpolate-components-1.1.1.tgz"
     },
     "interpret": {
       "version": "1.0.4",
@@ -4322,9 +4322,9 @@
       }
     },
     "node-sass": {
-      "version": "4.7.1",
+      "version": "4.7.2",
       "from": "node-sass@>=4.5.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.7.2.tgz",
       "dev": true,
       "dependencies": {
         "assert-plus": {
@@ -5804,14 +5804,14 @@
     },
     "schema-utils": {
       "version": "0.3.0",
-      "from": "schema-utils@>=0.3.0 <0.4.0",
+      "from": "schema-utils@^0.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
       "dev": true,
       "dependencies": {
         "ajv": {
-          "version": "5.3.0",
-          "from": "ajv@^5.0.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+          "version": "5.4.0",
+          "from": "ajv@>=5.0.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.4.0.tgz",
           "dev": true
         }
       }
@@ -6955,7 +6955,7 @@
     "wp-calypso": {
       "version": "0.17.0",
       "from": "automattic/wp-calypso",
-      "resolved": "git://github.com/automattic/wp-calypso.git#aac80448a10e22c9b131a9f73b015c0b278bc1eb",
+      "resolved": "git://github.com/automattic/wp-calypso.git#55e19d44d5574222120950413b2c23b31e9d88d2",
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
@@ -7752,9 +7752,9 @@
           "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz"
         },
         "binary-extensions": {
-          "version": "1.10.0",
-          "from": "binary-extensions@1.10.0",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz"
+          "version": "1.11.0",
+          "from": "binary-extensions@1.11.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz"
         },
         "bindings": {
           "version": "1.2.1",
@@ -7919,6 +7919,23 @@
           "version": "2.4.0",
           "from": "bytes@2.4.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
+        },
+        "cacache": {
+          "version": "10.0.1",
+          "from": "cacache@10.0.1",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.1.tgz",
+          "dependencies": {
+            "bluebird": {
+              "version": "3.5.1",
+              "from": "bluebird@3.5.1",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz"
+            },
+            "glob": {
+              "version": "7.1.2",
+              "from": "glob@7.1.2",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+            }
+          }
         },
         "callsite": {
           "version": "1.0.0",
@@ -8254,6 +8271,11 @@
           "from": "cookiejar@2.1.1",
           "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz"
         },
+        "copy-concurrently": {
+          "version": "1.0.5",
+          "from": "copy-concurrently@1.0.5",
+          "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz"
+        },
         "copy-webpack-plugin": {
           "version": "4.0.1",
           "from": "copy-webpack-plugin@4.0.1",
@@ -8347,6 +8369,11 @@
           "version": "0.4.1",
           "from": "currently-unhandled@0.4.1",
           "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz"
+        },
+        "cyclist": {
+          "version": "0.2.2",
+          "from": "cyclist@0.2.2",
+          "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz"
         },
         "d": {
           "version": "1.0.0",
@@ -8532,6 +8559,30 @@
           "version": "0.1.1",
           "from": "duplexer@0.1.1",
           "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+        },
+        "duplexify": {
+          "version": "3.5.1",
+          "from": "duplexify@3.5.1",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.3",
+              "from": "readable-stream@2.3.3",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@2.0.3",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                }
+              }
+            },
+            "string_decoder": {
+              "version": "1.0.3",
+              "from": "string_decoder@1.0.3",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+            }
+          }
         },
         "ecc-jsbn": {
           "version": "0.1.1",
@@ -9033,6 +9084,30 @@
           "from": "flag-icon-css@2.3.0",
           "resolved": "https://registry.npmjs.org/flag-icon-css/-/flag-icon-css-2.3.0.tgz"
         },
+        "flush-write-stream": {
+          "version": "1.0.2",
+          "from": "flush-write-stream@1.0.2",
+          "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.3",
+              "from": "readable-stream@2.3.3",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@2.0.3",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                }
+              }
+            },
+            "string_decoder": {
+              "version": "1.0.3",
+              "from": "string_decoder@1.0.3",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+            }
+          }
+        },
         "flux": {
           "version": "2.1.1",
           "from": "flux@2.1.1",
@@ -9105,10 +9180,39 @@
           "from": "from@0.1.7",
           "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz"
         },
+        "from2": {
+          "version": "2.3.0",
+          "from": "from2@2.3.0",
+          "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.3",
+              "from": "readable-stream@2.3.3",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@2.0.3",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                }
+              }
+            },
+            "string_decoder": {
+              "version": "1.0.3",
+              "from": "string_decoder@1.0.3",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+            }
+          }
+        },
         "fs-extra": {
           "version": "0.26.7",
           "from": "fs-extra@0.26.7",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz"
+        },
+        "fs-write-stream-atomic": {
+          "version": "1.0.10",
+          "from": "fs-write-stream-atomic@1.0.10",
+          "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz"
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -9443,11 +9547,6 @@
           "from": "html-minifier@1.5.0",
           "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-1.5.0.tgz",
           "dependencies": {
-            "async": {
-              "version": "0.2.10",
-              "from": "async@0.2.10",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-            },
             "commander": {
               "version": "2.9.0",
               "from": "commander@2.9.0",
@@ -9457,16 +9556,6 @@
               "version": "1.0.0",
               "from": "he@1.0.0",
               "resolved": "https://registry.npmjs.org/he/-/he-1.0.0.tgz"
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "from": "source-map@0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
-            },
-            "uglify-js": {
-              "version": "2.6.4",
-              "from": "uglify-js@2.6.4",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz"
             }
           }
         },
@@ -9524,6 +9613,11 @@
           "from": "ieee754@1.1.8",
           "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
         },
+        "iferr": {
+          "version": "0.1.5",
+          "from": "iferr@0.1.5",
+          "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz"
+        },
         "immediate": {
           "version": "3.0.6",
           "from": "immediate@3.0.6",
@@ -9550,6 +9644,11 @@
               "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz"
             }
           }
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "from": "imurmurhash@0.1.4",
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
         },
         "in-publish": {
           "version": "2.0.0",
@@ -10372,6 +10471,33 @@
           "from": "minimist@0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         },
+        "mississippi": {
+          "version": "1.3.0",
+          "from": "mississippi@1.3.0",
+          "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.3",
+              "from": "inherits@2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "readable-stream": {
+              "version": "2.3.3",
+              "from": "readable-stream@2.3.3",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+            },
+            "string_decoder": {
+              "version": "1.0.3",
+              "from": "string_decoder@1.0.3",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+            },
+            "through2": {
+              "version": "2.0.3",
+              "from": "through2@2.0.3",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+            }
+          }
+        },
         "mkdirp": {
           "version": "0.5.1",
           "from": "mkdirp@0.5.1",
@@ -10403,6 +10529,11 @@
               "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.2.tgz"
             }
           }
+        },
+        "move-concurrently": {
+          "version": "1.0.1",
+          "from": "move-concurrently@1.0.1",
+          "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz"
         },
         "ms": {
           "version": "0.7.1",
@@ -10740,6 +10871,28 @@
           "version": "1.0.6",
           "from": "pako@1.0.6",
           "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz"
+        },
+        "parallel-transform": {
+          "version": "1.1.0",
+          "from": "parallel-transform@1.1.0",
+          "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.3",
+              "from": "inherits@2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "readable-stream": {
+              "version": "2.3.3",
+              "from": "readable-stream@2.3.3",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+            },
+            "string_decoder": {
+              "version": "1.0.3",
+              "from": "string_decoder@1.0.3",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+            }
+          }
         },
         "param-case": {
           "version": "1.1.2",
@@ -11081,6 +11234,11 @@
           "from": "promise@7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz"
         },
+        "promise-inflight": {
+          "version": "1.0.1",
+          "from": "promise-inflight@1.0.1",
+          "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz"
+        },
         "prop-types": {
           "version": "15.5.10",
           "from": "prop-types@15.5.10",
@@ -11187,6 +11345,11 @@
           "version": "1.0.3",
           "from": "pump@1.0.3",
           "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz"
+        },
+        "pumpify": {
+          "version": "1.3.5",
+          "from": "pumpify@1.3.5",
+          "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz"
         },
         "punycode": {
           "version": "1.4.1",
@@ -11615,6 +11778,11 @@
           "from": "run-parallel@1.1.6",
           "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz"
         },
+        "run-queue": {
+          "version": "1.0.3",
+          "from": "run-queue@1.0.3",
+          "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz"
+        },
         "safe-buffer": {
           "version": "5.1.1",
           "from": "safe-buffer@5.1.1",
@@ -11651,6 +11819,11 @@
           "version": "1.2.4",
           "from": "sax@1.2.4",
           "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz"
+        },
+        "schema-utils": {
+          "version": "0.3.0",
+          "from": "schema-utils@0.3.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz"
         },
         "scss-tokenizer": {
           "version": "0.2.3",
@@ -11926,6 +12099,11 @@
           "from": "sshpk@1.13.1",
           "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz"
         },
+        "ssri": {
+          "version": "5.0.0",
+          "from": "ssri@5.0.0",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.0.0.tgz"
+        },
         "statuses": {
           "version": "1.4.0",
           "from": "statuses@1.4.0",
@@ -11987,6 +12165,11 @@
           "from": "stream-combiner@0.0.4",
           "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
         },
+        "stream-each": {
+          "version": "1.2.2",
+          "from": "stream-each@1.2.2",
+          "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz"
+        },
         "stream-http": {
           "version": "2.7.2",
           "from": "stream-http@2.7.2",
@@ -12010,6 +12193,11 @@
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
             }
           }
+        },
+        "stream-shift": {
+          "version": "1.0.0",
+          "from": "stream-shift@1.0.0",
+          "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -12306,9 +12494,9 @@
           "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz"
         },
         "uglify-js": {
-          "version": "2.7.0",
-          "from": "uglify-js@2.7.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.0.tgz",
+          "version": "2.6.4",
+          "from": "uglify-js@2.6.4",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
@@ -12328,10 +12516,15 @@
           "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
         },
         "uglifyjs-webpack-plugin": {
-          "version": "0.4.6",
-          "from": "uglifyjs-webpack-plugin@0.4.6",
-          "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
+          "version": "1.0.1",
+          "from": "uglifyjs-webpack-plugin@1.0.1",
+          "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.0.1.tgz",
           "dependencies": {
+            "commander": {
+              "version": "2.11.0",
+              "from": "commander@2.11.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
+            },
             "source-list-map": {
               "version": "2.0.0",
               "from": "source-list-map@2.0.0",
@@ -12342,10 +12535,17 @@
               "from": "source-map@0.5.7",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
             },
-            "uglify-js": {
-              "version": "2.8.29",
-              "from": "uglify-js@2.8.29",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz"
+            "uglify-es": {
+              "version": "3.1.10",
+              "from": "uglify-es@3.1.10",
+              "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.1.10.tgz",
+              "dependencies": {
+                "source-map": {
+                  "version": "0.6.1",
+                  "from": "source-map@0.6.1",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
+                }
+              }
             },
             "webpack-sources": {
               "version": "1.0.2",
@@ -12370,6 +12570,16 @@
           "version": "1.0.2",
           "from": "ultron@1.0.2",
           "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
+        },
+        "unique-filename": {
+          "version": "1.1.0",
+          "from": "unique-filename@1.1.0",
+          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz"
+        },
+        "unique-slug": {
+          "version": "2.0.0",
+          "from": "unique-slug@2.0.0",
+          "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz"
         },
         "unpipe": {
           "version": "1.0.0",
@@ -12532,23 +12742,6 @@
               "from": "async@2.6.0",
               "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz"
             },
-            "camelcase": {
-              "version": "4.1.0",
-              "from": "camelcase@4.1.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
-            },
-            "cliui": {
-              "version": "3.2.0",
-              "from": "cliui@3.2.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-              "dependencies": {
-                "string-width": {
-                  "version": "1.0.2",
-                  "from": "string-width@1.0.2",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
-                }
-              }
-            },
             "has-flag": {
               "version": "2.0.0",
               "from": "has-flag@2.0.0",
@@ -12621,6 +12814,23 @@
               "from": "supports-color@4.5.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz"
             },
+            "uglify-js": {
+              "version": "2.8.29",
+              "from": "uglify-js@2.8.29",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+              "dependencies": {
+                "yargs": {
+                  "version": "3.10.0",
+                  "from": "yargs@3.10.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+                }
+              }
+            },
+            "uglifyjs-webpack-plugin": {
+              "version": "0.4.6",
+              "from": "uglifyjs-webpack-plugin@0.4.6",
+              "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz"
+            },
             "webpack-sources": {
               "version": "1.0.2",
               "from": "webpack-sources@1.0.2",
@@ -12641,12 +12851,38 @@
             "yargs": {
               "version": "8.0.2",
               "from": "yargs@8.0.2",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "4.1.0",
+                  "from": "camelcase@4.1.0",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
+                },
+                "cliui": {
+                  "version": "3.2.0",
+                  "from": "cliui@3.2.0",
+                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                  "dependencies": {
+                    "string-width": {
+                      "version": "1.0.2",
+                      "from": "string-width@1.0.2",
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
             },
             "yargs-parser": {
               "version": "7.0.0",
               "from": "yargs-parser@7.0.0",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "4.1.0",
+                  "from": "camelcase@4.1.0",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
+                }
+              }
             }
           }
         },
@@ -12854,6 +13090,11 @@
           "version": "0.0.2",
           "from": "wordwrap@0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+        },
+        "worker-farm": {
+          "version": "1.5.2",
+          "from": "worker-farm@1.5.2",
+          "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz"
         },
         "wp-error": {
           "version": "1.3.0",

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -566,7 +566,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$settings_store        = new WC_Connect_Service_Settings_Store( $schemas_store, $api_client, $logger );
 			$payment_methods_store = new WC_Connect_Payment_Methods_Store( $settings_store, $api_client, $logger );
 			$tracks                = new WC_Connect_Tracks( $logger, __FILE__ );
-			$shipping_label        = new WC_Connect_Shipping_Label( $api_client, $settings_store, $schemas_store, $payment_methods_store );
+			$shipping_label        = new WC_Connect_Shipping_Label( $api_client, $settings_store, $schemas_store );
 			$nux                   = new WC_Connect_Nux( $tracks, $shipping_label );
 			$taxjar                = new WC_Connect_TaxJar_Integration( $api_client, $logger );
 			$options               = new WC_Connect_Options();


### PR DESCRIPTION
Fixes #1129

According to #846 no customs forms are needed for these regions, so we should be able to print labels for them as usual.

To test:
* place an order with an address from Puerto Rico or Virgin Islands (US)
* on the order page, the label metabox should appear
* you should be able to purchase and print a label just like for mainland states

Note:
* the address validation can be a bit picky when it comes to the addresses from there but it does work