### PR TITLE
🐛 Fix label printing on iOS [#1166]

### DIFF
--- a/client/lib/utils/pdf-support.js
+++ b/client/lib/utils/pdf-support.js
@@ -13,6 +13,9 @@ import _ from 'lodash';
  */
 export default _.memoize( () => {
 	if ( /iPad|iPhone|iPod/.test( navigator.userAgent ) && ! window.MSStream ) {
+		// iOS doesn't support triggering a print dialog, so we should load the pdf in a new tab
+		// instead. Windows Phones are filtered out with `! window.MSStream` since the user agent
+		// string can contain the false positive 'like iPhone'
 		return 'addon';
 	}
 

--- a/client/lib/utils/pdf-support.js
+++ b/client/lib/utils/pdf-support.js
@@ -12,6 +12,10 @@ import _ from 'lodash';
  * PDFs at all.
  */
 export default _.memoize( () => {
+	if ( /iPad|iPhone|iPod/.test( navigator.userAgent ) && ! window.MSStream ) {
+		return 'addon';
+	}
+
 	if ( navigator.userAgent.includes( 'Firefox' ) ) {
 		// Firefox has a long-lived bug (https://bugzilla.mozilla.org/show_bug.cgi?id=911444),
 		// it's not reliable to consider its PDF reader "native"


### PR DESCRIPTION
Mobile Safari and Chrome are smart enough to determine that `window.open` originated from a user click and is opening the pdf in a new browser tab.

Tested and working on:

- iPhone 6S (iOS 9.0, Mobile Safari)
- iPad Air 2 (iOS 8.0, Mobile Safari)
- iPad Air 2 (iOS 11, Mobile Safari)
- iPad Air 2 (iOS 11, Chrome)