### PR TITLE
Do not allow default 500 to be returned by stripe rest api endpoints

### DIFF
--- a/classes/class-wc-rest-connect-stripe-account-controller.php
+++ b/classes/class-wc-rest-connect-stripe-account-controller.php
@@ -21,12 +21,15 @@ class WC_REST_Connect_Stripe_Account_Controller extends WC_REST_Connect_Base_Con
 		$response = $this->stripe->get_account_details();
 
 		if ( is_wp_error( $response ) ) {
-			$response->add_data( array(
-				'message' => $response->get_error_message(),
-			), $response->get_error_code() );
-
 			$this->logger->debug( $response, __CLASS__ );
-			return $response;
+
+			return new WP_Error(
+				$response->get_error_code(),
+				$response->get_error_message(),
+				array(
+					'status' => 400
+				)
+			);
 		}
 
 		return array(
@@ -50,12 +53,15 @@ class WC_REST_Connect_Stripe_Account_Controller extends WC_REST_Connect_Base_Con
 		$response = $this->stripe->create_account( $data['email'], $data['country'] );
 
 		if ( is_wp_error( $response ) ) {
-			$response->add_data( array(
-				'message' => $response->get_error_message(),
-			), $response->get_error_code() );
-
 			$this->logger->debug( $response, __CLASS__ );
-			return $response;
+
+			return new WP_Error(
+				$response->get_error_code(),
+				$response->get_error_message(),
+				array(
+					'status' => 400
+				)
+			);
 		}
 
 		return array(

--- a/classes/class-wc-rest-connect-stripe-deauthorize-controller.php
+++ b/classes/class-wc-rest-connect-stripe-deauthorize-controller.php
@@ -21,12 +21,15 @@ class WC_REST_Connect_Stripe_Deauthorize_Controller extends WC_REST_Connect_Base
 		$response = $this->stripe->deauthorize_account();
 
 		if ( is_wp_error( $response ) ) {
-			$response->add_data( array(
-				'message' => $response->get_error_message(),
-			), $response->get_error_code() );
-
 			$this->logger->debug( $response, __CLASS__ );
-			return $response;
+
+			return new WP_Error(
+				$response->get_error_code(),
+				$response->get_error_message(),
+				array(
+					'status' => 400
+				)
+			);
 		}
 
 		return array(

--- a/classes/class-wc-rest-connect-stripe-oauth-connect-controller.php
+++ b/classes/class-wc-rest-connect-stripe-oauth-connect-controller.php
@@ -23,12 +23,15 @@ class WC_REST_Connect_Stripe_Oauth_Connect_Controller extends WC_REST_Connect_Ba
 		$response = $this->stripe->connect_oauth( $data['state'], $data['code'] );
 
 		if ( is_wp_error( $response ) ) {
-			$response->add_data( array(
-				'message' => $response->get_error_message(),
-			), $response->get_error_code() );
-
 			$this->logger->debug( $response, __CLASS__ );
-			return $response;
+
+			return new WP_Error(
+				$response->get_error_code(),
+				$response->get_error_message(),
+				array(
+					'status' => 400
+				)
+			);
 		}
 
 		return array(

--- a/classes/class-wc-rest-connect-stripe-oauth-init-controller.php
+++ b/classes/class-wc-rest-connect-stripe-oauth-init-controller.php
@@ -22,12 +22,15 @@ class WC_REST_Connect_Stripe_Oauth_Init_Controller extends WC_REST_Connect_Base_
 		$response = $this->stripe->get_oauth_url( $data['returnUrl'] );
 
 		if ( is_wp_error( $response ) ) {
-			$response->add_data( array(
-				'message' => $response->get_error_message(),
-			), $response->get_error_code() );
-
 			$this->logger->debug( $response, __CLASS__ );
-			return $response;
+
+			return new WP_Error(
+				$response->get_error_code(),
+				$response->get_error_message(),
+				array(
+					'status' => 400
+				)
+			);
 		}
 
 		return array(


### PR DESCRIPTION
Fixes #1203 

To Test:
* Install this branch as a plugin on a pressable site or other site that returns HTML for 500s
* Install the stripe connect test bench
* Navigate to https://{DOMAIN}/wp-admin/admin.php?page=wc-status&tab=sctbs
* Click each of the buttons and ensure JSON is returned even for errors (i.e. not HTML), e.g.

```
{"code":"wcc_server_error_response","message":"Error: The WooCommerce Services server returned: Bad Request Account already exists for the provided email. ( 400 )","data":{"status":400}}
```

