### PR TITLE
Add redirect link from label settings screen back to order

### DIFF
--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -49,7 +49,6 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				'needs_tax_environment_setup',
 				'stripe_state',
 				'banner_ppec',
-				'label_settings_redirect',
 			);
 		}
 

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -49,6 +49,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				'needs_tax_environment_setup',
 				'stripe_state',
 				'banner_ppec',
+				'label_settings_redirect',
 			);
 		}
 

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -77,12 +77,9 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 			}
 
 			$extra_args = array();
-			$referer_url = wp_get_referer();
-			$referer = parse_url( $referer_url );
-			if ( preg_match( '/\/wp-admin\/post\.php$/', $referer['path'] ) ) {
-				parse_str( $referer['query'], $query );
-				$extra_args['order_id'] = $query['post'];
-				$extra_args['order_href'] = $referer_url;
+			if ( isset( $_GET['from_order'] ) ) {
+				$extra_args['order_id'] = $_GET['from_order'];
+				$extra_args['order_href'] = get_edit_post_link( $_GET['from_order'] );
 			}
 
 			do_action( 'enqueue_wc_connect_script', 'wc-connect-account-settings', $extra_args );

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -76,15 +76,14 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 				<?php
 			}
 
+			$extra_args = array();
 			$referer_url = wp_get_referer();
 			$referer = parse_url( $referer_url );
 			if ( preg_match( '/\/wp-admin\/post\.php$/', $referer['path'] ) ) {
-				WC_Connect_Options::update_option( 'label_settings_redirect', $referer_url );
-			} else {
-				WC_Connect_Options::delete_option( 'label_settings_redirect' );
+				$extra_args['order_href'] = $referer_url;
 			}
 
-			do_action( 'enqueue_wc_connect_script', 'wc-connect-account-settings' );
+			do_action( 'enqueue_wc_connect_script', 'wc-connect-account-settings', $extra_args );
 		}
 
 		public function output_no_priv_account_screen() {

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -80,6 +80,8 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 			$referer_url = wp_get_referer();
 			$referer = parse_url( $referer_url );
 			if ( preg_match( '/\/wp-admin\/post\.php$/', $referer['path'] ) ) {
+				parse_str( $referer['query'], $query );
+				$extra_args['order_id'] = $query['post'];
 				$extra_args['order_href'] = $referer_url;
 			}
 

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -76,6 +76,14 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 				<?php
 			}
 
+			$referer_url = wp_get_referer();
+			$referer = parse_url( $referer_url );
+			if ( preg_match( '/\/wp-admin\/post\.php$/', $referer['path'] ) ) {
+				WC_Connect_Options::update_option( 'label_settings_redirect', $referer_url );
+			} else {
+				WC_Connect_Options::delete_option( 'label_settings_redirect' );
+			}
+
 			do_action( 'enqueue_wc_connect_script', 'wc-connect-account-settings' );
 		}
 

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -34,12 +34,10 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 			$email = '';
 		}
 
-		$formData = $this->settings_store->get_account_settings();
-
 		return new WP_REST_Response( array(
 			'success'  => true,
 			'storeOptions' => $this->settings_store->get_store_options(),
-			'formData' => $formData,
+			'formData' => $this->settings_store->get_account_settings(),
 			'formMeta' => array(
 				'can_manage_payments' => $this->can_user_manage_payment_methods(),
 				'can_edit_settings' => true,
@@ -47,7 +45,6 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 				'master_user_login' => is_a( $master_user, 'WP_User' ) ? $master_user->user_login : '',
 				'master_user_email' => $email,
 				'payment_methods' => $this->payment_methods_store->get_payment_methods(),
-				'order_href' => $formData['selected_payment_method_id'] ? WC_Connect_Options::get_option( 'label_settings_redirect' ) : '',
 			)
 		), 200 );
 	}

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -34,17 +34,20 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 			$email = '';
 		}
 
+		$formData = $this->settings_store->get_account_settings();
+
 		return new WP_REST_Response( array(
 			'success'  => true,
 			'storeOptions' => $this->settings_store->get_store_options(),
-			'formData' => $this->settings_store->get_account_settings(),
+			'formData' => $formData,
 			'formMeta' => array(
 				'can_manage_payments' => $this->can_user_manage_payment_methods(),
 				'can_edit_settings' => true,
 				'master_user_name' => is_a( $master_user, 'WP_User' ) ? $master_user->display_name : '',
 				'master_user_login' => is_a( $master_user, 'WP_User' ) ? $master_user->user_login : '',
 				'master_user_email' => $email,
- 				'payment_methods' => $this->payment_methods_store->get_payment_methods(),
+				'payment_methods' => $this->payment_methods_store->get_payment_methods(),
+				'order_href' => $formData['selected_payment_method_id'] ? WC_Connect_Options::get_option( 'label_settings_redirect' ) : '',
 			)
 		), 200 );
 	}

