### PR TITLE
Fix debug toggle on Status page.

### DIFF
--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -692,10 +692,8 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 				'formSchema'         => $this->get_form_schema(),
 				'formLayout'         => $this->get_form_layout(),
 				'formData'           => $this->get_form_data(),
-				'methodId'           => 'self_help',
-				'instanceId'         => 'self_help',
+				'methodId'           => 'self-help',
 				'nonce'              => wp_create_nonce( 'wp_rest' ),
-				'callbackURL'        => get_rest_url( null, '/wc/v1/connect/self-help' ),
 				'noticeDismissed'    => true,
 			) );
 

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -692,16 +692,13 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 				'formSchema'         => $this->get_form_schema(),
 				'formLayout'         => $this->get_form_layout(),
 				'formData'           => $this->get_form_data(),
-				'methodId'           => 'self-help',
-				'nonce'              => wp_create_nonce( 'wp_rest' ),
+				'formType'           => 'self-help',
 				'noticeDismissed'    => true,
 			) );
 
 			do_action( 'enqueue_wc_connect_script', 'wc-connect-admin-test-print', array(
 				'storeOptions'       => $this->service_settings_store->get_store_options(),
 				'paperSize'          => $this->service_settings_store->get_preferred_paper_size(),
-				'nonce'              => wp_create_nonce( 'wp_rest' ),
-				'labelsPreviewURL'   => get_rest_url( null, '/wc/v1/connect/label/preview' ),
 			) );
 		}
 

--- a/client/api/url.js
+++ b/client/api/url.js
@@ -23,7 +23,7 @@ export const labelTestPrint = () => `${ namespace }label/preview`;
 
 export const addressNormalization = () => `${ namespace }normalize-address`;
 
-export const settingsForm = ( methodId, instanceId = false, formType = false ) => {
+export const settingsForm = ( formType, methodId, instanceId ) => {
 	const path = _.filter( [ formType, methodId, instanceId ] ).join( '/' );
 
 	return namespace + path;

--- a/client/api/url.js
+++ b/client/api/url.js
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import _ from 'lodash';
+
 const namespace = 'wc/v1/connect/';
 
 export const accountSettings = () => namespace + 'account/settings';
@@ -18,8 +23,10 @@ export const labelTestPrint = () => `${ namespace }label/preview`;
 
 export const addressNormalization = () => `${ namespace }normalize-address`;
 
-export const shippingServiceSettings = ( methodId, instanceId = false ) => instanceId
-	? `${ namespace }services/${ methodId }/${ instanceId }`
-	: `${ namespace }services/${ methodId }`;
+export const settingsForm = ( methodId, instanceId = false, formType = false ) => {
+	const path = _.filter( [ formType, methodId, instanceId ] ).join( '/' );
+
+	return namespace + path;
+};
 
 export const dismissShippingSettingsNuxNotice = () => `${ namespace }services/dismiss_notice`;

--- a/client/apps/settings/state/actions.js
+++ b/client/apps/settings/state/actions.js
@@ -30,7 +30,7 @@ export const setFormProperty = ( field, value ) => {
 
 export const fetchForm = () => ( dispatch, getState, { methodId, instanceId, formType } ) => {
 	dispatch( setFormProperty( 'isFetching', true ) );
-	return api.get( api.url.settingsForm( methodId, instanceId, formType ) )
+	return api.get( api.url.settingsForm( formType, methodId, instanceId ) )
 		.then( ( response ) => {
 			dispatch( initForm( response ) );
 		} )

--- a/client/apps/settings/state/actions.js
+++ b/client/apps/settings/state/actions.js
@@ -28,9 +28,9 @@ export const setFormProperty = ( field, value ) => {
 	};
 };
 
-export const fetchForm = () => ( dispatch, getState, { methodId, instanceId } ) => {
+export const fetchForm = () => ( dispatch, getState, { methodId, instanceId, formType } ) => {
 	dispatch( setFormProperty( 'isFetching', true ) );
-	return api.get( api.url.shippingServiceSettings( methodId, instanceId ) )
+	return api.get( api.url.settingsForm( methodId, instanceId, formType ) )
 		.then( ( response ) => {
 			dispatch( initForm( response ) );
 		} )

--- a/client/apps/settings/state/values/actions.js
+++ b/client/apps/settings/state/values/actions.js
@@ -35,7 +35,7 @@ export const addArrayFieldItem = ( path, item ) => ( {
 	item,
 } );
 
-export const submit = ( schema, silent ) => ( dispatch, getState, { methodId, instanceId } ) => {
+export const submit = ( schema, silent ) => ( dispatch, getState, { methodId, instanceId, formType } ) => {
 	silent = ( true === silent );
 
 	const setIsSaving = ( value ) => dispatch( FormActions.setFormProperty( 'isSaving', value ) );
@@ -85,7 +85,7 @@ export const submit = ( schema, silent ) => ( dispatch, getState, { methodId, in
 	}
 
 	setIsSaving( true );
-	api.post( api.url.shippingServiceSettings( methodId, instanceId ), coercedValues )
+	api.post( api.url.settingsForm( methodId, instanceId, formType ), coercedValues )
 		.then( () => setSuccess( true ) )
 		.catch( ( error ) => {
 			if ( 'validation_failure' === _.get( error, 'data.error' ) && _.get( error, 'data.data.fields' ) ) {

--- a/client/apps/settings/state/values/actions.js
+++ b/client/apps/settings/state/values/actions.js
@@ -85,7 +85,7 @@ export const submit = ( schema, silent ) => ( dispatch, getState, { methodId, in
 	}
 
 	setIsSaving( true );
-	api.post( api.url.settingsForm( methodId, instanceId, formType ), coercedValues )
+	api.post( api.url.settingsForm( formType, methodId, instanceId ), coercedValues )
 		.then( () => setSuccess( true ) )
 		.catch( ( error ) => {
 			if ( 'validation_failure' === _.get( error, 'data.error' ) && _.get( error, 'data.data.fields' ) ) {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -631,7 +631,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$schemas_store = $this->get_service_schemas_store();
 			$service_schema = $schemas_store->get_service_schema_by_id_or_instance_id( $instance_id ? $instance_id : $method_id );
 			if ( ! $service_schema ) {
-				return array_merge( $settings, array (
+				return array_merge( $settings, array(
+					'formType'   => 'services',
 					'methodId'   => $method_id,
 					'instanceId' => $instance_id,
 				) );
@@ -642,6 +643,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				'formSchema'         => $service_schema->service_settings,
 				'formLayout'         => $service_schema->form_layout,
 				'formData'           => $settings_store->get_service_settings( $method_id, $instance_id ),
+				'formType'           => 'services',
 				'methodId'           => $method_id,
 				'instanceId'         => $instance_id,
 				'noticeDismissed'    => $this->nux->is_notice_dismissed( 'service_settings' ),


### PR DESCRIPTION
Refactor shipping settings form URL generation to be a generic settings form URL method.

This allows for separate handling of other forms that use the SettingsForm components, like the Status page debug toggle.

To test:
* Verify that shipping method form saving works
* Verify that toggling debug on Status page works