### PR TITLE
Limit wizard config init calls to user-initiated requests only

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -597,8 +597,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				add_action( 'woocommerce_shipping_zone_method_status_toggled', array( $this, 'shipping_zone_method_status_toggled' ), 10, 4 );
 
 				// Initialize user choices from the core setup wizard.
-				// Note: Avoid doing so from AJAX requests so we don't duplicate efforts.
-				if ( ! defined( 'DOING_AJAX' ) ) {
+				// Note: Avoid doing so on non-primary requests so we don't duplicate efforts.
+				if ( ! defined( 'DOING_AJAX' ) && is_admin() && ! isset( $_GET['noheader'] ) ) {
 					$this->init_core_wizard_shipping_config();
 					$this->init_core_wizard_payments_config();
 				}


### PR DESCRIPTION
Should address https://github.com/Automattic/woocommerce-services/issues/1194 in the typical case, by skipping the wizard config initialization functions in requests that are made subsequent to the initial (i.e. primary) request.

Testing the broader effect is tricky since the multiple requests reported in https://github.com/Automattic/woocommerce-services/issues/1194 are not reliably reproducible, but the condition passing only once per page load can be verified by logging inside the `if` statement.