### PR TITLE
Add TOS bypass for Atomic sites

### DIFF
--- a/classes/class-wc-connect-jetpack.php
+++ b/classes/class-wc-connect-jetpack.php
@@ -39,6 +39,18 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 		}
 
 		/**
+		 * Helper method to get whether the current site is an Atomic site
+		 * @return bool
+		 */
+		public static function is_atomic_site() {
+			if ( function_exists( 'jetpack_is_atomic_site' ) ) {
+				return jetpack_is_atomic_site();
+			}
+
+			return false;
+		}
+
+		/**
 		 * Helper method to get the Jetpack master user, IF we are connected
 		 * @return WP_User | false
 		 */

--- a/classes/class-wc-connect-jetpack.php
+++ b/classes/class-wc-connect-jetpack.php
@@ -45,6 +45,8 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 		public static function is_atomic_site() {
 			if ( function_exists( 'jetpack_is_atomic_site' ) ) {
 				return jetpack_is_atomic_site();
+			} elseif ( function_exists( 'jetpack_is_automated_transfer_site' ) ) {
+				return jetpack_is_automated_transfer_site();
 			}
 
 			return false;

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -380,15 +380,17 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function pre_wc_init() {
 			$this->load_dependencies();
 
+			$tos_accepted = WC_Connect_Options::get_option( 'tos_accepted' );
+
 			// Prevent presenting users with TOS they've already
 			// accepted in the core WC Setup Wizard or on WP.com
-			if ( get_option( 'woocommerce_setup_jetpack_opted_in' ) || WC_Connect_Jetpack::is_atomic_site() ) {
+			if ( ! $tos_accepted &&
+				( get_option( 'woocommerce_setup_jetpack_opted_in' ) || WC_Connect_Jetpack::is_atomic_site() )
+			) {
 				WC_Connect_Options::update_option( 'tos_accepted', true );
 				delete_option( 'woocommerce_setup_jetpack_opted_in' );
 
 				$tos_accepted = true;
-			} else {
-				$tos_accepted = WC_Connect_Options::get_option( 'tos_accepted' );
 			}
 
 			add_action( 'admin_init', array( $this, 'admin_enqueue_scripts' ) );

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -381,8 +381,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->load_dependencies();
 
 			// Prevent presenting users with TOS they've already
-			// accepted in the core WC Setup Wizard
-			if ( get_option( 'woocommerce_setup_jetpack_opted_in' ) ) {
+			// accepted in the core WC Setup Wizard or on WP.com
+			if ( get_option( 'woocommerce_setup_jetpack_opted_in' ) || WC_Connect_Jetpack::is_atomic_site() ) {
 				WC_Connect_Options::update_option( 'tos_accepted', true );
 				delete_option( 'woocommerce_setup_jetpack_opted_in' );
 


### PR DESCRIPTION
Because the "Ecommerce" section of the [WP.com TOS](https://en.wordpress.com/tos/) covers the functionality of this plugin, we can check if the site is an Atomic site as a condition for auto-accepting the TOS and proceeding.

To test, a) install/activate on Atomic site (use `npm run release` and upload ZIP) and verify plugin is functional without any TOS prompt, and b) activate on non-atomic site and verify that TOS prompt still shows up once Jetpack is activated (outside of WC wizard), and plugin doesn't work until TOS accepted, as before.

Note: `jetpack_is_atomic_site` appears to be somewhat of an undocumented function intended for internal use — it was actually [renamed](https://github.com/Automattic/jetpack/pull/7729) from `jetpack_is_automated_transfer_site` in Jetpack 5.4 — is there some risk in relying on it?

Fixes https://github.com/Automattic/wp-calypso/issues/16954
Closes https://github.com/Automattic/woocommerce-services/pull/1138