### PR TITLE
Fixed broken DB migration script

### DIFF
--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -321,6 +321,10 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		}
 
 		public function get_enabled_services_by_ids( $service_ids ) {
+			if ( empty( $service_ids ) ) {
+				return array();
+			}
+
 			$enabled_services = array();
 
 			// Note: We use esc_sql here instead of prepare because we are using WHERE IN


### PR DESCRIPTION
Fixes the Hydra-related issue in p8yzl4-1fK-p2

An argument can be made to remove the migration script completely, and the only other place where `get_enabled_services_by_ids()` is used is already making a check for an empty array, but I think it's a good practice to do that check inside this function to avoid this kind of errors if someone decides to use it somewhere else.