### PR TITLE
Set the latest Calypso rev as the dependency, fixed image imports

### DIFF
--- a/assets/stylesheets/_colors.scss
+++ b/assets/stylesheets/_colors.scss
@@ -1,50 +1,9 @@
-// Blues
-$blue-wordpress:         #0087be;
-$blue-light:             #99d9ed;
-$blue-medium:            #00a0d2;
-$blue-dark:              #005082;
-
-// Grays
-$gray:                   #87a6bc;
-$gray-light:             lighten( $gray, 33% ); //#f3f6f8
-$gray-dark:              darken( $gray, 38% ); //#2e4453
-
-// $gray-text: ideal for standard, non placeholder text
-// $gray-text-min: minimum contrast needed for WCAG 2.0 AA on white background
-$gray-text:              $gray-dark;
-$gray-text-min:          darken( $gray, 18% ); //#537994
+@import "~wp-calypso/assets/stylesheets/shared/_colors";
 
 //Purples
 $purple:                 #96588a;
 $purple-dark:            #a36597;
 $purple-light:           #bb77ae;
 
-// $gray color functions:
-//
-// lighten( $gray, 10% )
-// lighten( $gray, 20% )
-// lighten( $gray, 30% )
-// darken( $gray, 10% )
-// darken( $gray, 20% )
-// darken( $gray, 30% )
-//
-// See wordpress.com/design-handbook/colors/ for more info.
-
-// Oranges
-$orange-jazzy:           #f56e28;
-$orange-fire:            #d54e21;
-
-// Alerts
-$alert-yellow:           #ffb900;
-$alert-red:              #dc3232;
-$alert-green:            #46b450;
-
 // Link hovers
-$link-highlight:         tint($blue-medium, 20%);
 $button-hover:           #008ec2; //is-primary button
-
-// Essentials
-$white:                  rgba(255,255,255,1);
-$transparent:            rgba(255,255,255,0);
-
-$border-ultra-light-gray: #e8f0f5;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12642,7 +12642,7 @@
       "dev": true
     },
     "wp-calypso": {
-      "version": "github:automattic/wp-calypso#57e97f3606018e38a1920db861e1b95d1fb43b78",
+      "version": "github:automattic/wp-calypso#b807dae16ae7ebf88845704b0f1eebc7ec6d511f",
       "requires": {
         "assets-webpack-plugin": "3.5.1",
         "async": "0.9.0",
@@ -12725,7 +12725,7 @@
         "key-mirror": "1.0.1",
         "keymaster": "1.6.2",
         "localforage": "1.4.3",
-        "lodash": "4.15.0",
+        "lodash": "4.17.5",
         "lru": "3.1.0",
         "lunr": "0.5.7",
         "markdown-loader": "2.0.1",
@@ -12795,7 +12795,7 @@
           "version": "github:5to6/5to6-codemod#60306b71d8dde341e4d4bb968e6fbaf6875e19ae",
           "requires": {
             "jscodeshift": "0.3.30",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "recast": "0.12.9"
           },
           "dependencies": {
@@ -12807,11 +12807,6 @@
             "esprima": {
               "version": "4.0.0",
               "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-              "dev": true
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
               "dev": true
             },
             "recast": {
@@ -13298,7 +13293,7 @@
           "integrity": "sha1-a8vQOKM3xwYn5/zkQ4+lgYjwk3s=",
           "requires": {
             "browserslist": "1.3.6",
-            "caniuse-db": "1.0.30000800",
+            "caniuse-db": "1.0.30000802",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -13356,7 +13351,7 @@
           "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
           "requires": {
             "babel-code-frame": "6.26.0",
-            "babel-generator": "6.26.0",
+            "babel-generator": "6.26.1",
             "babel-helpers": "6.24.1",
             "babel-messages": "6.23.0",
             "babel-register": "6.24.1",
@@ -13368,7 +13363,7 @@
             "convert-source-map": "1.5.1",
             "debug": "2.2.0",
             "json5": "0.5.1",
-            "lodash": "4.15.0",
+            "lodash": "4.17.5",
             "minimatch": "3.0.4",
             "path-is-absolute": "1.0.1",
             "private": "0.1.8",
@@ -13402,23 +13397,19 @@
           }
         },
         "babel-generator": {
-          "version": "6.26.0",
-          "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+          "version": "6.26.1",
+          "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
           "requires": {
             "babel-messages": "6.23.0",
             "babel-runtime": "6.26.0",
             "babel-types": "6.26.0",
             "detect-indent": "4.0.0",
             "jsesc": "1.3.0",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "source-map": "0.5.7",
             "trim-right": "1.0.1"
           },
           "dependencies": {
-            "lodash": {
-              "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-            },
             "source-map": {
               "version": "0.5.7",
               "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
@@ -13469,13 +13460,7 @@
             "babel-helper-function-name": "6.24.1",
             "babel-runtime": "6.26.0",
             "babel-types": "6.26.0",
-            "lodash": "4.17.4"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-            }
+            "lodash": "4.17.5"
           }
         },
         "babel-helper-explode-assignable-expression": {
@@ -13538,13 +13523,7 @@
           "requires": {
             "babel-runtime": "6.26.0",
             "babel-types": "6.26.0",
-            "lodash": "4.17.4"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-            }
+            "lodash": "4.17.5"
           }
         },
         "babel-helper-remap-async-to-generator": {
@@ -13834,13 +13813,7 @@
             "babel-template": "6.26.0",
             "babel-traverse": "6.26.0",
             "babel-types": "6.26.0",
-            "lodash": "4.17.4"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-            }
+            "lodash": "4.17.5"
           }
         },
         "babel-plugin-transform-es2015-classes": {
@@ -14296,7 +14269,7 @@
             "babel-runtime": "6.26.0",
             "core-js": "2.5.3",
             "home-or-tmp": "2.0.0",
-            "lodash": "4.15.0",
+            "lodash": "4.17.5",
             "mkdirp": "0.5.1",
             "source-map-support": "0.4.18"
           },
@@ -14330,13 +14303,7 @@
             "babel-traverse": "6.26.0",
             "babel-types": "6.26.0",
             "babylon": "6.18.0",
-            "lodash": "4.17.4"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-            }
+            "lodash": "4.17.5"
           }
         },
         "babel-traverse": {
@@ -14351,7 +14318,7 @@
             "debug": "2.6.9",
             "globals": "9.18.0",
             "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "lodash": "4.17.5"
           },
           "dependencies": {
             "debug": {
@@ -14360,10 +14327,6 @@
               "requires": {
                 "ms": "2.0.0"
               }
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
             },
             "ms": {
               "version": "2.0.0",
@@ -14377,14 +14340,8 @@
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "2.0.2",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "to-fast-properties": "1.0.3"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-            }
           }
         },
         "babylon": {
@@ -14677,7 +14634,7 @@
           "version": "1.3.6",
           "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
           "requires": {
-            "caniuse-db": "1.0.30000800"
+            "caniuse-db": "1.0.30000802"
           }
         },
         "bser": {
@@ -14794,8 +14751,8 @@
           }
         },
         "caniuse-db": {
-          "version": "1.0.30000800",
-          "integrity": "sha1-qG5rwjvZpwfV30LzPmTQSVz9ohg="
+          "version": "1.0.30000802",
+          "integrity": "sha1-99yjQtocEs+E/yyAQy4kx+HMNtk="
         },
         "caniuse-lite": {
           "version": "1.0.30000792",
@@ -14820,7 +14777,7 @@
           "dev": true,
           "requires": {
             "fs-extra": "0.23.1",
-            "lodash": "4.15.0",
+            "lodash": "4.17.5",
             "vorpal": "1.12.0",
             "vorpal-autocomplete-fs": "0.0.3"
           },
@@ -14975,7 +14932,7 @@
             "dom-serializer": "0.1.0",
             "entities": "1.1.1",
             "htmlparser2": "3.9.2",
-            "lodash": "4.15.0",
+            "lodash": "4.17.5",
             "parse5": "3.0.3"
           }
         },
@@ -15497,7 +15454,7 @@
             "glob": "6.0.4",
             "is-glob": "3.1.0",
             "loader-utils": "0.2.17",
-            "lodash": "4.15.0",
+            "lodash": "4.17.5",
             "minimatch": "3.0.4",
             "node-dir": "0.1.17"
           },
@@ -16069,13 +16026,13 @@
           "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
           "dev": true,
           "requires": {
-            "acorn": "5.4.0",
+            "acorn": "5.4.1",
             "defined": "1.0.0"
           },
           "dependencies": {
             "acorn": {
-              "version": "5.4.0",
-              "integrity": "sha512-bkLTrtPfRASTxDXFaih7SbeYSsQ8MjrqCQKMrgZ4Hc7kYI//WVU6rDTAIqVrAudjgMFQEGthYfodtaw8dTRJrg==",
+              "version": "5.4.1",
+              "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
               "dev": true
             }
           }
@@ -16132,12 +16089,12 @@
           "dev": true,
           "requires": {
             "browserslist": "1.3.6",
-            "caniuse-db": "1.0.30000800",
+            "caniuse-db": "1.0.30000802",
             "css-rule-stream": "1.1.0",
             "duplexer2": "0.0.2",
             "jsonfilter": "1.1.2",
             "ldjson-stream": "1.2.1",
-            "lodash": "4.15.0",
+            "lodash": "4.17.5",
             "multimatch": "2.1.0",
             "postcss": "5.2.18",
             "source-map": "0.4.4",
@@ -16501,20 +16458,13 @@
             "function.prototype.name": "1.1.0",
             "has": "1.0.1",
             "is-subset": "0.1.1",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "object-is": "1.0.1",
             "object.assign": "4.1.0",
             "object.entries": "1.0.4",
             "object.values": "1.0.4",
             "raf": "3.4.0",
             "rst-selector-parser": "2.2.3"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-              "dev": true
-            }
           }
         },
         "enzyme-adapter-react-16": {
@@ -16523,7 +16473,7 @@
           "dev": true,
           "requires": {
             "enzyme-adapter-utils": "1.3.0",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "object.assign": "4.1.0",
             "object.values": "1.0.4",
             "prop-types": "15.6.0",
@@ -16531,11 +16481,6 @@
             "react-test-renderer": "16.2.0"
           },
           "dependencies": {
-            "lodash": {
-              "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-              "dev": true
-            },
             "prop-types": {
               "version": "15.6.0",
               "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
@@ -16553,16 +16498,11 @@
           "integrity": "sha512-vVXSt6uDv230DIv+ebCG66T1Pm36Kv+m74L1TrF4kaE7e1V7Q/LcxO0QRkajk5cA6R3uu9wJf5h13wOTezTbjA==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "object.assign": "4.1.0",
             "prop-types": "15.6.0"
           },
           "dependencies": {
-            "lodash": {
-              "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-              "dev": true
-            },
             "prop-types": {
               "version": "15.6.0",
               "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
@@ -16580,14 +16520,7 @@
           "integrity": "sha512-d8IfzVpwunct+bw6uWujjHKtskyLwWGKkAguouAdTMNTaTmoC0Y0N0mWpeOq+bFDM4YljRXmBRIsO6QNWrlZzA==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.4"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-              "dev": true
-            }
+            "lodash": "4.17.5"
           }
         },
         "errno": {
@@ -16940,7 +16873,7 @@
             "debug": "2.2.0",
             "doctrine": "1.5.0",
             "escope": "3.6.0",
-            "espree": "3.5.2",
+            "espree": "3.5.3",
             "estraverse": "4.2.0",
             "esutils": "2.0.2",
             "file-entry-cache": "2.0.0",
@@ -16954,7 +16887,7 @@
             "js-yaml": "3.10.0",
             "json-stable-stringify": "1.0.1",
             "levn": "0.3.0",
-            "lodash": "4.15.0",
+            "lodash": "4.17.5",
             "mkdirp": "0.5.1",
             "natural-compare": "1.4.0",
             "optionator": "0.8.2",
@@ -17012,7 +16945,7 @@
                 "cli-cursor": "1.0.2",
                 "cli-width": "2.2.0",
                 "figures": "1.7.0",
-                "lodash": "4.15.0",
+                "lodash": "4.17.5",
                 "readline2": "1.0.1",
                 "run-async": "0.1.0",
                 "rx-lite": "3.1.2",
@@ -17123,18 +17056,16 @@
           "integrity": "sha1-Yg2GbvSGGzMR91dm1SqFcrs8YzY="
         },
         "espree": {
-          "version": "3.5.2",
-          "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
-          "dev": true,
+          "version": "3.5.3",
+          "integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
           "requires": {
-            "acorn": "5.4.0",
+            "acorn": "5.4.1",
             "acorn-jsx": "3.0.1"
           },
           "dependencies": {
             "acorn": {
-              "version": "5.4.0",
-              "integrity": "sha512-bkLTrtPfRASTxDXFaih7SbeYSsQ8MjrqCQKMrgZ4Hc7kYI//WVU6rDTAIqVrAudjgMFQEGthYfodtaw8dTRJrg==",
-              "dev": true
+              "version": "5.4.1",
+              "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ=="
             }
           }
         },
@@ -18872,7 +18803,7 @@
           "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
           "requires": {
             "glob": "7.1.2",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "minimatch": "3.0.4"
           },
           "dependencies": {
@@ -18887,10 +18818,6 @@
                 "once": "1.4.0",
                 "path-is-absolute": "1.0.1"
               }
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
             }
           }
         },
@@ -19115,7 +19042,7 @@
           "requires": {
             "bluebird": "3.5.1",
             "level": "1.7.0",
-            "lodash": "4.15.0",
+            "lodash": "4.17.5",
             "mkdirp": "0.5.1",
             "source-list-map": "0.1.8",
             "source-map": "0.5.7",
@@ -20086,7 +20013,7 @@
               "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
               "dev": true,
               "requires": {
-                "lodash": "4.15.0"
+                "lodash": "4.17.5"
               }
             }
           }
@@ -20109,7 +20036,7 @@
           "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
           "dev": true,
           "requires": {
-            "babel-generator": "6.26.0",
+            "babel-generator": "6.26.1",
             "babel-template": "6.26.0",
             "babel-traverse": "6.26.0",
             "babel-types": "6.26.0",
@@ -21302,7 +21229,7 @@
             "colors": "1.1.2",
             "es6-promise": "3.3.1",
             "flow-parser": "0.64.0",
-            "lodash": "4.15.0",
+            "lodash": "4.17.5",
             "micromatch": "2.3.11",
             "node-dir": "0.1.8",
             "nomnom": "1.8.1",
@@ -21487,7 +21414,7 @@
           "dev": true,
           "requires": {
             "abab": "1.0.4",
-            "acorn": "5.4.0",
+            "acorn": "5.4.1",
             "acorn-globals": "4.1.0",
             "array-equal": "1.0.0",
             "browser-process-hrtime": "0.1.2",
@@ -21515,8 +21442,8 @@
           },
           "dependencies": {
             "acorn": {
-              "version": "5.4.0",
-              "integrity": "sha512-bkLTrtPfRASTxDXFaih7SbeYSsQ8MjrqCQKMrgZ4Hc7kYI//WVU6rDTAIqVrAudjgMFQEGthYfodtaw8dTRJrg==",
+              "version": "5.4.1",
+              "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
               "dev": true
             },
             "acorn-globals": {
@@ -21524,7 +21451,7 @@
               "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
               "dev": true,
               "requires": {
-                "acorn": "5.4.0"
+                "acorn": "5.4.1"
               }
             },
             "parse5": {
@@ -21880,12 +21807,12 @@
           }
         },
         "lodash": {
-          "version": "4.15.0",
-          "integrity": "sha1-MWI5HY8BQKoiz49rPDTWt/Y9Oqk="
+          "version": "4.17.5",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
         },
         "lodash-es": {
-          "version": "4.17.4",
-          "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
+          "version": "4.17.5",
+          "integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw=="
         },
         "lodash._arraycopy": {
           "version": "3.0.0",
@@ -22069,8 +21996,8 @@
           }
         },
         "lodash.mergewith": {
-          "version": "4.6.0",
-          "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU="
+          "version": "4.6.1",
+          "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
         },
         "lodash.pickby": {
           "version": "4.6.0",
@@ -22320,7 +22247,7 @@
           "version": "1.1.0",
           "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
           "requires": {
-            "mimic-fn": "1.1.0"
+            "mimic-fn": "1.2.0"
           }
         },
         "memory-fs": {
@@ -22485,8 +22412,8 @@
           }
         },
         "mimic-fn": {
-          "version": "1.1.0",
-          "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+          "version": "1.2.0",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
         },
         "minimalistic-assert": {
           "version": "1.0.0",
@@ -22760,7 +22687,7 @@
             "debug": "2.2.0",
             "deep-equal": "1.0.1",
             "json-stringify-safe": "5.0.1",
-            "lodash": "4.15.0",
+            "lodash": "4.17.5",
             "mkdirp": "0.5.1",
             "propagate": "0.4.0",
             "qs": "6.5.1"
@@ -22951,7 +22878,7 @@
             "in-publish": "2.0.0",
             "lodash.assign": "4.2.0",
             "lodash.clonedeep": "4.5.0",
-            "lodash.mergewith": "4.6.0",
+            "lodash.mergewith": "4.6.1",
             "meow": "3.7.0",
             "mkdirp": "0.5.1",
             "nan": "2.8.0",
@@ -24013,7 +23940,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.0.0",
-            "lodash": "4.15.0",
+            "lodash": "4.17.5",
             "log-symbols": "1.0.2",
             "postcss": "5.2.18"
           }
@@ -24808,7 +24735,7 @@
           }
         },
         "react-codemod": {
-          "version": "github:reactjs/react-codemod#8aa75e23cf6f6185a5c54b55fc40f47e26c5db4e",
+          "version": "github:reactjs/react-codemod#549dc17530770c4a91bfe3a64c25b420311d568d",
           "requires": {
             "babel-eslint": "6.1.2",
             "babel-jest": "15.0.0",
@@ -24925,7 +24852,7 @@
                 "doctrine": "1.5.0",
                 "es6-map": "0.1.5",
                 "escope": "3.6.0",
-                "espree": "3.5.2",
+                "espree": "3.5.3",
                 "estraverse": "4.2.0",
                 "esutils": "2.0.2",
                 "file-entry-cache": "1.3.1",
@@ -24939,7 +24866,7 @@
                 "js-yaml": "3.10.0",
                 "json-stable-stringify": "1.0.1",
                 "levn": "0.3.0",
-                "lodash": "4.15.0",
+                "lodash": "4.17.5",
                 "mkdirp": "0.5.1",
                 "optionator": "0.8.1",
                 "path-is-absolute": "1.0.1",
@@ -24991,7 +24918,7 @@
                 "cli-cursor": "1.0.2",
                 "cli-width": "2.2.0",
                 "figures": "1.7.0",
-                "lodash": "4.15.0",
+                "lodash": "4.17.5",
                 "readline2": "1.0.1",
                 "run-async": "0.1.0",
                 "rx-lite": "3.1.2",
@@ -25510,8 +25437,8 @@
           "requires": {
             "hoist-non-react-statics": "2.3.1",
             "invariant": "2.2.2",
-            "lodash": "4.15.0",
-            "lodash-es": "4.17.4",
+            "lodash": "4.17.5",
+            "lodash-es": "4.17.5",
             "loose-envify": "1.3.1",
             "prop-types": "15.5.10"
           },
@@ -25788,18 +25715,14 @@
             "hoist-non-react-statics": "2.3.1",
             "invariant": "2.2.2",
             "is-promise": "2.1.0",
-            "lodash": "4.17.4",
-            "lodash-es": "4.17.4",
+            "lodash": "4.17.5",
+            "lodash-es": "4.17.5",
             "prop-types": "15.5.10"
           },
           "dependencies": {
             "hoist-non-react-statics": {
               "version": "2.3.1",
               "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
             }
           }
         },
@@ -26055,7 +25978,7 @@
           "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
           "dev": true,
           "requires": {
-            "lodash": "4.15.0"
+            "lodash": "4.17.5"
           }
         },
         "request-promise-native": {
@@ -26380,7 +26303,7 @@
           "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
           "requires": {
             "glob": "7.1.2",
-            "lodash": "4.15.0",
+            "lodash": "4.17.5",
             "scss-tokenizer": "0.2.3",
             "yargs": "7.1.0"
           },
@@ -27224,7 +27147,7 @@
             "globjoin": "0.1.4",
             "html-tags": "1.2.0",
             "htmlparser2": "3.9.2",
-            "lodash": "4.15.0",
+            "lodash": "4.17.5",
             "log-symbols": "1.0.2",
             "meow": "3.7.0",
             "multimatch": "2.1.0",
@@ -27460,7 +27383,7 @@
             "ajv": "4.11.8",
             "ajv-keywords": "1.5.1",
             "chalk": "1.1.3",
-            "lodash": "4.15.0",
+            "lodash": "4.17.5",
             "slice-ansi": "0.0.4",
             "string-width": "2.1.1"
           },
@@ -28304,7 +28227,7 @@
             "chalk": "1.1.3",
             "in-publish": "2.0.0",
             "inquirer": "0.11.0",
-            "lodash": "4.15.0",
+            "lodash": "4.17.5",
             "log-update": "1.0.2",
             "minimist": "1.2.0",
             "node-localstorage": "0.6.0",
@@ -28423,7 +28346,7 @@
               "version": "2.6.0",
               "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
               "requires": {
-                "lodash": "4.15.0"
+                "lodash": "4.17.5"
               }
             }
           }
@@ -28437,7 +28360,7 @@
           "version": "3.10.0",
           "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
           "requires": {
-            "acorn": "5.4.0",
+            "acorn": "5.4.1",
             "acorn-dynamic-import": "2.0.2",
             "ajv": "5.5.2",
             "ajv-keywords": "2.1.1",
@@ -28462,8 +28385,8 @@
           },
           "dependencies": {
             "acorn": {
-              "version": "5.4.0",
-              "integrity": "sha512-bkLTrtPfRASTxDXFaih7SbeYSsQ8MjrqCQKMrgZ4Hc7kYI//WVU6rDTAIqVrAudjgMFQEGthYfodtaw8dTRJrg=="
+              "version": "5.4.1",
+              "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ=="
             },
             "ansi-regex": {
               "version": "3.0.0",
@@ -28473,7 +28396,7 @@
               "version": "2.6.0",
               "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
               "requires": {
-                "lodash": "4.15.0"
+                "lodash": "4.17.5"
               }
             },
             "has-flag": {
@@ -28680,14 +28603,14 @@
           "integrity": "sha1-Y+2G63HMTNqG9o5oWoRTC6ASZEk=",
           "dev": true,
           "requires": {
-            "acorn": "5.4.0",
+            "acorn": "5.4.1",
             "chalk": "1.1.3",
             "commander": "2.13.0",
             "ejs": "2.5.7",
             "express": "4.16.2",
-            "filesize": "3.5.11",
+            "filesize": "3.6.0",
             "gzip-size": "3.0.0",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "mkdirp": "0.5.1",
             "opener": "1.4.3",
             "ws": "4.0.0"
@@ -28703,8 +28626,8 @@
               }
             },
             "acorn": {
-              "version": "5.4.0",
-              "integrity": "sha512-bkLTrtPfRASTxDXFaih7SbeYSsQ8MjrqCQKMrgZ4Hc7kYI//WVU6rDTAIqVrAudjgMFQEGthYfodtaw8dTRJrg==",
+              "version": "5.4.1",
+              "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
               "dev": true
             },
             "body-parser": {
@@ -28822,8 +28745,8 @@
               }
             },
             "filesize": {
-              "version": "3.5.11",
-              "integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g==",
+              "version": "3.6.0",
+              "integrity": "sha512-g5OWtoZWcPI56js1DFhIEqyG9tnu/7sG3foHwgS9KGYFMfsYguI3E+PRVCmtmE96VajQIEMRU2OhN+ME589Gdw==",
               "dev": true
             },
             "finalhandler": {
@@ -28853,11 +28776,6 @@
             "ipaddr.js": {
               "version": "1.5.2",
               "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
-              "dev": true
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
               "dev": true
             },
             "merge-descriptors": {
@@ -29292,7 +29210,7 @@
           "requires": {
             "babylon": "6.8.4",
             "estree-walker": "0.2.1",
-            "lodash": "4.15.0"
+            "lodash": "4.17.5"
           },
           "dependencies": {
             "babylon": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-services",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -33,9 +33,9 @@
       }
     },
     "acorn": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-      "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+      "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
       "dev": true
     },
     "acorn-dynamic-import": {
@@ -234,12 +234,13 @@
       }
     },
     "aria-query": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-0.7.0.tgz",
-      "integrity": "sha512-/r2lHl09V3o74+2MLKEdewoj37YZqiQZnfen1O4iNlrOjUgeKuu1U2yF3iKh6HJxqF+OXkLMfQv65Z/cvxD6vA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-0.7.1.tgz",
+      "integrity": "sha1-Jsu1r/ZBRLCoJb4YRuCxbPoAsR4=",
       "dev": true,
       "requires": {
-        "ast-types-flow": "0.0.7"
+        "ast-types-flow": "0.0.7",
+        "commander": "2.13.0"
       }
     },
     "arr-diff": {
@@ -419,7 +420,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000798",
+        "caniuse-db": "1.0.30000800",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -432,8 +433,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000798",
-            "electron-to-chromium": "1.3.31"
+            "caniuse-db": "1.0.30000800",
+            "electron-to-chromium": "1.3.32"
           }
         }
       }
@@ -1662,7 +1663,7 @@
       "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "requires": {
         "caniuse-lite": "1.0.30000792",
-        "electron-to-chromium": "1.3.31"
+        "electron-to-chromium": "1.3.32"
       }
     },
     "buffer": {
@@ -1787,7 +1788,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000798",
+        "caniuse-db": "1.0.30000800",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -1798,16 +1799,16 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000798",
-            "electron-to-chromium": "1.3.31"
+            "caniuse-db": "1.0.30000800",
+            "electron-to-chromium": "1.3.32"
           }
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000798",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000798.tgz",
-      "integrity": "sha1-kvJvd/icwqTWBIf0Hgs9Kmw/40E=",
+      "version": "1.0.30000800",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000800.tgz",
+      "integrity": "sha1-qG5rwjvZpwfV30LzPmTQSVz9ohg=",
       "dev": true
     },
     "caniuse-lite": {
@@ -2439,9 +2440,9 @@
       }
     },
     "create-react-class": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
-      "integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
+      "version": "15.6.3",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
+      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
@@ -3008,9 +3009,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.31",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz",
-      "integrity": "sha512-XE4CLbswkZgZFn34cKFy1xaX+F5LHxeDLjY1+rsK9asDzknhbrd9g/n/01/acbU25KTsUSiLKwvlLyA+6XLUOA=="
+      "version": "1.3.32",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.32.tgz",
+      "integrity": "sha1-EdBoTAhA4APEvoko+KxfNdvCtOY="
     },
     "elliptic": {
       "version": "6.4.0",
@@ -3443,7 +3444,7 @@
       "integrity": "sha1-VFg9GuRCSDFi4EDhPMMYZUZRAOU=",
       "dev": true,
       "requires": {
-        "aria-query": "0.7.0",
+        "aria-query": "0.7.1",
         "array-includes": "3.0.3",
         "ast-types-flow": "0.0.7",
         "axobject-query": "0.1.0",
@@ -3501,7 +3502,7 @@
       "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.3.0",
+        "acorn": "5.4.1",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -5551,7 +5552,7 @@
       "requires": {
         "async": "1.5.2",
         "commander": "2.13.0",
-        "create-react-class": "15.6.2",
+        "create-react-class": "15.6.3",
         "debug": "2.2.0",
         "globby": "6.1.0",
         "interpolate-components": "1.1.1",
@@ -5597,7 +5598,7 @@
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.16"
+        "postcss": "6.0.17"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5638,9 +5639,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
-          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -6499,7 +6500,7 @@
         "socket.io": "1.7.3",
         "source-map": "0.5.7",
         "tmp": "0.0.31",
-        "useragent": "2.2.1"
+        "useragent": "2.3.0"
       },
       "dependencies": {
         "lodash": {
@@ -7491,13 +7492,13 @@
           "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
           "dev": true,
           "requires": {
-            "postcss": "6.0.16"
+            "postcss": "6.0.17"
           },
           "dependencies": {
             "postcss": {
-              "version": "6.0.16",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
-              "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+              "version": "6.0.17",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+              "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
               "dev": true,
               "requires": {
                 "chalk": "2.3.0",
@@ -8853,8 +8854,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000798",
-            "electron-to-chromium": "1.3.31"
+            "caniuse-db": "1.0.30000800",
+            "electron-to-chromium": "1.3.32"
           }
         }
       }
@@ -8916,7 +8917,7 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.16"
+        "postcss": "6.0.17"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8957,9 +8958,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
-          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -8991,7 +8992,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.16"
+        "postcss": "6.0.17"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9032,9 +9033,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
-          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -9066,7 +9067,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.16"
+        "postcss": "6.0.17"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9107,9 +9108,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
-          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -9141,7 +9142,7 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.16"
+        "postcss": "6.0.17"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9182,9 +9183,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
-          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -11860,21 +11861,13 @@
       }
     },
     "useragent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.2.1.tgz",
-      "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
+      "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
       "dev": true,
       "requires": {
-        "lru-cache": "2.2.4",
+        "lru-cache": "4.1.1",
         "tmp": "0.0.31"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
-          "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=",
-          "dev": true
-        }
       }
     },
     "util": {
@@ -12009,7 +12002,7 @@
       "integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
       "dev": true,
       "requires": {
-        "acorn": "5.3.0",
+        "acorn": "5.4.1",
         "acorn-dynamic-import": "2.0.2",
         "ajv": "4.11.8",
         "ajv-keywords": "1.5.1",
@@ -12649,7 +12642,7 @@
       "dev": true
     },
     "wp-calypso": {
-      "version": "github:automattic/wp-calypso#3d7221f3d59ff4111ab8f541595f2590ce519ba4",
+      "version": "github:automattic/wp-calypso#3c8a7c8b5b31a652bb7c531954cb566a47c01d89",
       "requires": {
         "assets-webpack-plugin": "3.5.1",
         "async": "0.9.0",
@@ -12684,6 +12677,7 @@
         "cookie": "0.1.2",
         "cookie-parser": "1.3.2",
         "copy-webpack-plugin": "4.0.1",
+        "cpf": "1.0.0",
         "create-react-class": "15.6.2",
         "creditcards": "2.1.2",
         "cross-env": "5.1.1",
@@ -12762,7 +12756,7 @@
         "react-day-picker": "6.2.1",
         "react-dom": "16.2.0",
         "react-hot-loader": "1.3.1",
-        "react-modal": "3.1.0",
+        "react-modal": "3.1.11",
         "react-pure-render": "1.0.2",
         "react-redux": "5.0.6",
         "react-transition-group": "1.2.1",
@@ -12793,7 +12787,7 @@
         "webpack-hot-middleware": "2.15.0",
         "wpcom": "5.4.0",
         "wpcom-oauth": "0.3.3",
-        "wpcom-proxy-request": "5.0.0",
+        "wpcom-proxy-request": "4.0.5",
         "wpcom-xhr-request": "1.1.1"
       },
       "dependencies": {
@@ -12835,8 +12829,8 @@
           }
         },
         "@babel/code-frame": {
-          "version": "7.0.0-beta.38",
-          "integrity": "sha512-JNHofQND7Iiuy3f6RXSillN1uBe87DAp+1ktsBfSxfL3xWeGFyJC9jH5zu2zs7eqVGp2qXWvJZFiJIwOYnaCQw==",
+          "version": "7.0.0-beta.39",
+          "integrity": "sha512-PConL+YIK9BgNUWWC2q4fbltj1g475TofpNVNivSypcAAKElfpSS1cv7MrpLYRG8TzZvwcVu9M30hLA/WAp1HQ==",
           "requires": {
             "chalk": "2.3.0",
             "esutils": "2.0.2",
@@ -13084,10 +13078,17 @@
           }
         },
         "aria-query": {
-          "version": "0.7.0",
-          "integrity": "sha512-/r2lHl09V3o74+2MLKEdewoj37YZqiQZnfen1O4iNlrOjUgeKuu1U2yF3iKh6HJxqF+OXkLMfQv65Z/cvxD6vA==",
+          "version": "0.7.1",
+          "integrity": "sha1-Jsu1r/ZBRLCoJb4YRuCxbPoAsR4=",
           "requires": {
-            "ast-types-flow": "0.0.7"
+            "ast-types-flow": "0.0.7",
+            "commander": "2.13.0"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.13.0",
+              "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+            }
           }
         },
         "arity-n": {
@@ -13262,7 +13263,7 @@
           "integrity": "sha1-a8vQOKM3xwYn5/zkQ4+lgYjwk3s=",
           "requires": {
             "browserslist": "1.3.6",
-            "caniuse-db": "1.0.30000798",
+            "caniuse-db": "1.0.30000800",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -14110,7 +14111,7 @@
               "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
               "requires": {
                 "caniuse-lite": "1.0.30000792",
-                "electron-to-chromium": "1.3.31"
+                "electron-to-chromium": "1.3.32"
               }
             },
             "semver": {
@@ -14598,7 +14599,7 @@
           "version": "1.3.6",
           "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
           "requires": {
-            "caniuse-db": "1.0.30000798"
+            "caniuse-db": "1.0.30000800"
           }
         },
         "bser": {
@@ -14712,8 +14713,8 @@
           }
         },
         "caniuse-db": {
-          "version": "1.0.30000798",
-          "integrity": "sha1-kvJvd/icwqTWBIf0Hgs9Kmw/40E="
+          "version": "1.0.30000800",
+          "integrity": "sha1-qG5rwjvZpwfV30LzPmTQSVz9ohg="
         },
         "caniuse-lite": {
           "version": "1.0.30000792",
@@ -15434,6 +15435,10 @@
             }
           }
         },
