### PR TITLE
Fix variation names in "Packaging" line item

### DIFF
--- a/classes/class-wc-connect-compatibility-wc26.php
+++ b/classes/class-wc-connect-compatibility-wc26.php
@@ -93,5 +93,16 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC26' ) ) {
 			/* translators: %d: Deleted Product ID */
 			return sprintf( __( '#%d - [Deleted product]', 'woocommerce-services' ), $product_id );
 		}
+
+		/**
+		 * For a given product, return it's name. In supported versions, variable
+		 * products will include their attributes.
+		 *
+		 * @param WC_Product $product Product (variable, simple, etc)
+		 * @return string The product (or variation) name, ready to print
+		 */
+		public function get_product_name( WC_Product $product ) {
+			return $product->get_title();
+		}
 	}
 }

--- a/classes/class-wc-connect-compatibility-wc30.php
+++ b/classes/class-wc-connect-compatibility-wc30.php
@@ -107,6 +107,17 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC30' ) ) {
 			/* translators: %d: Deleted Product ID */
 			return sprintf( __( '#%d - [Deleted product]', 'woocommerce-services' ), $product_id );
 		}
+
+		/**
+		 * For a given product, return it's name. In supported versions, variable
+		 * products will include their attributes.
+		 *
+		 * @param WC_Product $product Product (variable, simple, etc)
+		 * @return string The product (or variation) name, ready to print
+		 */
+		public function get_product_name( WC_Product $product ) {
+			return $product->get_name();
+		}
 	}
 
 }

--- a/classes/class-wc-connect-compatibility.php
+++ b/classes/class-wc-connect-compatibility.php
@@ -110,6 +110,15 @@ if ( ! class_exists( 'WC_Connect_Compatibility' ) ) {
 		 * @return string The product (or variation) name, ready to print
 		 */
 		abstract public function get_product_name_from_order( $product_id, $order );
+
+		/**
+		 * For a given product, return it's name. In supported versions, variable
+		 * products will include their attributes.
+		 *
+		 * @param WC_Product $product Product (variable, simple, etc)
+		 * @return string The product (or variation) name, ready to print
+		 */
+		abstract public function get_product_name( WC_Product $product );
 	}
 
 }

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -340,7 +340,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 							/** @var WC_Product $product */
 							$product = $this->lookup_product( $package, $package_item->product_id );
 							if ( $product ) {
-								$items[] = $product->get_name();
+								$items[] = WC_Connect_Compatibility::instance()->get_product_name( $product );
 							}
 						}
 

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -340,7 +340,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 							/** @var WC_Product $product */
 							$product = $this->lookup_product( $package, $package_item->product_id );
 							if ( $product ) {
-								$items[] = $product->get_title();
+								$items[] = $product->get_name();
 							}
 						}
 

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -230,7 +230,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 		private function lookup_product( $package, $product_id ) {
 			foreach ( $package[ 'contents' ] as $item ) {
-				if ( $item[ 'product_id' ] === $product_id ) {
+				if ( $item[ 'product_id' ] === $product_id || $item[ 'variation_id' ] === $product_id ) {
 					return $item[ 'data' ];
 				}
 			}


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/bug-variations-arent-put-into-packages/

The problem visualized:
![](https://cldup.com/nmMUyBcGnF.png)

To test:
* Add at least one simple product to cart
* Add at least one variable product to cart (choose a variation if there is a parent)
* Checkout
* Verify that the "Packaging" section of the order details contains all product names