### PR TITLE
Fix: deleted product results in fatal error.

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -200,7 +200,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 							$product_data['attributes'] = $formatted;
 						}
 					} else {
-						$product_data['name'] = WC_Connect_Compatibility::instance()->get_product_name_from_order( $item['product_id'], $order );
+						$product_data['name'] = WC_Connect_Compatibility::instance()->get_product_name_from_order( $product_data['product_id'], $order );
 					}
 
 					$formatted_packages[ $package_id ]['items'][ $item_index ] = $product_data;


### PR DESCRIPTION
Fix variable name typo.

This prevented order detail pages from loading when the order contained a deleted product.

cc: @WillBrubaker 