### PR TITLE
Added an email receipts setting option

### DIFF
--- a/classes/class-wc-connect-jetpack.php
+++ b/classes/class-wc-connect-jetpack.php
@@ -52,6 +52,14 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 			return false;
 		}
 
+		public static function get_connected_user_data( $user_id ) {
+			if ( method_exists( 'Jetpack', 'get_connected_user_data' ) ) {
+				return Jetpack::get_connected_user_data( $user_id );
+			}
+
+			return false;
+		}
+
 		/**
 		 * Helper method to get the Jetpack master user, IF we are connected
 		 * @return WP_User | false

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -59,6 +59,10 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			$result['paper_size'] = $this->get_preferred_paper_size();
 			$result = array_merge( $default, $result );
 
+			if ( ! isset( $result['email_receipts'] ) ) {
+				$result['email_receipts'] = true;
+			}
+
 			return $result;
 		}
 

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -27,6 +27,12 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 		$this->payment_methods_store->fetch_payment_methods_from_connect_server();
 
 		$master_user = WC_Connect_Jetpack::get_master_user();
+		if ( is_a( $master_user, 'WP_User' ) ) {
+			$connected_data = WC_Connect_Jetpack::get_connected_user_data( $master_user->ID );
+			$email = $connected_data['email'];
+		} else {
+			$email = '';
+		}
 
 		return new WP_REST_Response( array(
 			'success'  => true,
@@ -37,6 +43,7 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 				'can_edit_settings' => true,
 				'master_user_name' => is_a( $master_user, 'WP_User' ) ? $master_user->display_name : '',
 				'master_user_login' => is_a( $master_user, 'WP_User' ) ? $master_user->user_login : '',
+				'master_user_email' => $email,
  				'payment_methods' => $this->payment_methods_store->get_payment_methods(),
 			)
 		), 200 );


### PR DESCRIPTION
Adds the email receipts option to the settings endpoint.

See https://github.com/Automattic/wp-calypso/pull/21726 for test steps