### PR TITLE
Returning an origin normalized flag to avoid using the phone field

### DIFF
--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -125,13 +125,8 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				$wc_address_fields['postcode'] = '';
 			}
 
-			$stored_address_fields = WC_Connect_Options::get_option( 'origin_address', false );
-			if ( $stored_address_fields ) {
-				$wc_address_fields['normalized'] = true;
-				return array_merge( $wc_address_fields, $stored_address_fields );
-			}
-
-			return $wc_address_fields;
+			$stored_address_fields = WC_Connect_Options::get_option( 'origin_address', array() );
+			return array_merge( $wc_address_fields, $stored_address_fields );
 		}
 
 		public function get_preferred_paper_size() {

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -125,8 +125,13 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				$wc_address_fields['postcode'] = '';
 			}
 
-			$stored_address_fields = WC_Connect_Options::get_option( 'origin_address', array() );
-			return array_merge( $wc_address_fields, $stored_address_fields );
+			$stored_address_fields = WC_Connect_Options::get_option( 'origin_address', false );
+			if ( $stored_address_fields ) {
+				$wc_address_fields['normalized'] = true;
+				return array_merge( $wc_address_fields, $stored_address_fields );
+			}
+
+			return $wc_address_fields;
 		}
 
 		public function get_preferred_paper_size() {

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -299,9 +299,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				$destination['country'] = $origin['country'];
 			}
 
+			$origin_normalized = ( bool ) WC_Connect_Options::get_option( 'origin_address', false );
 			$destination_normalized = ( bool ) get_post_meta( $order_id, '_wc_connect_destination_normalized', true );
 
-			$form_data = compact( 'is_packed', 'selected_packages', 'origin', 'destination', 'destination_normalized' );
+			$form_data = compact( 'is_packed', 'selected_packages', 'origin', 'destination', 'origin_normalized', 'destination_normalized' );
 
 			$form_data['rates'] = array(
 				'selected'  => (object) $selected_rates,


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/20510 and server's 1011 remove the phone field requirement.

This means that the frontend needs a way to detect whether an address has been filled in by the merchant and normalized without checking the phone field. The "filled in" part is easy - just check each required field (done in Calypso). The destination already has a flag that determines if the address has been normalized. This adds a similar flag for the origin address.

To test:
* checkout https://github.com/Automattic/wp-calypso/pull/20510
* in this branch of WCS ensure that you `npm link` to the Calypso branch
* checkout server PR 1011
* delete `wc_connect_origin_address` to simulate unnormalized origin address
* verify that the normalization is started for the origin address when the label modal is open, and that it succeeds even without a phone number
* verify that the destination is valid without a phone number
* verify that you can still purchase labels