### PR TITLE
Added a control to refresh service schemas

### DIFF
--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -156,13 +156,29 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			// Check that we are able to talk to the WooCommerce Services server
 			$schemas = $this->service_schemas_store->get_service_schemas();
 			$last_fetch_timestamp = $this->service_schemas_store->get_last_fetch_timestamp();
+			$refresh_link = sprintf(
+				wp_kses(
+					__( '<a href="%s">Refresh</a>', 'woocommerce-services' ),
+					array( 'a' => array( 'href' => array() ) )
+				),
+				add_query_arg(
+					array(
+						'page' => 'wc-status',
+						'tab' => 'connect',
+						'refresh' => 'true',
+					),
+					admin_url( 'admin.php' )
+				)
+			);
 			if ( ! is_null( $last_fetch_timestamp ) ) {
 				$last_fetch_timestamp_formatted = sprintf(
-					_x( 'Last updated %s ago', '%s = human-readable time difference', 'woocommerce-services' ),
-					human_time_diff( $last_fetch_timestamp )
+					_x( 'Last updated %s ago. %s', '1st %s = human-readable time difference, 2nd %s = refresh url', 'woocommerce-services' ),
+					human_time_diff( $last_fetch_timestamp ),
+					$refresh_link
 				);
 			} else {
 				$last_fetch_timestamp = '';
+				$last_fetch_timestamp_formatted = $refresh_link;
 			}
 			if ( is_null( $schemas ) ) {
 				$health_item = $this->build_indicator(
@@ -170,7 +186,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 					'notice',
 					'is-error',
 					__( 'No service data available', 'woocommerce-services' ),
-					''
+					$last_fetch_timestamp_formatted
 				);
 			} else if ( is_null( $last_fetch_timestamp ) ) {
 				$health_item = $this->build_indicator(
@@ -178,7 +194,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 					'notice',
 					'is-warning',
 					__( 'Service data was found, but may be out of date', 'woocommerce-services' ),
-					''
+					$last_fetch_timestamp_formatted
 				);
 			} else if ( $last_fetch_timestamp < time() - WOOCOMMERCE_CONNECT_SCHEMA_AGE_ERROR_THRESHOLD ) {
 				$health_item = $this->build_indicator(
@@ -658,6 +674,12 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 		 * Localizes the bootstrap, enqueues the script and styles for the help page
 		 */
 		public function page() {
+			if ( isset( $_GET['refresh'] ) && 'true' === $_GET['refresh'] ) {
+				$schemas = $this->service_schemas_store->fetch_service_schemas_from_connect_server();
+				$url = remove_query_arg( 'refresh' );
+				wp_safe_redirect( $url );
+			}
+
 			$this->help_sections = array();
 
 			$this->add_fieldset(

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -158,7 +158,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			$last_fetch_timestamp = $this->service_schemas_store->get_last_fetch_timestamp();
 			$refresh_link = sprintf(
 				wp_kses(
-					__( '<a href="%s">Refresh</a>', 'woocommerce-services' ),
+					'<a href="%s">' . __( 'Refresh', 'woocommerce-services' ) . '</a>',
 					array( 'a' => array( 'href' => array() ) )
 				),
 				add_query_arg(

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -172,7 +172,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			);
 			if ( ! is_null( $last_fetch_timestamp ) ) {
 				$last_fetch_timestamp_formatted = sprintf(
-					_x( 'Last updated %s ago. %s', '1st %s = human-readable time difference, 2nd %s = refresh url', 'woocommerce-services' ),
+					_x( 'Last updated %1s ago. %2s', '%1s = human-readable time difference, %2s = refresh url', 'woocommerce-services' ),
 					human_time_diff( $last_fetch_timestamp ),
 					$refresh_link
 				);

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -675,7 +675,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 		 */
 		public function page() {
 			if ( isset( $_GET['refresh'] ) && 'true' === $_GET['refresh'] ) {
-				$schemas = $this->service_schemas_store->fetch_service_schemas_from_connect_server();
+				$this->service_schemas_store->fetch_service_schemas_from_connect_server();
 				$url = remove_query_arg( 'refresh' );
 				wp_safe_redirect( $url );
 			}


### PR DESCRIPTION
Fixes #462 

Adds a "Refresh" link next to the service data status:
<img width="301" alt="screen shot 2017-11-24 at 16 31 43" src="https://user-images.githubusercontent.com/800604/33218494-10fee67e-d135-11e7-932f-02f186532a92.png">
<img width="431" alt="screen shot 2017-11-24 at 16 31 33" src="https://user-images.githubusercontent.com/800604/33218498-156cec10-d135-11e7-9596-8aafc394ff83.png">

Clicking on it should attempt to fetch the schemas. Any errors should appear in the debug log (if enabled)