### PR TITLE
Map currency instead of country to shipping method in post-Wizard config init

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -438,12 +438,12 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		protected function add_method_to_shipping_zone( $zone_id, $method_id ) {
-			$method      = $this->get_service_schemas_store()->get_service_schema_by_id( $method_id );
+			$method = $this->get_service_schemas_store()->get_service_schema_by_id( $method_id );
 			if ( empty( $method ) ) {
 				return;
 			}
 
-			$zone        = WC_Shipping_Zones::get_zone( $zone_id );
+			$zone = WC_Shipping_Zones::get_zone( $zone_id );
 			$instance_id = $zone->add_shipping_method( $method->method_id );
 			$zone->save();
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -474,12 +474,14 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 
 			if ( get_option( 'woocommerce_setup_domestic_live_rates_zone' ) ) {
+				$store_country = WC()->countries->get_base_country();
+
 				// Find the "domestic" zone (only location must be the base country)
 				foreach ( WC_Shipping_Zones::get_zones() as $zone ) {
 					if (
 						1 === count( $zone['zone_locations'] ) &&
 						'country' === $zone['zone_locations'][0]->type &&
-						WC()->countries->get_base_country() === $zone['zone_locations'][0]->code
+						$store_country === $zone['zone_locations'][0]->code
 					) {
 						$this->add_method_to_shipping_zone( $zone['id'], $currency_method );
 						break;

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -458,18 +458,18 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		public function init_core_wizard_shipping_config() {
-			$store_country = WC()->countries->get_base_country();
+			$store_currency = get_woocommerce_currency();
 
-			if ( 'US' === $store_country ) {
-				$country_method = 'usps';
-			} elseif ( 'CA' === $store_country ) {
-				$country_method = 'canada_post';
+			if ( 'USD' === $store_currency ) {
+				$currency_method = 'usps';
+			} elseif ( 'CAD' === $store_currency ) {
+				$currency_method = 'canada_post';
 			} else {
-				return; // Only set up live rates for US and CA
+				return; // Only set up live rates for USD and CAD
 			}
 
 			if ( get_option( 'woocommerce_setup_intl_live_rates_zone' ) ) {
-				$this->add_method_to_shipping_zone( 0, $country_method );
+				$this->add_method_to_shipping_zone( 0, $currency_method );
 				delete_option( 'woocommerce_setup_intl_live_rates_zone' );
 			}
 
@@ -479,9 +479,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					if (
 						1 === count( $zone['zone_locations'] ) &&
 						'country' === $zone['zone_locations'][0]->type &&
-						$store_country === $zone['zone_locations'][0]->code
+						WC()->countries->get_base_country() === $zone['zone_locations'][0]->code
 					) {
-						$this->add_method_to_shipping_zone( $zone['id'], $country_method );
+						$this->add_method_to_shipping_zone( $zone['id'], $currency_method );
 						break;
 					}
 				}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -439,15 +439,21 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		protected function add_method_to_shipping_zone( $zone_id, $method_id ) {
 			$method      = $this->get_service_schemas_store()->get_service_schema_by_id( $method_id );
+			if ( empty( $method ) ) {
+				return;
+			}
+
 			$zone        = WC_Shipping_Zones::get_zone( $zone_id );
 			$instance_id = $zone->add_shipping_method( $method->method_id );
-
 			$zone->save();
 
 			$instance = WC_Shipping_Zones::get_shipping_method( $instance_id );
+			if ( empty( $instance ) ) {
+				return;
+			}
+
 			$schema   = $instance->get_service_schema();
 			$defaults = (object) $this->get_service_schema_defaults( $schema->service_settings );
-
 			WC_Connect_Options::update_shipping_method_option( 'form_settings', $defaults, $method->method_id, $instance_id );
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/Automattic/woocommerce-services/issues/1193

Avoids fatal error when shipping method is unavailable due to mismatch between country and currency, by adapting to the server's recently introduced mapping by _currency_ (rather than _country_ as initially established in https://github.com/Automattic/woocommerce-services/pull/1165.)

Also hardens `add_method_to_shipping_zone` by making sure the method and method instance exist before proceeding to configure them.

To test, set country to US or CA but currency to something other than USD or CAD — confirm that the wizard is completed without WCS-derived fatal error.