### PR TITLE
Return the PDF in JSON format (base64-encoded) if the "json" parameter is set

### DIFF
--- a/classes/class-wc-rest-connect-shipping-label-print-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-print-controller.php
@@ -53,9 +53,16 @@ class WC_REST_Connect_Shipping_Label_Print_Controller extends WC_REST_Connect_Ba
 			return $raw_response;
 		}
 
-		header( 'content-type: ' . $raw_response[ 'headers' ][ 'content-type' ] );
-		echo $raw_response[ 'body' ];
-		die();
+		if ( isset( $raw_params[ 'json' ] ) && $raw_params[ 'json' ] ) {
+			return array(
+				'mimeType' => $raw_response[ 'headers' ][ 'content-type' ],
+				'b64Content' => base64_encode( $raw_response[ 'body' ] ),
+			);
+		} else {
+			header( 'content-type: ' . $raw_response[ 'headers' ][ 'content-type' ] );
+			echo $raw_response[ 'body' ];
+			die();
+		}
 	}
 
 }


### PR DESCRIPTION
If the `conect/label/print` request has a POST parameter `"json": true`, instead of spitting the raw PDF, the endpoint will return a regular json, like this:
```js
{
  "mimeType": "application/pdf",
  "b64Content": "...THE....BINARY....PDF....CONTENT.....ENCODED...IN...BASE64...."
}
```

Printing from `WP-Admin` shouldn't be affected by this, this change is only for requests coming from `wp-calypso` (which will have the `json` flag set to `true`).