### PR TITLE
Avoid coercing null to object in coerceFormValues

### DIFF
--- a/client/lib/utils/coerce-values.js
+++ b/client/lib/utils/coerce-values.js
@@ -24,9 +24,13 @@ const getFieldSchema = ( fieldSchema, definitions ) => {
  * @param {Object} definitions - Schema definitions.
  * @returns {*} - Coerced value.
  */
-const coerceValue = ( schema, value, definitions ) => {
+export const coerceValue = ( schema, value, definitions ) => {
 	// If the value is undefined or we don't have a schema type to reference, leave it be.
-	if ( ( undefined === value ) || ! schema ) {
+	if (
+		undefined === value ||
+		null === value ||
+		! schema
+	) {
 		return value;
 	}
 	schema = getFieldSchema( schema, definitions );

--- a/client/lib/utils/test/coerce-values.js
+++ b/client/lib/utils/test/coerce-values.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { coerceValue } from '../coerce-values.js';
+
+describe( '#coerceValue', () => {
+	it( 'Returns null when value is null', () => {
+		const schema = {
+			$ref: '#/definitions/shipping_service'
+		};
+		const value = null;
+		const definitions = {
+			shipping_service: {
+				type: 'object',
+				properties: {
+					id: {
+						type: 'string',
+					},
+					enabled: {
+						type: 'boolean',
+						'default': false,
+					},
+					adjustment: {
+						type: 'number',
+						'default': 0,
+					},
+					adjustment_type: {
+						type: 'string',
+						'enum': [
+							'flat',
+							'percentage'
+						],
+						'default': 'flat',
+					}
+				}
+			},
+			services: [
+				{
+					id: 'pri',
+					name: 'PriorityMail',
+					group: 'priority',
+					group_name: 'PriorityMail',
+				},
+				{
+					id: 'pri_flat_env',
+					name: 'PriorityMail-FlatRateEnvelope',
+					group: 'priority',
+					group_name: 'PriorityMail',
+					predefined_package: 'flat_envelope',
+				},
+			],
+		};
+
+		const result = coerceValue( schema, value, definitions );
+
+		expect( result ).to.equal( null );
+	} );
+} );


### PR DESCRIPTION
Steps to repro:

Go to WooCommerce > Settings > Shipping zones > [one of your shipping zones] > Edit when there have been no USPS services selected for the zone.

You'll see this:

<img width="522" alt="screen shot 2017-10-30 at 11 11 13 am" src="https://user-images.githubusercontent.com/11487924/32178453-1abbccc6-bd63-11e7-8ca8-5bf34be67f5e.png">

This is the error:

> TypeError: Cannot convert undefined or null to object
> Object.keys( value )

It happens in https://github.com/Automattic/woocommerce-services/blob/master/client/lib/utils/coerce-values.js#L65 when the `value` argument of `coerceValue()` is equal to null.

I added a test to explain what I mean & to prevent regression.