### PR TITLE
Modify status indicator schema to fit with refactored object schema handling

### DIFF
--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -524,11 +524,14 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 				foreach ( $fieldset[ 'items' ] as $fieldsetitem ) {
 
 					if ( 'indicators' === $fieldsetitem->type ) {
+						$indicator_schema = $this->get_indicator_schema();
+
 						$form_properties[ $fieldsetitem->key ] = array(
-							'title' => $fieldsetitem->title,
-							'type' => 'object',
+							'title'      => $fieldsetitem->title,
+							'type'       => 'object',
 							'definition' => $fieldsetitem->key . '_definitions',
-							'items' => $this->get_indicator_schema()
+							'items'      => $indicator_schema,
+							'properties' => $indicator_schema->properties,
 						);
 
 						if ( property_exists( $fieldsetitem, 'subtitle' ) ) {
@@ -640,7 +643,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			foreach ( $this->fieldsets as $fieldset ) {
 				foreach ( $fieldset[ 'items' ] as $fieldsetitem ) {
 					if ( 'indicators' === $fieldsetitem->type ) {
-						$form_data[ $fieldsetitem->key ] = $fieldsetitem->items;
+						$form_data[ $fieldsetitem->key ] = current( $fieldsetitem->items );
 					} else {
 						$form_data[ $fieldsetitem->key ] = $fieldsetitem->value;
 					}

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -643,7 +643,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			foreach ( $this->fieldsets as $fieldset ) {
 				foreach ( $fieldset[ 'items' ] as $fieldsetitem ) {
 					if ( 'indicators' === $fieldsetitem->type ) {
-						$form_data[ $fieldsetitem->key ] = current( $fieldsetitem->items );
+						$form_data[ $fieldsetitem->key ] = reset( $fieldsetitem->items );
 					} else {
 						$form_data[ $fieldsetitem->key ] = $fieldsetitem->value;
 					}

--- a/client/apps/settings/components/settings-form/settings-item.js
+++ b/client/apps/settings/components/settings-form/settings-item.js
@@ -96,7 +96,7 @@ const SettingsItem = ( {
 				<Indicators
 					title={ fieldSchema.title }
 					subtitle={ fieldSchema.subtitle }
-					indicators={ Object.values( fieldValue ) }
+					indicators={ [ fieldValue ] }
 				/>
 			);
 


### PR DESCRIPTION
Modify status indicator schema to fit with refactored object schema handling in 012abb8050fbe0c6fc59338f9756f2502cf72dcd.

This is to be considered temporary - eventually we’ll remove the data-driven aspects of the status page.

To test:
* Verify that the self help (status) page renders as expected