### PR TITLE
Fix code typo: wcSevicesAdminPointers

### DIFF
--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -91,7 +91,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			}
 
 			wp_enqueue_style( 'wp-pointer' );
-			wp_localize_script( 'wc_services_admin_pointers', 'wcSevicesAdminPointers', $valid_pointers );
+			wp_localize_script( 'wc_services_admin_pointers', 'wcServicesAdminPointers', $valid_pointers );
 			wp_enqueue_script( 'wc_services_admin_pointers' );
 		}
 

--- a/client/admin-pointers.js
+++ b/client/admin-pointers.js
@@ -1,4 +1,4 @@
-/*global wcSevicesAdminPointers, ajaxurl */
+/*global wcServicesAdminPointers, ajaxurl */
 /**
  * External dependencies
  */
@@ -44,5 +44,5 @@ jQuery( document ).ready( function( $ ) {
 			$( '#wcs-pointer-page-dimmer' ).fadeIn( 500 );
 		}
 	}
-	show_pointer( wcSevicesAdminPointers, 0 );
+	show_pointer( wcServicesAdminPointers, 0 );
 } );


### PR DESCRIPTION
Fixes typo in code: `wcSevicesAdminPointers` -> `wcServicesAdminPointers`. Not quite user-facing, but it does appear in the page source.