### PR TITLE
Check for truth of "automated taxes" option (set by wizard) rather than specific value

### DIFF
--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -66,7 +66,7 @@ class WC_Connect_TaxJar_Integration {
 	 */
 	public function is_enabled() {
 		// Migrate automated taxes selection from the setup wizard
-		if ( 'yes' === get_option( self::SETUP_WIZARD_OPTION_NAME ) ) {
+		if ( get_option( self::SETUP_WIZARD_OPTION_NAME ) ) {
 			update_option( self::OPTION_NAME, 'yes' );
 			delete_option( self::SETUP_WIZARD_OPTION_NAME );
 


### PR DESCRIPTION
In the Extras step of the WooCommerce setup wizard, the automated taxes choice wasn't being honored because the wizard [sets `woocommerce_setup_automated_taxes` option to "1"](https://github.com/woocommerce/woocommerce/blob/1831d7ec37ea53ed865de335aa706eada71de030/includes/admin/class-wc-admin-setup-wizard.php#L1379) instead of "yes". This change loosens the condition.

To test, go through wizard and select "Automated taxes" in the Extras step. After completing the wizard, ensure that automated taxes are enabled (`/wp-admin/admin.php?page=wc-settings&tab=tax`, top setting).