### PR TITLE
Cleaned up the CSS color imports

### DIFF
--- a/assets/stylesheets/_colors.scss
+++ b/assets/stylesheets/_colors.scss
@@ -1,9 +1,5 @@
-@import "~wp-calypso/assets/stylesheets/shared/_colors";
-
-//Purples
-$purple:                 #96588a;
-$purple-dark:            #a36597;
-$purple-light:           #bb77ae;
+// Import colors from Calypso
+@import "shared/_colors";
 
 // Link hovers
 $button-hover:           #008ec2; //is-primary button


### PR DESCRIPTION
Cleanup after #1294 - removes the leftover variables from `_colors.scss` and simplifies the Calypso import.