--- a/client/apps/account-settings/index.js
+++ b/client/apps/account-settings/index.js
@@ -12,7 +12,7 @@ import reducer from 'woocommerce/woocommerce-services/state/label-settings/reduc
 import notices from 'state/notices/reducer';
 import { combineReducers } from 'state/utils';
 
-export default ( { order_href: orderHref } ) => ( {
+export default ( { order_id: orderId, order_href: orderHref } ) => ( {
 	getReducer() {
 		return combineReducers( {
 			extensions: combineReducers( {
@@ -45,6 +45,6 @@ export default ( { order_href: orderHref } ) => ( {
 	},
 
 	View: () => (
-		<ViewWrapper orderHref={ orderHref } />
+		<ViewWrapper orderId={ orderId } orderHref={ orderHref } />
 	),
 } );

--- a/client/apps/account-settings/index.js
+++ b/client/apps/account-settings/index.js
@@ -12,7 +12,7 @@ import reducer from 'woocommerce/woocommerce-services/state/label-settings/reduc
 import notices from 'state/notices/reducer';
 import { combineReducers } from 'state/utils';
 
-export default () => ( {
+export default ( { order_href: orderHref } ) => ( {
 	getReducer() {
 		return combineReducers( {
 			extensions: combineReducers( {
@@ -45,6 +45,6 @@ export default () => ( {
 	},
 
 	View: () => (
-		<ViewWrapper />
+		<ViewWrapper orderHref={ orderHref } />
 	),
 } );

--- a/client/apps/account-settings/view-wrapper.js
+++ b/client/apps/account-settings/view-wrapper.js
@@ -33,8 +33,9 @@ class LabelSettingsWrapper extends Component {
 	}
 
 	onSaveSuccess = () => {
-		const { noticeActions, translate } = this.props;
-		noticeActions.successNotice( translate( 'Your shipping label settings have been saved.' ), { duration: 5000 } );
+		const { noticeActions, translate, orderHref } = this.props;
+		const options = orderHref ? { button: 'Back to order', href: orderHref } : { duration: 5000 };
+		noticeActions.successNotice( translate( 'Your shipping label settings have been saved.' ), options );
 		this.setState( { pristine: true } );
 	}
 
@@ -78,6 +79,7 @@ function mapStateToProps( state ) {
 		siteId: getSelectedSiteId( state ),
 		isSaving: form.isSaving,
 		buttonDisabled: form.pristine,
+		orderHref: form.order_href,
 	};
 }
 

--- a/client/apps/account-settings/view-wrapper.js
+++ b/client/apps/account-settings/view-wrapper.js
@@ -34,7 +34,7 @@ class LabelSettingsWrapper extends Component {
 
 	onSaveSuccess = () => {
 		const { noticeActions, translate, orderHref } = this.props;
-		const options = orderHref ? { button: 'Back to order', href: orderHref } : { duration: 5000 };
+		const options = orderHref ? { button: translate( 'Back to order' ), href: orderHref } : { duration: 5000 };
 		noticeActions.successNotice( translate( 'Your shipping label settings have been saved.' ), options );
 		this.setState( { pristine: true } );
 	}

--- a/client/apps/account-settings/view-wrapper.js
+++ b/client/apps/account-settings/view-wrapper.js
@@ -33,10 +33,10 @@ class LabelSettingsWrapper extends Component {
 	}
 
 	onSaveSuccess = () => {
-		const { noticeActions, translate, orderHref, paymentMethodSelected } = this.props;
+		const { noticeActions, translate, orderId, orderHref, paymentMethodSelected } = this.props;
 		const options =
 			orderHref && paymentMethodSelected
-				? { button: translate( 'Back to order' ), href: orderHref }
+				? { button: translate( 'Back to Order #%(orderId)s', { args: { orderId } } ), href: orderHref }
 				: { duration: 5000 };
 
 		noticeActions.successNotice( translate( 'Your shipping label settings have been saved.' ), options );

--- a/client/apps/account-settings/view-wrapper.js
+++ b/client/apps/account-settings/view-wrapper.js
@@ -18,7 +18,7 @@ import { ProtectFormGuard } from 'lib/protect-form';
 import * as NoticeActions from 'state/notices/actions';
 import { submit } from 'woocommerce/woocommerce-services/state/label-settings/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getLabelSettingsFormMeta } from 'woocommerce/woocommerce-services/state/label-settings/selectors';
+import { getLabelSettingsFormMeta, getLabelSettingsFormData } from 'woocommerce/woocommerce-services/state/label-settings/selectors';
 
 class LabelSettingsWrapper extends Component {
 	constructor( props ) {
@@ -33,8 +33,12 @@ class LabelSettingsWrapper extends Component {
 	}
 
 	onSaveSuccess = () => {
-		const { noticeActions, translate, orderHref } = this.props;
-		const options = orderHref ? { button: translate( 'Back to order' ), href: orderHref } : { duration: 5000 };
+		const { noticeActions, translate, orderHref, paymentMethodSelected } = this.props;
+		const options =
+			orderHref && paymentMethodSelected
+				? { button: translate( 'Back to order' ), href: orderHref }
+				: { duration: 5000 };
+
 		noticeActions.successNotice( translate( 'Your shipping label settings have been saved.' ), options );
 		this.setState( { pristine: true } );
 	}
@@ -74,12 +78,13 @@ class LabelSettingsWrapper extends Component {
 }
 
 function mapStateToProps( state ) {
-	const form = getLabelSettingsFormMeta( state );
+	const formMeta = getLabelSettingsFormMeta( state );
+	const formData = getLabelSettingsFormData( state );
 	return {
 		siteId: getSelectedSiteId( state ),
-		isSaving: form.isSaving,
-		buttonDisabled: form.pristine,
-		orderHref: form.order_href,
+		isSaving: formMeta.isSaving,
+		buttonDisabled: formMeta.pristine,
+		paymentMethodSelected: Boolean( formData && formData.selected_payment_method_id ),
 	};
 }
 

--- a/client/apps/account-settings/view-wrapper.js
+++ b/client/apps/account-settings/view-wrapper.js
@@ -36,7 +36,7 @@ class LabelSettingsWrapper extends Component {
 		const { noticeActions, translate, orderId, orderHref, paymentMethodSelected } = this.props;
 		const options =
 			orderHref && paymentMethodSelected
-				? { button: translate( 'Back to Order #%(orderId)s', { args: { orderId } } ), href: orderHref }
+				? { button: translate( 'Return to Order #%(orderId)s', { args: { orderId } } ), href: orderHref }
 				: { duration: 5000 };
 
 		noticeActions.successNotice( translate( 'Your shipping label settings have been saved.' ), options );

--- a/client/apps/shipping-label/view-wrapper.js
+++ b/client/apps/shipping-label/view-wrapper.js
@@ -46,6 +46,7 @@ class ShippingLabelViewWrapper extends Component {
 	renderPaymentInfo = () => {
 		const {
 			translate,
+			orderId,
 			loaded,
 			selectedPaymentMethod,
 			paymentMethods,
@@ -64,7 +65,11 @@ class ShippingLabelViewWrapper extends Component {
 							args: { cardDigits: selectedPaymentMethod.card_digits },
 						} ) }
 					</p>
-					<p><a href="admin.php?page=wc-settings&tab=shipping&section=label-settings">{ translate( 'Manage cards' ) }</a></p>
+					<p>
+						<a href={ `admin.php?page=wc-settings&tab=shipping&section=label-settings&from_order=${ orderId }` }>
+							{ translate( 'Manage cards' ) }
+						</a>
+					</p>
 				</Notice>
 			);
 		}
@@ -74,7 +79,9 @@ class ShippingLabelViewWrapper extends Component {
 				<Notice isCompact={ true } showDismiss={ false } className="shipping-label__payment inline">
 					<p>{ translate( 'To purchase shipping labels, you will first need to select a credit card.' ) }</p>
 					<p>
-						<a href="admin.php?page=wc-settings&tab=shipping&section=label-settings">{ translate( 'Select a credit card' ) }</a>
+						<a href={ `admin.php?page=wc-settings&tab=shipping&section=label-settings&from_order=${ orderId }` }>
+							{ translate( 'Select a credit card' ) }
+						</a>
 					</p>
 				</Notice>
 			);


### PR DESCRIPTION
Implements "Solution 1" referred to in https://github.com/Automattic/woocommerce-services/issues/1115#issuecomment-325632978.

If (and only if) the label settings screen was arrived at from an order screen (i.e. an edit post screen), and settings are saved with a payment method selected, a "Back to order" link appears in the success notification (which also persists in this case, instead of disappearing after 5 seconds).

<img width="605" alt="screen shot 2018-02-05 at 2 41 09 pm" src="https://user-images.githubusercontent.com/1867547/35825061-b6302d66-0a82-11e8-81a6-513517f349d7.png">

Can change "Back to order" text if there are better ideas — "return" instead of "back"? to "order page"? or "Order ##"?