### PR TITLE
Add metadata to distinguish Stripe referral vs. connect requests

### DIFF
--- a/classes/class-wc-connect-stripe.php
+++ b/classes/class-wc-connect-stripe.php
@@ -81,8 +81,9 @@ if ( ! class_exists( 'WC_Connect_Stripe' ) ) {
 
 			$option_name = 'woocommerce_stripe_settings';
 			$options = array_merge( $default_options, get_option( $option_name, array() ) );
-			$options[ 'enabled' ]                   = 'yes';
-			$options[ 'testmode' ]                  = $is_test ? 'yes' : 'no';
+			$options['enabled']                     = 'yes';
+			$options['connect']                     = 'yes';
+			$options['testmode']                    = $is_test ? 'yes' : 'no';
 			$options[ $prefix . 'account_id' ]      = $result->accountId;
 			$options[ $prefix . 'publishable_key' ] = $result->publishableKey;
 			$options[ $prefix . 'secret_key' ]      = $result->secretKey;

--- a/classes/class-wc-connect-stripe.php
+++ b/classes/class-wc-connect-stripe.php
@@ -110,6 +110,9 @@ if ( ! class_exists( 'WC_Connect_Stripe' ) ) {
 			return $result;
 		}
 
+		/**
+		 * Differentiate Stripe Connect account requests by omitting User-Agent
+		 */
 		public function modify_request_headers( $headers ) {
 			$options = get_option( 'woocommerce_stripe_settings', array() );
 			if ( isset( $options['connect'] ) && 'yes' === $options['connect'] ) {

--- a/classes/class-wc-connect-stripe.php
+++ b/classes/class-wc-connect-stripe.php
@@ -29,6 +29,8 @@ if ( ! class_exists( 'WC_Connect_Stripe' ) ) {
 			$this->api = $client;
 			$this->options = $options;
 			$this->logger = $logger;
+
+			add_filter( 'woocommerce_stripe_request_headers', array( $this, 'modify_request_headers' ) );
 		}
 
 		public function is_stripe_plugin_enabled() {
@@ -106,6 +108,14 @@ if ( ! class_exists( 'WC_Connect_Stripe' ) ) {
 			}
 
 			return $result;
+		}
+
+		public function modify_request_headers( $headers ) {
+			$options = get_option( 'woocommerce_stripe_settings', array() );
+			if ( isset( $options['connect'] ) && 'yes' === $options['connect'] ) {
+				unset( $headers['User-Agent'] );
+			}
+			return $headers;
 		}
 	}
 }

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -500,10 +500,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				if ( is_wp_error( $response ) ) {
 					// TODO handle case of existing account
 					$this->logger->debug( $response, __CLASS__ );
-				} else {
-					$stripe_settings = get_option( 'woocommerce_stripe_settings', array() );
-					$stripe_settings['connect'] = 'yes';
-					update_option( 'woocommerce_stripe_settings', $stripe_settings );
 				}
 			}
 		}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -501,8 +501,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					// TODO handle case of existing account
 					$this->logger->debug( $response, __CLASS__ );
 				} else {
-					$stripe_settings = get_option( 'woocommerce_stripe_settings', false );
-					$stripe_settings[ 'connect' ] = 'yes';
+					$stripe_settings = get_option( 'woocommerce_stripe_settings', array() );
+					$stripe_settings['connect'] = 'yes';
 					update_option( 'woocommerce_stripe_settings', $stripe_settings );
 				}
 			}
@@ -587,7 +587,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * Hook plugin classes into WP/WC core.
 		 */
 		public function attach_hooks() {
-			add_filter( 'woocommerce_stripe_request_body', array( $this, 'woocommerce_stripe_request_metadata' ) );
+			add_filter( 'woocommerce_stripe_request_headers', array( $this, 'woocommerce_stripe_request_headers' ) );
 
 			$schemas_store = $this->get_service_schemas_store();
 			$schemas = $schemas_store->get_service_schemas();
@@ -903,16 +903,12 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			return $payment_gateways;
 		}
 
-		public function woocommerce_stripe_request_metadata( $request ) {
+		public function woocommerce_stripe_request_headers( $headers ) {
 			$stripe_settings = get_option( 'woocommerce_stripe_settings', array() );
-			if ( 'yes' === $stripe_settings[ 'connect' ] ) {
-				// Add metadata to request. See https://stripe.com/docs/api#metadata
-				if ( ! isset( $request[ 'metadata' ] ) ) {
-					$request[ 'metadata' ] = array();
-				}
-				$request[ 'metadata' ][ 'connect' ] = true;
+			if ( isset( $stripe_settings['connect'] ) && 'yes' === $stripe_settings['connect'] ) {
+				unset( $headers['User-Agent'] );
 			}
-			return $request;
+			return $headers;
 		}
 
 		function get_i18n_json() {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -583,8 +583,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * Hook plugin classes into WP/WC core.
 		 */
 		public function attach_hooks() {
-			add_filter( 'woocommerce_stripe_request_headers', array( $this, 'woocommerce_stripe_request_headers' ) );
-
 			$schemas_store = $this->get_service_schemas_store();
 			$schemas = $schemas_store->get_service_schemas();
 
@@ -897,14 +895,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		public function woocommerce_payment_gateways( $payment_gateways ) {
 			return $payment_gateways;
-		}
-
-		public function woocommerce_stripe_request_headers( $headers ) {
-			$stripe_settings = get_option( 'woocommerce_stripe_settings', array() );
-			if ( isset( $stripe_settings['connect'] ) && 'yes' === $stripe_settings['connect'] ) {
-				unset( $headers['User-Agent'] );
-			}
-			return $headers;
 		}
 
 		function get_i18n_json() {


### PR DESCRIPTION
~Adds [metadata](https://stripe.com/docs/api#metadata) (key: `connect`, value: `1`) to~ Removes User-Agent from Stripe requests from accounts created via WCS after WooCommerce setup wizard opt-in (discussion in p7bbVw-1Rh-p2)

Requires WooCommerce Stripe Payment Gateway 4.0.0 ([latest](https://github.com/woocommerce/woocommerce-gateway-stripe/tree/4.0.0)) but shouldn't break without it — tested by logging request data in the Stripe plugin's [API class](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/e0ac1c3c28e8718810e5c2ffd0ae84d411e415a4/includes/class-wc-stripe-api.php#L101).