### PR TITLE
Fix "undefined JETPACK__VERSION" warning

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1039,7 +1039,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$plugin_version = $plugin_data[ 'Version' ];
 
 			// Use the same version as Jetpack
-			wp_register_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array(), JETPACK__VERSION . '-' . gmdate( 'oW' ) );
+			$jetpack_version = defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '0';
+			wp_register_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array(), $jetpack_version . '-' . gmdate( 'oW' ) );
 			wp_register_style( 'wc_connect_admin', $this->wc_connect_base_url . 'woocommerce-services.css', array( 'noticons' ), $plugin_version );
 			wp_register_script( 'wc_connect_admin', $this->wc_connect_base_url . 'woocommerce-services.js', array(), $plugin_version );
 			wp_register_script( 'wc_services_admin_pointers', $this->wc_connect_base_url . 'woocommerce-services-admin-pointers.js', array( 'wp-pointer', 'jquery' ), $plugin_version );


### PR DESCRIPTION
Fixes #1241

Even when Jetpack isn't installed, the admin_enqueue_scripts function is run, so we can't assume that the `JETPACK__VERSION` constant is available. Since it's only used to put a cache-bustin querystring on the `noticons.css` URL, it's safe to replace with a dummy value if Jetpack is not available.

To test:
* Make sure `WP_DEBUG` is `TRUE`.
* Disable or uninstall Jetpack.
* Check that there's no `Undefined constant JETPACK__VERSION` PHP warning after visiting any WP-Admin page.