### PR TITLE
Option to feed tracking info to Shipment Tracking plugin

### DIFF
--- a/client/apps/shipping-label/components/label-item/index.js
+++ b/client/apps/shipping-label/components/label-item/index.js
@@ -19,6 +19,13 @@ import timeAgo from 'lib/utils/time-ago';
 import { openRefundDialog, openReprintDialog } from '../../state/actions';
 
 class LabelItem extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.shipmentTracking = document.querySelector( '#woocommerce-shipment-tracking' );
+		this.feedToShipmentTracking = this.feedToShipmentTracking.bind( this );
+	}
+
 	renderRefundLink = ( label ) => {
 		const today = new Date();
 		const thirtyDaysAgo = new Date().setDate( today.getDate() - 30 );
@@ -119,6 +126,28 @@ class LabelItem extends Component {
 		);
 	};
 
+	feedToShipmentTracking( event ) {
+		this.shipmentTracking.querySelector( '[name=tracking_number]' ).value = this.props.label.tracking;
+
+		const providerControl = this.shipmentTracking.querySelector( '[name=tracking_provider]' );
+		providerControl.value = 'usps';
+
+		// this.shipmentTracking.querySelector( '.button-save-form' ).click();
+		// Don't automatically save so that user can set ship date
+		this.shipmentTracking.scrollIntoView();
+		this.shipmentTracking.querySelector( '.button-show-form' ).click();
+		this.shipmentTracking.querySelector( '[name=tracking_number]' ).focus();
+		if ( 'createEvent' in document ) {
+			const evt = document.createEvent( 'HTMLEvents' );
+			evt.initEvent( 'change', false, true );
+			providerControl.dispatchEvent( evt );
+		} else {
+			providerControl.fireEvent( 'onchange' );
+		}
+
+		event.preventDefault();
+	}
+
 	render() {
 		const { label } = this.props;
 		const purchased = timeAgo( label.created );
@@ -135,6 +164,12 @@ class LabelItem extends Component {
 				</p>
 				<p className="label-item__tracking">
 					{ __( 'Tracking #: {{trackingLink/}}', { components: { trackingLink: <TrackingLink { ...label } /> } } ) }
+					{ ' ' }
+					{ this.shipmentTracking && (
+						<a href="#" onClick={ this.feedToShipmentTracking } title="Feed to Shipment Tracking" >
+							<Gridicon icon="arrow-up" size={ 12 } />
+						</a>
+					) }
 				</p>
 				<p className="label-item__actions" >
 					{ this.renderRefund( label ) }


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/1156

The design of this integration could perhaps use some more thought, but currently,  if the [Shipment Tracking](https://woocommerce.com/products/shipment-tracking/) plugin is active, it adds an action to the right of the tracking link:

<img width="298" alt="screen shot 2017-09-18 at 6 02 22 pm" src="https://user-images.githubusercontent.com/1867547/30566883-dbe4b1d0-9c9b-11e7-8dc3-bbc6a2fa53c9.png">

...which takes you to the filled-in Shipment Tracking form:

<img width="301" alt="screen shot 2017-09-18 at 6 02 54 pm" src="https://user-images.githubusercontent.com/1867547/30566887-deb1c510-9c9b-11e7-8b38-6f963922b190.png">

(It also could just submit the form for you, except that you'd lose the chance to set the ship date.)