### PR TITLE
Referencing CSS images from wordpress.com

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -81,8 +81,8 @@ const config = {
 						{
 							loader: 'css-loader',
 							options: {
-								root: '', //force absolute paths in url() to be rewritten
-							}
+								root: 'https://wordpress.com',
+							},
 						},
 						{
 							loader: 'postcss-loader',
@@ -107,17 +107,6 @@ const config = {
 			{
 				test: /\.html$/,
 				use: 'html-loader',
-			},
-			{
-				test: /\.svg$/,
-				use: 'svg-url-loader',
-			},
-			{
-				test: /\.png$/,
-				use: {
-					loader: 'url-loader',
-					options: { limit: 10000 },
-				},
 			},
 			{
 				test: /\.jsx?$/,
@@ -156,14 +145,6 @@ const config = {
 		} ),
 		new ExtractTextPlugin( {
 			filename: '[name].css',
-		} ),
-		//rewrite calypso images path
-		new webpack.NormalModuleReplacementPlugin( /calypso\/images/, ( resource ) => {
-			resource.request = resource.request
-				.replace(
-					/^.+calypso\/images/,
-					path.resolve( __dirname, 'node_modules', 'wp-calypso', 'public', 'images' )
-				);
 		} ),
 	],
 };


### PR DESCRIPTION
Changes the webpack config to modify the image URLs in CSS to point at wordpress.com instead of importing whole base64 or SVG strings.

To test:
* check that the images render correctly on the payments methods page
* verify that other areas of the plugin look ok (payment methods is the only area that uses images)