### PR TITLE
Output shipping debug messages on the Cart and Checkout pages.

### DIFF
--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -350,39 +350,91 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 		}
 
 		/**
-		 * Gets the last 10 lines from the WooCommerce Services log, if it exists
+		 * Gets the last 10 lines from the WooCommerce Services log by feature, if it exists
 		 */
-		protected function get_debug_log_data() {
-			$data = new stdClass;
-			$data->key = '';
-			$data->file = '';
+		protected function get_debug_log_data( $feature = '' ) {
+			$data       = new stdClass;
+			$data->key  = '';
+			$data->file = null;
 			$data->tail = array();
 
-			if ( method_exists( 'WC_Admin_Status', 'scan_log_files' ) ) {
-				$logs = WC_Admin_Status::scan_log_files();
-				$latest_file_date = 0;
-				$file = null;
-				$key = null;
+			if ( ! method_exists( 'WC_Admin_Status', 'scan_log_files' ) ) {
+				return $data;
+			}
 
-				foreach ( $logs as $log_key => $log_file ) {
-				    $log_file = WC_LOG_DIR . $log_file;
-					$file_date = filemtime( $log_file );
-					if ( 'wc-services-' === substr( $log_key, 0, 12 ) && $latest_file_date < $file_date ) {
-						$latest_file_date = $file_date;
-						$file = $log_file;
-						$key = $log_key;
-					}
+			$log_prefix = 'wc\-services';
+
+			if ( ! empty( $feature ) ) {
+				$log_prefix .= '\-' . $feature;
+			}
+
+			$logs             = WC_Admin_Status::scan_log_files();
+			$latest_file_date = 0;
+
+			foreach ( $logs as $log_key => $log_file ) {
+				if ( ! preg_match( '/' . $log_prefix . '\-[0-9a-f]{32}\-log/', $log_key ) ) {
+					continue;
 				}
 
-				if ( null !== $file ) {
-					$complete_log = file( $file );
-					$data->key = $key;
-					$data->file = $file;
-					$data->tail = array_slice( $complete_log, -10 );
+				$log_file_path = WC_LOG_DIR . $log_file;
+				$file_date     = filemtime( $log_file_path );
+
+				if ( $latest_file_date < $file_date ) {
+					$latest_file_date = $file_date;
+					$data->file       = $log_file_path;
+					$data->key        = $log_key;
 				}
 			}
 
+			if ( null !== $data->file ) {
+				$complete_log = file( $data->file );
+				$data->tail   = array_slice( $complete_log, -10 );
+			}
+
 			return $data;
+		}
+
+		protected function add_log_view( $title, $feature = '' ) {
+			// add connect log tail
+			$log_data   = $this->get_debug_log_data( $feature );
+			$line_count = count( $log_data->tail );
+
+			if ( $line_count < 1 ) {
+
+				$description = '';
+				$log_tail    = __( 'Log is empty', 'woocommerce-services' );
+
+			} else {
+
+				$url = add_query_arg(
+					array(
+						'page'     => 'wc-status',
+						'tab'      => 'logs',
+						'log_file' => $log_data->key
+					),
+					admin_url( 'admin.php' )
+				);
+
+				$description = sprintf(
+					wp_kses(
+						__( 'Last %d entries <a href="%s">Show full log</a>', 'woocommerce-services' ),
+						array(  'a' => array( 'href' => array() ) ) ),
+					$line_count,
+					esc_url( $url )
+				);
+
+				$log_tail = implode( $log_data->tail, '' );
+
+			}
+
+			return (object) array(
+				'key'         => 'wcc_' . $feature . '_log_tail',
+				'title'       => $title,
+				'type'        => 'textarea',
+				'description' => $description,
+				'readonly'    => true,
+				'value'       => $log_tail,
+			);
 		}
 
 		protected function get_debug_items() {
@@ -412,39 +464,9 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 				'save_on_toggle' => true,
 			);
 
-			// add connect log tail
-			$log_data = $this->get_debug_log_data();
-			$log_tail_line_count = count( $log_data->tail );
-			if ( $log_tail_line_count < 1 ) {
-				$description = '';
-				$log_tail = __( 'Log is empty', 'woocommerce-services' );
-			} else {
-				$url = add_query_arg(
-					array(
-						'page' => 'wc-status',
-						'tab' => 'logs',
-						'log_file' => $log_data->key
-					),
-					admin_url( 'admin.php' )
-				);
-				$description = sprintf(
-					wp_kses(
-						__( 'Last %d entries <a href="%s">Show full log</a>', 'woocommerce-services' ),
-						array(  'a' => array( 'href' => array() ) ) ),
-					$log_tail_line_count,
-					esc_url( $url )
-				);
-				$log_tail = implode( $log_data->tail, '' );
-			}
-
-			$debug_items[] = (object) array(
-				'key' => 'wcc_debug_log_tail',
-				'title' => __( 'Debug Log', 'woocommerce-services' ),
-				'type' => 'textarea',
-				'description' => $description,
-				'readonly' => true,
-				'value' => $log_tail
-			);
+			$debug_items[] = $this->add_log_view( __( 'Shipping Log', 'woocommerce-services' ), 'shipping' );
+			$debug_items[] = $this->add_log_view( __( 'Taxes Log', 'woocommerce-services' ), 'taxes' );
+			$debug_items[] = $this->add_log_view( __( 'Other Log', 'woocommerce-services' ) );
 
 			return $debug_items;
 		}

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -388,16 +388,28 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 		protected function get_debug_items() {
 			$debug_items = array();
 
+			// add logging on/off boolean
+			$debug_items[] = (object) array(
+				'key'            => 'wcc_logging_on',
+				'title'          => 'Logging',
+				'type'           => 'boolean',
+				'true_text'      => __( 'Enabled', 'woocommerce-services' ),
+				'false_text'     => __( 'Disabled', 'woocommerce-services' ),
+				'description'    => __( 'Write diagnostic messages to log files. Helpful when contacting support.', 'woocommerce-services' ),
+				'value'          => $this->logger->is_logging_enabled(),
+				'save_on_toggle' => true,
+			);
+
 			// add debug on/off boolean
 			$debug_items[] = (object) array(
-				'key' => 'wcc_debug_on',
-				'title' => 'Debug Logging',
-				'type' => 'boolean',
-				'true_text' => __( 'Enabled', 'woocommerce-services' ),
-				'false_text' => __( 'Disabled', 'woocommerce-services' ),
-				'description' => '',
-				'value' => $this->logger->is_debug_enabled(),
-				'save_on_toggle' => true
+				'key'            => 'wcc_debug_on',
+				'title'          => 'Debug',
+				'type'           => 'boolean',
+				'true_text'      => __( 'Enabled', 'woocommerce-services' ),
+				'false_text'     => __( 'Disabled', 'woocommerce-services' ),
+				'description'    => __( 'Display troubleshooting information on the Cart and Checkout pages.', 'woocommerce-services' ),
+				'value'          => $this->logger->is_debug_enabled(),
+				'save_on_toggle' => true,
 			);
 
 			// add connect log tail

--- a/classes/class-wc-connect-logger.php
+++ b/classes/class-wc-connect-logger.php
@@ -12,9 +12,12 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 		private $is_logging_enabled = false;
 		private $is_debug_enabled   = false;
 
-		public function __construct( WC_Logger $logger ) {
+		private $feature;
 
-			$this->logger = $logger;
+		public function __construct( WC_Logger $logger, $feature = '' ) {
+
+			$this->logger  = $logger;
+			$this->feature = strtolower( $feature );
 
 			$this->is_logging_enabled = WC_Connect_Options::get_option( 'debug_logging_enabled', false );
 			$this->is_debug_enabled   = WC_Connect_Options::get_option( 'debug_display_enabled', false );
@@ -116,7 +119,14 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 				return;
 			}
 
-			$this->logger->add( 'wc-services', $log_message );
+			$log_file = 'wc-services';
+
+			if ( ! empty( $this->feature ) ) {
+				$log_file .= '-' . $this->feature;
+			}
+
+			$this->logger->add( $log_file, $log_message );
+
 
 		}
 

--- a/classes/class-wc-connect-logger.php
+++ b/classes/class-wc-connect-logger.php
@@ -10,12 +10,14 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 		private $logger;
 
 		private $is_logging_enabled = false;
+		private $is_debug_enabled   = false;
 
 		public function __construct( WC_Logger $logger ) {
 
 			$this->logger = $logger;
 
 			$this->is_logging_enabled = WC_Connect_Options::get_option( 'debug_logging_enabled', false );
+			$this->is_debug_enabled   = WC_Connect_Options::get_option( 'debug_display_enabled', false );
 
 		}
 
@@ -54,19 +56,35 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 			$this->is_logging_enabled = false;
 		}
 
+		public function enable_debug() {
+			WC_Connect_Options::update_option( 'debug_display_enabled', true );
+			$this->is_debug_enabled = true;
+			$this->log( 'Debug enabled' );
+		}
+
+		public function disable_debug() {
+			$this->log( 'Debug disabled' );
+			WC_Connect_Options::update_option( 'debug_display_enabled', false );
+			$this->is_debug_enabled = false;
+		}
+
 		public function is_debug_enabled() {
+			return $this->is_debug_enabled;
+		}
+
+		public function is_logging_enabled() {
 			return $this->is_logging_enabled;
 		}
 
 		/**
-		 * Logs messages only when debugging is enabled
+		 * Log debug by printing it as notice when debugging is enabled.
 		 *
-		 * @param string $message Message to log
-		 * @param string $context Optional context (e.g. a class or function name)
+		 * @param string $message Debug message.
+		 * @param string $type    Notice type.
 		 */
-		public function debug( $message, $context = '' ) {
-			if ( $this->is_debug_enabled() ) {
-				$this->log( $message, $context );
+		public function debug( $message, $type = 'notice' ) {
+			if ( $this->is_debug_enabled()  ) {
+				wc_add_notice( $message, $type );
 			}
 		}
 
@@ -81,12 +99,25 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 			$this->log( $message, $context );
 		}
 
-		private function log( $message, $context = '' ) {
+		/**
+		 * Logs messages to file and error_log if WP_DEBUG
+		 *
+		 * @param string $message Message to log
+		 * @param string $context Optional context (e.g. a class or function name)
+		 */
+		public function log( $message, $context = '' ) {
 			$log_message = $this->format_message( $message, $context );
-			$this->logger->add( 'wc-services', $log_message );
+
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 				error_log( $log_message );
 			}
+
+			if ( ! $this->is_logging_enabled() ) {
+				return;
+			}
+
+			$this->logger->add( 'wc-services', $log_message );
+
 		}
 
 	}

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -39,6 +39,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				'tos_accepted',
 				'store_guid',
 				'debug_logging_enabled',
+				'debug_display_enabled',
 				'payment_methods',
 				'account_settings',
 				'paper_size',

--- a/classes/class-wc-connect-payment-methods-store.php
+++ b/classes/class-wc-connect-payment-methods-store.php
@@ -33,13 +33,13 @@ if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 			$response_body = $this->api_client->get_payment_methods();
 
 			if ( is_wp_error( $response_body ) ) {
-				$this->logger->debug( $response_body, __FUNCTION__ );
+				$this->logger->log( $response_body, __FUNCTION__ );
 				return;
 			}
 
 			$payment_methods = $this->get_payment_methods_from_response_body( $response_body );
 			if ( is_wp_error( $payment_methods ) ) {
-				$this->logger->debug( $payment_methods, __FUNCTION__ );
+				$this->logger->log( $payment_methods, __FUNCTION__ );
 				return;
 			}
 

--- a/classes/class-wc-connect-service-schemas-store.php
+++ b/classes/class-wc-connect-service-schemas-store.php
@@ -26,11 +26,11 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 			$response_body = $this->api_client->get_service_schemas();
 
 			if ( is_wp_error( $response_body ) ) {
-				$this->logger->debug( $response_body, __FUNCTION__ );
+				$this->logger->log( $response_body, __FUNCTION__ );
 				return false;
 			}
 
-			$this->logger->debug( 'Successfully loaded service schemas from server response.', __FUNCTION__ );
+			$this->logger->log( 'Successfully loaded service schemas from server response.', __FUNCTION__ );
 			$this->update_last_fetch_timestamp();
 			$this->maybe_update_heartbeat();
 

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -76,7 +76,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		public function update_account_settings( $settings ) {
 			// simple validation for now
 			if ( ! is_array( $settings ) ) {
-				$this->logger->debug( 'Array expected but not received', __FUNCTION__ );
+				$this->logger->log( 'Array expected but not received', __FUNCTION__ );
 				return false;
 			}
 
@@ -572,7 +572,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				case 'yd':
 					return __('yd', 'woocommerce-services');
 				default:
-					$this->logger->debug( 'Unexpected measurement unit: ' . $value, __FUNCTION__ );
+					$this->logger->log( 'Unexpected measurement unit: ' . $value, __FUNCTION__ );
 					return $value;
 			}
 		}

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -250,7 +250,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				return;
 			}
 
-			$this->debug( 'No rates found, adding fallback' );
+			$this->debug( 'No rates found, adding fallback', 'success' );
 
 			$rate_to_add = array(
 				'id'        => self::format_rate_id( 'fallback', $this->id, 0 ),

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -393,7 +393,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 						sprintf(
 							'Received rate: %s (%s)<br/><ul><li>%s</li></ul>',
 							$rate_to_add['label'],
-							$rate->rate,
+							wc_price( $rate->rate ),
 							implode( '</li><li>', $package_names )
 						),
 						'success'

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -49,7 +49,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			do_action( 'wc_connect_service_init', $this, $id_or_instance_id );
 
 			if ( ! $this->service_schema ) {
-				$this->debug(
+				$this->log_error(
 					'Error. A WC_Connect_Shipping_Method was constructed without an id or instance_id',
 					__FUNCTION__
 				);
@@ -138,7 +138,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		 * @param string|WP_Error $message
 		 * @param string $context
 		 */
-		protected function debug( $message, $context = '' ) {
+		protected function log( $message, $context = '' ) {
 
 			$logger = $this->get_logger();
 
@@ -150,7 +150,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 		}
 
-		protected function error( $message, $context = '' ) {
+		protected function log_error( $message, $context = '' ) {
 			$logger = $this->get_logger();
 			if ( is_a( $logger, 'WC_Connect_Logger' ) ) {
 				$logger->error( $message, $context );
@@ -266,7 +266,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			$settings_keys    = get_object_vars( $service_settings );
 
 			if ( empty( $settings_keys ) ) {
-				$this->debug(
+				$this->log(
 					sprintf(
 						'Service settings empty. Skipping %s rate request (instance id %d).',
 						$this->id,
@@ -294,7 +294,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			$response_body = $this->api_client->get_shipping_rates( $services, $package, $custom_boxes, $predefined_boxes );
 
 			if ( is_wp_error( $response_body ) ) {
-				$this->error(
+				$this->log_error(
 					sprintf(
 						'Error. Unable to get shipping rate(s) for %s instance id %d.',
 						$this->id,
@@ -305,7 +305,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 				$this->set_last_request_failed();
 
-				$this->error( $response_body, __FUNCTION__ );
+				$this->log_error( $response_body, __FUNCTION__ );
 				$this->add_fallback_rate( $service_settings );
 				return;
 			}
@@ -320,7 +320,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 			foreach ( (array) $instances as $instance ) {
 				if ( property_exists( $instance, 'error' ) ) {
-					$this->error( $instance->error, __FUNCTION__ );
+					$this->log_error( $instance->error, __FUNCTION__ );
 					$this->set_last_request_failed();
 				}
 

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -263,7 +263,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 		public function calculate_shipping( $package = array() ) {
 
-			$this->debug( 'WooCommerce Services debug mode is on - to hide these messages, turn debug mode off in the settings.' );
+			$this->debug( sprintf(
+				'WooCommerce Services debug mode is on - to hide these messages, turn debug mode off in the <a href="%s" style="text-decoration: underline;">settings</a>.',
+				admin_url( 'admin.php?page=wc-status&tab=connect' )
+			) );
 
 			if ( ! $this->is_valid_package_destination( $package ) ) {
 				return;

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -209,13 +209,13 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 			// Ensure that Country is specified
 			if ( empty( $country ) ) {
-				$this->debug( 'Skipping rate calculation - missing country' );
+				$this->debug( 'Skipping rate calculation - missing country', 'error' );
 				return false;
 			}
 
 			// Validate Postcode
 			if ( ! WC_Validation::is_postcode( $postcode, $country ) ) {
-				$this->debug( 'Skipping rate calculation - invalid postcode' );
+				$this->debug( 'Skipping rate calculation - invalid postcode', 'error' );
 				return false;
 			}
 
@@ -223,7 +223,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			$valid_states = WC()->countries->get_states( $country );
 
 			if ( $valid_states && ! array_key_exists( $state, $valid_states ) ) {
-				$this->debug( 'Skipping rate calculation - invalid/unsupported state' );
+				$this->debug( 'Skipping rate calculation - invalid/unsupported state', 'error' );
 				return false;
 			}
 

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -470,8 +470,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		 * @param string $type    Notice type.
 		 */
 		public function debug( $message, $type = 'notice' ) {
-			if ( $this->logger->is_debug_enabled() && ( is_cart() || is_checkout() ) ) {
-				wc_add_notice( sprintf( '%s (%s:%d)', $message, esc_html( $this->title ), $this->instance_id ), $type );
+			if ( is_cart() || is_checkout() ) {
+				$debug_message = sprintf( '%s (%s:%d)', $message, esc_html( $this->title ), $this->instance_id );
+
+				$this->logger->debug( $debug_message, $type );
 			}
 		}
 

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -389,15 +389,28 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 						),
 					);
 
-					$this->debug(
-						sprintf(
+					if ( $this->logger->is_debug_enabled() ) {
+						$rate_debug_message = sprintf(
 							'Received rate: %s (%s)<br/><ul><li>%s</li></ul>',
 							$rate_to_add['label'],
 							wc_price( $rate->rate ),
 							implode( '</li><li>', $package_names )
-						),
-						'success'
-					);
+						);
+
+						// Notify the merchant when the fallback rate is added by the WCS server.
+						if (
+							property_exists( $service_settings, 'fallback_rate' )
+							&& $rate->rate == $service_settings->fallback_rate
+							&& self::format_rate_title( $this->service_schema->carrier_name ) == $rate_to_add['label']
+						) {
+							$rate_debug_message .= '<strong>Note: this appears to be the fallback rate</strong><br/>';
+						}
+
+						$this->debug(
+							$rate_debug_message,
+							'success'
+						);
+					}
 
 					$this->add_rate( $rate_to_add );
 				}

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -144,7 +144,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 			if ( is_a( $logger, 'WC_Connect_Logger' ) ) {
 
-				$logger->debug( $message, $context );
+				$logger->log( $message, $context );
 
 			}
 

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -250,7 +250,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				return;
 			}
 
-			$this->debug( 'No rates found, adding fallback', 'success' );
+			$this->debug( 'No rates found, adding fallback.', 'error' );
 
 			$rate_to_add = array(
 				'id'        => self::format_rate_id( 'fallback', $this->id, 0 ),
@@ -390,26 +390,20 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 					);
 
 					if ( $this->logger->is_debug_enabled() ) {
-						$rate_debug_message = sprintf(
-							'Received rate: %s (%s)<br/><ul><li>%s</li></ul>',
-							$rate_to_add['label'],
-							wc_price( $rate->rate ),
-							implode( '</li><li>', $package_names )
-						);
-
-						// Notify the merchant when the fallback rate is added by the WCS server.
-						if (
-							property_exists( $service_settings, 'fallback_rate' )
-							&& $rate->rate == $service_settings->fallback_rate
-							&& self::format_rate_title( $this->service_schema->carrier_name ) == $rate_to_add['label']
-						) {
-							$rate_debug_message .= '<strong>Note: this appears to be the fallback rate</strong><br/>';
+						if ( 'fallback' === $services_list ) {
+							// Notify the merchant when the fallback rate is added by the WCS server.
+							$this->debug( 'No rates found, adding fallback.', 'error' );
+						} else {
+							$this->debug(
+								sprintf(
+									'Received rate: %s (%s)<br/><ul><li>%s</li></ul>',
+									$rate_to_add['label'],
+									wc_price( $rate->rate ),
+									implode( '</li><li>', $package_names )
+								),
+								'success'
+							);
 						}
-
-						$this->debug(
-							$rate_debug_message,
-							'success'
-						);
 					}
 
 					$this->add_rate( $rate_to_add );

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -477,7 +477,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		 * @param string $type    Notice type.
 		 */
 		public function debug( $message, $type = 'notice' ) {
-			if ( is_cart() || is_checkout() ) {
+			if ( is_cart() || is_checkout() || isset( $_POST['update_cart'] ) ) {
 				$debug_message = sprintf( '%s (%s:%d)', $message, esc_html( $this->title ), $this->instance_id );
 
 				$this->logger->debug( $debug_message, $type );

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -178,7 +178,7 @@ class WC_Connect_TaxJar_Integration {
 	public function _log( $message ) {
 		$formatted_message = is_scalar( $message ) ? $message : json_encode( $message );
 
-		$this->logger->debug( $formatted_message, 'WCS Tax' );
+		$this->logger->log( $formatted_message, 'WCS Tax' );
 	}
 
 	/**

--- a/classes/class-wc-connect-tracks.php
+++ b/classes/class-wc-connect-tracks.php
@@ -117,7 +117,7 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 
 		protected function debug( $message ) {
 			if ( ! is_null( $this->logger ) ) {
-				$this->logger->debug( $message );
+				$this->logger->log( $message );
 			}
 		}
 

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -71,7 +71,7 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 					$result->get_error_data()
 				)
 			);
-			$this->logger->debug( $error, __CLASS__ );
+			$this->logger->log( $error, __CLASS__ );
 			return $error;
 		}
 

--- a/classes/class-wc-rest-connect-address-normalization-controller.php
+++ b/classes/class-wc-rest-connect-address-normalization-controller.php
@@ -31,7 +31,7 @@ class WC_REST_Connect_Address_Normalization_Controller extends WC_REST_Connect_B
 				$response->get_error_message(),
 				array( 'message' => $response->get_error_message() )
 			);
-			$this->logger->debug( $error, __CLASS__ );
+			$this->logger->log( $error, __CLASS__ );
 			return $error;
 		}
 
@@ -41,7 +41,7 @@ class WC_REST_Connect_Address_Normalization_Controller extends WC_REST_Connect_B
 				$response->error->message,
 				array( 'message' => $response->error->message )
 			);
-			$this->logger->debug( $error, __CLASS__ );
+			$this->logger->log( $error, __CLASS__ );
 			return $error;
 		}
 

--- a/classes/class-wc-rest-connect-self-help-controller.php
+++ b/classes/class-wc-rest-connect-self-help-controller.php
@@ -14,19 +14,29 @@ class WC_REST_Connect_Self_Help_Controller extends WC_REST_Connect_Base_Controll
 	public function post( $request ) {
 		$settings = $request->get_json_params();
 
-		if ( empty( $settings ) || ! array_key_exists( 'wcc_debug_on', $settings ) ) {
+		if (
+			empty( $settings )
+			|| ! array_key_exists( 'wcc_debug_on', $settings )
+			|| ! array_key_exists( 'wcc_logging_on', $settings )
+		) {
 			$error = new WP_Error( 'bad_form_data',
 				__( 'Unable to update settings. The form data could not be read.', 'woocommerce-services' ),
 				array( 'status' => 400 )
 			);
-			$this->logger->debug( $error, __CLASS__ );
+			$this->logger->log( $error, __CLASS__ );
 			return $error;
 		}
 
-		if ( 1 == $settings['wcc_debug_on'] ) {
+		if ( 1 == $settings['wcc_logging_on'] ) {
 			$this->logger->enable_logging();
 		} else {
 			$this->logger->disable_logging();
+		}
+
+		if ( 1 == $settings['wcc_debug_on'] ) {
+			$this->logger->enable_debug();
+		} else {
+			$this->logger->disable_debug();
 		}
 
 		return new WP_REST_Response( array( 'success' => true ), 200 );

--- a/classes/class-wc-rest-connect-services-controller.php
+++ b/classes/class-wc-rest-connect-services-controller.php
@@ -59,7 +59,7 @@ class WC_REST_Connect_Services_Controller extends WC_REST_Connect_Base_Controlle
 				__( 'Unable to update service settings. Form data is missing service ID.', 'woocommerce-services' ),
 				array( 'status' => 400 )
 			);
-			$this->logger->debug( $error, __CLASS__ );
+			$this->logger->log( $error, __CLASS__ );
 			return $error;
 		}
 
@@ -70,7 +70,7 @@ class WC_REST_Connect_Services_Controller extends WC_REST_Connect_Base_Controlle
 				__( 'Unable to update service settings. The form data could not be read.', 'woocommerce-services' ),
 				array( 'status' => 400 )
 			);
-			$this->logger->debug( $error, __CLASS__ );
+			$this->logger->log( $error, __CLASS__ );
 			return $error;
 		}
 
@@ -87,7 +87,7 @@ class WC_REST_Connect_Services_Controller extends WC_REST_Connect_Base_Controlle
 					$validation_result->get_error_data()
 				)
 			);
-			$this->logger->debug( $error, __CLASS__ );
+			$this->logger->log( $error, __CLASS__ );
 			return $error;
 		}
 

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -53,7 +53,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 				$response->get_error_message(),
 				array( 'message' => $response->get_error_message() )
 			);
-			$this->logger->debug( $error, __CLASS__ );
+			$this->logger->log( $error, __CLASS__ );
 			return $error;
 		}
 
@@ -67,7 +67,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 					$label_data->error->message,
 					array( 'message' => $label_data->error->message )
 				);
-				$this->logger->debug( $error, __CLASS__ );
+				$this->logger->log( $error, __CLASS__ );
 				return $error;
 			}
 			$label_ids[] = $label_data->label->label_id;

--- a/classes/class-wc-rest-connect-shipping-label-preview-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-preview-controller.php
@@ -28,7 +28,7 @@ class WC_REST_Connect_Shipping_Label_Preview_Controller extends WC_REST_Connect_
 		$raw_response = $this->api_client->get_labels_preview_pdf( $params );
 
 		if ( is_wp_error( $raw_response ) ) {
-			$this->logger->debug( $raw_response, __CLASS__ );
+			$this->logger->log( $raw_response, __CLASS__ );
 			return $raw_response;
 		}
 

--- a/classes/class-wc-rest-connect-shipping-label-print-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-print-controller.php
@@ -33,7 +33,7 @@ class WC_REST_Connect_Shipping_Label_Print_Controller extends WC_REST_Connect_Ba
 					'status' => 400
 				)
 			);
-			$this->logger->debug( $error, __CLASS__ );
+			$this->logger->log( $error, __CLASS__ );
 			return $error;
 		}
 		$params[ 'labels' ] = array();
@@ -49,7 +49,7 @@ class WC_REST_Connect_Shipping_Label_Print_Controller extends WC_REST_Connect_Ba
 		$raw_response = $this->api_client->get_labels_print_pdf( $params );
 
 		if ( is_wp_error( $raw_response ) ) {
-			$this->logger->debug( $raw_response, __CLASS__ );
+			$this->logger->log( $raw_response, __CLASS__ );
 			return $raw_response;
 		}
 

--- a/classes/class-wc-rest-connect-shipping-label-refund-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-refund-controller.php
@@ -26,7 +26,7 @@ class WC_REST_Connect_Shipping_Label_Refund_Controller extends WC_REST_Connect_B
 				'message' => $response->get_error_message(),
 			), $response->get_error_code() );
 
-			$this->logger->debug( $response, __CLASS__ );
+			$this->logger->log( $response, __CLASS__ );
 			return $response;
 		}
 

--- a/classes/class-wc-rest-connect-shipping-label-status-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-status-controller.php
@@ -20,7 +20,7 @@ class WC_REST_Connect_Shipping_Label_Status_Controller extends WC_REST_Connect_B
 				$response->get_error_message(),
 				array( 'message' => $response->get_error_message() )
 			);
-			$this->logger->debug( $error, __CLASS__ );
+			$this->logger->log( $error, __CLASS__ );
 			return $error;
 		}
 

--- a/classes/class-wc-rest-connect-shipping-rates-controller.php
+++ b/classes/class-wc-rest-connect-shipping-rates-controller.php
@@ -33,7 +33,7 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WC_REST_Connect_Base_Con
 				$response->get_error_message(),
 				array( 'message' => $response->get_error_message() )
 			);
-			$this->logger->debug( $error, __CLASS__ );
+			$this->logger->log( $error, __CLASS__ );
 			return $error;
 		}
 

--- a/classes/class-wc-rest-connect-stripe-account-controller.php
+++ b/classes/class-wc-rest-connect-stripe-account-controller.php
@@ -21,7 +21,7 @@ class WC_REST_Connect_Stripe_Account_Controller extends WC_REST_Connect_Base_Con
 		$response = $this->stripe->get_account_details();
 
 		if ( is_wp_error( $response ) ) {
-			$this->logger->debug( $response, __CLASS__ );
+			$this->logger->log( $response, __CLASS__ );
 
 			return new WP_Error(
 				$response->get_error_code(),
@@ -53,7 +53,7 @@ class WC_REST_Connect_Stripe_Account_Controller extends WC_REST_Connect_Base_Con
 		$response = $this->stripe->create_account( $data['email'], $data['country'] );
 
 		if ( is_wp_error( $response ) ) {
-			$this->logger->debug( $response, __CLASS__ );
+			$this->logger->log( $response, __CLASS__ );
 
 			return new WP_Error(
 				$response->get_error_code(),

--- a/classes/class-wc-rest-connect-stripe-deauthorize-controller.php
+++ b/classes/class-wc-rest-connect-stripe-deauthorize-controller.php
@@ -21,7 +21,7 @@ class WC_REST_Connect_Stripe_Deauthorize_Controller extends WC_REST_Connect_Base
 		$response = $this->stripe->deauthorize_account();
 
 		if ( is_wp_error( $response ) ) {
-			$this->logger->debug( $response, __CLASS__ );
+			$this->logger->log( $response, __CLASS__ );
 
 			return new WP_Error(
 				$response->get_error_code(),

--- a/classes/class-wc-rest-connect-stripe-oauth-connect-controller.php
+++ b/classes/class-wc-rest-connect-stripe-oauth-connect-controller.php
@@ -23,7 +23,7 @@ class WC_REST_Connect_Stripe_Oauth_Connect_Controller extends WC_REST_Connect_Ba
 		$response = $this->stripe->connect_oauth( $data['state'], $data['code'] );
 
 		if ( is_wp_error( $response ) ) {
-			$this->logger->debug( $response, __CLASS__ );
+			$this->logger->log( $response, __CLASS__ );
 
 			return new WP_Error(
 				$response->get_error_code(),

--- a/classes/class-wc-rest-connect-stripe-oauth-init-controller.php
+++ b/classes/class-wc-rest-connect-stripe-oauth-init-controller.php
@@ -22,7 +22,7 @@ class WC_REST_Connect_Stripe_Oauth_Init_Controller extends WC_REST_Connect_Base_
 		$response = $this->stripe->get_oauth_url( $data['returnUrl'] );
 
 		if ( is_wp_error( $response ) ) {
-			$this->logger->debug( $response, __CLASS__ );
+			$this->logger->log( $response, __CLASS__ );
 
 			return new WP_Error(
 				$response->get_error_code(),

--- a/tests/php/test_class-wc-connect-shipping-method.php
+++ b/tests/php/test_class-wc-connect-shipping-method.php
@@ -107,7 +107,7 @@ class WP_Test_WC_Connect_Shipping_Method extends WP_UnitTestCase {
 
 		$shipping_method = $this->getMockBuilder( 'WC_Connect_Shipping_Method' )
 			->setConstructorArgs( array( 1 ) )
-			->setMethods( array( 'is_valid_package_destination', 'get_service_settings', 'debug' ) )
+			->setMethods( array( 'is_valid_package_destination', 'get_service_settings', 'log' ) )
 			->getMock();
 
 		$shipping_method->expects( $this->any() )
@@ -119,7 +119,7 @@ class WP_Test_WC_Connect_Shipping_Method extends WP_UnitTestCase {
 			->will( $this->returnValue( new stdClass() ) );
 
 		$shipping_method->expects( $this->once() )
-			->method( 'debug' )
+			->method( 'log' )
 			->with(
 				$this->stringContains( 'Service settings empty.' ),
 				$this->anything()

--- a/tests/php/test_woocommerce-connect-client.php
+++ b/tests/php/test_woocommerce-connect-client.php
@@ -22,7 +22,7 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 
 		$loader = $this->getMockBuilder( 'WC_Connect_Loader' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'get_service_schemas_store', 'get_api_client', 'get_logger', 'get_tracks' ) )
+			->setMethods( array( 'get_service_schemas_store', 'get_api_client', 'get_logger', 'get_shipping_logger', 'get_tracks' ) )
 			->getMock();
 
 		$loader->expects( $this->any() )
@@ -47,6 +47,10 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 
 		$loader->expects( $this->any() )
 			->method( 'get_logger' )
+			->will( $this->returnValue( $logger ) );
+
+		$loader->expects( $this->any() )
+			->method( 'get_shipping_logger' )
 			->will( $this->returnValue( $logger ) );
 
 		if ( ! $tracks ) {

--- a/tests/php/test_woocommerce-connect-tracks.php
+++ b/tests/php/test_woocommerce-connect-tracks.php
@@ -12,7 +12,7 @@ abstract class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 	public function setUp() {
 		$this->logger = $this->getMockBuilder( 'WC_Connect_Logger' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'debug' ) )
+			->setMethods( array( 'log' ) )
 			->getMock();
 
 		$this->tracks = new WC_Connect_Tracks( $this->logger, __FILE__ );
@@ -24,7 +24,7 @@ class WP_Test_WC_Connect_Tracks_No_Jetpack extends WP_Test_WC_Connect_Tracks {
 
 	public function test_no_jetpack() {
 		$this->logger->expects( $this->once() )
-			->method( 'debug' )
+			->method( 'log' )
 			->with(
 				$this->stringContains( 'Error' ),
 				$this->anything()
@@ -47,7 +47,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		$mock_recorded_tracks_events = array();
 
 		$this->logger->expects( $this->once() )
-			->method( 'debug' )
+			->method( 'log' )
 			->with(
 				$this->stringContains( 'woocommerceconnect_test' ),
 				$this->anything()
@@ -74,7 +74,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		$mock_recorded_tracks_events = array();
 
 		$this->logger->expects( $this->once() )
-			->method( 'debug' )
+			->method( 'log' )
 			->with(
 				$this->stringContains( 'woocommerceconnect_opted_in' ),
 				$this->anything()
@@ -101,7 +101,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		$mock_recorded_tracks_events = array();
 
 		$this->logger->expects( $this->once() )
-			->method( 'debug' )
+			->method( 'log' )
 			->with(
 				$this->stringContains( 'woocommerceconnect_opted_out' ),
 				$this->anything()
@@ -131,7 +131,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		// rather then the less precise for all versions
 		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
 			$this->logger->expects( $this->exactly(2) )
-				->method( 'debug' )
+				->method( 'log' )
 				->withConsecutive(
 					array(
 						$this->stringContains( 'woocommerceconnect_saved_service_settings' ),
@@ -144,14 +144,14 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 				);
 		} else {
 			$this->logger->expects( $this->at(0) )
-				->method( 'debug' )
+				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_saved_service_settings' ),
 					$this->anything()
 				);
 
 			$this->logger->expects( $this->at(1) )
-				->method( 'debug' )
+				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_saved_usps_settings' ),
 					$this->anything()
@@ -169,7 +169,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		// rather then the less precise for all versions
 		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
 			$this->logger->expects( $this->exactly(2) )
-				->method( 'debug' )
+				->method( 'log' )
 				->withConsecutive(
 					array(
 						$this->stringContains( 'woocommerceconnect_shipping_zone_method_added' ),
@@ -182,14 +182,14 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 				);
 		} else {
 			$this->logger->expects( $this->at(0) )
-				->method( 'debug' )
+				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_method_added' ),
 					$this->anything()
 				);
 
 			$this->logger->expects( $this->at(1) )
-				->method( 'debug' )
+				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_usps_added' ),
 					$this->anything()
@@ -207,7 +207,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		// rather then the less precise for all versions
 		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
 			$this->logger->expects( $this->exactly(2) )
-				->method( 'debug' )
+				->method( 'log' )
 				->withConsecutive(
 					array(
 						$this->stringContains( 'woocommerceconnect_shipping_zone_method_deleted' ),
@@ -220,14 +220,14 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 				);
 		} else {
 			$this->logger->expects( $this->at(0) )
-				->method( 'debug' )
+				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_method_deleted' ),
 					$this->anything()
 				);
 
 			$this->logger->expects( $this->at(1) )
-				->method( 'debug' )
+				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_canada_post_deleted' ),
 					$this->anything()
@@ -245,7 +245,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		// rather then the less precise for all versions
 		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
 			$this->logger->expects( $this->exactly(2) )
-				->method( 'debug' )
+				->method( 'log' )
 				->withConsecutive(
 					array(
 						$this->stringContains( 'woocommerceconnect_shipping_zone_method_enabled' ),
@@ -258,14 +258,14 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 				);
 		} else {
 			$this->logger->expects( $this->at(0) )
-				->method( 'debug' )
+				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_method_enabled' ),
 					$this->anything()
 				);
 
 			$this->logger->expects( $this->at(1) )
-				->method( 'debug' )
+				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_usps_enabled' ),
 					$this->anything()
@@ -283,7 +283,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		// rather then the less precise for all versions
 		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
 			$this->logger->expects( $this->exactly(2) )
-				->method( 'debug' )
+				->method( 'log' )
 				->withConsecutive(
 					array(
 						$this->stringContains( 'woocommerceconnect_shipping_zone_method_disabled' ),
@@ -296,14 +296,14 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 				);
 		} else {
 			$this->logger->expects( $this->at(0) )
-				->method( 'debug' )
+				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_method_disabled' ),
 					$this->anything()
 				);
 
 			$this->logger->expects( $this->at(1) )
-				->method( 'debug' )
+				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_usps_disabled' ),
 					$this->anything()


### PR DESCRIPTION
Addresses #1163.

Optional PR: https://github.com/Automattic/woocommerce-services/pull/1304 - feature separated logging.

<img width="740" alt="screen shot 2018-02-07 at 2 11 25 pm" src="https://user-images.githubusercontent.com/63922/35947692-630a8280-0c26-11e8-9b27-fdda479253b3.png">

This PR seeks to do the following:
* Separate the notion of "logging" and "debugging" based on front-end visibility
* Output USPS-extension-style debug messages in cart/checkout to help merchants troubleshoot their shipping setup

**Note: this can only output rates that are returned by the server - no packaging info will be displayed if no rates are found.**

<img width="1134" alt="screen shot 2018-02-06 at 9 57 37 am" src="https://user-images.githubusercontent.com/63922/35947684-5a6c6b20-0c26-11e8-8614-7804c524eb40.png">

Messages that can be displayed:
* Request error
* Response is missing `rates` property
* Received rate: <info>
* Skipping rate calculation - missing country
* Skipping rate calculation - invalid postcode
* Skipping rate calculation - invalid/unsupported state
* No rates found, adding fallback

_Note: if the fallback rate was added server side, the "Received rate" message will contain a note about it._