### PR TITLE
Added headers to indicate support for WooCommerce up to 3.3

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -9,7 +9,7 @@
  * Domain Path: /i18n/languages/
  * Version: 1.9.1
  * WC requires at least: 2.6.0
- * WC tested up to: 3.3.0
+ * WC tested up to: 3.2.6
  *
  * Copyright (c) 2017 Automattic
  *

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -8,6 +8,8 @@
  * Text Domain: woocommerce-services
  * Domain Path: /i18n/languages/
  * Version: 1.9.1
+ * WC requires at least: 2.6.0
+ * WC tested up to: 3.3.0
  *
  * Copyright (c) 2017 Automattic
  *


### PR DESCRIPTION
See the new headers explained here: https://woocommerce.wordpress.com/2017/08/28/new-version-check-in-woocommerce-3-2/

WooCommerce `3.3` isn't out yet, but I've been using WooCommerce `master` since a few months ago and I haven't noticed any breakage. Should we declare support for `3.3`, or do you guys think we should wait until `3.3` is closer to be released?