### PR TITLE
Fix non-Calypso-sourced component usage of request.js.

### DIFF
--- a/client/api/index.js
+++ b/client/api/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import * as request from './request';
+import request from './request';
 
 export * as url from './url';
 
@@ -13,8 +13,8 @@ const handleError = ( jsonError ) => {
 	throw JSON.stringify( jsonError );
 };
 
-export const post = ( url, data ) => request.post( url, data ).catch( handleError );
+export const post = ( url, data ) => request().post( url, data ).catch( handleError );
 
-export const get = ( url ) => request.get( url ).catch( handleError );
+export const get = ( url ) => request().get( url ).catch( handleError );
 
-export const createGetUrlWithNonce = ( url, queryString ) => request.createGetUrlWithNonce( url, queryString );
+export const createGetUrlWithNonce = ( url, queryString ) => request().createGetUrlWithNonce( url, queryString );

--- a/client/api/request.js
+++ b/client/api/request.js
@@ -49,12 +49,7 @@ const _request = ( url, data, method, namespace = '' ) => {
 	} );
 };
 
-export default () => ( {
-	post: ( url, data, namespace ) => _request( url, data, 'POST', namespace ),
-	get: ( url, namespace ) => _request( url, null, 'GET', namespace ),
-} );
-
-export const createGetUrlWithNonce = ( url, queryString ) => {
+const createGetUrlWithNonce = ( url, queryString ) => {
 	if ( queryString ) {
 		if ( startsWith( queryString, '?' ) ) {
 			queryString = queryString.substring( 1 );
@@ -69,3 +64,9 @@ export const createGetUrlWithNonce = ( url, queryString ) => {
 
 	return `${ baseURL }${ url }${ queryStart }_wpnonce=${ nonce }${ queryString }`;
 };
+
+export default () => ( {
+	post: ( url, data, namespace ) => _request( url, data, 'POST', namespace ),
+	get: ( url, namespace ) => _request( url, null, 'GET', namespace ),
+	createGetUrlWithNonce,
+} );


### PR DESCRIPTION
Error introduced in 653853a1ba548627eb23314156ada418964212ed.

To test:
* Saving shipping method instance fails on `master`
* Toggling "debug" fails on `master`
* Verify this branch fixes