### PR TITLE
Make paymentMethod not required for labels view

### DIFF
--- a/client/apps/shipping-label/view.js
+++ b/client/apps/shipping-label/view.js
@@ -130,7 +130,7 @@ ShippingLabelRootView.propTypes = {
 	loaded: PropTypes.bool.isRequired,
 	needToFetchLabelStatus: PropTypes.bool.isRequired,
 	numPaymentMethods: PropTypes.number.isRequired,
-	paymentMethod: PropTypes.string.isRequired,
+	paymentMethod: PropTypes.string,
 	labels: PropTypes.array.isRequired,
 	fetchLabelsStatus: PropTypes.func.isRequired,
 	openPrintingFlow: PropTypes.func.isRequired,


### PR DESCRIPTION
The payment method is null when it hasn't been entered yet, so it should not be a required prop.

Fixes this error:

<img width="965" alt="screen shot 2017-10-16 at 9 32 10 pm" src="https://user-images.githubusercontent.com/11487924/31949644-da54bffe-b8a7-11e7-8e80-453373551c91.png">
