### PR TITLE
Admin notice calling out missing product weight and/or dimensions

### DIFF
--- a/classes/class-wc-connect-error-notice.php
+++ b/classes/class-wc-connect-error-notice.php
@@ -43,6 +43,8 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 			if ( $this->notice_enabled() ) {
 				$this->show_notice();
 			}
+
+			$this->render_product_notice();
 		}
 
 		private function notice_enabled() {
@@ -64,6 +66,19 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 			</div>
 <?php
 			echo "";
+		}
+
+		public function render_product_notice() {
+			if ( ! WC_Connect_Options::get_option( 'product_notice', false ) ) {
+				return;
+			}
+
+			$message = __( 'Make sure to supply shipping weight and dimensions, in order for live rates to work with your products.', 'woocommerce-services' );
+?>
+			<div class="notice notice-warning">
+				<p><?php echo $message; ?></p>
+			</div>
+<?php
 		}
 	}
 

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -49,6 +49,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				'needs_tax_environment_setup',
 				'stripe_state',
 				'banner_ppec',
+				'product_notice',
 			);
 		}
 


### PR DESCRIPTION
Shows a notice when a product is saved with missing weight or dimensions.

<img width="820" alt="screen shot 2018-01-24 at 11 49 17 am" src="https://user-images.githubusercontent.com/1867547/35345099-b89ff692-00fc-11e8-88b0-29cae62cb38f.png">

TODO:
- [ ] check to see if there's actually a live rates shipping method enabled
- [ ] also hook into `wc_connect_shipping_zone_method_added`, `wc_connect_shipping_zone_method_status_toggled`, and `wc_connect_shipping_zone_method_deleted`

This can later be modified to:
- be dismissible
- list the products that lack details
- mention that flat rates will still work as long as they don't exceed the maximum (if only weight is missing, and if we support that in the future)