### PR TITLE
Labels: check USD and allow all supported countries (PR)

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -30,7 +30,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		private $supported_countries = array( 'US', 'PR' );
 
 		/**
-		 * @var array array of currently unsupported states, by country
+		 * @var array Supported currencies
+		 */
+		private $supported_currencies = array( 'USD' );
+
+		/**
+		 * @var array Unsupported states, by country
 		 */
 		private $unsupported_states = array(
 			'US' => array( 'AA', 'AE', 'AP' ),
@@ -328,6 +333,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return in_array( $country_code, $this->supported_countries );
 		}
 
+		private function is_supported_currency( $currency_code ) {
+			return in_array( $currency_code, $this->supported_currencies );
+		}
+
 		private function is_supported_address( $address ) {
 			$country_code = $address['country'];
 			if ( ! $country_code ) {
@@ -384,6 +393,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			// If the order already has purchased labels, show the meta-box no matter what
 			if ( get_post_meta( WC_Connect_Compatibility::instance()->get_order_id( $order ), 'wc_connect_labels', true ) ) {
 				return true;
+			}
+
+			// Restrict showing the metabox to supported store currencies.
+			$base_currency = get_woocommerce_currency();
+			if ( ! $this->is_supported_currency( $base_currency ) ) {
+				return false;
 			}
 
 			// Restrict showing the meta-box to supported origin and destinations: US domestic, for now

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -25,7 +25,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		protected $payment_methods_store;
 
 		/**
-		 * @var array array of currently supported countries
+		 * @var array Supported countries
 		 */
 		private $supported_countries = array( 'US', 'PR' );
 
@@ -324,13 +324,17 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return ! in_array( $state_code, $this->unsupported_states[ $country_code ] );
 		}
 
+		private function is_supported_country( $country_code ) {
+			return in_array( $country_code, $this->supported_countries );
+		}
+
 		private function is_supported_address( $address ) {
 			$country_code = $address['country'];
 			if ( ! $country_code ) {
 				return true;
 			}
 
-			if ( ! in_array( $country_code, $this->supported_countries ) ) {
+			if ( ! $this->is_supported_country( $country_code ) ) {
 				return false;
 			}
 
@@ -384,7 +388,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 			// Restrict showing the meta-box to supported origin and destinations: US domestic, for now
 			$base_location = wc_get_base_location();
-			if ( 'US' !== $base_location['country'] ) {
+			if ( ! $this->is_supported_country( $base_location['country'] ) ) {
 				return false;
 			}
 


### PR DESCRIPTION
Fixes #959 and allows label printing from Puerto Rico.

To test:
* Set your store's country to Puerto Rico
* Verify that label metabox shows on an order
* Set your store's currency to BTC
* Verify that label metabox does not show on an order (that doesn't already have labels printed)