### PR TITLE
Update TaxJar proxy to full integration

### DIFF
--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -46,6 +46,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				'predefined_packages',
 				'shipping_methods_migrated',
 				'should_display_nux_after_jp_cxn_banner',
+				'needs_tax_environment_setup',
 			);
 		}
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -716,7 +716,7 @@ class WC_Connect_TaxJar_Integration {
 
 			echo ',';
 
-			if ( $rate->tax_rate_country ) {
+			if ( $rate->tax_rate_state ) {
 				echo esc_attr( $rate->tax_rate_state );
 			} else {
 				echo '*';

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -12,9 +12,10 @@ class WC_Connect_TaxJar_Integration {
 	 */
 	public $logger;
 
-	const PROXY_PATH     = 'taxjar/v2';
-	const ENV_SETUP_FLAG = 'needs_tax_environment_setup';
-	const OPTION_NAME    = 'wc_connect_taxes_enabled';
+	const PROXY_PATH               = 'taxjar/v2';
+	const ENV_SETUP_FLAG           = 'needs_tax_environment_setup';
+	const OPTION_NAME              = 'wc_connect_taxes_enabled';
+	const SETUP_WIZARD_OPTION_NAME = 'woocommerce_setup_automated_taxes';
 
 	public function __construct(
 		WC_Connect_API_Client $api_client,
@@ -86,7 +87,7 @@ class WC_Connect_TaxJar_Integration {
 		$automated_taxes = array(
 			'title'    => __( 'Automated taxes', 'woocommerce-services' ),
 			'id'       => self::OPTION_NAME, // TODO: save in `wc_connect_options`?
-			'desc_tip' => __( 'Automate your sales tax calculations with WooCommerce Services.', 'woocommerce-services' ),
+			'desc_tip' => __( 'Automate your sales tax calculations with WooCommerce Services, powered by Jetpack.', 'woocommerce-services' ),
 			'default'  => 'no',
 			'type'     => 'select',
 			'class'    => 'wc-enhanced-select',

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -158,20 +158,12 @@ class WC_Connect_TaxJar_Integration {
 	 * @return array
 	 */
 	public function get_store_settings() {
-		$default_wc_settings     = explode( ':', get_option( 'woocommerce_default_country' ) );
-		$taxjar_city_setting     = get_option( 'woocommerce_store_city' );
-		$taxjar_zip_code_setting = get_option( 'woocommerce_store_postcode' );
-
-		$store_settings          = array(
-			'taxjar_zip_code_setting' => $taxjar_zip_code_setting,
-			'store_state_setting'     => null,
-			'store_country_setting'   => $default_wc_settings[0],
-			'taxjar_city_setting'     => $taxjar_city_setting,
+		$store_settings = array(
+			'taxjar_zip_code_setting' => WC()->countries->get_base_postcode(),
+			'store_state_setting'     => WC()->countries->get_base_state(),
+			'store_country_setting'   => WC()->countries->get_base_country(),
+			'taxjar_city_setting'     => WC()->countries->get_base_city(),
 		);
-
-		if ( isset( $default_wc_settings[1] ) ) {
-			$store_settings['store_state_setting'] = $default_wc_settings[1];
-		}
 
 		return $store_settings;
 	}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -41,10 +41,13 @@ class WC_Connect_TaxJar_Integration {
 		// Add toggle for automated taxes to the core settings page
 		add_filter( 'woocommerce_tax_settings', array( $this, 'add_tax_settings' ) );
 
-		// TODO: check if WCS Taxes are enabled
+		// Bow out if we're not wanted
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
 		$this->setup_environment();
 
-		// TODO: check if WCS Taxes are enabled before calculating rates for orders
 		// Calculate Taxes at Cart / Checkout
 		add_action( 'woocommerce_calculate_totals', array( $this, 'calculate_totals' ), 20 );
 
@@ -53,6 +56,15 @@ class WC_Connect_TaxJar_Integration {
 
 		// Set customer taxable location for local pickup
 		add_filter( 'woocommerce_customer_taxable_address', array( $this, 'append_base_address_to_customer_taxable_address' ), 10, 1 );
+	}
+
+	/**
+	 * Are automated taxes enabled?
+	 *
+	 * @return bool
+	 */
+	public function is_enabled() {
+		return ( 'yes' === get_option( self::OPTION_NAME ) );
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -12,7 +12,8 @@ class WC_Connect_TaxJar_Integration {
 	 */
 	public $logger;
 
-	const PROXY_PATH = 'taxjar/v2';
+	const PROXY_PATH     = 'taxjar/v2';
+	const ENV_SETUP_FLAG = 'needs_tax_environment_setup';
 
 	public function __construct(
 		WC_Connect_API_Client $api_client,
@@ -28,11 +29,8 @@ class WC_Connect_TaxJar_Integration {
 			return;
 		}
 
-		// TODO: check if WCS Taxes are enabled before configuring core tax settings
-		$this->configure_tax_settings();
-
-		// TODO: check if WCS Taxes are enabled before backup existing tax rates
-		$this->backup_existing_tax_rates();
+		// TODO: check if WCS Taxes are enabled
+		$this->setup_environment();
 
 		// TODO: check if WCS Taxes are enabled before calculating rates for orders
 		// Calculate Taxes at Cart / Checkout
@@ -43,6 +41,22 @@ class WC_Connect_TaxJar_Integration {
 
 		// Set customer taxable location for local pickup
 		add_filter( 'woocommerce_customer_taxable_address', array( $this, 'append_base_address_to_customer_taxable_address' ), 10, 1 );
+	}
+
+	/**
+	 * Put the WooCommerce tax settings in a known-good initial configuration.
+	 */
+	public function setup_environment() {
+		$needs_setup = WC_Connect_Options::get_option( self::ENV_SETUP_FLAG, true );
+
+		if ( ! $needs_setup ) {
+			return;
+		}
+
+		$this->configure_tax_settings();
+		$this->backup_existing_tax_rates();
+
+		WC_Connect_Options::update_option( self::ENV_SETUP_FLAG, false );
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -38,6 +38,8 @@ class WC_Connect_TaxJar_Integration {
 		// Calculate Taxes at Cart / Checkout
 		add_action( 'woocommerce_calculate_totals', array( $this, 'calculate_totals' ), 20 );
 
+		// Calculate Taxes for Backend Orders (Woo 2.6+)
+		add_action( 'woocommerce_before_save_order_items', array( $this, 'calculate_backend_totals' ), 20 );
 	}
 
 	/**
@@ -157,6 +159,93 @@ class WC_Connect_TaxJar_Integration {
 			$product = $cart_item['data'];
 			if ( isset( $this->line_items[ $product->get_id() ] ) ) {
 				$wc_cart_object->cart_contents[ $cart_item_key ]['line_tax'] = $this->line_items[ $product->get_id() ]->tax_collectable;
+			}
+		}
+	}
+
+	/**
+	 * Calculate tax / totals using TaxJar for backend orders
+	 *
+	 * Unchanged from the TaxJar plugin.
+	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/82bf7c587/includes/class-wc-taxjar-integration.php#L569
+	 *
+	 * @return void
+	 */
+	public function calculate_backend_totals( $order_id ) {
+		$order = wc_get_order( $order_id );
+		$to_country = isset( $_POST['country'] ) ? strtoupper( wc_clean( $_POST['country'] ) ) : false;
+		$to_state = isset( $_POST['state'] ) ? strtoupper( wc_clean( $_POST['state'] ) ) : false;
+		$to_zip = isset( $_POST['postcode'] ) ? strtoupper( wc_clean( $_POST['postcode'] ) ) : false;
+		$to_city = isset( $_POST['city'] ) ? strtoupper( wc_clean( $_POST['city'] ) ) : false;
+		$line_items = array();
+
+		if ( method_exists( $order, 'get_shipping_total' ) ) {
+			$shipping = $order->get_shipping_total(); // Woo 3.0+
+		} else {
+			$shipping = $order->get_total_shipping(); // Woo 2.6
+		}
+
+		foreach ( $order->get_items() as $item ) {
+			if ( is_object( $item ) ) { // Woo 3.0+
+				$id = $item->get_product_id();
+				$quantity = $item->get_quantity();
+				$discount = floatval( wc_format_decimal( ( $item->get_subtotal() - $item->get_total() ) / $quantity ) );
+				$tax_class = explode( '-', $item->get_tax_class() );
+			} else { // Woo 2.6
+				$id = $item['product_id'];
+				$quantity = $item['qty'];
+				$discount = floatval( wc_format_decimal( ( $item['line_subtotal'] - $item['line_total'] ) / $quantity ) );
+				$tax_class = explode( '-', $item['tax_class'] );
+			}
+
+			$product = wc_get_product( $id );
+			$unit_price = $product->get_price();
+			$tax_code = '';
+
+			if ( ! $product->is_taxable() ) {
+				$tax_code = '99999';
+			}
+
+			if ( isset( $tax_class[1] ) && is_numeric( $tax_class[1] ) ) {
+				$tax_code = $tax_class[1];
+			}
+
+			if ( $unit_price ) {
+				array_push($line_items, array(
+					'id' => $id,
+					'quantity' => $quantity,
+					'product_tax_code' => $tax_code,
+					'unit_price' => $unit_price,
+					'discount' => $discount,
+				));
+			}
+		}
+
+		$this->calculate_tax( array(
+			'to_city' => $to_city,
+			'to_state' => $to_state,
+			'to_country' => $to_country,
+			'to_zip' => $to_zip,
+			'shipping_amount' => $shipping,
+			'line_items' => $line_items,
+		) );
+
+		// Add tax rates manually for Woo 3.0+
+		// Woo 2.6 adds the rates automatically
+		foreach ( $order->get_items() as $item ) {
+			if ( is_object( $item ) ) { // Woo 3.0+
+				$product_id = $item->get_product_id();
+			}
+
+			if ( isset( $this->rate_ids[ $product_id ] ) ) {
+				$rate_id = $this->rate_ids[ $product_id ];
+
+				if ( class_exists( 'WC_Order_Item_Tax' ) ) { // Woo 3.0+
+					$item_tax = new WC_Order_Item_Tax();
+					$item_tax->set_rate( $rate_id );
+					$item_tax->set_order_id( $order_id );
+					$item_tax->save();
+				}
 			}
 		}
 	}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -8,9 +8,17 @@ class WC_Connect_TaxJar_Integration {
 	public $api_client;
 
 	const TAXJAR_URL = 'https://api.taxjar.com';
+	/**
+	 * @var WC_Connect_Logger
+	 */
+	public $logger;
 
-	public function __construct( WC_Connect_API_Client $api_client ) {
+	public function __construct(
+		WC_Connect_API_Client $api_client,
+		WC_Connect_Logger $logger
+	) {
 		$this->api_client = $api_client;
+		$this->logger = $logger;
 	}
 
 	public function init() {
@@ -54,6 +62,12 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	/**
+	 * @param $message
+	 */
+	public function _log( $message ) {
+		$this->logger->debug( $message, 'WCS Tax' );
+	}
+
 	 * Configure WooCommerce core tax settings for TaxJar integration.
 	 *
 	 * Ported from TaxJar's plugin.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -630,7 +630,7 @@ class WC_Connect_TaxJar_Integration {
 		) );
 
 		if ( is_wp_error( $response ) ) {
-			new WP_Error( 'request', __( 'There was an error retrieving the tax rates. Please check your server configuration.' ) );
+			return new WP_Error( 'request', __( 'There was an error retrieving the tax rates. Please check your server configuration.' ) );
 		} elseif ( 200 == $response['response']['code'] ) {
 			return $response;
 		} else {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -64,6 +64,14 @@ class WC_Connect_TaxJar_Integration {
 	 * @return bool
 	 */
 	public function is_enabled() {
+		// Migrate automated taxes selection from the setup wizard
+		if ( 'yes' === get_option( self::SETUP_WIZARD_OPTION_NAME ) ) {
+			update_option( self::OPTION_NAME, 'yes' );
+			delete_option( self::SETUP_WIZARD_OPTION_NAME );
+
+			return true;
+		}
+
 		return ( 'yes' === get_option( self::OPTION_NAME ) );
 	}
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -29,6 +29,14 @@ class WC_Connect_TaxJar_Integration {
 			return;
 		}
 
+		$store_settings = $this->get_store_settings();
+		$store_country  = $store_settings['store_country_setting'];
+
+		// TaxJar supports USA, Canada, Australia, and the European Union
+		if ( ! $this->is_supported_country( $store_country ) ) {
+			return;
+		}
+
 		// TODO: check if WCS Taxes are enabled
 		$this->setup_environment();
 
@@ -57,6 +65,36 @@ class WC_Connect_TaxJar_Integration {
 		$this->backup_existing_tax_rates();
 
 		WC_Connect_Options::update_option( self::ENV_SETUP_FLAG, false );
+	}
+
+	/**
+	 * TaxJar supports USA, Canada, Australia, and the European Union
+	 * See: https://developers.taxjar.com/api/reference/#countries
+	 *
+	 * @return array Countries supported by TaxJar.
+	 */
+	public function get_supported_countries() {
+		$supported_countries = array_merge(
+			array(
+				'US',
+				'CA',
+				'AU',
+			),
+			WC()->countries->get_european_union_countries()
+		);
+
+		return $supported_countries;
+	}
+
+	/**
+	 * Check if a given country is supported by TaxJar.
+	 *
+	 * @param $country Two character country code.
+	 *
+	 * @return bool Whether or not the country is supported by TaxJar.
+	 */
+	public function is_supported_country( $country ) {
+		return in_array( $country, $this->get_supported_countries() );
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -7,81 +7,14 @@ class WC_Connect_TaxJar_Integration {
 	 */
 	public $api_client;
 
-	/**
-	 * @var WC_Taxjar_Integration
-	 */
-	protected $taxjar_integration;
-
 	const TAXJAR_URL = 'https://api.taxjar.com';
-	const PROXY_PATH = 'taxjar';
-	const FAKE_TOKEN = '[Managed by WooCommerce Services]';
 
 	public function __construct( WC_Connect_API_Client $api_client ) {
 		$this->api_client = $api_client;
 	}
 
 	public function init() {
-		add_filter( 'default_option_woocommerce_taxjar-integration_settings', array( $this, 'override_taxjar_settings' ) );
-		add_filter( 'option_woocommerce_taxjar-integration_settings', array( $this, 'check_taxjar_settings' ) );
-	}
-
-	public function check_taxjar_settings( $settings ) {
-		if (
-			isset( $settings['api_token'] ) &&
-			( $settings['api_token'] === strtolower( self::FAKE_TOKEN ) )
-		) {
-			return $this->override_taxjar_settings( $settings );
-		}
-
-		return $settings;
-	}
-
-	public function override_taxjar_settings( $settings ) {
-		$store_city     = get_option( 'woocommerce_store_city' );
-		$store_postcode = get_option( 'woocommerce_store_postcode' );
-
-		// Check for store address before hijacking requests.
-		if ( empty( $store_city ) || empty( $store_postcode ) ) {
-			return $settings;
-		}
-
-		// Attach proxy filter.
-		add_filter( 'pre_http_request', array( $this, 'proxy_taxjar_requests' ), 10, 3 );
-
-		if ( ! is_array( $settings ) ) {
-			$settings = array();
-		}
-
-		$settings = array_merge( $settings, array(
-			'api_token'  => self::FAKE_TOKEN,
-			'enabled'    => 'yes',
-			'store_city' => $store_city,
-			'store_zip'  => $store_postcode,
-		) );
-
-		return $settings;
-	}
-
-	public function proxy_taxjar_requests( $pre, $r, $url ) {
-		// TODO: get verification requests working through proxy
-		if ( 'https://api.taxjar.com/v2/verify' === $url ) {
-			return array(
-				'response' => array(
-					'code' => 200,
-				),
-				'body' => '',
-			);
-		}
-
-		// Proxy all TaxJar requests through the WCS server
-		if ( strpos( $url, self::TAXJAR_URL ) === 0 ) {
-			$taxjar_url  = trailingslashit( self::TAXJAR_URL );
-			$wcs_path    = trailingslashit( self::PROXY_PATH );
-			$proxy_path  = str_replace( $taxjar_url, $wcs_path, $url );
-
-			return $this->api_client->proxy_request( $proxy_path, $r );
-		}
-
-		return $pre;
+		// TODO: check if TaxJar plugin is enabled, abort if so
+		// TODO: backup existing tax rates if enabled
 	}
 }

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -14,7 +14,10 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	public function init() {
-		// TODO: check if TaxJar plugin is enabled, abort if so
+		// Only enable WCS TaxJar integration if the official TaxJar plugin isn't active.
+		if ( class_exists( 'WC_Taxjar' ) ) {
+			return;
+		}
 
 		// TODO: check if WCS Taxes are enabled before backup existing tax rates
 		$this->backup_existing_tax_rates();

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -27,6 +27,33 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	/**
+	 * Gets the store's location settings.
+	 *
+	 * Modified version of TaxJar's plugin.
+	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/82bf7c58/includes/class-wc-taxjar-integration.php#L796
+	 *
+	 * @return array
+	 */
+	public function get_store_settings() {
+		$default_wc_settings     = explode( ':', get_option( 'woocommerce_default_country' ) );
+		$taxjar_city_setting     = get_option( 'woocommerce_store_city' );
+		$taxjar_zip_code_setting = get_option( 'woocommerce_store_postcode' );
+
+		$store_settings          = array(
+			'taxjar_zip_code_setting' => $taxjar_zip_code_setting,
+			'store_state_setting'     => null,
+			'store_country_setting'   => $default_wc_settings[0],
+			'taxjar_city_setting'     => $taxjar_city_setting,
+		);
+
+		if ( isset( $default_wc_settings[1] ) ) {
+			$store_settings['store_state_setting'] = $default_wc_settings[1];
+		}
+
+		return $store_settings;
+	}
+
+	/**
 	 * Configure WooCommerce core tax settings for TaxJar integration.
 	 *
 	 * Ported from TaxJar's plugin.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -205,7 +205,7 @@ class WC_Connect_TaxJar_Integration {
 			$quantity = $cart_item['quantity'];
 			$unit_price = $product->get_price();
 			$line_subtotal = $cart_item['line_subtotal'];
-			$discount = ( $unit_price - $wc_cart_object->get_discounted_price( $cart_item, $unit_price ) ) * $quantity;
+			$discount = $line_subtotal - $cart_item['line_total'];
 			$tax_class = explode( '-', $product->get_tax_class() );
 			$tax_code = '';
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -15,6 +15,131 @@ class WC_Connect_TaxJar_Integration {
 
 	public function init() {
 		// TODO: check if TaxJar plugin is enabled, abort if so
-		// TODO: backup existing tax rates if enabled
+
+		// TODO: check if WCS Taxes are enabled before backup existing tax rates
+		$this->backup_existing_tax_rates();
+	}
+
+	/**
+	 * Exports existing tax rates to a CSV and clears the table.
+	 *
+	 * Ported from TaxJar's plugin.
+	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/42cd4cd0/taxjar-woocommerce.php#L75
+	 */
+	public function backup_existing_tax_rates() {
+		global $wpdb;
+
+		// Export Tax Rates
+		$rates = $wpdb->get_results( $wpdb->prepare(
+			"SELECT * FROM {$wpdb->prefix}woocommerce_tax_rates
+			ORDER BY tax_rate_order
+			LIMIT %d, %d
+			",
+			0,
+			10000
+		) );
+
+		ob_start();
+		$header =
+			__( 'Country Code', 'woocommerce' ) . ',' .
+			__( 'State Code', 'woocommerce' ) . ',' .
+			__( 'ZIP/Postcode', 'woocommerce' ) . ',' .
+			__( 'City', 'woocommerce' ) . ',' .
+			__( 'Rate %', 'woocommerce' ) . ',' .
+			__( 'Tax Name', 'woocommerce' ) . ',' .
+			__( 'Priority', 'woocommerce' ) . ',' .
+			__( 'Compound', 'woocommerce' ) . ',' .
+			__( 'Shipping', 'woocommerce' ) . ',' .
+			__( 'Tax Class', 'woocommerce' ) . "\n";
+
+		echo $header;
+
+		foreach ( $rates as $rate ) {
+			if ( $rate->tax_rate_country ) {
+				echo esc_attr( $rate->tax_rate_country );
+			} else {
+				echo '*';
+			}
+
+			echo ',';
+
+			if ( $rate->tax_rate_country ) {
+				echo esc_attr( $rate->tax_rate_state );
+			} else {
+				echo '*';
+			}
+
+			echo ',';
+
+			$locations = $wpdb->get_col( $wpdb->prepare( "SELECT location_code FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE location_type='postcode' AND tax_rate_id = %d ORDER BY location_code", $rate->tax_rate_id ) );
+
+			if ( $locations ) {
+				echo esc_attr( implode( '; ', $locations ) );
+			} else {
+				echo '*';
+			}
+
+			echo ',';
+
+			$locations = $wpdb->get_col( $wpdb->prepare( "SELECT location_code FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE location_type='city' AND tax_rate_id = %d ORDER BY location_code", $rate->tax_rate_id ) );
+			if ( $locations ) {
+				echo esc_attr( implode( '; ', $locations ) );
+			} else {
+				echo '*';
+			}
+
+			echo ',';
+
+			if ( $rate->tax_rate ) {
+				echo esc_attr( $rate->tax_rate );
+			} else {
+				echo '0';
+			}
+
+			echo ',';
+
+			if ( $rate->tax_rate_name ) {
+				echo esc_attr( $rate->tax_rate_name );
+			} else {
+				echo '*';
+			}
+
+			echo ',';
+
+			if ( $rate->tax_rate_priority ) {
+				echo esc_attr( $rate->tax_rate_priority );
+			} else {
+				echo '1';
+			}
+
+			echo ',';
+
+			if ( $rate->tax_rate_compound ) {
+				echo esc_attr( $rate->tax_rate_compound );
+			} else {
+				echo '0';
+			}
+
+			echo ',';
+
+			if ( $rate->tax_rate_shipping ) {
+				echo esc_attr( $rate->tax_rate_shipping );
+			} else {
+				echo '0';
+			}
+
+			echo ',';
+
+			echo "\n";
+		} // End foreach().
+
+		$csv = ob_get_contents();
+		ob_end_clean();
+		$upload_dir = wp_upload_dir();
+		file_put_contents( $upload_dir['basedir'] . '/taxjar-wc_tax_rates-' . date( 'm-d-Y' ) . '-' . time() . '.csv', $csv );
+
+		// Delete all tax rates
+		$wpdb->query( 'TRUNCATE ' . $wpdb->prefix . 'woocommerce_tax_rates' );
+		$wpdb->query( 'TRUNCATE ' . $wpdb->prefix . 'woocommerce_tax_rate_locations' );
 	}
 }

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -19,8 +19,46 @@ class WC_Connect_TaxJar_Integration {
 			return;
 		}
 
+		// TODO: check if WCS Taxes are enabled before configuring core tax settings
+		$this->configure_tax_settings();
+
 		// TODO: check if WCS Taxes are enabled before backup existing tax rates
 		$this->backup_existing_tax_rates();
+	}
+
+	/**
+	 * Configure WooCommerce core tax settings for TaxJar integration.
+	 *
+	 * Ported from TaxJar's plugin.
+	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/82bf7c58/includes/class-wc-taxjar-integration.php#L66-L91
+	 */
+	public function configure_tax_settings() {
+		// If TaxJar is enabled and a user disables taxes we renable them
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+
+		// Users can set either billing or shipping address for tax rates but not shop
+		update_option( 'woocommerce_tax_based_on', 'shipping' );
+
+		// Rate calculations assume tax not included
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+
+		// Don't ever set a default customer address
+		update_option( 'woocommerce_default_customer_address', '' );
+
+		// Use no special handling on shipping taxes, our API handles that
+		update_option( 'woocommerce_shipping_tax_class', '' );
+
+		// API handles rounding precision
+		update_option( 'woocommerce_tax_round_at_subtotal', 'no' );
+
+		// Rates are calculated in the cart assuming tax not included
+		update_option( 'woocommerce_tax_display_shop', 'excl' );
+
+		// TaxJar returns one total amount, not line item amounts
+		update_option( 'woocommerce_tax_display_cart', 'excl' );
+
+		// TaxJar returns one total amount, not line item amounts
+		update_option( 'woocommerce_tax_total_display', 'single' );
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -171,7 +171,9 @@ class WC_Connect_TaxJar_Integration {
 	 * @param $message
 	 */
 	public function _log( $message ) {
-		$this->logger->debug( $message, 'WCS Tax' );
+		$formatted_message = is_scalar( $message ) ? $message : json_encode( $message );
+
+		$this->logger->debug( $formatted_message, 'WCS Tax' );
 	}
 
 	/**

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -23,6 +23,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * WooCommerce Services incorporates code from WooCommerce Sales Tax Plugin by TaxJar, Copyright 2014-2017 TaxJar.
+ * WooCommerce Sales Tax Plugin by TaxJar is distributed under the terms of the GNU GPL, Version 2 (or later).
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -387,7 +387,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 
 			add_action( 'woocommerce_init', array( $this, 'after_wc_init' ) );
-			$this->taxjar->init();
 		}
 
 		/**
@@ -497,6 +496,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			$tracks = $this->get_tracks();
 			$tracks->init();
+
+			$this->taxjar->init();
 		}
 
 		public function tos_rest_init() {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -430,7 +430,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$tracks                = new WC_Connect_Tracks( $logger, __FILE__ );
 			$shipping_label        = new WC_Connect_Shipping_Label( $api_client, $settings_store, $schemas_store, $payment_methods_store );
 			$nux                   = new WC_Connect_Nux( $tracks, $shipping_label );
-			$taxjar                = new WC_Connect_TaxJar_Integration( $api_client );
+			$taxjar                = new WC_Connect_TaxJar_Integration( $api_client, $logger );
 
 			$this->set_logger( $logger );
 			$this->set_api_client( $api_client );


### PR DESCRIPTION
This PR seeks to:

* Remove the dependence on a separate TaxJar plugin
* Only integrate sales tax calculation - order syncing and nexus functionality is not required

To test:
* Ensure your store is in a supported country ([#](https://developers.taxjar.com/api/reference/#countries))
* Go to WooCommerce > Settings > Tax and enable "Automated taxes"
* Verify that any previously configured tax rates have been exported to CSV (uploads dir)
* Verify that taxes are calculated in cart (behavior will vary based on store location)
* Verify that taxes are calculated for manually created orders in the dashboard

cc: @allendav