### PR TITLE
Fix missing 'plugins' state now required by wp-calypso

### DIFF
--- a/client/apps/shipping-label/index.js
+++ b/client/apps/shipping-label/index.js
@@ -9,6 +9,7 @@ import React from 'react';
 import ShippingLabelViewWrapper from './view-wrapper';
 // from calypso
 import notices from 'state/notices/reducer';
+import plugins from 'state/plugins/reducer';
 import reducer from 'woocommerce/woocommerce-services/state/shipping-label/reducer';
 import packagesReducer from 'woocommerce/woocommerce-services/state/packages/reducer';
 import labelSettingsReducer from 'woocommerce/woocommerce-services/state/label-settings/reducer';
@@ -39,6 +40,7 @@ export default ( { orderId } ) => ( {
 				} ),
 			} ),
 			notices,
+			plugins,
 			ui: () => ( {
 				selectedSiteId: 1,
 			} ),


### PR DESCRIPTION
Provides the `state.plugins` Redux sub-tree, now required by `shipping-label` state imported from Calypso.

Alternatively, we can look into where it's being used and whether we can avoid this call altogether.