+        "cpf": {
+          "version": "1.0.0",
+          "integrity": "sha1-geCsZajzSfRuuHZYkFFzt3TuTJY="
+        },
         "crc32": {
           "version": "0.2.2",
           "integrity": "sha1-etIg1v/c0Rn5/BJ6d3LKzqOQpLo="
@@ -15915,13 +15920,13 @@
           "version": "4.7.1",
           "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
           "requires": {
-            "acorn": "5.3.0",
+            "acorn": "5.4.0",
             "defined": "1.0.0"
           },
           "dependencies": {
             "acorn": {
-              "version": "5.3.0",
-              "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
+              "version": "5.4.0",
+              "integrity": "sha512-bkLTrtPfRASTxDXFaih7SbeYSsQ8MjrqCQKMrgZ4Hc7kYI//WVU6rDTAIqVrAudjgMFQEGthYfodtaw8dTRJrg=="
             }
           }
         },
@@ -15973,7 +15978,7 @@
           "integrity": "sha1-GJLRC2Gpo1at2/K2FJM+gfi7ODQ=",
           "requires": {
             "browserslist": "1.3.6",
-            "caniuse-db": "1.0.30000798",
+            "caniuse-db": "1.0.30000800",
             "css-rule-stream": "1.1.0",
             "duplexer2": "0.0.2",
             "jsonfilter": "1.1.2",
@@ -16161,8 +16166,8 @@
           "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
         },
         "electron-to-chromium": {
-          "version": "1.3.31",
-          "integrity": "sha512-XE4CLbswkZgZFn34cKFy1xaX+F5LHxeDLjY1+rsK9asDzknhbrd9g/n/01/acbU25KTsUSiLKwvlLyA+6XLUOA=="
+          "version": "1.3.32",
+          "integrity": "sha1-EdBoTAhA4APEvoko+KxfNdvCtOY="
         },
         "elliptic": {
           "version": "6.4.0",
@@ -16859,7 +16864,7 @@
           "version": "6.0.3",
           "integrity": "sha1-VFg9GuRCSDFi4EDhPMMYZUZRAOU=",
           "requires": {
-            "aria-query": "0.7.0",
+            "aria-query": "0.7.1",
             "array-includes": "3.0.3",
             "ast-types-flow": "0.0.7",
             "axobject-query": "0.1.0",
@@ -16898,13 +16903,13 @@
           "version": "3.5.2",
           "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
           "requires": {
-            "acorn": "5.3.0",
+            "acorn": "5.4.0",
             "acorn-jsx": "3.0.1"
           },
           "dependencies": {
             "acorn": {
-              "version": "5.3.0",
-              "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
+              "version": "5.4.0",
+              "integrity": "sha512-bkLTrtPfRASTxDXFaih7SbeYSsQ8MjrqCQKMrgZ4Hc7kYI//WVU6rDTAIqVrAudjgMFQEGthYfodtaw8dTRJrg=="
             }
           }
         },
@@ -20140,7 +20145,7 @@
           "requires": {
             "jest-mock": "22.1.0",
             "jest-util": "22.1.4",
-            "jsdom": "11.6.1"
+            "jsdom": "11.6.2"
           }
         },
         "jest-environment-node": {
@@ -20369,7 +20374,7 @@
           "version": "22.1.0",
           "integrity": "sha512-kftcoawOeOVUGuGWmMupJt7FGLK1pqOrh02FlJwtImmPGZ2yTWCTx2D+N/g95qD2jCbQ/ntH1goBixhAIIxL+g==",
           "requires": {
-            "@babel/code-frame": "7.0.0-beta.38",
+            "@babel/code-frame": "7.0.0-beta.39",
             "chalk": "2.3.0",
             "micromatch": "2.3.11",
             "slash": "1.0.0",
@@ -20999,11 +21004,11 @@
           }
         },
         "jsdom": {
-          "version": "11.6.1",
-          "integrity": "sha512-x1vDo5CQuwsuP0w3kuU04vQdem9Q8apRV2PXp8GeSFQpgtYvSwbcypIbNgRrXu82O4TMroGYSAbu9wyVZHcehw==",
+          "version": "11.6.2",
+          "integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
           "requires": {
             "abab": "1.0.4",
-            "acorn": "5.3.0",
+            "acorn": "5.4.0",
             "acorn-globals": "4.1.0",
             "array-equal": "1.0.0",
             "browser-process-hrtime": "0.1.2",
@@ -21031,14 +21036,14 @@
           },
           "dependencies": {
             "acorn": {
-              "version": "5.3.0",
-              "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
+              "version": "5.4.0",
+              "integrity": "sha512-bkLTrtPfRASTxDXFaih7SbeYSsQ8MjrqCQKMrgZ4Hc7kYI//WVU6rDTAIqVrAudjgMFQEGthYfodtaw8dTRJrg=="
             },
             "acorn-globals": {
               "version": "4.1.0",
               "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
               "requires": {
-                "acorn": "5.3.0"
+                "acorn": "5.4.0"
               }
             },
             "parse5": {
@@ -23339,7 +23344,7 @@
           "integrity": "sha512-eNR2h9T9ciKMoQEORrPjH33XeN/nuvVuxArOKmHtsFbGbNss631tgTrKou3/pmjAZbA4QQkhLIkPQkIk3WW+8w==",
           "requires": {
             "balanced-match": "1.0.0",
-            "postcss": "6.0.16"
+            "postcss": "6.0.17"
           },
           "dependencies": {
             "ansi-styles": {
@@ -23376,8 +23381,8 @@
               "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
             },
             "postcss": {
-              "version": "6.0.16",
-              "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+              "version": "6.0.17",
+              "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
               "requires": {
                 "chalk": "2.3.0",
                 "source-map": "0.6.1",
@@ -23426,7 +23431,7 @@
           "version": "1.0.2",
           "integrity": "sha1-/0XPM1S4ee6JpOtoaA9GrJuxT5Q=",
           "requires": {
-            "postcss": "6.0.16"
+            "postcss": "6.0.17"
           },
           "dependencies": {
             "ansi-styles": {
@@ -23463,8 +23468,8 @@
               "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
             },
             "postcss": {
-              "version": "6.0.16",
-              "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+              "version": "6.0.17",
+              "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
               "requires": {
                 "chalk": "2.3.0",
                 "source-map": "0.6.1",
@@ -23520,7 +23525,7 @@
             "npmlog": "4.1.2",
             "os-homedir": "1.0.2",
             "pump": "1.0.3",
-            "rc": "1.2.4",
+            "rc": "1.2.5",
             "simple-get": "1.4.3",
             "tar-fs": "1.16.0",
             "tunnel-agent": "0.6.0",
@@ -24109,8 +24114,8 @@
           }
         },
         "rc": {
-          "version": "1.2.4",
-          "integrity": "sha1-oPYGyq4qO4YrvQ74VILAElsxX6M=",
+          "version": "1.2.5",
+          "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
           "requires": {
             "deep-extend": "0.4.2",
             "ini": "1.3.5",
@@ -24162,7 +24167,7 @@
           }
         },
         "react-codemod": {
-          "version": "github:reactjs/react-codemod#b69f98231088ad2f9a29608580f81873474c132e",
+          "version": "github:reactjs/react-codemod#8aa75e23cf6f6185a5c54b55fc40f47e26c5db4e",
           "requires": {
             "babel-eslint": "6.1.2",
             "babel-jest": "15.0.0",
@@ -24767,11 +24772,12 @@
           }
         },
         "react-modal": {
-          "version": "3.1.0",
-          "integrity": "sha512-4sVW7Flm6sdaQeWr8OxXqMOuothdg+jnCA4MqloP65g2iWtOtho8VeI+z3SCsqunWefbuCHCnncxIBmDgPehQQ==",
+          "version": "3.1.11",
+          "integrity": "sha512-Pm4QAc+sWYrfRC+WRERV+JGeGZIfodZGdbvWmjPzeSWqP+EW5ATK4N1U/btNHZWFzKL1UOmkmNtozEQlEg7c+A==",
           "requires": {
             "exenv": "1.2.2",
-            "prop-types": "15.5.10"
+            "prop-types": "15.5.10",
+            "warning": "3.0.0"
           }
         },
         "react-pure-render": {
@@ -25205,7 +25211,7 @@
           "version": "3.1.0",
           "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "requires": {
-            "rc": "1.2.4"
+            "rc": "1.2.5"
           }
         },
         "regjsgen": {
@@ -25510,7 +25516,7 @@
             "chalk": "2.3.0",
             "findup": "0.1.5",
             "mkdirp": "0.5.1",
-            "postcss": "6.0.16",
+            "postcss": "6.0.17",
             "strip-json-comments": "2.0.1"
           },
           "dependencies": {
@@ -25539,8 +25545,8 @@
               "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
             },
             "postcss": {
-              "version": "6.0.16",
-              "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+              "version": "6.0.17",
+              "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
               "requires": {
                 "chalk": "2.3.0",
                 "source-map": "0.6.1",
@@ -27562,7 +27568,7 @@
           "version": "3.10.0",
           "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
           "requires": {
-            "acorn": "5.3.0",
+            "acorn": "5.4.0",
             "acorn-dynamic-import": "2.0.2",
             "ajv": "5.5.2",
             "ajv-keywords": "2.1.1",
@@ -27587,8 +27593,8 @@
           },
           "dependencies": {
             "acorn": {
-              "version": "5.3.0",
-              "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
+              "version": "5.4.0",
+              "integrity": "sha512-bkLTrtPfRASTxDXFaih7SbeYSsQ8MjrqCQKMrgZ4Hc7kYI//WVU6rDTAIqVrAudjgMFQEGthYfodtaw8dTRJrg=="
             },
             "ansi-regex": {
               "version": "3.0.0",
@@ -27804,7 +27810,7 @@
           "version": "2.9.2",
           "integrity": "sha1-Y+2G63HMTNqG9o5oWoRTC6ASZEk=",
           "requires": {
-            "acorn": "5.3.0",
+            "acorn": "5.4.0",
             "chalk": "1.1.3",
             "commander": "2.13.0",
             "ejs": "2.5.7",
@@ -27826,8 +27832,8 @@
               }
             },
             "acorn": {
-              "version": "5.3.0",
-              "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
+              "version": "5.4.0",
+              "integrity": "sha512-bkLTrtPfRASTxDXFaih7SbeYSsQ8MjrqCQKMrgZ4Hc7kYI//WVU6rDTAIqVrAudjgMFQEGthYfodtaw8dTRJrg=="
             },
             "body-parser": {
               "version": "1.18.2",
@@ -28290,8 +28296,8 @@
           }
         },
         "wpcom-proxy-request": {
-          "version": "5.0.0",
-          "integrity": "sha512-dHCBAWDi/DMVQ+bF2PZ+ySDuBVjobFXMHGJdqAjcGoM8H4O7f046I0qf9tvhuzcKsjBBhK8SEIdK0PU979gh9w==",
+          "version": "4.0.5",
+          "integrity": "sha512-eTt+n4qDvNNybYOMNXCPSehcQUCFENWLANp6th3ST+cwuKjzF6wKuMGQko1sHVPz0VKOCksOf/Ye8+rGPa6eAQ==",
           "requires": {
             "component-event": "0.1.4",
             "debug": "2.2.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12642,7 +12642,7 @@
       "dev": true
     },
     "wp-calypso": {
-      "version": "github:automattic/wp-calypso#3c8a7c8b5b31a652bb7c531954cb566a47c01d89",
+      "version": "github:automattic/wp-calypso#57e97f3606018e38a1920db861e1b95d1fb43b78",
       "requires": {
         "assets-webpack-plugin": "3.5.1",
         "async": "0.9.0",
@@ -12801,19 +12801,23 @@
           "dependencies": {
             "ast-types": {
               "version": "0.10.1",
-              "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
+              "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ==",
+              "dev": true
             },
             "esprima": {
               "version": "4.0.0",
-              "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+              "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+              "dev": true
             },
             "lodash": {
               "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+              "dev": true
             },
             "recast": {
               "version": "0.12.9",
               "integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
+              "dev": true,
               "requires": {
                 "ast-types": "0.10.1",
                 "core-js": "2.5.3",
@@ -12824,13 +12828,15 @@
             },
             "source-map": {
               "version": "0.6.1",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
             }
           }
         },
         "@babel/code-frame": {
           "version": "7.0.0-beta.39",
           "integrity": "sha512-PConL+YIK9BgNUWWC2q4fbltj1g475TofpNVNivSypcAAKElfpSS1cv7MrpLYRG8TzZvwcVu9M30hLA/WAp1HQ==",
+          "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "esutils": "2.0.2",
@@ -12840,6 +12846,7 @@
             "ansi-styles": {
               "version": "3.2.0",
               "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "dev": true,
               "requires": {
                 "color-convert": "1.9.1"
               }
@@ -12847,6 +12854,7 @@
             "chalk": {
               "version": "2.3.0",
               "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
               "requires": {
                 "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
@@ -12855,15 +12863,18 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
             },
             "has-flag": {
               "version": "2.0.0",
-              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+              "dev": true
             },
             "supports-color": {
               "version": "4.5.0",
               "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
               "requires": {
                 "has-flag": "2.0.0"
               }
@@ -12872,11 +12883,13 @@
         },
         "@types/node": {
           "version": "9.4.0",
-          "integrity": "sha512-zkYho6/4wZyX6o9UQ8rd0ReEaiEYNNCqYFIAACe2Tf9DrYlgzWW27OigYHnnztnnZQwVRpwWmZKegFmDpinIsA=="
+          "integrity": "sha512-zkYho6/4wZyX6o9UQ8rd0ReEaiEYNNCqYFIAACe2Tf9DrYlgzWW27OigYHnnztnnZQwVRpwWmZKegFmDpinIsA==",
+          "dev": true
         },
         "JSONStream": {
           "version": "0.8.4",
           "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
+          "dev": true,
           "requires": {
             "jsonparse": "0.0.5",
             "through": "2.3.8"
@@ -12884,7 +12897,8 @@
         },
         "abab": {
           "version": "1.0.4",
-          "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+          "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+          "dev": true
         },
         "abbrev": {
           "version": "1.1.1",
@@ -12938,13 +12952,15 @@
         "acorn-jsx": {
           "version": "3.0.1",
           "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+          "dev": true,
           "requires": {
             "acorn": "3.3.0"
           },
           "dependencies": {
             "acorn": {
               "version": "3.3.0",
-              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+              "dev": true
             }
           }
         },
@@ -12978,6 +12994,7 @@
         "alter": {
           "version": "0.2.0",
           "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
+          "dev": true,
           "requires": {
             "stable": "0.1.6"
           }
@@ -12988,11 +13005,13 @@
         },
         "ansi-escapes": {
           "version": "1.4.0",
-          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+          "dev": true
         },
         "ansi-gray": {
           "version": "0.1.1",
           "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+          "dev": true,
           "requires": {
             "ansi-wrap": "0.1.0"
           }
@@ -13011,11 +13030,13 @@
         },
         "ansi-wrap": {
           "version": "0.1.0",
-          "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+          "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+          "dev": true
         },
         "ansicolors": {
           "version": "0.2.1",
-          "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
+          "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=",
+          "dev": true
         },
         "anymatch": {
           "version": "1.3.2",
@@ -13028,6 +13049,7 @@
         "append-transform": {
           "version": "0.4.0",
           "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+          "dev": true,
           "requires": {
             "default-require-extensions": "1.0.0"
           }
@@ -13073,6 +13095,7 @@
         "argparse": {
           "version": "1.0.9",
           "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+          "dev": true,
           "requires": {
             "sprintf-js": "1.0.3"
           }
@@ -13080,6 +13103,7 @@
         "aria-query": {
           "version": "0.7.1",
           "integrity": "sha1-Jsu1r/ZBRLCoJb4YRuCxbPoAsR4=",
+          "dev": true,
           "requires": {
             "ast-types-flow": "0.0.7",
             "commander": "2.13.0"
@@ -13087,7 +13111,8 @@
           "dependencies": {
             "commander": {
               "version": "2.13.0",
-              "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+              "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+              "dev": true
             }
           }
         },
@@ -13108,11 +13133,13 @@
         },
         "array-differ": {
           "version": "1.0.0",
-          "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+          "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+          "dev": true
         },
         "array-equal": {
           "version": "1.0.0",
-          "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+          "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+          "dev": true
         },
         "array-filter": {
           "version": "0.0.1",
@@ -13129,6 +13156,7 @@
         "array-includes": {
           "version": "3.0.3",
           "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+          "dev": true,
           "requires": {
             "define-properties": "1.1.2",
             "es-abstract": "1.10.0"
@@ -13195,7 +13223,8 @@
         },
         "assertion-error": {
           "version": "1.1.0",
-          "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+          "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+          "dev": true
         },
         "assets-webpack-plugin": {
           "version": "3.5.1",
@@ -13210,7 +13239,8 @@
         },
         "ast-traverse": {
           "version": "0.1.1",
-          "integrity": "sha1-ac8rg4bxnc2hux4F1o/jWdiJfeY="
+          "integrity": "sha1-ac8rg4bxnc2hux4F1o/jWdiJfeY=",
+          "dev": true
         },
         "ast-types": {
           "version": "0.9.6",
@@ -13218,11 +13248,13 @@
         },
         "ast-types-flow": {
           "version": "0.0.7",
-          "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="
+          "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+          "dev": true
         },
         "astral-regex": {
           "version": "1.0.0",
-          "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+          "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+          "dev": true
         },
         "async": {
           "version": "0.9.0",
@@ -13239,6 +13271,7 @@
         "async-kit": {
           "version": "2.2.3",
           "integrity": "sha1-JkdRonndxfWbQZY4uAWuLEmFj7c=",
+          "dev": true,
           "requires": {
             "nextgen-events": "0.9.9",
             "tree-kit": "0.5.26"
@@ -13246,13 +13279,15 @@
           "dependencies": {
             "nextgen-events": {
               "version": "0.9.9",
-              "integrity": "sha1-OaivxKK4RTiMV+LGu5cWcRmGo6A="
+              "integrity": "sha1-OaivxKK4RTiMV+LGu5cWcRmGo6A=",
+              "dev": true
             }
           }
         },
         "async-limiter": {
           "version": "1.0.0",
-          "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+          "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+          "dev": true
         },
         "asynckit": {
           "version": "0.4.0",
@@ -13285,6 +13320,7 @@
         "axobject-query": {
           "version": "0.1.0",
           "integrity": "sha1-YvWdvFnJ+SQnWco0mWDnov48NsA=",
+          "dev": true,
           "requires": {
             "ast-types-flow": "0.0.7"
           }
@@ -13349,6 +13385,7 @@
         "babel-eslint": {
           "version": "6.1.2",
           "integrity": "sha1-UpNBn+NnLWZZjTJ9qWlFZ7pqXy8=",
+          "dev": true,
           "requires": {
             "babel-traverse": "6.26.0",
             "babel-types": "6.26.0",
@@ -13359,7 +13396,8 @@
           "dependencies": {
             "lodash.assign": {
               "version": "4.2.0",
-              "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+              "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+              "dev": true
             }
           }
         },
@@ -13543,6 +13581,7 @@
         "babel-jest": {
           "version": "22.1.0",
           "integrity": "sha512-5pKRFTlDr+x1JESNRd5leqvxEJk3dRwVvIXikB6Lr4BWZbBppk1Wp+BLUzxWL8tM+EYGLCWgfqkD35Sft8r8Lw==",
+          "dev": true,
           "requires": {
             "babel-plugin-istanbul": "4.1.5",
             "babel-preset-jest": "22.1.0"
@@ -13577,23 +13616,28 @@
         },
         "babel-plugin-constant-folding": {
           "version": "1.0.1",
-          "integrity": "sha1-g2HTZMmORJw2kr26Ue/whEKQqo4="
+          "integrity": "sha1-g2HTZMmORJw2kr26Ue/whEKQqo4=",
+          "dev": true
         },
         "babel-plugin-dead-code-elimination": {
           "version": "1.0.2",
-          "integrity": "sha1-X3xFEnTc18zNv7s+C4XdKBIfD2U="
+          "integrity": "sha1-X3xFEnTc18zNv7s+C4XdKBIfD2U=",
+          "dev": true
         },
         "babel-plugin-eval": {
           "version": "1.0.1",
-          "integrity": "sha1-ovrtJc5r5preS/7CY/cBaRlZUNo="
+          "integrity": "sha1-ovrtJc5r5preS/7CY/cBaRlZUNo=",
+          "dev": true
         },
         "babel-plugin-inline-environment-variables": {
           "version": "1.0.1",
-          "integrity": "sha1-H1jOkSB61qgmqL9kX6/mj/X+P/4="
+          "integrity": "sha1-H1jOkSB61qgmqL9kX6/mj/X+P/4=",
+          "dev": true
         },
         "babel-plugin-istanbul": {
           "version": "4.1.5",
           "integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
+          "dev": true,
           "requires": {
             "find-up": "2.1.0",
             "istanbul-lib-instrument": "1.9.1",
@@ -13602,52 +13646,63 @@
         },
         "babel-plugin-jest-hoist": {
           "version": "22.1.0",
-          "integrity": "sha512-Og5sjbOZc4XUI3njqwYhS6WLTlHQUJ/y5+dOqmst8eHrozYZgT4OMzAaYaxhk75c2fBVYwn7+mNEN97XDO7cOw=="
+          "integrity": "sha512-Og5sjbOZc4XUI3njqwYhS6WLTlHQUJ/y5+dOqmst8eHrozYZgT4OMzAaYaxhk75c2fBVYwn7+mNEN97XDO7cOw==",
+          "dev": true
         },
         "babel-plugin-jscript": {
           "version": "1.0.4",
-          "integrity": "sha1-jzQsOCduh6R9X6CovT1etsytj8w="
+          "integrity": "sha1-jzQsOCduh6R9X6CovT1etsytj8w=",
+          "dev": true
         },
         "babel-plugin-member-expression-literals": {
           "version": "1.0.1",
-          "integrity": "sha1-zF7bD6qNyScXDnTW0cAkQAIWJNM="
+          "integrity": "sha1-zF7bD6qNyScXDnTW0cAkQAIWJNM=",
+          "dev": true
         },
         "babel-plugin-property-literals": {
           "version": "1.0.1",
-          "integrity": "sha1-AlIwGQAZKYCxwRjv6kjOk6q4MzY="
+          "integrity": "sha1-AlIwGQAZKYCxwRjv6kjOk6q4MzY=",
+          "dev": true
         },
         "babel-plugin-proto-to-assign": {
           "version": "1.0.4",
           "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
+          "dev": true,
           "requires": {
             "lodash": "3.10.1"
           },
           "dependencies": {
             "lodash": {
               "version": "3.10.1",
-              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+              "dev": true
             }
           }
         },
         "babel-plugin-react-constant-elements": {
           "version": "1.0.3",
-          "integrity": "sha1-lGc26DeEKcvDSdz/YvUcFDs041o="
+          "integrity": "sha1-lGc26DeEKcvDSdz/YvUcFDs041o=",
+          "dev": true
         },
         "babel-plugin-react-display-name": {
           "version": "1.0.3",
-          "integrity": "sha1-dU/jiSboQkpOexWrbqYTne4FFPw="
+          "integrity": "sha1-dU/jiSboQkpOexWrbqYTne4FFPw=",
+          "dev": true
         },
         "babel-plugin-remove-console": {
           "version": "1.0.1",
-          "integrity": "sha1-2PJFVsOgUAXUKqqv0neH9T/wE6c="
+          "integrity": "sha1-2PJFVsOgUAXUKqqv0neH9T/wE6c=",
+          "dev": true
         },
         "babel-plugin-remove-debugger": {
           "version": "1.0.1",
-          "integrity": "sha1-/S6jzWGkKK0fO5yJiC/0KT6MFMc="
+          "integrity": "sha1-/S6jzWGkKK0fO5yJiC/0KT6MFMc=",
+          "dev": true
         },
         "babel-plugin-runtime": {
           "version": "1.0.7",
-          "integrity": "sha1-v3x9lm3Vbs1cF/ocslPJrLflSq8="
+          "integrity": "sha1-v3x9lm3Vbs1cF/ocslPJrLflSq8=",
+          "dev": true
         },
         "babel-plugin-syntax-async-functions": {
           "version": "6.13.0",
@@ -13659,7 +13714,8 @@
         },
         "babel-plugin-syntax-class-constructor-call": {
           "version": "6.18.0",
-          "integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY="
+          "integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY=",
+          "dev": true
         },
         "babel-plugin-syntax-class-properties": {
           "version": "6.13.0",
@@ -13683,7 +13739,8 @@
         },
         "babel-plugin-syntax-flow": {
           "version": "6.18.0",
-          "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+          "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+          "dev": true
         },
         "babel-plugin-syntax-jsx": {
           "version": "6.18.0",
@@ -13718,6 +13775,7 @@
         "babel-plugin-transform-builtin-extend": {
           "version": "1.1.2",
           "integrity": "sha1-Xpb+z1i4+h7XTvytiEdbKvPJEW4=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "babel-template": "6.26.0"
@@ -13726,6 +13784,7 @@
         "babel-plugin-transform-class-constructor-call": {
           "version": "6.24.1",
           "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
+          "dev": true,
           "requires": {
             "babel-plugin-syntax-class-constructor-call": "6.18.0",
             "babel-runtime": "6.26.0",
@@ -13952,6 +14011,7 @@
         "babel-plugin-transform-es3-member-expression-literals": {
           "version": "6.22.0",
           "integrity": "sha1-cz00RPPsxBvvjtGmpOCWV7iWnrs=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0"
           }
@@ -13959,6 +14019,7 @@
         "babel-plugin-transform-es3-property-literals": {
           "version": "6.22.0",
           "integrity": "sha1-sgeNWELiKr9A9z6M3pzTcRq9V1g=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0"
           }
@@ -13983,6 +14044,7 @@
         "babel-plugin-transform-flow-strip-types": {
           "version": "6.22.0",
           "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+          "dev": true,
           "requires": {
             "babel-plugin-syntax-flow": "6.18.0",
             "babel-runtime": "6.26.0"
@@ -14047,17 +14109,20 @@
         "babel-plugin-undeclared-variables-check": {
           "version": "1.0.2",
           "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
+          "dev": true,
           "requires": {
             "leven": "1.0.2"
           }
         },
         "babel-plugin-undefined-to-void": {
           "version": "1.1.6",
-          "integrity": "sha1-f1eO+LeN+uYAM4XYQXph7aBuL4E="
+          "integrity": "sha1-f1eO+LeN+uYAM4XYQXph7aBuL4E=",
+          "dev": true
         },
         "babel-polyfill": {
           "version": "6.26.0",
           "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "core-js": "2.5.3",
@@ -14066,7 +14131,8 @@
           "dependencies": {
             "regenerator-runtime": {
               "version": "0.10.5",
-              "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+              "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+              "dev": true
             }
           }
         },
@@ -14123,6 +14189,7 @@
         "babel-preset-es2015": {
           "version": "6.24.1",
           "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+          "dev": true,
           "requires": {
             "babel-plugin-check-es2015-constants": "6.22.0",
             "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
@@ -14153,6 +14220,7 @@
         "babel-preset-fbjs": {
           "version": "1.0.0",
           "integrity": "sha1-yXLlybMB1OyeeXH0rsPhSsAXqLA=",
+          "dev": true,
           "requires": {
             "babel-plugin-check-es2015-constants": "6.22.0",
             "babel-plugin-syntax-flow": "6.18.0",
@@ -14183,6 +14251,7 @@
         "babel-preset-jest": {
           "version": "22.1.0",
           "integrity": "sha512-ps2UYz7IQpP2IgZ41tJjUuUDTxJioprHXD8fi9DoycKDGNqB3nAX/ggy1S3plaQd43ktBvMS1FkkyGNoBujFpg==",
+          "dev": true,
           "requires": {
             "babel-plugin-jest-hoist": "22.1.0",
             "babel-plugin-syntax-object-rest-spread": "6.13.0"
@@ -14191,6 +14260,7 @@
         "babel-preset-stage-1": {
           "version": "6.24.1",
           "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
+          "dev": true,
           "requires": {
             "babel-plugin-transform-class-constructor-call": "6.24.1",
             "babel-plugin-transform-export-extensions": "6.22.0",
@@ -14327,7 +14397,8 @@
         },
         "bail": {
           "version": "1.0.2",
-          "integrity": "sha1-99bBcxYwqfnw1NNe0fli4gdKF2Q="
+          "integrity": "sha1-99bBcxYwqfnw1NNe0fli4gdKF2Q=",
+          "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
@@ -14347,7 +14418,8 @@
         },
         "base64id": {
           "version": "0.1.0",
-          "integrity": "sha1-As4P3u4M709ACA4ec+g08LG/zj8="
+          "integrity": "sha1-As4P3u4M709ACA4ec+g08LG/zj8=",
+          "dev": true
         },
         "basic-auth": {
           "version": "1.0.0",
@@ -14363,7 +14435,8 @@
         },
         "beeper": {
           "version": "1.1.1",
-          "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
+          "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+          "dev": true
         },
         "benchmark": {
           "version": "1.0.0",
@@ -14475,7 +14548,8 @@
         },
         "boolbase": {
           "version": "1.0.0",
-          "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+          "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+          "dev": true
         },
         "boom": {
           "version": "4.3.1",
@@ -14510,7 +14584,8 @@
         },
         "breakable": {
           "version": "1.0.0",
-          "integrity": "sha1-eEp5eRWjjq0nutRWtVcstLuqeME="
+          "integrity": "sha1-eEp5eRWjjq0nutRWtVcstLuqeME=",
+          "dev": true
         },
         "brorand": {
           "version": "1.1.0",
@@ -14522,18 +14597,21 @@
         },
         "browser-process-hrtime": {
           "version": "0.1.2",
-          "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
+          "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+          "dev": true
         },
         "browser-resolve": {
           "version": "1.11.2",
           "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+          "dev": true,
           "requires": {
             "resolve": "1.1.7"
           },
           "dependencies": {
             "resolve": {
               "version": "1.1.7",
-              "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+              "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+              "dev": true
             }
           }
         },
@@ -14605,6 +14683,7 @@
         "bser": {
           "version": "2.0.0",
           "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+          "dev": true,
           "requires": {
             "node-int64": "0.4.0"
           }
@@ -14674,6 +14753,7 @@
         "caller-path": {
           "version": "0.1.0",
           "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+          "dev": true,
           "requires": {
             "callsites": "0.2.0"
           }
@@ -14684,7 +14764,8 @@
         },
         "callsites": {
           "version": "0.2.0",
-          "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+          "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+          "dev": true
         },
         "camel-case": {
           "version": "1.2.2",
@@ -14723,6 +14804,7 @@
         "cardinal": {
           "version": "1.0.0",
           "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
+          "dev": true,
           "requires": {
             "ansicolors": "0.2.1",
             "redeyed": "1.0.1"
@@ -14735,6 +14817,7 @@
         "cash-touch": {
           "version": "0.2.0",
           "integrity": "sha1-h8F8D2uTPFda2d00NyyKEUsK6J0=",
+          "dev": true,
           "requires": {
             "fs-extra": "0.23.1",
             "lodash": "4.15.0",
@@ -14745,6 +14828,7 @@
             "fs-extra": {
               "version": "0.23.1",
               "integrity": "sha1-ZhHbpq3yq43Jxp+rN83fiBgVfj0=",
+              "dev": true,
               "requires": {
                 "graceful-fs": "4.1.11",
                 "jsonfile": "2.4.0",
@@ -14765,6 +14849,7 @@
         "chai": {
           "version": "3.5.0",
           "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+          "dev": true,
           "requires": {
             "assertion-error": "1.1.0",
             "deep-eql": "0.1.3",
@@ -14774,6 +14859,7 @@
         "chai-enzyme": {
           "version": "1.0.0-beta.0",
           "integrity": "sha512-b2XJjyW1PfnW5a5ZBBcZWZJUhq8CA1kpTyXLf4Nac+EaiTuIyYeYN0Ft0qYoW+clinusKDhvJygiVktjhvvFvg==",
+          "dev": true,
           "requires": {
             "html": "1.0.0"
           }
@@ -14842,11 +14928,13 @@
         },
         "character-entities": {
           "version": "1.2.1",
-          "integrity": "sha1-92hxvl72bdt/j440eOzDdMJ9bco="
+          "integrity": "sha1-92hxvl72bdt/j440eOzDdMJ9bco=",
+          "dev": true
         },
         "character-entities-legacy": {
           "version": "1.1.1",
-          "integrity": "sha1-9Ad53xoQGHK7UQo9KV4fzPFHIC8="
+          "integrity": "sha1-9Ad53xoQGHK7UQo9KV4fzPFHIC8=",
+          "dev": true
         },
         "character-parser": {
           "version": "2.2.0",
@@ -14857,7 +14945,8 @@
         },
         "character-reference-invalid": {
           "version": "1.1.1",
-          "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw="
+          "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw=",
+          "dev": true
         },
         "check-node-version": {
           "version": "2.1.0",
@@ -14880,6 +14969,7 @@
         "cheerio": {
           "version": "1.0.0-rc.2",
           "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+          "dev": true,
           "requires": {
             "css-select": "1.2.0",
             "dom-serializer": "0.1.0",
@@ -14934,7 +15024,8 @@
         },
         "ci-info": {
           "version": "1.1.2",
-          "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA=="
+          "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+          "dev": true
         },
         "cipher-base": {
           "version": "1.0.4",
@@ -14946,11 +15037,13 @@
         },
         "circular-json": {
           "version": "0.3.3",
-          "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+          "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+          "dev": true
         },
         "cjk-regex": {
           "version": "1.0.2",
-          "integrity": "sha512-NwSMtwULPLk8Ka9DEUcoFXhMRnV/bpyKDnoyDiVw/Qy5przhvHTvXLcsKaOmx13o8J4XEsPVT1baoCUj5zQs3w=="
+          "integrity": "sha512-NwSMtwULPLk8Ka9DEUcoFXhMRnV/bpyKDnoyDiVw/Qy5przhvHTvXLcsKaOmx13o8J4XEsPVT1baoCUj5zQs3w==",
+          "dev": true
         },
         "classnames": {
           "version": "1.1.1",
@@ -14983,6 +15076,7 @@
         "cli-cursor": {
           "version": "1.0.2",
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
           "requires": {
             "restore-cursor": "1.0.1"
           }
@@ -14990,19 +15084,22 @@
         "cli-table": {
           "version": "0.3.1",
           "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+          "dev": true,
           "requires": {
             "colors": "1.0.3"
           },
           "dependencies": {
             "colors": {
               "version": "1.0.3",
-              "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+              "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+              "dev": true
             }
           }
         },
         "cli-usage": {
           "version": "0.1.7",
           "integrity": "sha512-x/Q52iLSZsRrRb2ePmTsVYXrGcrPQ8G4yRAY7QpMlumxAfPVrnDOH2X6Z5s8qsAX7AA7YuIi8AXFrvH0wWEesA==",
+          "dev": true,
           "requires": {
             "marked": "0.3.12",
             "marked-terminal": "2.0.0"
@@ -15010,13 +15107,15 @@
           "dependencies": {
             "marked": {
               "version": "0.3.12",
-              "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA=="
+              "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA==",
+              "dev": true
             }
           }
         },
         "cli-width": {
           "version": "1.1.1",
-          "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0="
+          "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
+          "dev": true
         },
         "click-outside": {
           "version": "2.0.1",
@@ -15047,11 +15146,13 @@
         },
         "clone": {
           "version": "1.0.3",
-          "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+          "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+          "dev": true
         },
         "clone-regexp": {
           "version": "1.0.0",
           "integrity": "sha1-6uCiQT9VwJQvgYwin+/OhF1/Oxw=",
+          "dev": true,
           "requires": {
             "is-regexp": "1.0.0",
             "is-supported-regexp-flag": "1.0.0"
@@ -15059,7 +15160,8 @@
         },
         "clone-stats": {
           "version": "0.0.1",
-          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+          "dev": true
         },
         "co": {
           "version": "4.6.0",
@@ -15071,7 +15173,8 @@
         },
         "collapse-white-space": {
           "version": "1.0.3",
-          "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw="
+          "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw=",
+          "dev": true
         },
         "color-convert": {
           "version": "1.9.1",
@@ -15082,7 +15185,8 @@
         },
         "color-diff": {
           "version": "0.1.7",
-          "integrity": "sha1-bbeM2UgqjkWdQIIer0tQMoPcuOI="
+          "integrity": "sha1-bbeM2UgqjkWdQIIer0tQMoPcuOI=",
+          "dev": true
         },
         "color-name": {
           "version": "1.1.3",
@@ -15090,11 +15194,13 @@
         },
         "color-support": {
           "version": "1.1.3",
-          "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+          "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+          "dev": true
         },
         "colorguard": {
           "version": "1.2.1",
           "integrity": "sha512-qYVKTg626qpDg4/eBnPXidEPXn5+krbYqHVfyyEFBWV5z3IF4p44HKY/eE2t1ohlcrlIkDgHmFJMfQ8qMLnSFw==",
+          "dev": true,
           "requires": {
             "chalk": "1.1.3",
             "color-diff": "0.1.7",
@@ -15111,6 +15217,7 @@
             "chalk": {
               "version": "1.1.3",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
               "requires": {
                 "ansi-styles": "2.2.1",
                 "escape-string-regexp": "1.0.3",
@@ -15121,11 +15228,13 @@
             },
             "supports-color": {
               "version": "2.0.0",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
             },
             "yargs": {
               "version": "1.3.3",
-              "integrity": "sha1-BU3oth8i7v23IHBZ6u+da4P7kxo="
+              "integrity": "sha1-BU3oth8i7v23IHBZ6u+da4P7kxo=",
+              "dev": true
             }
           }
         },
@@ -15151,6 +15260,7 @@
         "commoner": {
           "version": "0.10.8",
           "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
+          "dev": true,
           "requires": {
             "commander": "2.13.0",
             "detective": "4.7.1",
@@ -15165,11 +15275,13 @@
           "dependencies": {
             "commander": {
               "version": "2.13.0",
-              "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+              "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+              "dev": true
             },
             "glob": {
               "version": "5.0.15",
               "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "dev": true,
               "requires": {
                 "inflight": "1.0.6",
                 "inherits": "2.0.1",
@@ -15180,7 +15292,8 @@
             },
             "q": {
               "version": "1.5.1",
-              "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+              "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+              "dev": true
             }
           }
         },
@@ -15262,6 +15375,7 @@
         "configstore": {
           "version": "0.3.2",
           "integrity": "sha1-JeTBbDdoq/dcWmW8YXYfSVBVtFk=",
+          "dev": true,
           "requires": {
             "graceful-fs": "3.0.11",
             "js-yaml": "3.10.0",
@@ -15276,13 +15390,15 @@
             "graceful-fs": {
               "version": "3.0.11",
               "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+              "dev": true,
               "requires": {
                 "natives": "1.1.1"
               }
             },
             "object-assign": {
               "version": "2.1.1",
-              "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+              "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+              "dev": true
             }
           }
         },
@@ -15333,7 +15449,8 @@
         },
         "content-type-parser": {
           "version": "1.0.2",
-          "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
+          "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
+          "dev": true
         },
         "convert-source-map": {
           "version": "1.5.1",
@@ -15419,6 +15536,7 @@
         "cosmiconfig": {
           "version": "3.1.0",
           "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+          "dev": true,
           "requires": {
             "is-directory": "0.3.1",
             "js-yaml": "3.10.0",
@@ -15429,6 +15547,7 @@
             "parse-json": {
               "version": "3.0.0",
               "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+              "dev": true,
               "requires": {
                 "error-ex": "1.3.1"
               }
@@ -15554,11 +15673,13 @@
         },
         "css-color-names": {
           "version": "0.0.3",
-          "integrity": "sha1-3gzvFvTYqoIioyDVttfpu62nufY="
+          "integrity": "sha1-3gzvFvTYqoIioyDVttfpu62nufY=",
+          "dev": true
         },
         "css-rule-stream": {
           "version": "1.1.0",
           "integrity": "sha1-N4bnGYmD2WWibjGVfgkHjLt3BaI=",
+          "dev": true,
           "requires": {
             "css-tokenize": "1.0.1",
             "duplexer2": "0.0.2",
@@ -15569,6 +15690,7 @@
         "css-select": {
           "version": "1.2.0",
           "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+          "dev": true,
           "requires": {
             "boolbase": "1.0.0",
             "css-what": "2.1.0",
@@ -15579,6 +15701,7 @@
             "domutils": {
               "version": "1.5.1",
               "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+              "dev": true,
               "requires": {
                 "dom-serializer": "0.1.0",
                 "domelementtype": "1.3.0"
@@ -15589,6 +15712,7 @@
         "css-tokenize": {
           "version": "1.0.1",
           "integrity": "sha1-RiXLHtohwUOFi3+B1oA8HSb8FL4=",
+          "dev": true,
           "requires": {
             "inherits": "2.0.1",
             "readable-stream": "1.1.14"
@@ -15596,15 +15720,18 @@
         },
         "css-what": {
           "version": "2.1.0",
-          "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
+          "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
+          "dev": true
         },
         "cssom": {
           "version": "0.3.2",
-          "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+          "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+          "dev": true
         },
         "cssstyle": {
           "version": "0.2.37",
           "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+          "dev": true,
           "requires": {
             "cssom": "0.3.2"
           }
@@ -15619,6 +15746,7 @@
         "cwise-compiler": {
           "version": "1.1.3",
           "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
+          "dev": true,
           "requires": {
             "uniq": "1.0.1"
           }
@@ -15698,7 +15826,8 @@
         },
         "damerau-levenshtein": {
           "version": "1.0.4",
-          "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ="
+          "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
+          "dev": true
         },
         "dashdash": {
           "version": "1.14.1",
@@ -15709,11 +15838,13 @@
         },
         "dashify": {
           "version": "0.2.2",
-          "integrity": "sha1-agdBWgHJH69KMuONnfunH2HLIP4="
+          "integrity": "sha1-agdBWgHJH69KMuONnfunH2HLIP4=",
+          "dev": true
         },
         "data-uri-to-buffer": {
           "version": "0.0.3",
-          "integrity": "sha1-GK6XmmoMqZSwYlhTkW0mYruuCxo="
+          "integrity": "sha1-GK6XmmoMqZSwYlhTkW0mYruuCxo=",
+          "dev": true
         },
         "date-now": {
           "version": "0.1.4",
@@ -15721,7 +15852,8 @@
         },
         "dateformat": {
           "version": "2.2.0",
-          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+          "dev": true
         },
         "debug": {
           "version": "2.2.0",
@@ -15737,13 +15869,15 @@
         "deep-eql": {
           "version": "0.1.3",
           "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+          "dev": true,
           "requires": {
             "type-detect": "0.1.1"
           },
           "dependencies": {
             "type-detect": {
               "version": "0.1.1",
-              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
+              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+              "dev": true
             }
           }
         },
@@ -15757,15 +15891,18 @@
         },
         "deep-freeze": {
           "version": "0.0.1",
-          "integrity": "sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ="
+          "integrity": "sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ=",
+          "dev": true
         },
         "deep-is": {
           "version": "0.1.3",
-          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+          "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
           "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+          "dev": true,
           "requires": {
             "strip-bom": "2.0.0"
           }
@@ -15773,6 +15910,7 @@
         "defaults-deep": {
           "version": "0.2.3",
           "integrity": "sha1-Y+mAg9i+0GNmWf4T8FeMeBqenKE=",
+          "dev": true,
           "requires": {
             "for-own": "0.1.5",
             "is-extendable": "0.1.1",
@@ -15781,7 +15919,8 @@
           "dependencies": {
             "lazy-cache": {
               "version": "0.2.7",
-              "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
+              "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+              "dev": true
             }
           }
         },
@@ -15802,11 +15941,13 @@
         },
         "defined": {
           "version": "1.0.0",
-          "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+          "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+          "dev": true
         },
         "defs": {
           "version": "1.1.1",
           "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
+          "dev": true,
           "requires": {
             "alter": "0.2.0",
             "ast-traverse": "0.1.1",
@@ -15822,15 +15963,18 @@
           "dependencies": {
             "esprima-fb": {
               "version": "15001.1001.0-dev-harmony-fb",
-              "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
+              "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+              "dev": true
             },
             "window-size": {
               "version": "0.1.4",
-              "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+              "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+              "dev": true
             },
             "yargs": {
               "version": "3.27.0",
               "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
+              "dev": true,
               "requires": {
                 "camelcase": "1.2.1",
                 "cliui": "2.1.0",
@@ -15845,6 +15989,7 @@
         "del": {
           "version": "2.2.2",
           "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+          "dev": true,
           "requires": {
             "globby": "5.0.0",
             "is-path-cwd": "1.0.0",
@@ -15858,6 +16003,7 @@
             "globby": {
               "version": "5.0.0",
               "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+              "dev": true,
               "requires": {
                 "array-union": "1.0.2",
                 "arrify": "1.0.1",
@@ -15869,7 +16015,8 @@
             },
             "pify": {
               "version": "2.3.0",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
             }
           }
         },
@@ -15914,11 +16061,13 @@
         },
         "detect-newline": {
           "version": "2.1.0",
-          "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+          "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+          "dev": true
         },
         "detective": {
           "version": "4.7.1",
           "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+          "dev": true,
           "requires": {
             "acorn": "5.4.0",
             "defined": "1.0.0"
@@ -15926,7 +16075,8 @@
           "dependencies": {
             "acorn": {
               "version": "5.4.0",
-              "integrity": "sha512-bkLTrtPfRASTxDXFaih7SbeYSsQ8MjrqCQKMrgZ4Hc7kYI//WVU6rDTAIqVrAudjgMFQEGthYfodtaw8dTRJrg=="
+              "integrity": "sha512-bkLTrtPfRASTxDXFaih7SbeYSsQ8MjrqCQKMrgZ4Hc7kYI//WVU6rDTAIqVrAudjgMFQEGthYfodtaw8dTRJrg==",
+              "dev": true
             }
           }
         },
@@ -15945,11 +16095,13 @@
         },
         "discontinuous-range": {
           "version": "1.0.0",
-          "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
+          "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
+          "dev": true
         },
         "disparity": {
           "version": "2.0.0",
           "integrity": "sha1-V92stHMkrl9Y0swNqIbbTOnutxg=",
+          "dev": true,
           "requires": {
             "ansi-styles": "2.2.1",
             "diff": "1.4.0"
@@ -15957,7 +16109,8 @@
           "dependencies": {
             "diff": {
               "version": "1.4.0",
-              "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
+              "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+              "dev": true
             }
           }
         },
@@ -15976,6 +16129,7 @@
         "doiuse": {
           "version": "2.6.0",
           "integrity": "sha1-GJLRC2Gpo1at2/K2FJM+gfi7ODQ=",
+          "dev": true,
           "requires": {
             "browserslist": "1.3.6",
             "caniuse-db": "1.0.30000800",
@@ -15994,6 +16148,7 @@
             "source-map": {
               "version": "0.4.4",
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "dev": true,
               "requires": {
                 "amdefine": "1.0.1"
               }
@@ -16033,6 +16188,7 @@
         "domexception": {
           "version": "1.0.1",
           "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+          "dev": true,
           "requires": {
             "webidl-conversions": "4.0.2"
           }
@@ -16075,6 +16231,7 @@
         "duplexer2": {
           "version": "0.0.2",
           "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+          "dev": true,
           "requires": {
             "readable-stream": "1.1.14"
           }
@@ -16128,6 +16285,7 @@
         "editorconfig": {
           "version": "0.14.2",
           "integrity": "sha512-tghjvKwo1gakrhFiZWlbo5ILWAfnuOu1JFztW0li+vzbnInN0CMZuF4F0T/Pnn9UWpT7Mr1aFTWdHVuxiR9K9A==",
+          "dev": true,
           "requires": {
             "bluebird": "3.5.1",
             "commander": "2.13.0",
@@ -16138,15 +16296,18 @@
           "dependencies": {
             "bluebird": {
               "version": "3.5.1",
-              "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+              "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+              "dev": true
             },
             "commander": {
               "version": "2.13.0",
-              "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+              "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+              "dev": true
             },
             "lru-cache": {
               "version": "3.2.0",
               "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+              "dev": true,
               "requires": {
                 "pseudomap": "1.0.2"
               }
@@ -16155,7 +16316,8 @@
         },
         "editorconfig-to-prettier": {
           "version": "0.0.6",
-          "integrity": "sha512-Ysw+hBdwhPFruYmLapKRm7Or5XgMzhasbqu4AN07V2l/AkqpgooWm2xtTQPzTD6S0tq54A+WbSxNt6qmsO3hoA=="
+          "integrity": "sha512-Ysw+hBdwhPFruYmLapKRm7Or5XgMzhasbqu4AN07V2l/AkqpgooWm2xtTQPzTD6S0tq54A+WbSxNt6qmsO3hoA==",
+          "dev": true
         },
         "ee-first": {
           "version": "1.1.1",
@@ -16163,7 +16325,8 @@
         },
         "ejs": {
           "version": "2.5.7",
-          "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
+          "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo=",
+          "dev": true
         },
         "electron-to-chromium": {
           "version": "1.3.32",
@@ -16192,7 +16355,8 @@
         },
         "emoji-regex": {
           "version": "6.5.1",
-          "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ=="
+          "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
+          "dev": true
         },
         "emoji-text": {
           "version": "0.2.6",
@@ -16207,7 +16371,8 @@
         },
         "encodeurl": {
           "version": "1.0.2",
-          "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+          "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+          "dev": true
         },
         "encoding": {
           "version": "0.1.12",
@@ -16226,6 +16391,7 @@
         "engine.io": {
           "version": "1.6.8",
           "integrity": "sha1-3gWga3V+dRdpXgiMewUcR4GfURs=",
+          "dev": true,
           "requires": {
             "accepts": "1.1.4",
             "base64id": "0.1.0",
@@ -16237,6 +16403,7 @@
             "accepts": {
               "version": "1.1.4",
               "integrity": "sha1-1xyW99QdD+2iw4zRToonwEFY30o=",
+              "dev": true,
               "requires": {
                 "mime-types": "2.0.14",
                 "negotiator": "0.4.9"
@@ -16244,18 +16411,21 @@
             },
             "mime-db": {
               "version": "1.12.0",
-              "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
+              "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc=",
+              "dev": true
             },
             "mime-types": {
               "version": "2.0.14",
               "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
+              "dev": true,
               "requires": {
                 "mime-db": "1.12.0"
               }
             },
             "negotiator": {
               "version": "0.4.9",
-              "integrity": "sha1-kuRrbbU8fkIe1koryU8IvnYw3z8="
+              "integrity": "sha1-kuRrbbU8fkIe1koryU8IvnYw3z8=",
+              "dev": true
             }
           }
         },
@@ -16325,6 +16495,7 @@
         "enzyme": {
           "version": "3.2.0",
           "integrity": "sha512-l0HcjycivXjB4IXkwuRc1K5z8hzWIVZB2b/Y/H2bao9eFTpBz4ACOwAQf44SgG5Nu3d1jF41LasxDgFWZeeysA==",
+          "dev": true,
           "requires": {
             "cheerio": "1.0.0-rc.2",
             "function.prototype.name": "1.1.0",
@@ -16341,13 +16512,15 @@
           "dependencies": {
             "lodash": {
               "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+              "dev": true
             }
           }
         },
         "enzyme-adapter-react-16": {
           "version": "1.1.1",
           "integrity": "sha512-kC8pAtU2Jk3OJ0EG8Y2813dg9Ol0TXi7UNxHzHiWs30Jo/hj7alc//G1YpKUsPP1oKl9X+Lkx+WlGJpPYA+nvw==",
+          "dev": true,
           "requires": {
             "enzyme-adapter-utils": "1.3.0",
             "lodash": "4.17.4",
@@ -16360,11 +16533,13 @@
           "dependencies": {
             "lodash": {
               "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+              "dev": true
             },
             "prop-types": {
               "version": "15.6.0",
               "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+              "dev": true,
               "requires": {
                 "fbjs": "0.8.16",
                 "loose-envify": "1.3.1",
@@ -16376,6 +16551,7 @@
         "enzyme-adapter-utils": {
           "version": "1.3.0",
           "integrity": "sha512-vVXSt6uDv230DIv+ebCG66T1Pm36Kv+m74L1TrF4kaE7e1V7Q/LcxO0QRkajk5cA6R3uu9wJf5h13wOTezTbjA==",
+          "dev": true,
           "requires": {
             "lodash": "4.17.4",
             "object.assign": "4.1.0",
@@ -16384,11 +16560,13 @@
           "dependencies": {
             "lodash": {
               "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+              "dev": true
             },
             "prop-types": {
               "version": "15.6.0",
               "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+              "dev": true,
               "requires": {
                 "fbjs": "0.8.16",
                 "loose-envify": "1.3.1",
@@ -16400,13 +16578,15 @@
         "enzyme-to-json": {
           "version": "3.3.0",
           "integrity": "sha512-d8IfzVpwunct+bw6uWujjHKtskyLwWGKkAguouAdTMNTaTmoC0Y0N0mWpeOq+bFDM4YljRXmBRIsO6QNWrlZzA==",
+          "dev": true,
           "requires": {
             "lodash": "4.17.4"
           },
           "dependencies": {
             "lodash": {
               "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+              "dev": true
             }
           }
         },
@@ -16494,7 +16674,8 @@
         },
         "es6-promise": {
           "version": "3.3.1",
-          "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+          "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+          "dev": true
         },
         "es6-set": {
           "version": "0.1.5",
@@ -16552,6 +16733,7 @@
         "escodegen": {
           "version": "1.9.0",
           "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+          "dev": true,
           "requires": {
             "esprima": "3.1.3",
             "estraverse": "4.2.0",
@@ -16563,6 +16745,7 @@
             "source-map": {
               "version": "0.5.7",
               "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true,
               "optional": true
             }
           }
@@ -16580,6 +16763,7 @@
         "esformatter": {
           "version": "0.7.3",
           "integrity": "sha1-p0NztHLt6PNVkgsj391vnV7g6Ko=",
+          "dev": true,
           "requires": {
             "debug": "0.7.4",
             "disparity": "2.0.0",
@@ -16604,15 +16788,18 @@
           "dependencies": {
             "debug": {
               "version": "0.7.4",
-              "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+              "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+              "dev": true
             },
             "espree": {
               "version": "1.12.3",
-              "integrity": "sha1-BM7q2pG9oHejjAQMEluhhrE7s8w="
+              "integrity": "sha1-BM7q2pG9oHejjAQMEluhhrE7s8w=",
+              "dev": true
             },
             "glob": {
               "version": "5.0.15",
               "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "dev": true,
               "requires": {
                 "inflight": "1.0.6",
                 "inherits": "2.0.1",
@@ -16623,23 +16810,28 @@
             },
             "minimist": {
               "version": "1.2.0",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true
             },
             "semver": {
               "version": "2.2.1",
-              "integrity": "sha1-eUEYKz/8xYC/8cF5QqzfeVHA0hM="
+              "integrity": "sha1-eUEYKz/8xYC/8cF5QqzfeVHA0hM=",
+              "dev": true
             },
             "strip-json-comments": {
               "version": "0.1.3",
-              "integrity": "sha1-Fkxk43Coo8wAyeAbU55WmCPw7lQ="
+              "integrity": "sha1-Fkxk43Coo8wAyeAbU55WmCPw7lQ=",
+              "dev": true
             },
             "supports-color": {
               "version": "1.3.1",
-              "integrity": "sha1-FXWN8J2P87SswwdTn6vicJXhBC0="
+              "integrity": "sha1-FXWN8J2P87SswwdTn6vicJXhBC0=",
+              "dev": true
             },
             "user-home": {
               "version": "2.0.0",
               "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+              "dev": true,
               "requires": {
                 "os-homedir": "1.0.2"
               }
@@ -16649,6 +16841,7 @@
         "esformatter-braces": {
           "version": "1.2.1",
           "integrity": "sha1-c+BxdEat5LsmnO7OtGw3AujB6Cc=",
+          "dev": true,
           "requires": {
             "rocambole-token": "1.2.1"
           }
@@ -16656,6 +16849,7 @@
         "esformatter-collapse-objects-a8c": {
           "version": "0.1.0",
           "integrity": "sha1-vFUbXqZL6bzWgf8DoUHqGOod5rI=",
+          "dev": true,
           "requires": {
             "defaults-deep": "0.2.3",
             "rocambole": "0.5.1",
@@ -16664,11 +16858,13 @@
           "dependencies": {
             "esprima": {
               "version": "2.7.3",
-              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+              "dev": true
             },
             "rocambole": {
               "version": "0.5.1",
               "integrity": "sha1-MEj2SyOIuN2Okz+a1EPws4mrYI8=",
+              "dev": true,
               "requires": {
                 "esprima": "2.7.3"
               }
@@ -16678,6 +16874,7 @@
         "esformatter-dot-notation": {
           "version": "1.3.1",
           "integrity": "sha1-21uqJBQyFOVA+jJ9JV7rBPWxV+A=",
+          "dev": true,
           "requires": {
             "rocambole": "0.6.0",
             "rocambole-token": "1.2.1",
@@ -16686,11 +16883,13 @@
           "dependencies": {
             "esprima": {
               "version": "2.7.3",
-              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+              "dev": true
             },
             "rocambole": {
               "version": "0.6.0",
               "integrity": "sha1-U08jWih8wX+bBXuVvRHQ8Nw1RSw=",
+              "dev": true,
               "requires": {
                 "esprima": "2.7.3"
               }
@@ -16699,15 +16898,18 @@
         },
         "esformatter-quotes": {
           "version": "1.0.3",
-          "integrity": "sha1-B0Cv5G30B8jj3heaqZKNs9hZqiA="
+          "integrity": "sha1-B0Cv5G30B8jj3heaqZKNs9hZqiA=",
+          "dev": true
         },
         "esformatter-semicolons": {
           "version": "1.1.1",
-          "integrity": "sha1-CauHaUwRn67f1a+HM4kz0aFrKSs="
+          "integrity": "sha1-CauHaUwRn67f1a+HM4kz0aFrKSs=",
+          "dev": true
         },
         "esformatter-special-bangs": {
           "version": "1.0.1",
           "integrity": "sha1-JNyzG58DuRJk+xbMbr9bqQjP4tk=",
+          "dev": true,
           "requires": {
             "rocambole-token": "1.2.1"
           }
@@ -16715,6 +16917,7 @@
         "eslines": {
           "version": "1.1.0",
           "integrity": "sha1-eA3YIE5bluBb3I8BUCzVJ1q/xGQ=",
+          "dev": true,
           "requires": {
             "jest-docblock": "20.0.3",
             "optionator": "0.8.1"
@@ -16722,13 +16925,15 @@
           "dependencies": {
             "jest-docblock": {
               "version": "20.0.3",
-              "integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI="
+              "integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI=",
+              "dev": true
             }
           }
         },
         "eslint": {
           "version": "3.8.1",
           "integrity": "sha1-fQLbRM1ar0+nqkieHwg7qkVDQro=",
+          "dev": true,
           "requires": {
             "chalk": "1.1.3",
             "concat-stream": "1.5.2",
@@ -16768,6 +16973,7 @@
             "chalk": {
               "version": "1.1.3",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
               "requires": {
                 "ansi-styles": "2.2.1",
                 "escape-string-regexp": "1.0.3",
@@ -16778,11 +16984,13 @@
             },
             "cli-width": {
               "version": "2.2.0",
-              "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+              "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+              "dev": true
             },
             "doctrine": {
               "version": "1.5.0",
               "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+              "dev": true,
               "requires": {
                 "esutils": "2.0.2",
                 "isarray": "1.0.0"
@@ -16790,11 +16998,13 @@
             },
             "fast-levenshtein": {
               "version": "2.0.6",
-              "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+              "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+              "dev": true
             },
             "inquirer": {
               "version": "0.12.0",
               "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+              "dev": true,
               "requires": {
                 "ansi-escapes": "1.4.0",
                 "ansi-regex": "2.1.1",
@@ -16814,6 +17024,7 @@
             "optionator": {
               "version": "0.8.2",
               "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+              "dev": true,
               "requires": {
                 "deep-is": "0.1.3",
                 "fast-levenshtein": "2.0.6",
@@ -16825,44 +17036,53 @@
             },
             "strip-bom": {
               "version": "3.0.0",
-              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+              "dev": true
             },
             "strip-json-comments": {
               "version": "1.0.4",
-              "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
+              "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+              "dev": true
             },
             "supports-color": {
               "version": "2.0.0",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
             },
             "user-home": {
               "version": "2.0.0",
               "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+              "dev": true,
               "requires": {
                 "os-homedir": "1.0.2"
               }
             },
             "wordwrap": {
               "version": "1.0.0",
-              "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+              "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+              "dev": true
             }
           }
         },
         "eslint-config-wpcalypso": {
           "version": "2.0.0",
-          "integrity": "sha512-m/G31U8K2U5qV/u/BOHSTNtJGOBDR7Y84rH5hRBMhg/jWcXnJCEPy1sA0tFKfPL1GMJkJOosRVGTdMqMjiZJoQ=="
+          "integrity": "sha512-m/G31U8K2U5qV/u/BOHSTNtJGOBDR7Y84rH5hRBMhg/jWcXnJCEPy1sA0tFKfPL1GMJkJOosRVGTdMqMjiZJoQ==",
+          "dev": true
         },
         "eslint-eslines": {
           "version": "0.0.6",
-          "integrity": "sha1-9MXWe+pmYx6cXgnK/ZMsbMMAdcM="
+          "integrity": "sha1-9MXWe+pmYx6cXgnK/ZMsbMMAdcM=",
+          "dev": true
         },
         "eslint-plugin-jest": {
           "version": "21.2.0",
-          "integrity": "sha512-pe7JWoZiXWHfVCBArxX5o3laRZp24tkBSeIHImJJyX2mDIqzlrXkUGkfbC6tPKER3WbcQ3YxKDMgp8uqt8fjfw=="
+          "integrity": "sha512-pe7JWoZiXWHfVCBArxX5o3laRZp24tkBSeIHImJJyX2mDIqzlrXkUGkfbC6tPKER3WbcQ3YxKDMgp8uqt8fjfw==",
+          "dev": true
         },
         "eslint-plugin-jsx-a11y": {
           "version": "6.0.3",
           "integrity": "sha1-VFg9GuRCSDFi4EDhPMMYZUZRAOU=",
+          "dev": true,
           "requires": {
             "aria-query": "0.7.1",
             "array-includes": "3.0.3",
@@ -16876,6 +17096,7 @@
         "eslint-plugin-react": {
           "version": "7.1.0",
           "integrity": "sha1-J3cKzzn1/UnNCvQIPOWBBOs5DUw=",
+          "dev": true,
           "requires": {
             "doctrine": "2.0.0",
             "has": "1.0.1",
@@ -16884,13 +17105,15 @@
           "dependencies": {
             "jsx-ast-utils": {
               "version": "1.4.1",
-              "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE="
+              "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
+              "dev": true
             }
           }
         },
         "eslint-plugin-wpcalypso": {
           "version": "3.4.1",
           "integrity": "sha512-rHbCINm3qJmCgASUDKdmRiulwt06EcJTy9Hd+MpZMS4o9eFfS23Q1z1bBYVsJ4nFexvWswqcfCsgRQnFPtT5pQ==",
+          "dev": true,
           "requires": {
             "requireindex": "1.1.0"
           }
@@ -16902,6 +17125,7 @@
         "espree": {
           "version": "3.5.2",
           "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+          "dev": true,
           "requires": {
             "acorn": "5.4.0",
             "acorn-jsx": "3.0.1"
@@ -16909,7 +17133,8 @@
           "dependencies": {
             "acorn": {
               "version": "5.4.0",
-              "integrity": "sha512-bkLTrtPfRASTxDXFaih7SbeYSsQ8MjrqCQKMrgZ4Hc7kYI//WVU6rDTAIqVrAudjgMFQEGthYfodtaw8dTRJrg=="
+              "integrity": "sha512-bkLTrtPfRASTxDXFaih7SbeYSsQ8MjrqCQKMrgZ4Hc7kYI//WVU6rDTAIqVrAudjgMFQEGthYfodtaw8dTRJrg==",
+              "dev": true
             }
           }
         },
@@ -16977,6 +17202,7 @@
         "exec-sh": {
           "version": "0.2.1",
           "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
+          "dev": true,
           "requires": {
             "merge": "1.2.0"
           }
@@ -16997,6 +17223,7 @@
         "execall": {
           "version": "1.0.0",
           "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
+          "dev": true,
           "requires": {
             "clone-regexp": "1.0.0"
           }
@@ -17007,11 +17234,13 @@
         },
         "exit": {
           "version": "0.1.2",
-          "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+          "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+          "dev": true
         },
         "exit-hook": {
           "version": "1.1.1",
-          "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+          "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+          "dev": true
         },
         "expand-brackets": {
           "version": "0.1.5",
@@ -17042,6 +17271,7 @@
         "expect": {
           "version": "22.1.0",
           "integrity": "sha512-8K+8TjNnZq73KYtqNWKWTbYbN8z4loeL+Pn2bqpmtTdBtLNXJtpz9vkUcQlFsgKMDRA3VM8GXRA6qbV/oBF7Bw==",
+          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "jest-diff": "22.1.0",
@@ -17054,6 +17284,7 @@
             "ansi-styles": {
               "version": "3.2.0",
               "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "dev": true,
               "requires": {
                 "color-convert": "1.9.1"
               }
@@ -17169,6 +17400,7 @@
         "fancy-log": {
           "version": "1.3.2",
           "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+          "dev": true,
           "requires": {
             "ansi-gray": "0.1.1",
             "color-support": "1.1.3",
@@ -17189,7 +17421,8 @@
         },
         "fast-levenshtein": {
           "version": "1.1.4",
-          "integrity": "sha1-5qdUzI8V5YmHqpy9J69m/W9OWvk="
+          "integrity": "sha1-5qdUzI8V5YmHqpy9J69m/W9OWvk=",
+          "dev": true
         },
         "fast-luhn": {
           "version": "1.0.3",
@@ -17202,6 +17435,7 @@
         "fault": {
           "version": "1.0.1",
           "integrity": "sha1-3o01Df1IviS13BsChn4IcbkTUJI=",
+          "dev": true,
           "requires": {
             "format": "0.2.2"
           }
@@ -17209,6 +17443,7 @@
         "fb-watchman": {
           "version": "2.0.0",
           "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+          "dev": true,
           "requires": {
             "bser": "2.0.0"
           }
@@ -17242,6 +17477,7 @@
         "fbjs-scripts": {
           "version": "0.7.1",
           "integrity": "sha1-TxFeIY4kPjrdvw7dqsHjxi9wP6w=",
+          "dev": true,
           "requires": {
             "babel-core": "6.25.0",
             "babel-preset-fbjs": "1.0.0",
@@ -17255,11 +17491,13 @@
           "dependencies": {
             "core-js": {
               "version": "1.2.7",
-              "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+              "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+              "dev": true
             },
             "cross-spawn": {
               "version": "3.0.1",
               "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+              "dev": true,
               "requires": {
                 "lru-cache": "4.1.1",
                 "which": "1.3.0"
@@ -17267,11 +17505,13 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true
             },
             "readable-stream": {
               "version": "2.3.3",
               "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+              "dev": true,
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -17285,6 +17525,7 @@
             "string_decoder": {
               "version": "1.0.3",
               "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+              "dev": true,
               "requires": {
                 "safe-buffer": "5.1.1"
               }
@@ -17292,6 +17533,7 @@
             "through2": {
               "version": "2.0.3",
               "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+              "dev": true,
               "requires": {
                 "readable-stream": "2.3.3",
                 "xtend": "4.0.1"
@@ -17302,6 +17544,7 @@
         "figures": {
           "version": "1.7.0",
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
           "requires": {
             "escape-string-regexp": "1.0.5",
             "object-assign": "4.1.1"
@@ -17309,13 +17552,15 @@
           "dependencies": {
             "escape-string-regexp": {
               "version": "1.0.5",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
             }
           }
         },
         "file-entry-cache": {
           "version": "2.0.0",
           "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+          "dev": true,
           "requires": {
             "flat-cache": "1.3.0",
             "object-assign": "4.1.1"
@@ -17328,6 +17573,7 @@
         "fileset": {
           "version": "2.0.3",
           "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+          "dev": true,
           "requires": {
             "glob": "7.0.3",
             "minimatch": "3.0.4"
@@ -17369,7 +17615,8 @@
         },
         "find-parent-dir": {
           "version": "0.3.0",
-          "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ="
+          "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+          "dev": true
         },
         "find-up": {
           "version": "2.1.0",
@@ -17412,6 +17659,7 @@
         "flat-cache": {
           "version": "1.3.0",
           "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+          "dev": true,
           "requires": {
             "circular-json": "0.3.3",
             "del": "2.2.2",
@@ -17421,11 +17669,13 @@
         },
         "flatten": {
           "version": "1.0.2",
-          "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
+          "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
+          "dev": true
         },
         "flow-parser": {
           "version": "0.64.0",
-          "integrity": "sha1-hYZk7yJGiA+agbBeafvTCKG4Zck="
+          "integrity": "sha1-hYZk7yJGiA+agbBeafvTCKG4Zck=",
+          "dev": true
         },
         "flush-write-stream": {
           "version": "1.0.2",
@@ -17525,11 +17775,13 @@
         },
         "format": {
           "version": "0.2.2",
-          "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
+          "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
+          "dev": true
         },
         "formatio": {
           "version": "1.1.1",
           "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+          "dev": true,
           "requires": {
             "samsam": "1.1.2"
           }
@@ -17599,7 +17851,8 @@
         },
         "fs-readdir-recursive": {
           "version": "0.1.2",
-          "integrity": "sha1-MVtPuMHKW4xH3v7zGdBz2tNWgFk="
+          "integrity": "sha1-MVtPuMHKW4xH3v7zGdBz2tNWgFk=",
+          "dev": true
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
@@ -18420,6 +18673,7 @@
         "function.prototype.name": {
           "version": "1.1.0",
           "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
+          "dev": true,
           "requires": {
             "define-properties": "1.1.2",
             "function-bind": "1.1.1",
@@ -18477,6 +18731,7 @@
         "get-pixels": {
           "version": "3.3.0",
           "integrity": "sha1-jZeVvq4YhQuED3SVgbrcBdPjbkE=",
+          "dev": true,
           "requires": {
             "data-uri-to-buffer": "0.0.3",
             "jpeg-js": "0.1.2",
@@ -18524,6 +18779,7 @@
         "glob": {
           "version": "7.0.3",
           "integrity": "sha1-CqI1kxpKlqwT1g/6wvuHe9btT1g=",
+          "dev": true,
           "requires": {
             "inflight": "1.0.6",
             "inherits": "2.0.1",
@@ -18608,7 +18864,8 @@
         },
         "globjoin": {
           "version": "0.1.4",
-          "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM="
+          "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
+          "dev": true
         },
         "globule": {
           "version": "1.2.0",
@@ -18640,6 +18897,7 @@
         "glogg": {
           "version": "1.0.1",
           "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+          "dev": true,
           "requires": {
             "sparkles": "1.0.0"
           }
@@ -18654,6 +18912,7 @@
         "got": {
           "version": "3.3.1",
           "integrity": "sha1-5dDtSvVfw+701WAHdp2YGSvLLso=",
+          "dev": true,
           "requires": {
             "duplexify": "3.5.3",
             "infinity-agent": "2.0.3",
@@ -18669,7 +18928,8 @@
           "dependencies": {
             "object-assign": {
               "version": "3.0.0",
-              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+              "dev": true
             }
           }
         },
@@ -18684,6 +18944,7 @@
         "graphql": {
           "version": "0.10.5",
           "integrity": "sha512-Q7cx22DiLhwHsEfUnUip1Ww/Vfx7FS0w6+iHItNuN61+XpegHSa3k5U0+6M5BcpavQImBwFiy0z3uYwY7cXMLQ==",
+          "dev": true,
           "requires": {
             "iterall": "1.1.4"
           }
@@ -18697,11 +18958,13 @@
         },
         "growly": {
           "version": "1.3.0",
-          "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+          "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+          "dev": true
         },
         "gulp-util": {
           "version": "3.0.8",
           "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+          "dev": true,
           "requires": {
             "array-differ": "1.0.0",
             "array-uniq": "1.0.3",
@@ -18725,19 +18988,23 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.3",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true
             },
             "minimist": {
               "version": "1.2.0",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true
             },
             "object-assign": {
               "version": "3.0.0",
-              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+              "dev": true
             },
             "readable-stream": {
               "version": "2.3.3",
               "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+              "dev": true,
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -18750,11 +19017,13 @@
             },
             "replace-ext": {
               "version": "0.0.1",
-              "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+              "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+              "dev": true
             },
             "string_decoder": {
               "version": "1.0.3",
               "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+              "dev": true,
               "requires": {
                 "safe-buffer": "5.1.1"
               }
@@ -18762,6 +19031,7 @@
             "through2": {
               "version": "2.0.3",
               "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+              "dev": true,
               "requires": {
                 "readable-stream": "2.3.3",
                 "xtend": "4.0.1"
@@ -18772,6 +19042,7 @@
         "gulplog": {
           "version": "1.0.0",
           "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+          "dev": true,
           "requires": {
             "glogg": "1.0.1"
           }
@@ -18779,6 +19050,7 @@
         "gzip-size": {
           "version": "3.0.0",
           "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
+          "dev": true,
           "requires": {
             "duplexer": "0.1.1"
           }
@@ -18786,6 +19058,7 @@
         "handlebars": {
           "version": "4.0.11",
           "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+          "dev": true,
           "requires": {
             "async": "1.5.2",
             "optimist": "0.6.1",
@@ -18795,11 +19068,13 @@
           "dependencies": {
             "async": {
               "version": "1.5.2",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+              "dev": true
             },
             "source-map": {
               "version": "0.4.4",
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "dev": true,
               "requires": {
                 "amdefine": "1.0.1"
               }
@@ -18887,7 +19162,8 @@
         },
         "has-color": {
           "version": "0.1.7",
-          "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+          "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+          "dev": true
         },
         "has-cors": {
           "version": "1.1.0",
@@ -18900,6 +19176,7 @@
         "has-gulplog": {
           "version": "0.1.0",
           "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+          "dev": true,
           "requires": {
             "sparkles": "1.0.0"
           }
@@ -18979,6 +19256,7 @@
         "html": {
           "version": "1.0.0",
           "integrity": "sha1-pUT6nqVJK/s6LMqCEKEL57WvH2E=",
+          "dev": true,
           "requires": {
             "concat-stream": "1.5.2"
           }
@@ -18986,6 +19264,7 @@
         "html-encoding-sniffer": {
           "version": "1.0.2",
           "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+          "dev": true,
           "requires": {
             "whatwg-encoding": "1.0.3"
           }
@@ -19051,7 +19330,8 @@
         },
         "html-tags": {
           "version": "1.2.0",
-          "integrity": "sha1-x43mW1Zjqll5id0rerSSANfk25g="
+          "integrity": "sha1-x43mW1Zjqll5id0rerSSANfk25g=",
+          "dev": true
         },
         "html-to-react": {
           "version": "1.3.1",
@@ -19146,6 +19426,7 @@
         "husky": {
           "version": "0.13.3",
           "integrity": "sha1-vCBmCAutyLj+NRbogfW8aKVwUv8=",
+          "dev": true,
           "requires": {
             "chalk": "1.1.3",
             "find-parent-dir": "0.3.0",
@@ -19156,6 +19437,7 @@
             "chalk": {
               "version": "1.1.3",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
               "requires": {
                 "ansi-styles": "2.2.1",
                 "escape-string-regexp": "1.0.3",
@@ -19166,11 +19448,13 @@
             },
             "normalize-path": {
               "version": "1.0.0",
-              "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k="
+              "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+              "dev": true
             },
             "supports-color": {
               "version": "2.0.0",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
             }
           }
         },
@@ -19222,7 +19506,8 @@
         },
         "ignore": {
           "version": "3.3.5",
-          "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw=="
+          "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
+          "dev": true
         },
         "immediate": {
           "version": "3.0.6",
@@ -19242,6 +19527,7 @@
         "import-local": {
           "version": "1.0.0",
           "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+          "dev": true,
           "requires": {
             "pkg-dir": "2.0.0",
             "resolve-cwd": "2.0.0"
@@ -19284,7 +19570,8 @@
         },
         "indexes-of": {
           "version": "1.0.1",
-          "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+          "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+          "dev": true
         },
         "indexof": {
           "version": "0.0.1",
@@ -19292,7 +19579,8 @@
         },
         "infinity-agent": {
           "version": "2.0.3",
-          "integrity": "sha1-ReDi/3qesDCyfWK3SzdEt6esQhY="
+          "integrity": "sha1-ReDi/3qesDCyfWK3SzdEt6esQhY=",
+          "dev": true
         },
         "inflight": {
           "version": "1.0.6",
@@ -19321,6 +19609,7 @@
         "inquirer": {
           "version": "0.11.0",
           "integrity": "sha1-dEi/qSQJKvMR1HFzu6uZDK4rsCc=",
+          "dev": true,
           "requires": {
             "ansi-escapes": "1.4.0",
             "ansi-regex": "2.1.1",
@@ -19338,7 +19627,8 @@
           "dependencies": {
             "lodash": {
               "version": "3.10.1",
-              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+              "dev": true
             }
           }
         },
@@ -19368,7 +19658,8 @@
         },
         "iota-array": {
           "version": "1.0.0",
-          "integrity": "sha1-ge9X/l0FgUzVjCSDYyqZwwoOgIc="
+          "integrity": "sha1-ge9X/l0FgUzVjCSDYyqZwwoOgIc=",
+          "dev": true
         },
         "ipaddr.js": {
           "version": "1.0.5",
@@ -19376,15 +19667,18 @@
         },
         "irregular-plurals": {
           "version": "1.4.0",
-          "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
+          "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
+          "dev": true
         },
         "is-alphabetical": {
           "version": "1.0.1",
-          "integrity": "sha1-x3B5zJHU76x3W+EDS/LSQ/lebwg="
+          "integrity": "sha1-x3B5zJHU76x3W+EDS/LSQ/lebwg=",
+          "dev": true
         },
         "is-alphanumerical": {
           "version": "1.0.1",
           "integrity": "sha1-37SqTRCF4zvbYcLe6cgOnGwZ9Ts=",
+          "dev": true,
           "requires": {
             "is-alphabetical": "1.0.1",
             "is-decimal": "1.0.1"
@@ -19419,6 +19713,7 @@
         "is-ci": {
           "version": "1.1.0",
           "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+          "dev": true,
           "requires": {
             "ci-info": "1.1.2"
           }
@@ -19429,11 +19724,13 @@
         },
         "is-decimal": {
           "version": "1.0.1",
-          "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI="
+          "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI=",
+          "dev": true
         },
         "is-directory": {
           "version": "0.3.1",
-          "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
+          "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+          "dev": true
         },
         "is-dotfile": {
           "version": "1.0.3",
@@ -19484,7 +19781,8 @@
         },
         "is-generator-fn": {
           "version": "1.0.0",
-          "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go="
+          "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
+          "dev": true
         },
         "is-glob": {
           "version": "3.1.0",
@@ -19495,7 +19793,8 @@
         },
         "is-hexadecimal": {
           "version": "1.0.1",
-          "integrity": "sha1-bghLvJIGH7sJcexYts5tQE4k2mk="
+          "integrity": "sha1-bghLvJIGH7sJcexYts5tQE4k2mk=",
+          "dev": true
         },
         "is-integer": {
           "version": "1.0.7",
@@ -19523,7 +19822,8 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+          "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+          "dev": true
         },
         "is-number": {
           "version": "2.1.0",
@@ -19534,11 +19834,13 @@
         },
         "is-path-cwd": {
           "version": "1.0.0",
-          "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+          "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+          "dev": true
         },
         "is-path-in-cwd": {
           "version": "1.0.0",
           "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+          "dev": true,
           "requires": {
             "is-path-inside": "1.0.1"
           }
@@ -19546,13 +19848,15 @@
         "is-path-inside": {
           "version": "1.0.1",
           "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+          "dev": true,
           "requires": {
             "path-is-inside": "1.0.2"
           }
         },
         "is-plain-obj": {
           "version": "1.1.0",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+          "dev": true
         },
         "is-posix-bracket": {
           "version": "0.1.1",
@@ -19572,7 +19876,8 @@
         },
         "is-redirect": {
           "version": "1.0.0",
-          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+          "dev": true
         },
         "is-regex": {
           "version": "1.0.4",
@@ -19583,11 +19888,13 @@
         },
         "is-regexp": {
           "version": "1.0.0",
-          "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
+          "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+          "dev": true
         },
         "is-resolvable": {
           "version": "1.1.0",
-          "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
+          "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+          "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
@@ -19595,11 +19902,13 @@
         },
         "is-subset": {
           "version": "0.1.1",
-          "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY="
+          "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+          "dev": true
         },
         "is-supported-regexp-flag": {
           "version": "1.0.0",
-          "integrity": "sha1-i1IMhfrnolM4LUsCZS4EVXbhO7g="
+          "integrity": "sha1-i1IMhfrnolM4LUsCZS4EVXbhO7g=",
+          "dev": true
         },
         "is-symbol": {
           "version": "1.0.1",
@@ -19629,7 +19938,8 @@
         },
         "is-whitespace-character": {
           "version": "1.0.1",
-          "integrity": "sha1-muAXbzKCtlRXoZks2whPil+DPjs="
+          "integrity": "sha1-muAXbzKCtlRXoZks2whPil+DPjs=",
+          "dev": true
         },
         "is-windows": {
           "version": "1.0.1",
@@ -19637,7 +19947,8 @@
         },
         "is-word-character": {
           "version": "1.0.1",
-          "integrity": "sha1-WgP6HqkazopusMfNdw64bWXIvvs="
+          "integrity": "sha1-WgP6HqkazopusMfNdw64bWXIvvs=",
+          "dev": true
         },
         "isarray": {
           "version": "1.0.0",
@@ -19669,6 +19980,7 @@
         "istanbul": {
           "version": "0.4.5",
           "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+          "dev": true,
           "requires": {
             "abbrev": "1.0.9",
             "async": "1.5.2",
@@ -19688,15 +20000,18 @@
           "dependencies": {
             "abbrev": {
               "version": "1.0.9",
-              "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
+              "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+              "dev": true
             },
             "async": {
               "version": "1.5.2",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+              "dev": true
             },
             "escodegen": {
               "version": "1.8.1",
               "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+              "dev": true,
               "requires": {
                 "esprima": "2.7.3",
                 "estraverse": "1.9.3",
@@ -19707,15 +20022,18 @@
             },
             "esprima": {
               "version": "2.7.3",
-              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+              "dev": true
             },
             "estraverse": {
               "version": "1.9.3",
-              "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
+              "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+              "dev": true
             },
             "glob": {
               "version": "5.0.15",
               "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "dev": true,
               "requires": {
                 "inflight": "1.0.6",
                 "inherits": "2.0.1",
@@ -19726,11 +20044,13 @@
             },
             "resolve": {
               "version": "1.1.7",
-              "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+              "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+              "dev": true
             },
             "source-map": {
               "version": "0.2.0",
               "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+              "dev": true,
               "optional": true,
               "requires": {
                 "amdefine": "1.0.1"
@@ -19738,13 +20058,15 @@
             },
             "wordwrap": {
               "version": "1.0.0",
-              "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+              "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+              "dev": true
             }
           }
         },
         "istanbul-api": {
           "version": "1.2.1",
           "integrity": "sha512-oFCwXvd65amgaPCzqrR+a2XjanS1MvpXN6l/MlMUTv6uiA1NOgGX+I0uyq8Lg3GDxsxPsaP1049krz3hIJ5+KA==",
+          "dev": true,
           "requires": {
             "async": "2.6.0",
             "fileset": "2.0.3",
@@ -19762,6 +20084,7 @@
             "async": {
               "version": "2.6.0",
               "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+              "dev": true,
               "requires": {
                 "lodash": "4.15.0"
               }
@@ -19770,11 +20093,13 @@
         },
         "istanbul-lib-coverage": {
           "version": "1.1.1",
-          "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q=="
+          "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
+          "dev": true
         },
         "istanbul-lib-hook": {
           "version": "1.1.0",
           "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
+          "dev": true,
           "requires": {
             "append-transform": "0.4.0"
           }
@@ -19782,6 +20107,7 @@
         "istanbul-lib-instrument": {
           "version": "1.9.1",
           "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
+          "dev": true,
           "requires": {
             "babel-generator": "6.26.0",
             "babel-template": "6.26.0",
@@ -19794,13 +20120,15 @@
           "dependencies": {
             "semver": {
               "version": "5.5.0",
-              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+              "dev": true
             }
           }
         },
         "istanbul-lib-report": {
           "version": "1.1.2",
           "integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
+          "dev": true,
           "requires": {
             "istanbul-lib-coverage": "1.1.1",
             "mkdirp": "0.5.1",
@@ -19811,6 +20139,7 @@
         "istanbul-lib-source-maps": {
           "version": "1.2.2",
           "integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
+          "dev": true,
           "requires": {
             "debug": "3.1.0",
             "istanbul-lib-coverage": "1.1.1",
@@ -19822,30 +20151,35 @@
             "debug": {
               "version": "3.1.0",
               "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "dev": true,
               "requires": {
                 "ms": "2.0.0"
               }
             },
             "ms": {
               "version": "2.0.0",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
             },
             "source-map": {
               "version": "0.5.7",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
             }
           }
         },
         "istanbul-reports": {
           "version": "1.1.3",
           "integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
+          "dev": true,
           "requires": {
             "handlebars": "4.0.11"
           }
         },
         "iterall": {
           "version": "1.1.4",
-          "integrity": "sha512-eaDsM/PY8D/X5mYQhecVc5/9xvSHED7yPON+ffQroBeTuqUVm7dfphMkK8NksXuImqZlVRoKtrNfMIVCYIqaUQ=="
+          "integrity": "sha512-eaDsM/PY8D/X5mYQhecVc5/9xvSHED7yPON+ffQroBeTuqUVm7dfphMkK8NksXuImqZlVRoKtrNfMIVCYIqaUQ==",
+          "dev": true
         },
         "jed": {
           "version": "1.0.2",
@@ -19854,32 +20188,38 @@
         "jest": {
           "version": "22.0.3",
           "integrity": "sha512-90H1wLqiNR3tLhQUgwhC6GWHfRCG+Da14m7vxD608Mt/QTKR0TA751D+QH09x5bvcrLfvxLtxArtA0VEC0ORow==",
+          "dev": true,
           "requires": {
             "jest-cli": "22.1.4"
           },
           "dependencies": {
             "ansi-escapes": {
               "version": "3.0.0",
-              "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+              "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+              "dev": true
             },
             "ansi-regex": {
               "version": "3.0.0",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
             },
             "ansi-styles": {
               "version": "3.2.0",
               "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "dev": true,
               "requires": {
                 "color-convert": "1.9.1"
               }
             },
             "camelcase": {
               "version": "4.1.0",
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+              "dev": true
             },
             "chalk": {
               "version": "2.3.0",
               "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
               "requires": {
                 "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
@@ -19889,6 +20229,7 @@
             "cliui": {
               "version": "4.0.0",
               "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+              "dev": true,
               "requires": {
                 "string-width": "2.1.1",
                 "strip-ansi": "4.0.0",
@@ -19897,11 +20238,13 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
             },
             "glob": {
               "version": "7.1.2",
               "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+              "dev": true,
               "requires": {
                 "fs.realpath": "1.0.0",
                 "inflight": "1.0.6",
@@ -19913,15 +20256,18 @@
             },
             "has-flag": {
               "version": "2.0.0",
-              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+              "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
             },
             "jest-cli": {
               "version": "22.1.4",
               "integrity": "sha512-p7yOu0Q5uuXb3Q93qEg3LE6eNGgAGueakifxXNEqQx4b0lOl2YlC9t6BLQWNOJ+z42VWK/BIdFjf6lxKcTkjFA==",
+              "dev": true,
               "requires": {
                 "ansi-escapes": "3.0.0",
                 "chalk": "2.3.0",
@@ -19961,6 +20307,7 @@
             "os-locale": {
               "version": "2.1.0",
               "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+              "dev": true,
               "requires": {
                 "execa": "0.7.0",
                 "lcid": "1.0.0",
@@ -19970,6 +20317,7 @@
             "string-width": {
               "version": "2.1.1",
               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "dev": true,
               "requires": {
                 "is-fullwidth-code-point": "2.0.0",
                 "strip-ansi": "4.0.0"
@@ -19978,6 +20326,7 @@
             "strip-ansi": {
               "version": "4.0.0",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
               "requires": {
                 "ansi-regex": "3.0.0"
               }
@@ -19985,17 +20334,20 @@
             "supports-color": {
               "version": "4.5.0",
               "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
               "requires": {
                 "has-flag": "2.0.0"
               }
             },
             "which-module": {
               "version": "2.0.0",
-              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+              "dev": true
             },
             "yargs": {
               "version": "10.1.2",
               "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+              "dev": true,
               "requires": {
                 "cliui": "4.0.0",
                 "decamelize": "1.2.0",
@@ -20014,6 +20366,7 @@
             "yargs-parser": {
               "version": "8.1.0",
               "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+              "dev": true,
               "requires": {
                 "camelcase": "4.1.0"
               }
@@ -20023,6 +20376,7 @@
         "jest-changed-files": {
           "version": "22.1.4",
           "integrity": "sha512-EpqJhwt+N/wEHRT+5KrjagVrunduOfMgAb7fjjHkXHFCPRZoVZwl896S7krx7txf5hrMNUkpECnOnO2wBgzJCw==",
+          "dev": true,
           "requires": {
             "throat": "4.1.0"
           }
@@ -20030,6 +20384,7 @@
         "jest-config": {
           "version": "22.1.4",
           "integrity": "sha512-ZImFp7STrUDOgQLW5I5UloCiCRMh6HmMIYIoWqaQkxnR5ws7MuZFG/Ns9sZFyfrnyWCvcW91e+XcEfNeoa4Jew==",
+          "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "glob": "7.1.2",
@@ -20047,6 +20402,7 @@
             "ansi-styles": {
               "version": "3.2.0",
               "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "dev": true,
               "requires": {
                 "color-convert": "1.9.1"
               }
@@ -20054,6 +20410,7 @@
             "chalk": {
               "version": "2.3.0",
               "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
               "requires": {
                 "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
@@ -20062,11 +20419,13 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
             },
             "glob": {
               "version": "7.1.2",
               "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+              "dev": true,
               "requires": {
                 "fs.realpath": "1.0.0",
                 "inflight": "1.0.6",
@@ -20078,11 +20437,13 @@
             },
             "has-flag": {
               "version": "2.0.0",
-              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+              "dev": true
             },
             "supports-color": {
               "version": "4.5.0",
               "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
               "requires": {
                 "has-flag": "2.0.0"
               }
@@ -20092,6 +20453,7 @@
         "jest-diff": {
           "version": "22.1.0",
           "integrity": "sha512-lowdbU/dzXh+2/MR5QcvU5KPNkO4JdAEYw0PkQCbIQIuy5+g3QZBuVhWh8179Fmpg4CQrz1WgoK/yQHDCHbqqw==",
+          "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "diff": "3.4.0",
@@ -20102,6 +20464,7 @@
             "ansi-styles": {
               "version": "3.2.0",
               "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "dev": true,
               "requires": {
                 "color-convert": "1.9.1"
               }
@@ -20109,6 +20472,7 @@
             "chalk": {
               "version": "2.3.0",
               "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
               "requires": {
                 "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
@@ -20117,15 +20481,18 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
             },
             "has-flag": {
               "version": "2.0.0",
-              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+              "dev": true
             },
             "supports-color": {
               "version": "4.5.0",
               "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
               "requires": {
                 "has-flag": "2.0.0"
               }
@@ -20135,6 +20502,7 @@
         "jest-docblock": {
           "version": "22.0.3",
           "integrity": "sha512-LhviP2rqIg2IzS6m97W7T032oMrT699Tr6Njjhhl4FCLj+75BUy9CsSmGgfoVEql1uc+myBkssvcbn7T9xDR+A==",
+          "dev": true,
           "requires": {
             "detect-newline": "2.1.0"
           }
@@ -20142,6 +20510,7 @@
         "jest-environment-jsdom": {
           "version": "22.1.4",
           "integrity": "sha512-YGqFJzei/kq5BgQ8su7igLoCl34ytUffr5ZoqwLrDzCmXUKyIiuwBFbWe3xFMG/crlDb1emhBXdzWM1yDEDw5Q==",
+          "dev": true,
           "requires": {
             "jest-mock": "22.1.0",
             "jest-util": "22.1.4",
@@ -20151,6 +20520,7 @@
         "jest-environment-node": {
           "version": "22.1.4",
           "integrity": "sha512-rQmtzgZVdyCzeXsE8i7Alw2483KSd2PYjssZWZYeNzonN/lBeUjjaOCgLWp6FspBzSTnYF7x6cN4umGZxYAhow==",
+          "dev": true,
           "requires": {
             "jest-mock": "22.1.0",
             "jest-util": "22.1.4"
@@ -20158,15 +20528,18 @@
         },
         "jest-file-exists": {
           "version": "17.0.0",
-          "integrity": "sha1-f2Prc6HEOhP0Yb4mF2i0WvLN0Wk="
+          "integrity": "sha1-f2Prc6HEOhP0Yb4mF2i0WvLN0Wk=",
+          "dev": true
         },
         "jest-get-type": {
           "version": "22.1.0",
-          "integrity": "sha512-nD97IVOlNP6fjIN5i7j5XRH+hFsHL7VlauBbzRvueaaUe70uohrkz7pL/N8lx/IAwZRTJ//wOdVgh85OgM7g3w=="
+          "integrity": "sha512-nD97IVOlNP6fjIN5i7j5XRH+hFsHL7VlauBbzRvueaaUe70uohrkz7pL/N8lx/IAwZRTJ//wOdVgh85OgM7g3w==",
+          "dev": true
         },
         "jest-haste-map": {
           "version": "22.1.0",
           "integrity": "sha512-vETdC6GboGlZX6+9SMZkXtYRQSKBbQ47sFF7NGglbMN4eyIZBODply8rlcO01KwBiAeiNCKdjUyfonZzJ93JEg==",
+          "dev": true,
           "requires": {
             "fb-watchman": "2.0.0",
             "graceful-fs": "4.1.11",
@@ -20179,6 +20552,7 @@
             "jest-docblock": {
               "version": "22.1.0",
               "integrity": "sha512-/+OGgBVRJb5wCbXrB1LQvibQBz2SdrvDdKRNzY1gL+OISQJZCR9MOewbygdT5rVzbbkfhC4AR2x+qWmNUdJfjw==",
+              "dev": true,
               "requires": {
                 "detect-newline": "2.1.0"
               }
@@ -20188,6 +20562,7 @@
         "jest-jasmine2": {
           "version": "22.1.4",
           "integrity": "sha512-+KoRiG4PUwURB7UXei2jzxvbCebhXgTYS+xWl3FsSYUn3flcxdcOgAsFolx31Dkk/B1bVf1HIKt/B6Ubucp9aQ==",
+          "dev": true,
           "requires": {
             "callsites": "2.0.0",
             "chalk": "2.3.0",
@@ -20205,17 +20580,20 @@
             "ansi-styles": {
               "version": "3.2.0",
               "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "dev": true,
               "requires": {
                 "color-convert": "1.9.1"
               }
             },
             "callsites": {
               "version": "2.0.0",
-              "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+              "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+              "dev": true
             },
             "chalk": {
               "version": "2.3.0",
               "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
               "requires": {
                 "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
@@ -20224,19 +20602,23 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
             },
             "has-flag": {
               "version": "2.0.0",
-              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+              "dev": true
             },
             "source-map": {
               "version": "0.6.1",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
             },
             "source-map-support": {
               "version": "0.5.3",
               "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
+              "dev": true,
               "requires": {
                 "source-map": "0.6.1"
               }
@@ -20244,6 +20626,7 @@
             "supports-color": {
               "version": "4.5.0",
               "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
               "requires": {
                 "has-flag": "2.0.0"
               }
@@ -20253,6 +20636,7 @@
         "jest-junit-reporter": {
           "version": "1.1.0",
           "integrity": "sha1-iNYAbsE/gt9AxHiCyGQJic3LFDQ=",
+          "dev": true,
           "requires": {
             "xml": "1.0.1"
           }
@@ -20260,6 +20644,7 @@
         "jest-leak-detector": {
           "version": "22.1.0",
           "integrity": "sha512-8QsCWkncWAqdvrXN4yXQp9vgWF6CT3RkRey+d06SIHX913uXzAJhJdZyo6eE+uHVYMxUbxqW93npbUFhAR0YxA==",
+          "dev": true,
           "requires": {
             "pretty-format": "22.1.0"
           }
@@ -20267,6 +20652,7 @@
         "jest-matcher-utils": {
           "version": "22.1.0",
           "integrity": "sha512-Zn1OD9wVjILOdvRxgAnqiCN36OX6KJx+P2FHN+3lzQ0omG2N2OAguxE1QXuJJneG2yndlkXjekXFP254c0cSpw==",
+          "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "jest-get-type": "22.1.0",
@@ -20276,6 +20662,7 @@
             "ansi-styles": {
               "version": "3.2.0",
               "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "dev": true,
               "requires": {
                 "color-convert": "1.9.1"
               }
@@ -20283,6 +20670,7 @@
             "chalk": {
               "version": "2.3.0",
               "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
               "requires": {
                 "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
@@ -20291,15 +20679,18 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
             },
             "has-flag": {
               "version": "2.0.0",
-              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+              "dev": true
             },
             "supports-color": {
               "version": "4.5.0",
               "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
               "requires": {
                 "has-flag": "2.0.0"
               }
@@ -20309,6 +20700,7 @@
         "jest-matchers": {
           "version": "17.0.3",
           "integrity": "sha1-iLlTSMkZND24bQjxI1SoZQrn7d8=",
+          "dev": true,
           "requires": {
             "jest-diff": "17.0.3",
             "jest-matcher-utils": "17.0.3",
@@ -20318,6 +20710,7 @@
             "chalk": {
               "version": "1.1.3",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
               "requires": {
                 "ansi-styles": "2.2.1",
                 "escape-string-regexp": "1.0.3",
@@ -20329,6 +20722,7 @@
             "jest-diff": {
               "version": "17.0.3",
               "integrity": "sha1-j7Me+rOzFNe2G3tmsL3qYX7xwC8=",
+              "dev": true,
               "requires": {
                 "chalk": "1.1.3",
                 "diff": "3.4.0",
@@ -20339,6 +20733,7 @@
             "jest-matcher-utils": {
               "version": "17.0.3",
               "integrity": "sha1-8Qjkm5VuFSxmJtzAq6hk9Zq3sNM=",
+              "dev": true,
               "requires": {
                 "chalk": "1.1.3",
                 "pretty-format": "4.2.3"
@@ -20346,11 +20741,13 @@
             },
             "jest-mock": {
               "version": "17.0.2",
-              "integrity": "sha1-Pf6SIa/ZqmGz2ZkoQIE6NYuy9Ck="
+              "integrity": "sha1-Pf6SIa/ZqmGz2ZkoQIE6NYuy9Ck=",
+              "dev": true
             },
             "jest-util": {
               "version": "17.0.2",
               "integrity": "sha1-n9nagJHpkE+5dtp+TYkSyiaWhjg=",
+              "dev": true,
               "requires": {
                 "chalk": "1.1.3",
                 "diff": "3.4.0",
@@ -20362,17 +20759,20 @@
             },
             "pretty-format": {
               "version": "4.2.3",
-              "integrity": "sha1-iJTCrIFBnPgBYp2PZjIKJTgNiwU="
+              "integrity": "sha1-iJTCrIFBnPgBYp2PZjIKJTgNiwU=",
+              "dev": true
             },
             "supports-color": {
               "version": "2.0.0",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
             }
           }
         },
         "jest-message-util": {
           "version": "22.1.0",
           "integrity": "sha512-kftcoawOeOVUGuGWmMupJt7FGLK1pqOrh02FlJwtImmPGZ2yTWCTx2D+N/g95qD2jCbQ/ntH1goBixhAIIxL+g==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "7.0.0-beta.39",
             "chalk": "2.3.0",
@@ -20384,6 +20784,7 @@
             "ansi-styles": {
               "version": "3.2.0",
               "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "dev": true,
               "requires": {
                 "color-convert": "1.9.1"
               }
@@ -20391,6 +20792,7 @@
             "chalk": {
               "version": "2.3.0",
               "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
               "requires": {
                 "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
@@ -20399,15 +20801,18 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
             },
             "has-flag": {
               "version": "2.0.0",
-              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+              "dev": true
             },
             "supports-color": {
               "version": "4.5.0",
               "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
               "requires": {
                 "has-flag": "2.0.0"
               }
@@ -20416,15 +20821,18 @@
         },
         "jest-mock": {
           "version": "22.1.0",
-          "integrity": "sha512-gL3/C8ds6e1PWiOTsV7sIejPP/ECYQgDbwMzbNCc+ZFPuPH3EpwsVLGmQqPK6okgnDagimbbQnss3kPJ8HCMtA=="
+          "integrity": "sha512-gL3/C8ds6e1PWiOTsV7sIejPP/ECYQgDbwMzbNCc+ZFPuPH3EpwsVLGmQqPK6okgnDagimbbQnss3kPJ8HCMtA==",
+          "dev": true
         },
         "jest-regex-util": {
           "version": "22.1.0",
-          "integrity": "sha512-on0LqVS6Xeh69sw3d1RukVnur+lVOl3zkmb0Q54FHj9wHoq6dbtWqb3TSlnVUyx36hqjJhjgs/QLqs07Bzu72Q=="
+          "integrity": "sha512-on0LqVS6Xeh69sw3d1RukVnur+lVOl3zkmb0Q54FHj9wHoq6dbtWqb3TSlnVUyx36hqjJhjgs/QLqs07Bzu72Q==",
+          "dev": true
         },
         "jest-resolve": {
           "version": "22.1.4",
           "integrity": "sha512-/HuCMeiTD6YJ+NF15bU1mal1r7Gov0GJozA7232XiYve7cOOnU2JwXBx3EQmcIuG38uNrRPjtgpiXkBqfnk4Og==",
+          "dev": true,
           "requires": {
             "browser-resolve": "1.11.2",
             "chalk": "2.3.0"
@@ -20433,6 +20841,7 @@
             "ansi-styles": {
               "version": "3.2.0",
               "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "dev": true,
               "requires": {
                 "color-convert": "1.9.1"
               }
@@ -20440,6 +20849,7 @@
             "chalk": {
               "version": "2.3.0",
               "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
               "requires": {
                 "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
@@ -20448,15 +20858,18 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
             },
             "has-flag": {
               "version": "2.0.0",
-              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+              "dev": true
             },
             "supports-color": {
               "version": "4.5.0",
               "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
               "requires": {
                 "has-flag": "2.0.0"
               }
@@ -20466,6 +20879,7 @@
         "jest-resolve-dependencies": {
           "version": "22.1.0",
           "integrity": "sha512-76Ll61bD/Sus8wK8d+lw891EtiBJGJkWG8OuVDTEX0z3z2+jPujvQqSB2eQ+kCHyCsRwJ2PSjhn3UHqae/oEtA==",
+          "dev": true,
           "requires": {
             "jest-regex-util": "22.1.0"
           }
@@ -20473,6 +20887,7 @@
         "jest-runner": {
           "version": "22.1.4",
           "integrity": "sha512-HAyZ0Q2Fyk7mlbtbSKP75hNs9IP0Md7kzPUN1uNKbvQfZkXA/e7P0ttzAIGQtEbRx656tYwkfWNW+hXvs1i4/g==",
+          "dev": true,
           "requires": {
             "exit": "0.1.2",
             "jest-config": "22.1.4",
@@ -20490,6 +20905,7 @@
             "jest-docblock": {
               "version": "22.1.0",
               "integrity": "sha512-/+OGgBVRJb5wCbXrB1LQvibQBz2SdrvDdKRNzY1gL+OISQJZCR9MOewbygdT5rVzbbkfhC4AR2x+qWmNUdJfjw==",
+              "dev": true,
               "requires": {
                 "detect-newline": "2.1.0"
               }
@@ -20499,6 +20915,7 @@
         "jest-runtime": {
           "version": "22.1.4",
           "integrity": "sha512-r/UjVuQppDRwbUprDlLYdd8MTYY+H8H6BCqRujGjo5/QyIt3b0hppNoOQHF+0bHNtuz/sR9chJ9HJ3A1fiv9Pw==",
+          "dev": true,
           "requires": {
             "babel-core": "6.25.0",
             "babel-jest": "22.1.0",
@@ -20523,22 +20940,26 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
             },
             "ansi-styles": {
               "version": "3.2.0",
               "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "dev": true,
               "requires": {
                 "color-convert": "1.9.1"
               }
             },
             "camelcase": {
               "version": "4.1.0",
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+              "dev": true
             },
             "chalk": {
               "version": "2.3.0",
               "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
               "requires": {
                 "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
@@ -20548,6 +20969,7 @@
             "cliui": {
               "version": "4.0.0",
               "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+              "dev": true,
               "requires": {
                 "string-width": "2.1.1",
                 "strip-ansi": "4.0.0",
@@ -20556,19 +20978,23 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
             },
             "has-flag": {
               "version": "2.0.0",
-              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+              "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
             },
             "os-locale": {
               "version": "2.1.0",
               "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+              "dev": true,
               "requires": {
                 "execa": "0.7.0",
                 "lcid": "1.0.0",
@@ -20578,6 +21004,7 @@
             "string-width": {
               "version": "2.1.1",
               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "dev": true,
               "requires": {
                 "is-fullwidth-code-point": "2.0.0",
                 "strip-ansi": "4.0.0"
@@ -20586,28 +21013,33 @@
             "strip-ansi": {
               "version": "4.0.0",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
               "requires": {
                 "ansi-regex": "3.0.0"
               }
             },
             "strip-bom": {
               "version": "3.0.0",
-              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+              "dev": true
             },
             "supports-color": {
               "version": "4.5.0",
               "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
               "requires": {
                 "has-flag": "2.0.0"
               }
             },
             "which-module": {
               "version": "2.0.0",
-              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+              "dev": true
             },
             "write-file-atomic": {
               "version": "2.3.0",
               "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+              "dev": true,
               "requires": {
                 "graceful-fs": "4.1.11",
                 "imurmurhash": "0.1.4",
@@ -20617,6 +21049,7 @@
             "yargs": {
               "version": "10.1.2",
               "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+              "dev": true,
               "requires": {
                 "cliui": "4.0.0",
                 "decamelize": "1.2.0",
@@ -20635,6 +21068,7 @@
             "yargs-parser": {
               "version": "8.1.0",
               "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+              "dev": true,
               "requires": {
                 "camelcase": "4.1.0"
               }
@@ -20644,6 +21078,7 @@
         "jest-snapshot": {
           "version": "22.1.2",
           "integrity": "sha512-45co/M0gTe6Y6yHaJLydEZKHOFpFHESLah40jW35DWd3pd7q188bsi0oUY4Kls7PDXUamvTWuTKTZXCtzwSvCw==",
+          "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "jest-diff": "22.1.0",
@@ -20656,6 +21091,7 @@
             "ansi-styles": {
               "version": "3.2.0",
               "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "dev": true,
               "requires": {
                 "color-convert": "1.9.1"
               }
@@ -20663,6 +21099,7 @@
             "chalk": {
               "version": "2.3.0",
               "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
               "requires": {
                 "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
@@ -20671,15 +21108,18 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
             },
             "has-flag": {
               "version": "2.0.0",
-              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+              "dev": true
             },
             "supports-color": {
               "version": "4.5.0",
               "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
               "requires": {
                 "has-flag": "2.0.0"
               }
@@ -20689,6 +21129,7 @@
         "jest-util": {
           "version": "22.1.4",
           "integrity": "sha512-zM29idoVBPvmpsGubS7YmywVyPe4/m1wE2YhmKp0vVmrQmuby7ObuMqabp82EYlM0Rdp4GNEtaDamW9jg8lgTg==",
+          "dev": true,
           "requires": {
             "callsites": "2.0.0",
             "chalk": "2.3.0",
@@ -20702,17 +21143,20 @@
             "ansi-styles": {
               "version": "3.2.0",
               "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "dev": true,
               "requires": {
                 "color-convert": "1.9.1"
               }
             },
             "callsites": {
               "version": "2.0.0",
-              "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+              "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+              "dev": true
             },
             "chalk": {
               "version": "2.3.0",
               "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
               "requires": {
                 "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
@@ -20721,15 +21165,18 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
             },
             "has-flag": {
               "version": "2.0.0",
-              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+              "dev": true
             },
             "supports-color": {
               "version": "4.5.0",
               "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
               "requires": {
                 "has-flag": "2.0.0"
               }
@@ -20739,6 +21186,7 @@
         "jest-validate": {
           "version": "22.1.2",
           "integrity": "sha512-IjvMsV7GW5ghg5PTQvU23zJqTBmnq10eY+4n47awUeXYEGH27N+JajFPOg6tsN+OYvEPsohPquKoqQ5XBVs/ow==",
+          "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "jest-get-type": "22.1.0",
@@ -20749,6 +21197,7 @@
             "ansi-styles": {
               "version": "3.2.0",
               "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "dev": true,
               "requires": {
                 "color-convert": "1.9.1"
               }
@@ -20756,6 +21205,7 @@
             "chalk": {
               "version": "2.3.0",
               "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
               "requires": {
                 "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
@@ -20764,19 +21214,23 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
             },
             "has-flag": {
               "version": "2.0.0",
-              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+              "dev": true
             },
             "leven": {
               "version": "2.1.0",
-              "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+              "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+              "dev": true
             },
             "supports-color": {
               "version": "4.5.0",
               "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
               "requires": {
                 "has-flag": "2.0.0"
               }
@@ -20786,13 +21240,15 @@
         "jest-worker": {
           "version": "22.1.0",
           "integrity": "sha512-ezLueYAQowk5N6g2J7bNZfq4NWZvMNB5Qd24EmOZLcM5SXTdiFvxykZIoNiMj9C98cCbPaojX8tfR7b1LJwNig==",
+          "dev": true,
           "requires": {
             "merge-stream": "1.0.1"
           }
         },
         "jpeg-js": {
           "version": "0.1.2",
-          "integrity": "sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4="
+          "integrity": "sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4=",
+          "dev": true
         },
         "jquery": {
           "version": "1.12.3",
@@ -20813,6 +21269,7 @@
         "js-yaml": {
           "version": "3.10.0",
           "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "dev": true,
           "requires": {
             "argparse": "1.0.9",
             "esprima": "4.0.0"
@@ -20820,7 +21277,8 @@
           "dependencies": {
             "esprima": {
               "version": "4.0.0",
-              "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+              "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+              "dev": true
             }
           }
         },
@@ -20832,6 +21290,7 @@
         "jscodeshift": {
           "version": "0.3.30",
           "integrity": "sha1-c/RZ2Pw7OoCEGZGut9JICc7238U=",
+          "dev": true,
           "requires": {
             "async": "1.5.2",
             "babel-core": "5.8.38",
@@ -20854,11 +21313,13 @@
           "dependencies": {
             "async": {
               "version": "1.5.2",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+              "dev": true
             },
             "babel-core": {
               "version": "5.8.38",
               "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
+              "dev": true,
               "requires": {
                 "babel-plugin-constant-folding": "1.0.1",
                 "babel-plugin-dead-code-elimination": "1.0.2",
@@ -20910,25 +21371,30 @@
               "dependencies": {
                 "babylon": {
                   "version": "5.8.38",
-                  "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0="
+                  "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
+                  "dev": true
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                  "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+                  "dev": true
                 }
               }
             },
             "colors": {
               "version": "1.1.2",
-              "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+              "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+              "dev": true
             },
             "core-js": {
               "version": "1.2.7",
-              "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+              "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+              "dev": true
             },
             "detect-indent": {
               "version": "3.0.1",
               "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
+              "dev": true,
               "requires": {
                 "get-stdin": "4.0.1",
                 "minimist": "1.2.0",
@@ -20937,11 +21403,13 @@
             },
             "globals": {
               "version": "6.4.1",
-              "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08="
+              "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
+              "dev": true
             },
             "home-or-tmp": {
               "version": "1.0.0",
               "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
+              "dev": true,
               "requires": {
                 "os-tmpdir": "1.0.2",
                 "user-home": "1.1.1"
@@ -20949,45 +21417,54 @@
             },
             "js-tokens": {
               "version": "1.0.1",
-              "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4="
+              "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
+              "dev": true
             },
             "json5": {
               "version": "0.4.0",
-              "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+              "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
+              "dev": true
             },
             "minimatch": {
               "version": "2.0.10",
               "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+              "dev": true,
               "requires": {
                 "brace-expansion": "1.1.8"
               }
             },
             "minimist": {
               "version": "1.2.0",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true
             },
             "node-dir": {
               "version": "0.1.8",
-              "integrity": "sha1-VfuN62mQcHB/tn+RpGDwRIKUx30="
+              "integrity": "sha1-VfuN62mQcHB/tn+RpGDwRIKUx30=",
+              "dev": true
             },
             "path-exists": {
               "version": "1.0.0",
-              "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE="
+              "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
+              "dev": true
             },
             "repeating": {
               "version": "1.1.3",
               "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+              "dev": true,
               "requires": {
                 "is-finite": "1.0.2"
               }
             },
             "source-map": {
               "version": "0.5.7",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
             },
             "source-map-support": {
               "version": "0.2.10",
               "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
+              "dev": true,
               "requires": {
                 "source-map": "0.1.32"
               },
@@ -20995,6 +21472,7 @@
                 "source-map": {
                   "version": "0.1.32",
                   "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
+                  "dev": true,
                   "requires": {
                     "amdefine": "1.0.1"
                   }
@@ -21006,6 +21484,7 @@
         "jsdom": {
           "version": "11.6.2",
           "integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
+          "dev": true,
           "requires": {
             "abab": "1.0.4",
             "acorn": "5.4.0",
@@ -21037,26 +21516,31 @@
           "dependencies": {
             "acorn": {
               "version": "5.4.0",
-              "integrity": "sha512-bkLTrtPfRASTxDXFaih7SbeYSsQ8MjrqCQKMrgZ4Hc7kYI//WVU6rDTAIqVrAudjgMFQEGthYfodtaw8dTRJrg=="
+              "integrity": "sha512-bkLTrtPfRASTxDXFaih7SbeYSsQ8MjrqCQKMrgZ4Hc7kYI//WVU6rDTAIqVrAudjgMFQEGthYfodtaw8dTRJrg==",
+              "dev": true
             },
             "acorn-globals": {
               "version": "4.1.0",
               "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+              "dev": true,
               "requires": {
                 "acorn": "5.4.0"
               }
             },
             "parse5": {
               "version": "4.0.0",
-              "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+              "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+              "dev": true
             },
             "ultron": {
               "version": "1.1.1",
-              "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+              "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+              "dev": true
             },
             "ws": {
               "version": "4.0.0",
               "integrity": "sha512-QYslsH44bH8O7/W2815u5DpnCpXWpEK44FmaHffNwgJI4JMaSZONgPBTOfrxJ29mXKbXak+LsJ2uAkDTYq2ptQ==",
+              "dev": true,
               "requires": {
                 "async-limiter": "1.0.0",
                 "safe-buffer": "5.1.1",
@@ -21110,6 +21594,7 @@
         "jsonfilter": {
           "version": "1.1.2",
           "integrity": "sha1-Ie987cdRk4E8dZMulqmL4gW6WhE=",
+          "dev": true,
           "requires": {
             "JSONStream": "0.8.4",
             "minimist": "1.2.0",
@@ -21119,11 +21604,13 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true
             },
             "stream-combiner": {
               "version": "0.2.2",
               "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+              "dev": true,
               "requires": {
                 "duplexer": "0.1.1",
                 "through": "2.3.8"
@@ -21137,7 +21624,8 @@
         },
         "jsonparse": {
           "version": "0.0.5",
-          "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ="
+          "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=",
+          "dev": true
         },
         "jsonpointer": {
           "version": "4.0.1",
@@ -21190,6 +21678,7 @@
         "jsx-ast-utils": {
           "version": "2.0.1",
           "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+          "dev": true,
           "requires": {
             "array-includes": "3.0.3"
           }
@@ -21219,6 +21708,7 @@
         "latest-version": {
           "version": "1.0.1",
           "integrity": "sha1-cs/Ebj6NG+ZR4eu1Tqn26pbzdLs=",
+          "dev": true,
           "requires": {
             "package-json": "1.2.0"
           }
@@ -21237,6 +21727,7 @@
         "ldjson-stream": {
           "version": "1.2.1",
           "integrity": "sha1-kb7O2lrE7SsX5kn7d356v6AYnCs=",
+          "dev": true,
           "requires": {
             "split2": "0.2.1",
             "through2": "0.6.5"
@@ -21244,7 +21735,8 @@
         },
         "left-pad": {
           "version": "1.2.0",
-          "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4="
+          "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
+          "dev": true
         },
         "level": {
           "version": "1.7.0",
@@ -21320,11 +21812,13 @@
         },
         "leven": {
           "version": "1.0.2",
-          "integrity": "sha1-kUS27ryl8dBoAWnxpncNzqYLdcM="
+          "integrity": "sha1-kUS27ryl8dBoAWnxpncNzqYLdcM=",
+          "dev": true
         },
         "levn": {
           "version": "0.3.0",
           "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+          "dev": true,
           "requires": {
             "prelude-ls": "1.1.2",
             "type-check": "0.3.2"
@@ -21412,6 +21906,7 @@
         "lodash._baseclone": {
           "version": "3.3.0",
           "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+          "dev": true,
           "requires": {
             "lodash._arraycopy": "3.0.0",
             "lodash._arrayeach": "3.0.0",
@@ -21431,11 +21926,13 @@
         },
         "lodash._basetostring": {
           "version": "3.0.1",
-          "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
+          "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+          "dev": true
         },
         "lodash._basevalues": {
           "version": "3.0.0",
-          "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
+          "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+          "dev": true
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
@@ -21460,19 +21957,23 @@
         },
         "lodash._reescape": {
           "version": "3.0.0",
-          "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
+          "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+          "dev": true
         },
         "lodash._reevaluate": {
           "version": "3.0.0",
-          "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
+          "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+          "dev": true
         },
         "lodash._reinterpolate": {
           "version": "3.0.0",
-          "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+          "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+          "dev": true
         },
         "lodash._root": {
           "version": "3.0.1",
-          "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
+          "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+          "dev": true
         },
         "lodash.assign": {
           "version": "3.2.0",
@@ -21494,6 +21995,7 @@
         "lodash.escape": {
           "version": "3.2.0",
           "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+          "dev": true,
           "requires": {
             "lodash._root": "3.0.1"
           }
@@ -21504,7 +22006,8 @@
         },
         "lodash.flattendeep": {
           "version": "4.4.0",
-          "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
+          "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+          "dev": true
         },
         "lodash.isarguments": {
           "version": "3.1.0",
@@ -21571,7 +22074,8 @@
         },
         "lodash.pickby": {
           "version": "4.6.0",
-          "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8="
+          "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=",
+          "dev": true
         },
         "lodash.restparam": {
           "version": "3.6.1",
@@ -21583,11 +22087,13 @@
         },
         "lodash.sortby": {
           "version": "4.7.0",
-          "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+          "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+          "dev": true
         },
         "lodash.template": {
           "version": "3.6.2",
           "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+          "dev": true,
           "requires": {
             "lodash._basecopy": "3.0.1",
             "lodash._basetostring": "3.0.1",
@@ -21603,6 +22109,7 @@
         "lodash.templatesettings": {
           "version": "3.1.1",
           "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+          "dev": true,
           "requires": {
             "lodash._reinterpolate": "3.0.0",
             "lodash.escape": "3.2.0"
@@ -21610,7 +22117,8 @@
         },
         "lodash.toarray": {
           "version": "4.4.0",
-          "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
+          "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+          "dev": true
         },
         "lodash.toplainobject": {
           "version": "3.0.0",
@@ -21622,11 +22130,13 @@
         },
         "lodash.unescape": {
           "version": "4.0.1",
-          "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
+          "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
+          "dev": true
         },
         "log-symbols": {
           "version": "1.0.2",
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
           "requires": {
             "chalk": "1.0.0"
           }
@@ -21634,6 +22144,7 @@
         "log-update": {
           "version": "1.0.2",
           "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+          "dev": true,
           "requires": {
             "ansi-escapes": "1.4.0",
             "cli-cursor": "1.0.2"
@@ -21641,7 +22152,8 @@
         },
         "lolex": {
           "version": "1.3.2",
-          "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE="
+          "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+          "dev": true
         },
         "longest": {
           "version": "1.0.1",
@@ -21675,7 +22187,8 @@
         },
         "lowercase-keys": {
           "version": "1.0.0",
-          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+          "dev": true
         },
         "lru": {
           "version": "3.1.0",
@@ -21706,6 +22219,7 @@
         "makeerror": {
           "version": "1.0.11",
           "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+          "dev": true,
           "requires": {
             "tmpl": "1.0.4"
           }
@@ -21724,7 +22238,8 @@
         },
         "markdown-escapes": {
           "version": "1.0.1",
-          "integrity": "sha1-GZTfLTr0gR3lmmcUk0wrIpJzRRg="
+          "integrity": "sha1-GZTfLTr0gR3lmmcUk0wrIpJzRRg=",
+          "dev": true
         },
         "markdown-loader": {
           "version": "2.0.1",
@@ -21741,6 +22256,7 @@
         "marked-terminal": {
           "version": "2.0.0",
           "integrity": "sha1-Xq9Wi+ZvaGVBr6UqVYKAMQox3i0=",
+          "dev": true,
           "requires": {
             "cardinal": "1.0.0",
             "chalk": "1.1.3",
@@ -21752,6 +22268,7 @@
             "chalk": {
               "version": "1.1.3",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
               "requires": {
                 "ansi-styles": "2.2.1",
                 "escape-string-regexp": "1.0.3",
@@ -21762,17 +22279,20 @@
             },
             "lodash.assign": {
               "version": "4.2.0",
-              "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+              "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+              "dev": true
             },
             "supports-color": {
               "version": "2.0.0",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
             }
           }
         },
         "md5-file": {
           "version": "3.1.0",
-          "integrity": "sha1-obCC/KOtQjHTaIAGIkJfs1x03VM="
+          "integrity": "sha1-obCC/KOtQjHTaIAGIkJfs1x03VM=",
+          "dev": true
         },
         "md5.js": {
           "version": "1.3.4",
@@ -21861,7 +22381,8 @@
         },
         "merge": {
           "version": "1.2.0",
-          "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+          "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+          "dev": true
         },
         "merge-descriptors": {
           "version": "1.0.0",
@@ -21870,17 +22391,20 @@
         "merge-stream": {
           "version": "1.0.1",
           "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+          "dev": true,
           "requires": {
             "readable-stream": "2.3.3"
           },
           "dependencies": {
             "inherits": {
               "version": "2.0.3",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true
             },
             "readable-stream": {
               "version": "2.3.3",
               "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+              "dev": true,
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -21894,6 +22418,7 @@
             "string_decoder": {
               "version": "1.0.3",
               "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+              "dev": true,
               "requires": {
                 "safe-buffer": "5.1.1"
               }
@@ -22035,6 +22560,7 @@
         "mixedindentlint": {
           "version": "1.2.0",
           "integrity": "sha1-/5P4dqoTCzfLN+920wfhvsoo89g=",
+          "dev": true,
           "requires": {
             "globby": "6.1.0",
             "minimist": "1.2.0"
@@ -22042,7 +22568,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true
             }
           }
         },
@@ -22086,7 +22613,8 @@
         },
         "mout": {
           "version": "1.1.0",
-          "integrity": "sha512-XsP0vf4As6BfqglxZqbqQ8SR6KQot2AgxvR0gG+WtUkf90vUXchMOZQtPf/Hml1rEffJupqL/tIrU6EYhsUQjw=="
+          "integrity": "sha512-XsP0vf4As6BfqglxZqbqQ8SR6KQot2AgxvR0gG+WtUkf90vUXchMOZQtPf/Hml1rEffJupqL/tIrU6EYhsUQjw==",
+          "dev": true
         },
         "move-concurrently": {
           "version": "1.0.1",
@@ -22107,6 +22635,7 @@
         "multimatch": {
           "version": "2.1.0",
           "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+          "dev": true,
           "requires": {
             "array-differ": "1.0.0",
             "array-union": "1.0.2",
@@ -22117,13 +22646,15 @@
         "multipipe": {
           "version": "0.1.2",
           "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+          "dev": true,
           "requires": {
             "duplexer2": "0.0.2"
           }
         },
         "mute-stream": {
           "version": "0.0.5",
-          "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
+          "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+          "dev": true
         },
         "name-all-modules-plugin": {
           "version": "1.0.1",
@@ -22135,11 +22666,13 @@
         },
         "natives": {
           "version": "1.1.1",
-          "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA=="
+          "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
+          "dev": true
         },
         "natural-compare": {
           "version": "1.4.0",
-          "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+          "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+          "dev": true
         },
         "ncname": {
           "version": "1.0.0",
@@ -22151,6 +22684,7 @@
         "ndarray": {
           "version": "1.0.18",
           "integrity": "sha1-tg06cyJOxVXQ+qeXEeUCRI/T95M=",
+          "dev": true,
           "requires": {
             "iota-array": "1.0.0",
             "is-buffer": "1.1.6"
@@ -22159,6 +22693,7 @@
         "ndarray-pack": {
           "version": "1.2.1",
           "integrity": "sha1-jK6+qqJNXs9w/4YCBjeXfajuWFo=",
+          "dev": true,
           "requires": {
             "cwise-compiler": "1.1.3",
             "ndarray": "1.0.18"
@@ -22167,6 +22702,7 @@
         "nearley": {
           "version": "2.11.0",
           "integrity": "sha512-clqqhEuP0ZCJQ85Xv2I/4o2Gs/fvSR6fCg5ZHVE2c8evWyNk2G++ih4JOO3lMb/k/09x6ihQ2nzKUlB/APCWjg==",
+          "dev": true,
           "requires": {
             "nomnom": "1.6.2",
             "railroad-diagrams": "1.0.0",
@@ -22175,11 +22711,13 @@
           "dependencies": {
             "colors": {
               "version": "0.5.1",
-              "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q="
+              "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
+              "dev": true
             },
             "nomnom": {
               "version": "1.6.2",
               "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
+              "dev": true,
               "requires": {
                 "colors": "0.5.1",
                 "underscore": "1.4.4"
@@ -22187,7 +22725,8 @@
             },
             "underscore": {
               "version": "1.4.4",
-              "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+              "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
+              "dev": true
             }
           }
         },
@@ -22202,17 +22741,20 @@
         "nested-error-stacks": {
           "version": "1.0.2",
           "integrity": "sha1-GfYZWRUZ8JZ2mlupqG5u7sgjw88=",
+          "dev": true,
           "requires": {
             "inherits": "2.0.1"
           }
         },
         "nextgen-events": {
           "version": "0.10.2",
-          "integrity": "sha512-P6efDoVOOJjVLOhwINq+aqhC2B3a9IxojbWMn9fTv2coDiyRaaGLSgWsm84wQHlQeuqVgqiLEE+xiHXf3EVN6w=="
+          "integrity": "sha512-P6efDoVOOJjVLOhwINq+aqhC2B3a9IxojbWMn9fTv2coDiyRaaGLSgWsm84wQHlQeuqVgqiLEE+xiHXf3EVN6w==",
+          "dev": true
         },
         "nock": {
           "version": "8.0.0",
           "integrity": "sha1-+G1nZWjHOjuyFE68gHkdRHuzNNI=",
+          "dev": true,
           "requires": {
             "chai": "3.5.0",
             "debug": "2.2.0",
@@ -22226,7 +22768,8 @@
           "dependencies": {
             "qs": {
               "version": "6.5.1",
-              "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+              "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+              "dev": true
             }
           }
         },
@@ -22245,7 +22788,8 @@
         },
         "node-bitmap": {
           "version": "0.0.1",
-          "integrity": "sha1-GA6scAPgxwdhjvMTaPYvhLKmkJE="
+          "integrity": "sha1-GA6scAPgxwdhjvMTaPYvhLKmkJE=",
+          "dev": true
         },
         "node-contains": {
           "version": "1.0.0",
@@ -22261,6 +22805,7 @@
         "node-emoji": {
           "version": "1.8.1",
           "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
+          "dev": true,
           "requires": {
             "lodash.toarray": "4.4.0"
           }
@@ -22312,7 +22857,8 @@
         },
         "node-int64": {
           "version": "0.4.0",
-          "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+          "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+          "dev": true
         },
         "node-libs-browser": {
           "version": "2.1.0",
@@ -22371,11 +22917,13 @@
         },
         "node-localstorage": {
           "version": "0.6.0",
-          "integrity": "sha1-RaBgHGky395mRKIzYfG+Fzx1068="
+          "integrity": "sha1-RaBgHGky395mRKIzYfG+Fzx1068=",
+          "dev": true
         },
         "node-notifier": {
           "version": "5.2.1",
           "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+          "dev": true,
           "requires": {
             "growly": "1.3.0",
             "semver": "5.5.0",
@@ -22385,7 +22933,8 @@
           "dependencies": {
             "semver": {
               "version": "5.5.0",
-              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+              "dev": true
             }
           }
         },
@@ -22457,6 +23006,7 @@
         "nodemon": {
           "version": "1.4.1",
           "integrity": "sha1-7EDqKOgyYZtr+byTcO3MBilm3ss=",
+          "dev": true,
           "requires": {
             "minimatch": "0.3.0",
             "ps-tree": "0.0.3",
@@ -22467,17 +23017,20 @@
             "event-stream": {
               "version": "0.5.3",
               "integrity": "sha1-t3uTCfcQet3+q2PwwOr9jbC9jBw=",
+              "dev": true,
               "requires": {
                 "optimist": "0.2.8"
               }
             },
             "lru-cache": {
               "version": "2.7.3",
-              "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+              "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+              "dev": true
             },
             "minimatch": {
               "version": "0.3.0",
               "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+              "dev": true,
               "requires": {
                 "lru-cache": "2.7.3",
                 "sigmund": "1.0.1"
@@ -22486,6 +23039,7 @@
             "nopt": {
               "version": "1.0.10",
               "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+              "dev": true,
               "requires": {
                 "abbrev": "1.1.1"
               }
@@ -22493,6 +23047,7 @@
             "optimist": {
               "version": "0.2.8",
               "integrity": "sha1-6YGrfiaLRXlIWTtVZ0wJmoFcrDE=",
+              "dev": true,
               "requires": {
                 "wordwrap": "0.0.2"
               }
@@ -22500,6 +23055,7 @@
             "ps-tree": {
               "version": "0.0.3",
               "integrity": "sha1-2/jXUqf+Ivp9WGNWiUmWEOknbdw=",
+              "dev": true,
               "requires": {
                 "event-stream": "0.5.3"
               }
@@ -22507,6 +23063,7 @@
             "touch": {
               "version": "1.0.0",
               "integrity": "sha1-RJy+LbrlqMgDjjDXH6D/RklHxN4=",
+              "dev": true,
               "requires": {
                 "nopt": "1.0.10"
               }
@@ -22516,6 +23073,7 @@
         "nomnom": {
           "version": "1.8.1",
           "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+          "dev": true,
           "requires": {
             "chalk": "0.4.0",
             "underscore": "1.6.0"
@@ -22523,11 +23081,13 @@
           "dependencies": {
             "ansi-styles": {
               "version": "1.0.0",
-              "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
+              "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+              "dev": true
             },
             "chalk": {
               "version": "0.4.0",
               "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+              "dev": true,
               "requires": {
                 "ansi-styles": "1.0.0",
                 "has-color": "0.1.7",
@@ -22536,7 +23096,8 @@
             },
             "strip-ansi": {
               "version": "0.1.1",
-              "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
+              "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+              "dev": true
             }
           }
         },
@@ -22574,7 +23135,8 @@
         },
         "normalize-selector": {
           "version": "0.2.0",
-          "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM="
+          "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
+          "dev": true
         },
         "notifications-panel": {
           "version": "2.1.4",
@@ -22583,6 +23145,7 @@
         "npm-path": {
           "version": "1.1.0",
           "integrity": "sha1-BHSuAEGcMn1UcBt88s0F3Ii+EUA=",
+          "dev": true,
           "requires": {
             "which": "1.3.0"
           }
@@ -22590,6 +23153,7 @@
         "npm-run": {
           "version": "1.1.1",
           "integrity": "sha1-xDEkUfOCt67npIWOYCg6vz26yOw=",
+          "dev": true,
           "requires": {
             "minimist": "1.2.0",
             "npm-path": "1.1.0",
@@ -22599,7 +23163,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true
             }
           }
         },
@@ -22687,6 +23252,7 @@
         "nth-check": {
           "version": "1.0.1",
           "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+          "dev": true,
           "requires": {
             "boolbase": "1.0.0"
           }
@@ -22705,7 +23271,8 @@
         },
         "nwmatcher": {
           "version": "1.4.3",
-          "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw=="
+          "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
+          "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -22725,7 +23292,8 @@
         },
         "object-is": {
           "version": "1.0.1",
-          "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+          "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+          "dev": true
         },
         "object-keys": {
           "version": "1.0.11",
@@ -22744,6 +23312,7 @@
         "object.entries": {
           "version": "1.0.4",
           "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+          "dev": true,
           "requires": {
             "define-properties": "1.1.2",
             "es-abstract": "1.10.0",
@@ -22754,6 +23323,7 @@
         "object.getownpropertydescriptors": {
           "version": "2.0.3",
           "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+          "dev": true,
           "requires": {
             "define-properties": "1.1.2",
             "es-abstract": "1.10.0"
@@ -22770,6 +23340,7 @@
         "object.values": {
           "version": "1.0.4",
           "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
+          "dev": true,
           "requires": {
             "define-properties": "1.1.2",
             "es-abstract": "1.10.0",
@@ -22779,7 +23350,8 @@
         },
         "omggif": {
           "version": "1.0.9",
-          "integrity": "sha1-3LcCTazVDFK00wPwSALJHAV8dl8="
+          "integrity": "sha1-3LcCTazVDFK00wPwSALJHAV8dl8=",
+          "dev": true
         },
         "on-finished": {
           "version": "2.3.0",
@@ -22797,19 +23369,23 @@
         },
         "onecolor": {
           "version": "3.0.5",
-          "integrity": "sha1-Nu/zIgE3nv3xGA+0ReUajiQl+fY="
+          "integrity": "sha1-Nu/zIgE3nv3xGA+0ReUajiQl+fY=",
+          "dev": true
         },
         "onetime": {
           "version": "1.1.0",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
         },
         "opener": {
           "version": "1.4.3",
-          "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg="
+          "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
+          "dev": true
         },
         "optimist": {
           "version": "0.6.1",
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "dev": true,
           "requires": {
             "minimist": "0.0.8",
             "wordwrap": "0.0.2"
@@ -22818,6 +23394,7 @@
         "optionator": {
           "version": "0.8.1",
           "integrity": "sha1-4xtJMs3V+4Yqiw0QvGPT7h7H14s=",
+          "dev": true,
           "requires": {
             "deep-is": "0.1.3",
             "fast-levenshtein": "1.1.4",
@@ -22829,7 +23406,8 @@
           "dependencies": {
             "wordwrap": {
               "version": "1.0.0",
-              "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+              "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+              "dev": true
             }
           }
         },
@@ -22867,6 +23445,7 @@
         "output-file-sync": {
           "version": "1.1.2",
           "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "mkdirp": "0.5.1",
@@ -22898,6 +23477,7 @@
         "package-json": {
           "version": "1.2.0",
           "integrity": "sha1-yOysCUInzfdqMWh07QXifMk5oOA=",
+          "dev": true,
           "requires": {
             "got": "3.3.1",
             "registry-url": "3.1.0"
@@ -22983,6 +23563,7 @@
         "parse-data-uri": {
           "version": "0.2.0",
           "integrity": "sha1-vwTYUd1ch7CrI45dAazklLYEtMk=",
+          "dev": true,
           "requires": {
             "data-uri-to-buffer": "0.0.3"
           }
@@ -22990,6 +23571,7 @@
         "parse-entities": {
           "version": "1.1.1",
           "integrity": "sha1-gRLYhHExnyerrk1klksSL+ThuJA=",
+          "dev": true,
           "requires": {
             "character-entities": "1.2.1",
             "character-entities-legacy": "1.1.1",
@@ -23047,6 +23629,7 @@
         "parse5": {
           "version": "3.0.3",
           "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+          "dev": true,
           "requires": {
             "@types/node": "9.4.0"
           }
@@ -23087,6 +23670,7 @@
         "path": {
           "version": "0.12.7",
           "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+          "dev": true,
           "requires": {
             "process": "0.11.10",
             "util": "0.10.3"
@@ -23113,7 +23697,8 @@
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+          "dev": true
         },
         "path-key": {
           "version": "2.0.1",
@@ -23126,13 +23711,15 @@
         "path-root": {
           "version": "0.1.1",
           "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+          "dev": true,
           "requires": {
             "path-root-regex": "0.1.2"
           }
         },
         "path-root-regex": {
           "version": "0.1.2",
-          "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0="
+          "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+          "dev": true
         },
         "path-to-regexp": {
           "version": "0.1.7",
@@ -23222,6 +23809,7 @@
         "pipetteur": {
           "version": "2.0.3",
           "integrity": "sha1-GVV2CVno0aEcsqUOyD7sRwYz5J8=",
+          "dev": true,
           "requires": {
             "onecolor": "3.0.5",
             "synesthesia": "1.0.1"
@@ -23237,21 +23825,25 @@
         "plur": {
           "version": "2.1.2",
           "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+          "dev": true,
           "requires": {
             "irregular-plurals": "1.4.0"
           }
         },
         "pluralize": {
           "version": "1.2.1",
-          "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU="
+          "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+          "dev": true
         },
         "pn": {
           "version": "1.1.0",
-          "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+          "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+          "dev": true
         },
         "pngjs": {
           "version": "2.3.1",
-          "integrity": "sha1-EdHhK5y2TWPjDBQ6Mw9MH1Z9qF8="
+          "integrity": "sha1-EdHhK5y2TWPjDBQ6Mw9MH1Z9qF8=",
+          "dev": true
         },
         "postcss": {
           "version": "5.2.18",
@@ -23405,17 +23997,20 @@
         "postcss-less": {
           "version": "1.1.3",
           "integrity": "sha512-WS0wsQxRm+kmN8wEYAGZ3t4lnoNfoyx9EJZrhiPR1K0lMHR0UNWnz52Ya5QRXChHtY75Ef+kDc05FpnBujebgw==",
+          "dev": true,
           "requires": {
             "postcss": "5.2.18"
           }
         },
         "postcss-media-query-parser": {
           "version": "0.2.3",
-          "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ="
+          "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
+          "dev": true
         },
         "postcss-reporter": {
           "version": "1.4.1",
           "integrity": "sha1-wTbwpbFhkV83ndN2XGEHX357mvI=",
+          "dev": true,
           "requires": {
             "chalk": "1.0.0",
             "lodash": "4.15.0",
@@ -23425,11 +24020,13 @@
         },
         "postcss-resolve-nested-selector": {
           "version": "0.1.1",
-          "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4="
+          "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
+          "dev": true
         },
         "postcss-scss": {
           "version": "1.0.2",
           "integrity": "sha1-/0XPM1S4ee6JpOtoaA9GrJuxT5Q=",
+          "dev": true,
           "requires": {
             "postcss": "6.0.17"
           },
@@ -23437,6 +24034,7 @@
             "ansi-styles": {
               "version": "3.2.0",
               "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "dev": true,
               "requires": {
                 "color-convert": "1.9.1"
               }
@@ -23444,6 +24042,7 @@
             "chalk": {
               "version": "2.3.0",
               "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
               "requires": {
                 "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
@@ -23453,6 +24052,7 @@
                 "supports-color": {
                   "version": "4.5.0",
                   "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+                  "dev": true,
                   "requires": {
                     "has-flag": "2.0.0"
                   }
@@ -23461,15 +24061,18 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
             },
             "has-flag": {
               "version": "2.0.0",
-              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+              "dev": true
             },
             "postcss": {
               "version": "6.0.17",
               "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+              "dev": true,
               "requires": {
                 "chalk": "2.3.0",
                 "source-map": "0.6.1",
@@ -23478,11 +24081,13 @@
             },
             "source-map": {
               "version": "0.6.1",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
             },
             "supports-color": {
               "version": "5.1.0",
               "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+              "dev": true,
               "requires": {
                 "has-flag": "2.0.0"
               }
@@ -23492,6 +24097,7 @@
         "postcss-selector-parser": {
           "version": "2.2.3",
           "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+          "dev": true,
           "requires": {
             "flatten": "1.0.2",
             "indexes-of": "1.0.1",
@@ -23505,6 +24111,7 @@
         "postcss-values-parser": {
           "version": "1.3.1",
           "integrity": "sha512-chFn9CnFAAUpQ3cwrxvVjKB8c0y6BfONv6eapndJoTXJ3h8fr1uAiue8lGP3rUIpBI2KgJGdgCVk9KNvXh0n6A==",
+          "dev": true,
           "requires": {
             "flatten": "1.0.2",
             "indexes-of": "1.0.1",
@@ -23540,11 +24147,13 @@
         },
         "prelude-ls": {
           "version": "1.1.2",
-          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+          "dev": true
         },
         "prepend-http": {
           "version": "1.0.4",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+          "dev": true
         },
         "preserve": {
           "version": "0.2.0",
@@ -23596,11 +24205,13 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
             },
             "ansi-styles": {
               "version": "3.2.0",
               "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "dev": true,
               "requires": {
                 "color-convert": "1.9.1"
               }
@@ -23608,6 +24219,7 @@
             "babel-code-frame": {
               "version": "7.0.0-beta.3",
               "integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
+              "dev": true,
               "requires": {
                 "chalk": "2.1.0",
                 "esutils": "2.0.2",
@@ -23616,15 +24228,18 @@
             },
             "babylon": {
               "version": "7.0.0-beta.34",
-              "integrity": "sha512-ribEzWEhWKKjY+1FdKCryo+HiN/1idPjUB8vyR5Yf221MtGzCd5+7OwPvWvYHerHHC2eJLr6MhvumbTocXGY7Q=="
+              "integrity": "sha512-ribEzWEhWKKjY+1FdKCryo+HiN/1idPjUB8vyR5Yf221MtGzCd5+7OwPvWvYHerHHC2eJLr6MhvumbTocXGY7Q==",
+              "dev": true
             },
             "camelcase": {
               "version": "4.1.0",
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+              "dev": true
             },
             "chalk": {
               "version": "2.1.0",
               "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+              "dev": true,
               "requires": {
                 "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
@@ -23633,42 +24248,51 @@
             },
             "diff": {
               "version": "3.2.0",
-              "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
+              "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+              "dev": true
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
             },
             "flow-parser": {
               "version": "0.59.0",
-              "integrity": "sha1-9uvK5h/6GH5CCZnUDOCoAfObJjU="
+              "integrity": "sha1-9uvK5h/6GH5CCZnUDOCoAfObJjU=",
+              "dev": true
             },
             "has-flag": {
               "version": "2.0.0",
-              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+              "dev": true
             },
             "ignore": {
               "version": "3.3.7",
-              "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
+              "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+              "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
             },
             "jest-docblock": {
               "version": "21.3.0-beta.11",
               "integrity": "sha512-sxSwZUm7JyCO8dverup5g/OKJhjYRrBdgEdezIO1qAmMGWuza7ewovpfDmxp+JLvlm0i2WRFKUQNNIMGmPGTVg==",
+              "dev": true,
               "requires": {
                 "detect-newline": "2.1.0"
               }
             },
             "jest-get-type": {
               "version": "21.2.0",
-              "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q=="
+              "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+              "dev": true
             },
             "jest-validate": {
               "version": "21.1.0",
               "integrity": "sha512-xS0cyErNWpsLFlGkn/b87pk/Mv7J+mCTs8hQ4KmtOIIoM1sHYobXII8AtkoN8FC7E3+Ptxjo+/3xWk6LK1dKcw==",
+              "dev": true,
               "requires": {
                 "chalk": "2.1.0",
                 "jest-get-type": "21.2.0",
@@ -23678,15 +24302,18 @@
             },
             "leven": {
               "version": "2.1.0",
-              "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+              "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+              "dev": true
             },
             "minimist": {
               "version": "1.2.0",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true
             },
             "pretty-format": {
               "version": "21.2.1",
               "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+              "dev": true,
               "requires": {
                 "ansi-regex": "3.0.0",
                 "ansi-styles": "3.2.0"
@@ -23694,11 +24321,13 @@
             },
             "semver": {
               "version": "5.4.1",
-              "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+              "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+              "dev": true
             },
             "string-width": {
               "version": "2.1.1",
               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "dev": true,
               "requires": {
                 "is-fullwidth-code-point": "2.0.0",
                 "strip-ansi": "4.0.0"
@@ -23707,6 +24336,7 @@
             "strip-ansi": {
               "version": "4.0.0",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
               "requires": {
                 "ansi-regex": "3.0.0"
               }
@@ -23714,6 +24344,7 @@
             "supports-color": {
               "version": "4.5.0",
               "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
               "requires": {
                 "has-flag": "2.0.0"
               }
@@ -23722,11 +24353,13 @@
         },
         "pretty-bytes": {
           "version": "4.0.2",
-          "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
+          "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
+          "dev": true
         },
         "pretty-format": {
           "version": "22.1.0",
           "integrity": "sha512-0HHR5hCmjDGU4sez3w5zRDAAwn7V0vT4SgPiYPZ1XDm5sT3Icb+Bh+fsOP3+Y3UwPjMr7TbRj+L7eQyMkPAxAw==",
+          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0",
             "ansi-styles": "3.2.0"
@@ -23734,11 +24367,13 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
             },
             "ansi-styles": {
               "version": "3.2.0",
               "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "dev": true,
               "requires": {
                 "color-convert": "1.9.1"
               }
@@ -23783,7 +24418,8 @@
         },
         "progress": {
           "version": "1.1.8",
-          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
+          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+          "dev": true
         },
         "progress-event": {
           "version": "1.0.0",
@@ -23810,11 +24446,13 @@
         },
         "propagate": {
           "version": "0.4.0",
-          "integrity": "sha1-8/zKCm/gZzanulcpZgaWF8EwtIE="
+          "integrity": "sha1-8/zKCm/gZzanulcpZgaWF8EwtIE=",
+          "dev": true
         },
         "protochain": {
           "version": "1.0.5",
-          "integrity": "sha1-mRxAfpneJkqt+PgVBLXn+ve/omA="
+          "integrity": "sha1-mRxAfpneJkqt+PgVBLXn+ve/omA=",
+          "dev": true
         },
         "proxy-addr": {
           "version": "1.0.10",
@@ -24032,13 +24670,15 @@
         "raf": {
           "version": "3.4.0",
           "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
+          "dev": true,
           "requires": {
             "performance-now": "2.1.0"
           }
         },
         "railroad-diagrams": {
           "version": "1.0.0",
-          "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
+          "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
+          "dev": true
         },
         "ramda": {
           "version": "0.24.1",
@@ -24047,6 +24687,7 @@
         "randexp": {
           "version": "0.4.6",
           "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+          "dev": true,
           "requires": {
             "discontinuous-range": "1.0.0",
             "ret": "0.1.15"
@@ -24182,11 +24823,13 @@
           "dependencies": {
             "acorn": {
               "version": "4.0.13",
-              "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+              "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+              "dev": true
             },
             "babel-jest": {
               "version": "15.0.0",
               "integrity": "sha1-ap4uOZnyQTg9uaseLvZwRAHXQkI=",
+              "dev": true,
               "requires": {
                 "babel-core": "6.25.0",
                 "babel-plugin-istanbul": "2.0.3",
@@ -24196,6 +24839,7 @@
             "babel-plugin-istanbul": {
               "version": "2.0.3",
               "integrity": "sha1-JmswS5EJYH1gdIR0OUZ2mC9mDfQ=",
+              "dev": true,
               "requires": {
                 "find-up": "1.1.2",
                 "istanbul-lib-instrument": "1.9.1",
@@ -24205,11 +24849,13 @@
             },
             "babel-plugin-jest-hoist": {
               "version": "15.0.0",
-              "integrity": "sha1-ey/b0M0S/DaoTT9f8AHsUEJiu1k="
+              "integrity": "sha1-ey/b0M0S/DaoTT9f8AHsUEJiu1k=",
+              "dev": true
             },
             "babel-preset-jest": {
               "version": "15.0.0",
               "integrity": "sha1-8jmI8fkYZz/5tHD9/WD8wZvGGPU=",
+              "dev": true,
               "requires": {
                 "babel-plugin-jest-hoist": "15.0.0"
               }
@@ -24217,21 +24863,25 @@
             "bser": {
               "version": "1.0.2",
               "integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
+              "dev": true,
               "requires": {
                 "node-int64": "0.4.0"
               }
             },
             "callsites": {
               "version": "2.0.0",
-              "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+              "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+              "dev": true
             },
             "camelcase": {
               "version": "3.0.0",
-              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+              "dev": true
             },
             "chalk": {
               "version": "1.1.3",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
               "requires": {
                 "ansi-styles": "2.2.1",
                 "escape-string-regexp": "1.0.3",
@@ -24242,11 +24892,13 @@
             },
             "cli-width": {
               "version": "2.2.0",
-              "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+              "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+              "dev": true
             },
             "cliui": {
               "version": "3.2.0",
               "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+              "dev": true,
               "requires": {
                 "string-width": "1.0.2",
                 "strip-ansi": "3.0.1",
@@ -24256,6 +24908,7 @@
             "doctrine": {
               "version": "1.5.0",
               "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+              "dev": true,
               "requires": {
                 "esutils": "2.0.2",
                 "isarray": "1.0.0"
@@ -24264,6 +24917,7 @@
             "eslint": {
               "version": "2.13.1",
               "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
+              "dev": true,
               "requires": {
                 "chalk": "1.1.3",
                 "concat-stream": "1.5.2",
@@ -24303,6 +24957,7 @@
             "fb-watchman": {
               "version": "1.9.2",
               "integrity": "sha1-okz0eCf4LTj7Waaa1wt247auc4M=",
+              "dev": true,
               "requires": {
                 "bser": "1.0.2"
               }
@@ -24310,6 +24965,7 @@
             "file-entry-cache": {
               "version": "1.3.1",
               "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
+              "dev": true,
               "requires": {
                 "flat-cache": "1.3.0",
                 "object-assign": "4.1.1"
@@ -24318,6 +24974,7 @@
             "find-up": {
               "version": "1.1.2",
               "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "dev": true,
               "requires": {
                 "path-exists": "2.1.0",
                 "pinkie-promise": "2.0.1"
@@ -24326,6 +24983,7 @@
             "inquirer": {
               "version": "0.12.0",
               "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+              "dev": true,
               "requires": {
                 "ansi-escapes": "1.4.0",
                 "ansi-regex": "2.1.1",
@@ -24345,6 +25003,7 @@
             "jest": {
               "version": "17.0.3",
               "integrity": "sha1-icQ7MLCqrUJGLp6nATUtrLrUo1Q=",
+              "dev": true,
               "requires": {
                 "jest-cli": "17.0.3"
               },
@@ -24352,6 +25011,7 @@
                 "jest-cli": {
                   "version": "17.0.3",
                   "integrity": "sha1-cAuMAqnqDsnqsM1an9QtioWM4UY=",
+                  "dev": true,
                   "requires": {
                     "ansi-escapes": "1.4.0",
                     "callsites": "2.0.0",
@@ -24387,11 +25047,13 @@
             },
             "jest-changed-files": {
               "version": "17.0.2",
-              "integrity": "sha1-9WV3WHNplvWQpRuH5ck2nZBLp7c="
+              "integrity": "sha1-9WV3WHNplvWQpRuH5ck2nZBLp7c=",
+              "dev": true
             },
             "jest-config": {
               "version": "17.0.3",
               "integrity": "sha1-tu112Q0JC3Mf2JQjGQTK231aXfI=",
+              "dev": true,
               "requires": {
                 "chalk": "1.1.3",
                 "istanbul": "0.4.5",
@@ -24407,6 +25069,7 @@
             "jest-diff": {
               "version": "17.0.3",
               "integrity": "sha1-j7Me+rOzFNe2G3tmsL3qYX7xwC8=",
+              "dev": true,
               "requires": {
                 "chalk": "1.1.3",
                 "diff": "3.4.0",
@@ -24417,6 +25080,7 @@
             "jest-environment-jsdom": {
               "version": "17.0.2",
               "integrity": "sha1-owmNwpgG1AgCxStiuEiraqAP26A=",
+              "dev": true,
               "requires": {
                 "jest-mock": "17.0.2",
                 "jest-util": "17.0.2",
@@ -24426,6 +25090,7 @@
             "jest-environment-node": {
               "version": "17.0.2",
               "integrity": "sha1-r/YTP0yi+t3MWwzn0lzsg+FthGM=",
+              "dev": true,
               "requires": {
                 "jest-mock": "17.0.2",
                 "jest-util": "17.0.2"
@@ -24434,6 +25099,7 @@
             "jest-haste-map": {
               "version": "17.0.3",
               "integrity": "sha1-UjJ4PnBXche2sX0qHBdmY3odL70=",
+              "dev": true,
               "requires": {
                 "fb-watchman": "1.9.2",
                 "graceful-fs": "4.1.11",
@@ -24445,6 +25111,7 @@
             "jest-jasmine2": {
               "version": "17.0.3",
               "integrity": "sha1-1DNrifOtKIJpocjiv8GA3PicatE=",
+              "dev": true,
               "requires": {
                 "graceful-fs": "4.1.11",
                 "jest-matchers": "17.0.3",
@@ -24455,6 +25122,7 @@
             "jest-matcher-utils": {
               "version": "17.0.3",
               "integrity": "sha1-8Qjkm5VuFSxmJtzAq6hk9Zq3sNM=",
+              "dev": true,
               "requires": {
                 "chalk": "1.1.3",
                 "pretty-format": "4.2.3"
@@ -24462,11 +25130,13 @@
             },
             "jest-mock": {
               "version": "17.0.2",
-              "integrity": "sha1-Pf6SIa/ZqmGz2ZkoQIE6NYuy9Ck="
+              "integrity": "sha1-Pf6SIa/ZqmGz2ZkoQIE6NYuy9Ck=",
+              "dev": true
             },
             "jest-resolve": {
               "version": "17.0.3",
               "integrity": "sha1-dpKnneKDGHQ3Xp1mS8eCwp5NomI=",
+              "dev": true,
               "requires": {
                 "browser-resolve": "1.11.2",
                 "jest-file-exists": "17.0.0",
@@ -24477,6 +25147,7 @@
             "jest-resolve-dependencies": {
               "version": "17.0.3",
               "integrity": "sha1-u9N/RkNwS5epgJJyEvOrErBuiJQ=",
+              "dev": true,
               "requires": {
                 "jest-file-exists": "17.0.0",
                 "jest-resolve": "17.0.3"
@@ -24485,6 +25156,7 @@
             "jest-runtime": {
               "version": "17.0.3",
               "integrity": "sha1-7/QFX+jD4XyV7Rqq9fcZxCC4ax8=",
+              "dev": true,
               "requires": {
                 "babel-core": "6.25.0",
                 "babel-jest": "17.0.2",
@@ -24506,6 +25178,7 @@
                 "babel-jest": {
                   "version": "17.0.2",
                   "integrity": "sha1-jVHg0DdZcTwzHxCOsLLqpMbv/3Q=",
+                  "dev": true,
                   "requires": {
                     "babel-core": "6.25.0",
                     "babel-plugin-istanbul": "2.0.3",
@@ -24514,11 +25187,13 @@
                 },
                 "babel-plugin-jest-hoist": {
                   "version": "17.0.2",
-                  "integrity": "sha1-ITSIzoJZkKzUww+IfcoJ//60UjU="
+                  "integrity": "sha1-ITSIzoJZkKzUww+IfcoJ//60UjU=",
+                  "dev": true
                 },
                 "babel-preset-jest": {
                   "version": "17.0.2",
                   "integrity": "sha1-FB6TXevhZKqgNkwiDTHMshdkk7I=",
+                  "dev": true,
                   "requires": {
                     "babel-plugin-jest-hoist": "17.0.2"
                   }
@@ -24528,6 +25203,7 @@
             "jest-snapshot": {
               "version": "17.0.3",
               "integrity": "sha1-yBmdtMy9VRXP7MjoAKsHa92nq8A=",
+              "dev": true,
               "requires": {
                 "jest-diff": "17.0.3",
                 "jest-file-exists": "17.0.0",
@@ -24540,6 +25216,7 @@
             "jest-util": {
               "version": "17.0.2",
               "integrity": "sha1-n9nagJHpkE+5dtp+TYkSyiaWhjg=",
+              "dev": true,
               "requires": {
                 "chalk": "1.1.3",
                 "diff": "3.4.0",
@@ -24552,6 +25229,7 @@
             "jsdom": {
               "version": "9.12.0",
               "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
+              "dev": true,
               "requires": {
                 "abab": "1.0.4",
                 "acorn": "4.0.13",
@@ -24577,6 +25255,7 @@
             "lodash.clonedeep": {
               "version": "3.0.2",
               "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+              "dev": true,
               "requires": {
                 "lodash._baseclone": "3.3.0",
                 "lodash._bindcallback": "3.0.1"
@@ -24584,11 +25263,13 @@
             },
             "minimist": {
               "version": "1.2.0",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true
             },
             "node-notifier": {
               "version": "4.6.1",
               "integrity": "sha1-BW0UJE89zBzq3+aK+c/wxUc6M/M=",
+              "dev": true,
               "requires": {
                 "cli-usage": "0.1.7",
                 "growly": "1.3.0",
@@ -24601,22 +25282,26 @@
             },
             "parse5": {
               "version": "1.5.1",
-              "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
+              "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+              "dev": true
             },
             "path-exists": {
               "version": "2.1.0",
               "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+              "dev": true,
               "requires": {
                 "pinkie-promise": "2.0.1"
               }
             },
             "pretty-format": {
               "version": "4.2.3",
-              "integrity": "sha1-iJTCrIFBnPgBYp2PZjIKJTgNiwU="
+              "integrity": "sha1-iJTCrIFBnPgBYp2PZjIKJTgNiwU=",
+              "dev": true
             },
             "sane": {
               "version": "1.4.1",
               "integrity": "sha1-iPdj10BA9fDCVrYWPbOZvxEKxxU=",
+              "dev": true,
               "requires": {
                 "exec-sh": "0.2.1",
                 "fb-watchman": "1.9.2",
@@ -24628,15 +25313,18 @@
             },
             "strip-json-comments": {
               "version": "1.0.4",
-              "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
+              "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+              "dev": true
             },
             "supports-color": {
               "version": "2.0.0",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
             },
             "test-exclude": {
               "version": "2.1.3",
               "integrity": "sha1-qNiWjh2oMmb5hk8oUsVeIg8GQ0o=",
+              "dev": true,
               "requires": {
                 "arrify": "1.0.1",
                 "micromatch": "2.3.11",
@@ -24647,26 +25335,31 @@
             },
             "throat": {
               "version": "3.2.0",
-              "integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w=="
+              "integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w==",
+              "dev": true
             },
             "tr46": {
               "version": "0.0.3",
-              "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+              "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+              "dev": true
             },
             "user-home": {
               "version": "2.0.0",
               "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+              "dev": true,
               "requires": {
                 "os-homedir": "1.0.2"
               }
             },
             "watch": {
               "version": "0.10.0",
-              "integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw="
+              "integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw=",
+              "dev": true
             },
             "whatwg-url": {
               "version": "4.8.0",
               "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
+              "dev": true,
               "requires": {
                 "tr46": "0.0.3",
                 "webidl-conversions": "3.0.1"
@@ -24674,17 +25367,20 @@
               "dependencies": {
                 "webidl-conversions": {
                   "version": "3.0.1",
-                  "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+                  "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+                  "dev": true
                 }
               }
             },
             "xml-name-validator": {
               "version": "2.0.1",
-              "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
+              "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+              "dev": true
             },
             "yargs": {
               "version": "6.6.0",
               "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+              "dev": true,
               "requires": {
                 "camelcase": "3.0.0",
                 "cliui": "3.2.0",
@@ -24704,6 +25400,7 @@
             "yargs-parser": {
               "version": "4.2.1",
               "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+              "dev": true,
               "requires": {
                 "camelcase": "3.0.0"
               }
@@ -24787,6 +25484,7 @@
         "react-reconciler": {
           "version": "0.7.0",
           "integrity": "sha512-50JwZ3yNyMS8fchN+jjWEJOH3Oze7UmhxeoJLn2j6f3NjpfCRbcmih83XTWmzqtar/ivd5f7tvQhvvhism2fgg==",
+          "dev": true,
           "requires": {
             "fbjs": "0.8.16",
             "loose-envify": "1.3.1",
@@ -24797,6 +25495,7 @@
             "prop-types": {
               "version": "15.6.0",
               "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+              "dev": true,
               "requires": {
                 "fbjs": "0.8.16",
                 "loose-envify": "1.3.1",
@@ -24826,6 +25525,7 @@
         "react-test-renderer": {
           "version": "16.2.0",
           "integrity": "sha512-Kd4gJFtpNziR9ElOE/C23LeflKLZPRpNQYWP3nQBY43SJ5a+xyEGSeMrm2zxNKXcnCbBS/q1UpD9gqd5Dv+rew==",
+          "dev": true,
           "requires": {
             "fbjs": "0.8.16",
             "object-assign": "4.1.1",
@@ -24835,6 +25535,7 @@
             "prop-types": {
               "version": "15.6.0",
               "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+              "dev": true,
               "requires": {
                 "fbjs": "0.8.16",
                 "loose-envify": "1.3.1",
@@ -24880,6 +25581,7 @@
         "read-all-stream": {
           "version": "3.1.0",
           "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
+          "dev": true,
           "requires": {
             "pinkie-promise": "2.0.1",
             "readable-stream": "2.3.3"
@@ -24887,11 +25589,13 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.3",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true
             },
             "readable-stream": {
               "version": "2.3.3",
               "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+              "dev": true,
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -24905,6 +25609,7 @@
             "string_decoder": {
               "version": "1.0.3",
               "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+              "dev": true,
               "requires": {
                 "safe-buffer": "5.1.1"
               }
@@ -25006,11 +25711,13 @@
         },
         "readline-sync": {
           "version": "1.4.5",
-          "integrity": "sha1-xw0rFHPsq8Hk1TPLrz6CSft36ZI="
+          "integrity": "sha1-xw0rFHPsq8Hk1TPLrz6CSft36ZI=",
+          "dev": true
         },
         "readline2": {
           "version": "1.0.1",
           "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+          "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -25020,6 +25727,7 @@
         "realpath-native": {
           "version": "1.0.0",
           "integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
+          "dev": true,
           "requires": {
             "util.promisify": "1.0.0"
           }
@@ -25051,13 +25759,15 @@
         "redeyed": {
           "version": "1.0.1",
           "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
+          "dev": true,
           "requires": {
             "esprima": "3.0.0"
           },
           "dependencies": {
             "esprima": {
               "version": "3.0.0",
-              "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k="
+              "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k=",
+              "dev": true
             }
           }
         },
@@ -25104,6 +25814,7 @@
         "regenerator": {
           "version": "0.8.40",
           "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
+          "dev": true,
           "requires": {
             "commoner": "0.10.8",
             "defs": "1.1.1",
@@ -25115,15 +25826,18 @@
           "dependencies": {
             "ast-types": {
               "version": "0.8.12",
-              "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w="
+              "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w=",
+              "dev": true
             },
             "esprima-fb": {
               "version": "15001.1001.0-dev-harmony-fb",
-              "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
+              "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+              "dev": true
             },
             "recast": {
               "version": "0.10.33",
               "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
+              "dev": true,
               "requires": {
                 "ast-types": "0.8.12",
                 "esprima-fb": "15001.1001.0-dev-harmony-fb",
@@ -25133,7 +25847,8 @@
             },
             "source-map": {
               "version": "0.5.7",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
             }
           }
         },
@@ -25160,6 +25875,7 @@
         "regexpu": {
           "version": "1.3.0",
           "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
+          "dev": true,
           "requires": {
             "esprima": "2.7.3",
             "recast": "0.10.43",
@@ -25170,15 +25886,18 @@
           "dependencies": {
             "ast-types": {
               "version": "0.8.15",
-              "integrity": "sha1-ju8IJ/BN/w7IhXupJavj/qYZTlI="
+              "integrity": "sha1-ju8IJ/BN/w7IhXupJavj/qYZTlI=",
+              "dev": true
             },
             "esprima": {
               "version": "2.7.3",
-              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+              "dev": true
             },
             "recast": {
               "version": "0.10.43",
               "integrity": "sha1-uV1Q9tYHYaX2JS4V2AZ4FoSRzn8=",
+              "dev": true,
               "requires": {
                 "ast-types": "0.8.15",
                 "esprima-fb": "15001.1001.0-dev-harmony-fb",
@@ -25188,13 +25907,15 @@
               "dependencies": {
                 "esprima-fb": {
                   "version": "15001.1001.0-dev-harmony-fb",
-                  "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
+                  "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+                  "dev": true
                 }
               }
             },
             "source-map": {
               "version": "0.5.7",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
             }
           }
         },
@@ -25210,6 +25931,7 @@
         "registry-url": {
           "version": "3.1.0",
           "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+          "dev": true,
           "requires": {
             "rc": "1.2.5"
           }
@@ -25238,6 +25960,7 @@
         "remark-frontmatter": {
           "version": "1.1.0",
           "integrity": "sha512-mLbYtwP9w1L9TA8dX+I/HyDF5lCpa0dmYvvW9Io+zUPpqEZ49QMKWb0hSpunpLVA+Squy0SowzSzjHVPbxWq1g==",
+          "dev": true,
           "requires": {
             "fault": "1.0.1",
             "xtend": "4.0.1"
@@ -25246,6 +25969,7 @@
         "remark-parse": {
           "version": "4.0.0",
           "integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
+          "dev": true,
           "requires": {
             "collapse-white-space": "1.0.3",
             "is-alphabetical": "1.0.1",
@@ -25285,7 +26009,8 @@
         },
         "replace-ext": {
           "version": "1.0.0",
-          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+          "dev": true
         },
         "request": {
           "version": "2.83.0",
@@ -25328,6 +26053,7 @@
         "request-promise-core": {
           "version": "1.1.1",
           "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+          "dev": true,
           "requires": {
             "lodash": "4.15.0"
           }
@@ -25335,6 +26061,7 @@
         "request-promise-native": {
           "version": "1.0.5",
           "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+          "dev": true,
           "requires": {
             "request-promise-core": "1.1.1",
             "stealthy-require": "1.1.1",
@@ -25347,7 +26074,8 @@
         },
         "require-from-string": {
           "version": "2.0.1",
-          "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8="
+          "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+          "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
@@ -25356,6 +26084,7 @@
         "require-uncached": {
           "version": "1.0.3",
           "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+          "dev": true,
           "requires": {
             "caller-path": "0.1.0",
             "resolve-from": "1.0.1"
@@ -25363,7 +26092,8 @@
         },
         "requireindex": {
           "version": "1.1.0",
-          "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI="
+          "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
+          "dev": true
         },
         "resolve": {
           "version": "1.5.0",
@@ -25375,23 +26105,27 @@
         "resolve-cwd": {
           "version": "2.0.0",
           "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+          "dev": true,
           "requires": {
             "resolve-from": "3.0.0"
           },
           "dependencies": {
             "resolve-from": {
               "version": "3.0.0",
-              "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+              "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+              "dev": true
             }
           }
         },
         "resolve-from": {
           "version": "1.0.1",
-          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+          "dev": true
         },
         "restore-cursor": {
           "version": "1.0.1",
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
           "requires": {
             "exit-hook": "1.1.1",
             "onetime": "1.1.0"
@@ -25399,7 +26133,8 @@
         },
         "ret": {
           "version": "0.1.15",
-          "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+          "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+          "dev": true
         },
         "reverse-arguments": {
           "version": "1.0.0",
@@ -25444,19 +26179,22 @@
         "rocambole": {
           "version": "0.7.0",
           "integrity": "sha1-9seVBVF9xCtvuECEK4uVOw+WhYU=",
+          "dev": true,
           "requires": {
             "esprima": "2.7.3"
           },
           "dependencies": {
             "esprima": {
               "version": "2.7.3",
-              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+              "dev": true
             }
           }
         },
         "rocambole-indent": {
           "version": "2.0.4",
           "integrity": "sha1-oYokl3ygQAuGHapGMehh3LUtCFw=",
+          "dev": true,
           "requires": {
             "debug": "2.2.0",
             "mout": "0.11.1",
@@ -25465,13 +26203,15 @@
           "dependencies": {
             "mout": {
               "version": "0.11.1",
-              "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k="
+              "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k=",
+              "dev": true
             }
           }
         },
         "rocambole-linebreak": {
           "version": "1.0.2",
           "integrity": "sha1-A2IVFbQ7RyHJflocG8paA2Y2jy8=",
+          "dev": true,
           "requires": {
             "debug": "2.2.0",
             "rocambole-token": "1.2.1",
@@ -25480,21 +26220,25 @@
           "dependencies": {
             "semver": {
               "version": "4.3.6",
-              "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+              "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+              "dev": true
             }
           }
         },
         "rocambole-node": {
           "version": "1.0.0",
-          "integrity": "sha1-21tJ3nQHsAgN1RSHLyjjk9D3/z8="
+          "integrity": "sha1-21tJ3nQHsAgN1RSHLyjjk9D3/z8=",
+          "dev": true
         },
         "rocambole-token": {
           "version": "1.2.1",
-          "integrity": "sha1-x4XfdCjcPLJ614lwR71SOMwHDTU="
+          "integrity": "sha1-x4XfdCjcPLJ614lwR71SOMwHDTU=",
+          "dev": true
         },
         "rocambole-whitespace": {
           "version": "1.0.0",
           "integrity": "sha1-YzMJSSVrKZQfWbGQRZ+ZnGsdO/k=",
+          "dev": true,
           "requires": {
             "debug": "2.2.0",
             "repeat-string": "1.6.1",
@@ -25504,6 +26248,7 @@
         "rst-selector-parser": {
           "version": "2.2.3",
           "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
+          "dev": true,
           "requires": {
             "lodash.flattendeep": "4.4.0",
             "nearley": "2.11.0"
@@ -25578,6 +26323,7 @@
         "run-async": {
           "version": "0.1.0",
           "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+          "dev": true,
           "requires": {
             "once": "1.4.0"
           }
@@ -25595,7 +26341,8 @@
         },
         "rx-lite": {
           "version": "3.1.2",
-          "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
+          "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+          "dev": true
         },
         "safe-buffer": {
           "version": "5.1.1",
@@ -25603,11 +26350,13 @@
         },
         "samsam": {
           "version": "1.1.2",
-          "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc="
+          "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+          "dev": true
         },
         "sane": {
           "version": "2.3.0",
           "integrity": "sha512-6GB9zPCsqJqQPAGcvEkUPijM1ZUFI+A/DrscL++dXO3Ltt5q5mPDayGxZtr3cBRkrbb4akbwszVVkTIFefEkcg==",
+          "dev": true,
           "requires": {
             "anymatch": "1.3.2",
             "exec-sh": "0.2.1",
@@ -25621,7 +26370,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true
             }
           }
         },
@@ -25683,7 +26433,8 @@
         },
         "sax": {
           "version": "1.2.4",
-          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+          "dev": true
         },
         "schema-utils": {
           "version": "0.3.0",
@@ -25724,6 +26475,7 @@
         "semver-diff": {
           "version": "2.1.0",
           "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+          "dev": true,
           "requires": {
             "semver": "5.1.0"
           }
@@ -25778,6 +26530,7 @@
         "serializerr": {
           "version": "1.0.3",
           "integrity": "sha1-EtTFqhw/+49tHcXzlaqUVVacP5E=",
+          "dev": true,
           "requires": {
             "protochain": "1.0.5"
           }
@@ -25878,15 +26631,18 @@
         },
         "shelljs": {
           "version": "0.6.1",
-          "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg="
+          "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
+          "dev": true
         },
         "shellwords": {
           "version": "0.1.1",
-          "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+          "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+          "dev": true
         },
         "sigmund": {
           "version": "1.0.1",
-          "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+          "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+          "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
@@ -25894,7 +26650,8 @@
         },
         "simple-fmt": {
           "version": "0.1.0",
-          "integrity": "sha1-GRv1ZqWeZTBILLJatTtKjchcOms="
+          "integrity": "sha1-GRv1ZqWeZTBILLJatTtKjchcOms=",
+          "dev": true
         },
         "simple-get": {
           "version": "1.4.3",
@@ -25907,11 +26664,13 @@
         },
         "simple-is": {
           "version": "0.2.0",
-          "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA="
+          "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA=",
+          "dev": true
         },
         "sinon": {
           "version": "1.17.7",
           "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+          "dev": true,
           "requires": {
             "formatio": "1.1.1",
             "lolex": "1.3.2",
@@ -25921,7 +26680,8 @@
         },
         "sinon-chai": {
           "version": "2.8.0",
-          "integrity": "sha1-Qyqbv9Uab8AHmPTSUmqCnAYGh6w="
+          "integrity": "sha1-Qyqbv9Uab8AHmPTSUmqCnAYGh6w=",
+          "dev": true
         },
         "slash": {
           "version": "1.0.0",
@@ -25929,11 +26689,13 @@
         },
         "slice-ansi": {
           "version": "0.0.4",
-          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+          "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+          "dev": true
         },
         "snake-case": {
           "version": "1.1.2",
@@ -25956,6 +26718,7 @@
         "socket.io": {
           "version": "1.4.5",
           "integrity": "sha1-8gL0nuuc989sCXGtddjZbUUepPc=",
+          "dev": true,
           "requires": {
             "debug": "2.2.0",
             "engine.io": "1.6.8",
@@ -25968,6 +26731,7 @@
         "socket.io-adapter": {
           "version": "0.4.0",
           "integrity": "sha1-+5+CqxqmUpC/csNleVW5MKmRok8=",
+          "dev": true,
           "requires": {
             "debug": "2.2.0",
             "socket.io-parser": "2.2.2"
@@ -25975,19 +26739,23 @@
           "dependencies": {
             "component-emitter": {
               "version": "1.1.2",
-              "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM="
+              "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
+              "dev": true
             },
             "isarray": {
               "version": "0.0.1",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+              "dev": true
             },
             "json3": {
               "version": "3.2.6",
-              "integrity": "sha1-9u/JPAagTemuxTBT3yVZuxniA4s="
+              "integrity": "sha1-9u/JPAagTemuxTBT3yVZuxniA4s=",
+              "dev": true
             },
             "socket.io-parser": {
               "version": "2.2.2",
               "integrity": "sha1-PXr2tkSX6Va32f53X5mXFgJ/lBc=",
+              "dev": true,
               "requires": {
                 "benchmark": "1.0.0",
                 "component-emitter": "1.1.2",
@@ -25998,7 +26766,8 @@
               "dependencies": {
                 "debug": {
                   "version": "0.7.4",
-                  "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+                  "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+                  "dev": true
                 }
               }
             }
@@ -26071,7 +26840,8 @@
         },
         "sparkles": {
           "version": "1.0.0",
-          "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
+          "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+          "dev": true
         },
         "spdx-correct": {
           "version": "1.0.2",
@@ -26090,7 +26860,8 @@
         },
         "specificity": {
           "version": "0.2.1",
-          "integrity": "sha1-OnBHwqF581Ni45kHRc6lOfFRYbg="
+          "integrity": "sha1-OnBHwqF581Ni45kHRc6lOfFRYbg=",
+          "dev": true
         },
         "split": {
           "version": "0.3.3",
@@ -26102,13 +26873,15 @@
         "split2": {
           "version": "0.2.1",
           "integrity": "sha1-At2smtwD7Au3jBKC7Aecpuha6QA=",
+          "dev": true,
           "requires": {
             "through2": "0.6.5"
           }
         },
         "sprintf-js": {
           "version": "1.0.3",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
         },
         "sshpk": {
           "version": "1.13.1",
@@ -26133,15 +26906,18 @@
         },
         "stable": {
           "version": "0.1.6",
-          "integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA="
+          "integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA=",
+          "dev": true
         },
         "stack-utils": {
           "version": "1.0.1",
-          "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
+          "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+          "dev": true
         },
         "state-toggle": {
           "version": "1.0.0",
-          "integrity": "sha1-0g+aYWu08MO5i5GSLSW2QKorxCU="
+          "integrity": "sha1-0g+aYWu08MO5i5GSLSW2QKorxCU=",
+          "dev": true
         },
         "statuses": {
           "version": "1.4.0",
@@ -26149,7 +26925,8 @@
         },
         "stdin": {
           "version": "0.0.1",
-          "integrity": "sha1-0wQZgarsPf28d6GzjWNy449ftx4="
+          "integrity": "sha1-0wQZgarsPf28d6GzjWNy449ftx4=",
+          "dev": true
         },
         "stdout-stream": {
           "version": "1.4.0",
@@ -26186,7 +26963,8 @@
         },
         "stealthy-require": {
           "version": "1.1.1",
-          "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+          "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+          "dev": true
         },
         "store": {
           "version": "1.3.16",
@@ -26289,6 +27067,7 @@
         "string-kit": {
           "version": "0.6.7",
           "integrity": "sha512-vp0M5wCN2U1R3W3lBfs+Kyt9nAY5sGnn97OQ94dW9ifTEPm9StbGkhhv4boea6koioTRmFTtbuyof+2nu7c5uw==",
+          "dev": true,
           "requires": {
             "xregexp": "3.2.0"
           }
@@ -26296,6 +27075,7 @@
         "string-length": {
           "version": "2.0.0",
           "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+          "dev": true,
           "requires": {
             "astral-regex": "1.0.0",
             "strip-ansi": "4.0.0"
@@ -26303,11 +27083,13 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
               "requires": {
                 "ansi-regex": "3.0.0"
               }
@@ -26338,11 +27120,13 @@
         },
         "stringmap": {
           "version": "0.2.2",
-          "integrity": "sha1-VWwTeyWPlCuHdvWy71gqoGnX0bE="
+          "integrity": "sha1-VWwTeyWPlCuHdvWy71gqoGnX0bE=",
+          "dev": true
         },
         "stringset": {
           "version": "0.2.1",
-          "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU="
+          "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU=",
+          "dev": true
         },
         "stringstream": {
           "version": "0.0.5",
@@ -26384,6 +27168,7 @@
         "stylehacks": {
           "version": "2.3.2",
           "integrity": "sha1-ZMg+BDimjJ7fRJ6MVSp9mrYAmws=",
+          "dev": true,
           "requires": {
             "browserslist": "1.3.6",
             "chalk": "1.1.3",
@@ -26401,6 +27186,7 @@
             "chalk": {
               "version": "1.1.3",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
               "requires": {
                 "ansi-styles": "2.2.1",
                 "escape-string-regexp": "1.0.3",
@@ -26411,17 +27197,20 @@
             },
             "minimist": {
               "version": "1.2.0",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true
             },
             "supports-color": {
               "version": "2.0.0",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
             }
           }
         },
         "stylelint": {
           "version": "6.9.0",
           "integrity": "sha1-LSOHCXwetU5uMjuMSGdyXaXgIUg=",
+          "dev": true,
           "requires": {
             "autoprefixer": "6.3.5",
             "balanced-match": "0.4.2",
@@ -26458,11 +27247,13 @@
           "dependencies": {
             "balanced-match": {
               "version": "0.4.2",
-              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+              "dev": true
             },
             "chalk": {
               "version": "1.1.3",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
               "requires": {
                 "ansi-styles": "2.2.1",
                 "escape-string-regexp": "1.0.3",
@@ -26474,6 +27265,7 @@
             "cosmiconfig": {
               "version": "1.1.0",
               "integrity": "sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=",
+              "dev": true,
               "requires": {
                 "graceful-fs": "4.1.11",
                 "js-yaml": "3.10.0",
@@ -26487,11 +27279,13 @@
             },
             "get-stdin": {
               "version": "5.0.1",
-              "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
+              "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+              "dev": true
             },
             "globby": {
               "version": "5.0.0",
               "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+              "dev": true,
               "requires": {
                 "array-union": "1.0.2",
                 "arrify": "1.0.1",
@@ -26503,15 +27297,18 @@
             },
             "minimist": {
               "version": "1.2.0",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true
             },
             "pify": {
               "version": "2.3.0",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
             },
             "postcss-less": {
               "version": "0.14.0",
               "integrity": "sha1-xjGwicbM5CK5oQ86lY0r7dOBkyQ=",
+              "dev": true,
               "requires": {
                 "postcss": "5.2.18"
               }
@@ -26519,27 +27316,32 @@
             "postcss-scss": {
               "version": "0.1.9",
               "integrity": "sha1-dgbK/2S7SzS3YFq3SVdM942Iawg=",
+              "dev": true,
               "requires": {
                 "postcss": "5.2.18"
               }
             },
             "require-from-string": {
               "version": "1.2.1",
-              "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
+              "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+              "dev": true
             },
             "resolve-from": {
               "version": "2.0.0",
-              "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+              "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+              "dev": true
             },
             "supports-color": {
               "version": "2.0.0",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
             }
           }
         },
         "sugarss": {
           "version": "0.1.6",
           "integrity": "sha1-/jrA4eBygq7x3oSoC3I4b/Tn6jc=",
+          "dev": true,
           "requires": {
             "postcss": "5.2.18"
           }
@@ -26606,6 +27408,7 @@
         "supertest": {
           "version": "2.0.0",
           "integrity": "sha1-Bg4Y7a5W49YrlcbpxOKl5OUJef8=",
+          "dev": true,
           "requires": {
             "methods": "1.1.2",
             "superagent": "2.1.0"
@@ -26620,7 +27423,8 @@
         },
         "svg-tags": {
           "version": "1.0.0",
-          "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q="
+          "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
+          "dev": true
         },
         "swap-case": {
           "version": "1.1.2",
@@ -26632,15 +27436,18 @@
         },
         "symbol-tree": {
           "version": "3.2.2",
-          "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+          "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+          "dev": true
         },
         "sync-exec": {
           "version": "0.5.0",
-          "integrity": "sha1-P3JY5KW6FyRTgZCfpqb2z1BuFmE="
+          "integrity": "sha1-P3JY5KW6FyRTgZCfpqb2z1BuFmE=",
+          "dev": true
         },
         "synesthesia": {
           "version": "1.0.1",
           "integrity": "sha1-XvlepUjA1cbm+btLDQcx3/hkp3c=",
+          "dev": true,
           "requires": {
             "css-color-names": "0.0.3"
           }
@@ -26648,6 +27455,7 @@
         "table": {
           "version": "3.8.3",
           "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+          "dev": true,
           "requires": {
             "ajv": "4.11.8",
             "ajv-keywords": "1.5.1",
@@ -26660,6 +27468,7 @@
             "ajv": {
               "version": "4.11.8",
               "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+              "dev": true,
               "requires": {
                 "co": "4.6.0",
                 "json-stable-stringify": "1.0.1"
@@ -26667,15 +27476,18 @@
             },
             "ajv-keywords": {
               "version": "1.5.1",
-              "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
+              "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+              "dev": true
             },
             "ansi-regex": {
               "version": "3.0.0",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
             },
             "chalk": {
               "version": "1.1.3",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
               "requires": {
                 "ansi-styles": "2.2.1",
                 "escape-string-regexp": "1.0.3",
@@ -26686,11 +27498,13 @@
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
             },
             "string-width": {
               "version": "2.1.1",
               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "dev": true,
               "requires": {
                 "is-fullwidth-code-point": "2.0.0",
                 "strip-ansi": "4.0.0"
@@ -26699,6 +27513,7 @@
                 "strip-ansi": {
                   "version": "4.0.0",
                   "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                  "dev": true,
                   "requires": {
                     "ansi-regex": "3.0.0"
                   }
@@ -26707,7 +27522,8 @@
             },
             "supports-color": {
               "version": "2.0.0",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
             }
           }
         },
@@ -26773,6 +27589,7 @@
         "temp": {
           "version": "0.8.3",
           "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+          "dev": true,
           "requires": {
             "os-tmpdir": "1.0.2",
             "rimraf": "2.2.8"
@@ -26780,13 +27597,15 @@
           "dependencies": {
             "rimraf": {
               "version": "2.2.8",
-              "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+              "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+              "dev": true
             }
           }
         },
         "terminal-kit": {
           "version": "1.13.13",
           "integrity": "sha512-6A8b5OJd9oMLvbfPIaRr4F+FBnuH4/sQQPlVCnhbuQ+EwAyUbFB9Z+KTuivtmbWOUErXIYtlQ8t36+YBz5T2vA==",
+          "dev": true,
           "requires": {
             "async-kit": "2.2.3",
             "get-pixels": "3.3.0",
@@ -26799,6 +27618,7 @@
         "test-exclude": {
           "version": "4.1.1",
           "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
+          "dev": true,
           "requires": {
             "arrify": "1.0.1",
             "micromatch": "2.3.11",
@@ -26809,11 +27629,13 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+          "dev": true
         },
         "throat": {
           "version": "4.1.0",
-          "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
+          "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+          "dev": true
         },
         "through": {
           "version": "2.3.8",
@@ -26845,11 +27667,13 @@
         },
         "time-stamp": {
           "version": "1.1.0",
-          "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+          "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+          "dev": true
         },
         "timed-out": {
           "version": "2.0.0",
-          "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo="
+          "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo=",
+          "dev": true
         },
         "timers-browserify": {
           "version": "2.0.6",
@@ -26880,7 +27704,8 @@
         },
         "tmpl": {
           "version": "1.0.4",
-          "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+          "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+          "dev": true
         },
         "to-array": {
           "version": "0.1.4",
@@ -26948,13 +27773,15 @@
         "tr46": {
           "version": "1.0.1",
           "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
           "requires": {
             "punycode": "2.1.0"
           },
           "dependencies": {
             "punycode": {
               "version": "2.1.0",
-              "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+              "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+              "dev": true
             }
           }
         },
@@ -26964,11 +27791,13 @@
         },
         "tree-kit": {
           "version": "0.5.26",
-          "integrity": "sha1-hXHIb6JNHbdU5bDLOn4J9B50qN8="
+          "integrity": "sha1-hXHIb6JNHbdU5bDLOn4J9B50qN8=",
+          "dev": true
         },
         "trim": {
           "version": "0.0.1",
-          "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+          "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+          "dev": true
         },
         "trim-newlines": {
           "version": "1.0.0",
@@ -26980,19 +27809,23 @@
         },
         "trim-trailing-lines": {
           "version": "1.1.0",
-          "integrity": "sha1-eu+7eAjfnWafbaLkOMrIxGradoQ="
+          "integrity": "sha1-eu+7eAjfnWafbaLkOMrIxGradoQ=",
+          "dev": true
         },
         "trough": {
           "version": "1.0.1",
-          "integrity": "sha1-qf2LA5Swro//guBjOgo2zK1bX4Y="
+          "integrity": "sha1-qf2LA5Swro//guBjOgo2zK1bX4Y=",
+          "dev": true
         },
         "try-resolve": {
           "version": "1.0.1",
-          "integrity": "sha1-z95vq9ctY+V5fPqrhzq76OcA6RI="
+          "integrity": "sha1-z95vq9ctY+V5fPqrhzq76OcA6RI=",
+          "dev": true
         },
         "tryor": {
           "version": "0.1.2",
-          "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys="
+          "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys=",
+          "dev": true
         },
         "tty-browserify": {
           "version": "0.0.0",
@@ -27021,13 +27854,15 @@
         "type-check": {
           "version": "0.3.2",
           "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+          "dev": true,
           "requires": {
             "prelude-ls": "1.1.2"
           }
         },
         "type-detect": {
           "version": "1.0.0",
-          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
+          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+          "dev": true
         },
         "type-is": {
           "version": "1.6.15",
@@ -27043,11 +27878,13 @@
         },
         "typescript": {
           "version": "2.6.2",
-          "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
+          "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+          "dev": true
         },
         "typescript-eslint-parser": {
           "version": "9.0.1",
           "integrity": "sha512-w1jqotvnhLtLukD9H3gQPAlbD0kLf7ZkoQGwiwSIshKIlzRL7i0OY9Y7VIdE1xtytZXThg678eomxMZ1rZXGVQ==",
+          "dev": true,
           "requires": {
             "lodash.unescape": "4.0.1",
             "semver": "5.4.1"
@@ -27055,7 +27892,8 @@
           "dependencies": {
             "semver": {
               "version": "5.4.1",
-              "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+              "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+              "dev": true
             }
           }
         },
@@ -27152,7 +27990,8 @@
         },
         "underscore": {
           "version": "1.6.0",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+          "dev": true
         },
         "underscore.string": {
           "version": "3.0.3",
@@ -27171,6 +28010,7 @@
         "unherit": {
           "version": "1.1.0",
           "integrity": "sha1-a5qu379z3xdWrZ4xbdmBiFhAzX0=",
+          "dev": true,
           "requires": {
             "inherits": "2.0.1",
             "xtend": "4.0.1"
@@ -27178,11 +28018,13 @@
         },
         "unicode-regex": {
           "version": "1.0.1",
-          "integrity": "sha1-+BngUBkdW5VhozmljdO5CV7ZSzU="
+          "integrity": "sha1-+BngUBkdW5VhozmljdO5CV7ZSzU=",
+          "dev": true
         },
         "unified": {
           "version": "6.1.6",
           "integrity": "sha512-pW2f82bCIo2ifuIGYcV12fL96kMMYgw7JKVEgh7ODlrM9rj6vXSY3BV+H6lCcv1ksxynFf582hwWLnA1qRFy4w==",
+          "dev": true,
           "requires": {
             "bail": "1.0.2",
             "extend": "3.0.1",
@@ -27195,7 +28037,8 @@
         },
         "uniq": {
           "version": "1.0.1",
-          "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+          "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+          "dev": true
         },
         "unique-filename": {
           "version": "1.1.0",
@@ -27213,22 +28056,26 @@
         },
         "unist-util-is": {
           "version": "2.1.1",
-          "integrity": "sha1-DDEmKeP5YMZukx6BLT2A53AQlHs="
+          "integrity": "sha1-DDEmKeP5YMZukx6BLT2A53AQlHs=",
+          "dev": true
         },
         "unist-util-remove-position": {
           "version": "1.1.1",
           "integrity": "sha1-WoXBVV/BugwQG4ZwfRXlD6TIcbs=",
+          "dev": true,
           "requires": {
             "unist-util-visit": "1.3.0"
           }
         },
         "unist-util-stringify-position": {
           "version": "1.1.1",
-          "integrity": "sha1-PMvcU2ee7W7PN3fdf14yKcG2qjw="
+          "integrity": "sha1-PMvcU2ee7W7PN3fdf14yKcG2qjw=",
+          "dev": true
         },
         "unist-util-visit": {
           "version": "1.3.0",
           "integrity": "sha512-9ntYcxPFtl44gnwXrQKZ5bMqXMY0ZHzUpqMFiU4zcc8mmf/jzYm8GhYgezuUlX4cJIM1zIDYaO6fG/fI+L6iiQ==",
+          "dev": true,
           "requires": {
             "unist-util-is": "2.1.1"
           }
@@ -27239,7 +28086,8 @@
         },
         "unquoted-property-validator": {
           "version": "1.0.2",
-          "integrity": "sha512-LokWcfN2q9UnQTTIpRkTZNsLVVO2KaXeO3oUMQ7JShGhMdO8P+zN1MfrPMf1IwR/Cyh283lGaxbRcNGyq2IXYQ=="
+          "integrity": "sha512-LokWcfN2q9UnQTTIpRkTZNsLVVO2KaXeO3oUMQ7JShGhMdO8P+zN1MfrPMf1IwR/Cyh283lGaxbRcNGyq2IXYQ==",
+          "dev": true
         },
         "unreachable-branch-transform": {
           "version": "0.3.0",
@@ -27281,6 +28129,7 @@
         "update-notifier": {
           "version": "0.3.2",
           "integrity": "sha1-IqhzW6re8zIOLbko9pPaiY3Id3c=",
+          "dev": true,
           "requires": {
             "chalk": "1.0.0",
             "configstore": "0.3.2",
@@ -27293,6 +28142,7 @@
             "string-length": {
               "version": "1.0.1",
               "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
+              "dev": true,
               "requires": {
                 "strip-ansi": "3.0.1"
               }
@@ -27333,7 +28183,8 @@
         },
         "user-home": {
           "version": "1.1.1",
-          "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+          "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+          "dev": true
         },
         "utf8": {
           "version": "2.1.0",
@@ -27353,6 +28204,7 @@
         "util.promisify": {
           "version": "1.0.0",
           "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+          "dev": true,
           "requires": {
             "define-properties": "1.1.2",
             "object.getownpropertydescriptors": "2.0.3"
@@ -27394,6 +28246,7 @@
         "vfile": {
           "version": "2.3.0",
           "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+          "dev": true,
           "requires": {
             "is-buffer": "1.1.6",
             "replace-ext": "1.0.0",
@@ -27403,11 +28256,13 @@
         },
         "vfile-location": {
           "version": "2.0.2",
-          "integrity": "sha1-02dcWch3SY5JK0dW/2Xkrxp1IlU="
+          "integrity": "sha1-02dcWch3SY5JK0dW/2Xkrxp1IlU=",
+          "dev": true
         },
         "vfile-message": {
           "version": "1.0.0",
           "integrity": "sha512-HPREhzTOB/sNDc9/Mxf8w0FmHnThg5CRSJdR9VRFkD2riqYWs+fuXlj5z8mIpv2LrD7uU41+oPWFOL4Mjlf+dw==",
+          "dev": true,
           "requires": {
             "unist-util-stringify-position": "1.1.1"
           }
@@ -27415,6 +28270,7 @@
         "vinyl": {
           "version": "0.5.3",
           "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+          "dev": true,
           "requires": {
             "clone": "1.0.3",
             "clone-stats": "0.0.1",
@@ -27423,7 +28279,8 @@
           "dependencies": {
             "replace-ext": {
               "version": "0.0.1",
-              "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+              "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+              "dev": true
             }
           }
         },
@@ -27441,6 +28298,7 @@
         "vorpal": {
           "version": "1.12.0",
           "integrity": "sha1-S+eypOSPj8/JzzZIxBnTEcUiFZ0=",
+          "dev": true,
           "requires": {
             "babel-polyfill": "6.26.0",
             "chalk": "1.1.3",
@@ -27457,6 +28315,7 @@
             "chalk": {
               "version": "1.1.3",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
               "requires": {
                 "ansi-styles": "2.2.1",
                 "escape-string-regexp": "1.0.3",
@@ -27467,17 +28326,20 @@
             },
             "minimist": {
               "version": "1.2.0",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true
             },
             "supports-color": {
               "version": "2.0.0",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
             }
           }
         },
         "vorpal-autocomplete-fs": {
           "version": "0.0.3",
           "integrity": "sha1-15b3sr1A2LbdxkE69M/QFv9QnQE=",
+          "dev": true,
           "requires": {
             "chalk": "1.1.3",
             "strip-ansi": "3.0.1"
@@ -27486,6 +28348,7 @@
             "chalk": {
               "version": "1.1.3",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
               "requires": {
                 "ansi-styles": "2.2.1",
                 "escape-string-regexp": "1.0.3",
@@ -27496,13 +28359,15 @@
             },
             "supports-color": {
               "version": "2.0.0",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
             }
           }
         },
         "w3c-hr-time": {
           "version": "1.0.1",
           "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+          "dev": true,
           "requires": {
             "browser-process-hrtime": "0.1.2"
           }
@@ -27517,6 +28382,7 @@
         "walker": {
           "version": "1.0.7",
           "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+          "dev": true,
           "requires": {
             "makeerror": "1.0.11"
           }
@@ -27531,6 +28397,7 @@
         "watch": {
           "version": "0.18.0",
           "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+          "dev": true,
           "requires": {
             "exec-sh": "0.2.1",
             "minimist": "1.2.0"
@@ -27538,7 +28405,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true
             }
           }
         },
@@ -27562,7 +28430,8 @@
         },
         "webidl-conversions": {
           "version": "4.0.2",
-          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
         },
         "webpack": {
           "version": "3.10.0",
@@ -27809,6 +28678,7 @@
         "webpack-bundle-analyzer": {
           "version": "2.9.2",
           "integrity": "sha1-Y+2G63HMTNqG9o5oWoRTC6ASZEk=",
+          "dev": true,
           "requires": {
             "acorn": "5.4.0",
             "chalk": "1.1.3",
@@ -27826,6 +28696,7 @@
             "accepts": {
               "version": "1.3.4",
               "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+              "dev": true,
               "requires": {
                 "mime-types": "2.1.17",
                 "negotiator": "0.6.1"
@@ -27833,11 +28704,13 @@
             },
             "acorn": {
               "version": "5.4.0",
-              "integrity": "sha512-bkLTrtPfRASTxDXFaih7SbeYSsQ8MjrqCQKMrgZ4Hc7kYI//WVU6rDTAIqVrAudjgMFQEGthYfodtaw8dTRJrg=="
+              "integrity": "sha512-bkLTrtPfRASTxDXFaih7SbeYSsQ8MjrqCQKMrgZ4Hc7kYI//WVU6rDTAIqVrAudjgMFQEGthYfodtaw8dTRJrg==",
+              "dev": true
             },
             "body-parser": {
               "version": "1.18.2",
               "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+              "dev": true,
               "requires": {
                 "bytes": "3.0.0",
                 "content-type": "1.0.4",
@@ -27853,11 +28726,13 @@
             },
             "bytes": {
               "version": "3.0.0",
-              "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+              "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+              "dev": true
             },
             "chalk": {
               "version": "1.1.3",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
               "requires": {
                 "ansi-styles": "2.2.1",
                 "escape-string-regexp": "1.0.3",
@@ -27868,42 +28743,51 @@
             },
             "commander": {
               "version": "2.13.0",
-              "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+              "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+              "dev": true
             },
             "content-disposition": {
               "version": "0.5.2",
-              "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+              "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+              "dev": true
             },
             "cookie": {
               "version": "0.3.1",
-              "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+              "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+              "dev": true
             },
             "cookie-signature": {
               "version": "1.0.6",
-              "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+              "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+              "dev": true
             },
             "debug": {
               "version": "2.6.9",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
               "requires": {
                 "ms": "2.0.0"
               }
             },
             "destroy": {
               "version": "1.0.4",
-              "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+              "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+              "dev": true
             },
             "escape-html": {
               "version": "1.0.3",
-              "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+              "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+              "dev": true
             },
             "etag": {
               "version": "1.8.1",
-              "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+              "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+              "dev": true
             },
             "express": {
               "version": "4.16.2",
               "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+              "dev": true,
               "requires": {
                 "accepts": "1.3.4",
                 "array-flatten": "1.1.1",
@@ -27939,11 +28823,13 @@
             },
             "filesize": {
               "version": "3.5.11",
-              "integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g=="
+              "integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g==",
+              "dev": true
             },
             "finalhandler": {
               "version": "1.1.0",
               "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+              "dev": true,
               "requires": {
                 "debug": "2.6.9",
                 "encodeurl": "1.0.2",
@@ -27956,39 +28842,48 @@
             },
             "fresh": {
               "version": "0.5.2",
-              "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+              "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+              "dev": true
             },
             "iconv-lite": {
               "version": "0.4.19",
-              "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+              "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+              "dev": true
             },
             "ipaddr.js": {
               "version": "1.5.2",
-              "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
+              "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
+              "dev": true
             },
             "lodash": {
               "version": "4.17.4",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+              "dev": true
             },
             "merge-descriptors": {
               "version": "1.0.1",
-              "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+              "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+              "dev": true
             },
             "mime": {
               "version": "1.4.1",
-              "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+              "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+              "dev": true
             },
             "ms": {
               "version": "2.0.0",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
             },
             "negotiator": {
               "version": "0.6.1",
-              "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+              "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+              "dev": true
             },
             "proxy-addr": {
               "version": "2.0.2",
               "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+              "dev": true,
               "requires": {
                 "forwarded": "0.1.2",
                 "ipaddr.js": "1.5.2"
@@ -27996,15 +28891,18 @@
             },
             "qs": {
               "version": "6.5.1",
-              "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+              "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+              "dev": true
             },
             "range-parser": {
               "version": "1.2.0",
-              "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+              "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+              "dev": true
             },
             "raw-body": {
               "version": "2.3.2",
               "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+              "dev": true,
               "requires": {
                 "bytes": "3.0.0",
                 "http-errors": "1.6.2",
@@ -28015,6 +28913,7 @@
             "send": {
               "version": "0.16.1",
               "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+              "dev": true,
               "requires": {
                 "debug": "2.6.9",
                 "depd": "1.1.2",
@@ -28034,6 +28933,7 @@
             "serve-static": {
               "version": "1.13.1",
               "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+              "dev": true,
               "requires": {
                 "encodeurl": "1.0.2",
                 "escape-html": "1.0.3",
@@ -28043,31 +28943,38 @@
             },
             "setprototypeof": {
               "version": "1.1.0",
-              "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+              "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+              "dev": true
             },
             "statuses": {
               "version": "1.3.1",
-              "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+              "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+              "dev": true
             },
             "supports-color": {
               "version": "2.0.0",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
             },
             "ultron": {
               "version": "1.1.1",
-              "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+              "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+              "dev": true
             },
             "utils-merge": {
               "version": "1.0.1",
-              "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+              "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+              "dev": true
             },
             "vary": {
               "version": "1.1.2",
-              "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+              "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+              "dev": true
             },
             "ws": {
               "version": "4.0.0",
               "integrity": "sha512-QYslsH44bH8O7/W2815u5DpnCpXWpEK44FmaHffNwgJI4JMaSZONgPBTOfrxJ29mXKbXak+LsJ2uAkDTYq2ptQ==",
+              "dev": true,
               "requires": {
                 "async-limiter": "1.0.0",
                 "safe-buffer": "5.1.1",
@@ -28134,13 +29041,15 @@
         "whatwg-encoding": {
           "version": "1.0.3",
           "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+          "dev": true,
           "requires": {
             "iconv-lite": "0.4.19"
           },
           "dependencies": {
             "iconv-lite": {
               "version": "0.4.19",
-              "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+              "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+              "dev": true
             }
           }
         },
@@ -28151,6 +29060,7 @@
         "whatwg-url": {
           "version": "6.4.0",
           "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+          "dev": true,
           "requires": {
             "lodash.sortby": "4.7.0",
             "tr46": "1.0.1",
@@ -28330,6 +29240,7 @@
         "write": {
           "version": "0.2.1",
           "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+          "dev": true,
           "requires": {
             "mkdirp": "0.5.1"
           }
@@ -28337,6 +29248,7 @@
         "write-file-atomic": {
           "version": "1.3.4",
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "imurmurhash": "0.1.4",
@@ -28345,7 +29257,8 @@
         },
         "write-file-stdout": {
           "version": "0.0.2",
-          "integrity": "sha1-wlLXx8WxtAKJdjDjRTx7/mkNnKE="
+          "integrity": "sha1-wlLXx8WxtAKJdjDjRTx7/mkNnKE=",
+          "dev": true
         },
         "ws": {
           "version": "1.0.1",
@@ -28357,15 +29270,18 @@
         },
         "x-is-function": {
           "version": "1.0.4",
-          "integrity": "sha1-XSlNw9Joy90GJYDgxd93o5HR+h4="
+          "integrity": "sha1-XSlNw9Joy90GJYDgxd93o5HR+h4=",
+          "dev": true
         },
         "x-is-string": {
           "version": "0.1.0",
-          "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
+          "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
+          "dev": true
         },
         "xdg-basedir": {
           "version": "1.0.1",
           "integrity": "sha1-FP+PY6T9vLBdW27qIrNvMDO58E4=",
+          "dev": true,
           "requires": {
             "user-home": "1.1.1"
           }
@@ -28390,7 +29306,8 @@
         },
         "xml": {
           "version": "1.0.1",
-          "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
+          "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+          "dev": true
         },
         "xml-char-classes": {
           "version": "1.0.0",
@@ -28398,7 +29315,8 @@
         },
         "xml-name-validator": {
           "version": "3.0.0",
-          "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+          "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+          "dev": true
         },
         "xmlhttprequest-ssl": {
           "version": "1.5.1",
@@ -28406,7 +29324,8 @@
         },
         "xregexp": {
           "version": "3.2.0",
-          "integrity": "sha1-yzYBmHv+JpW1hAAMGPHEqMMih44="
+          "integrity": "sha1-yzYBmHv+JpW1hAAMGPHEqMMih44=",
+          "dev": true
         },
         "xtend": {
           "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,6 @@
     "redux-thunk": "^2.2.0",
     "reselect": "^2.5.4",
     "whatwg-fetch": "^2.0.2",
-    "wp-calypso": "github:automattic/wp-calypso"
+    "wp-calypso": "github:automattic/wp-calypso#3c8a7c8b5b31a652bb7c531954cb566a47c01d89"
   }
 }

--- a/package.json
+++ b/package.json
@@ -103,6 +103,6 @@
     "redux-thunk": "^2.2.0",
     "reselect": "^2.5.4",
     "whatwg-fetch": "^2.0.2",
-    "wp-calypso": "github:automattic/wp-calypso#57e97f3606018e38a1920db861e1b95d1fb43b78"
+    "wp-calypso": "github:automattic/wp-calypso#b807dae16ae7ebf88845704b0f1eebc7ec6d511f"
   }
 }

--- a/package.json
+++ b/package.json
@@ -103,6 +103,6 @@
     "redux-thunk": "^2.2.0",
     "reselect": "^2.5.4",
     "whatwg-fetch": "^2.0.2",
-    "wp-calypso": "github:automattic/wp-calypso#3c8a7c8b5b31a652bb7c531954cb566a47c01d89"
+    "wp-calypso": "github:automattic/wp-calypso#57e97f3606018e38a1920db861e1b95d1fb43b78"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const webpack = require( 'webpack' );
 const path = require( 'path' );
+const fs = require( 'fs' );
 const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 const autoprefixer = require( 'autoprefixer' );
 const escapeStringRegexp = require( 'escape-string-regexp' );
@@ -159,12 +160,18 @@ const config = {
 		} ),
 		//rewrite calypso images path
 		new webpack.NormalModuleReplacementPlugin( /calypso\/images/, ( resource ) => {
-			resource.request = resource.request
+			let newPath = resource.request
 				.replace(
 					/^.+calypso\/images/,
 					path.resolve( __dirname, 'node_modules', 'wp-calypso', 'public', 'images' )
 				)
 				.replace( /is-([^/]+)$/, '$1' );
+
+			if ( ! fs.existsSync( newPath ) ) {
+				newPath = newPath.replace( /cc-([^/]+)$/, '$1' );
+			}
+
+			resource.request = newPath;
 		} ),
 	],
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 const webpack = require( 'webpack' );
 const path = require( 'path' );
-const fs = require( 'fs' );
 const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 const autoprefixer = require( 'autoprefixer' );
 const escapeStringRegexp = require( 'escape-string-regexp' );
@@ -160,18 +159,11 @@ const config = {
 		} ),
 		//rewrite calypso images path
 		new webpack.NormalModuleReplacementPlugin( /calypso\/images/, ( resource ) => {
-			let newPath = resource.request
+			resource.request = resource.request
 				.replace(
 					/^.+calypso\/images/,
 					path.resolve( __dirname, 'node_modules', 'wp-calypso', 'public', 'images' )
-				)
-				.replace( /is-([^/]+)$/, '$1' );
-
-			if ( ! fs.existsSync( newPath ) ) {
-				newPath = newPath.replace( /cc-([^/]+)$/, '$1' );
-			}
-
-			resource.request = newPath;
+				);
 		} ),
 	],
 };


### PR DESCRIPTION
Sets the Calypso dependency to the commit https://github.com/Automattic/wp-calypso/commit/3c8a7c8b5b31a652bb7c531954cb566a47c01d89 (latest at the time of this PR) which should fix the tests/builds randomly failing after `npm install`

Also fixes the image imports broken by the recent changes in Calypso.

It should also fix the tests failing in #1292