### PR TITLE
Fixes the URL to print a label when the "Permalink" setting is off

### DIFF
--- a/client/api/request.js
+++ b/client/api/request.js
@@ -31,6 +31,9 @@ const _request = ( url, data, method, namespace = '' ) => {
 	if ( namespace && ! namespace.endsWith( '/' ) ) {
 		namespace += '/';
 	}
+	if ( -1 !== baseURL.indexOf( '?' ) ) {
+		url = url.replace( '?', '&' );
+	}
 	return fetch( baseURL + namespace + url, request ).then( ( response ) => {
 		return parseJson( response ).then( ( json ) => {
 			if ( json.success ) {


### PR DESCRIPTION
Fixes #1260

The bug was introduced in `1.9.0`, when we hybridized the extension. The plugin code is using the `api.js` module from `wp-calypso`, and that handles URL structures differently.

This is the minimal change, I have prepared a more comprehenxsive fix that cleans up some code, but I figured I should leave that for the release after we unfreeze the code.

To test:
* Go to `Settings -> Permalinks` and select the option `Plain`.
* Try to purchase or reprint a label. It should work.