### PR TITLE
Fix waay too many automated tax requests

### DIFF
--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -197,8 +197,10 @@ class WC_Connect_TaxJar_Integration {
 			return;
 		}
 
-		// Skip during Jetpack REST API proxy requests (via XMLRPC)
-		if ( defined( 'XMLRPC_REQUEST' ) ) {
+		// Skip during REST API or XMLRPC requests
+		if ( defined( 'REST_REQUEST' ) || defined( 'REST_API_REQUEST' ) || defined( 'XMLRPC_REQUEST' ) ) {
+			return;
+		}
 			return;
 		}
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -187,13 +187,18 @@ class WC_Connect_TaxJar_Integration {
 	 * @param $wc_cart_object
 	 */
 	public function maybe_calculate_totals( $wc_cart_object ) {
-		// Skip tax calculations for carts loaded from session in the dashboard
+		// Skip for carts loaded from session in the dashboard
 		if ( is_admin() && did_action( 'woocommerce_cart_loaded_from_session' ) ) {
 			return;
 		}
 
-		// Skip tax calculations during Jetpack JITM requests
+		// Skip during Jetpack JITM requests
 		if ( false !== strpos( $_SERVER['REQUEST_URI'], 'jetpack/v4/jitm' ) ) {
+			return;
+		}
+
+		// Skip during Jetpack REST API proxy requests (via XMLRPC)
+		if ( defined( 'XMLRPC_REQUEST' ) ) {
 			return;
 		}
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -77,7 +77,7 @@ class WC_Connect_TaxJar_Integration {
 			return true;
 		}
 
-		return ( 'yes' === get_option( self::OPTION_NAME ) );
+		return ( wc_tax_enabled() && 'yes' === get_option( self::OPTION_NAME ) );
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -201,6 +201,9 @@ class WC_Connect_TaxJar_Integration {
 		if ( defined( 'REST_REQUEST' ) || defined( 'REST_API_REQUEST' ) || defined( 'XMLRPC_REQUEST' ) ) {
 			return;
 		}
+
+		// Skip during Jetpack REST API proxy requests
+		if ( isset( $_GET['rest_route'] ) && isset( $_GET['_for'] ) && ( 'jetpack' === $_GET['_for'] ) ) {
 			return;
 		}
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -192,8 +192,8 @@ class WC_Connect_TaxJar_Integration {
 			return;
 		}
 
-		// Skip during Jetpack JITM requests
-		if ( false !== strpos( $_SERVER['REQUEST_URI'], 'jetpack/v4/jitm' ) ) {
+		// Skip during Jetpack API requests
+		if ( false !== strpos( $_SERVER['REQUEST_URI'], 'jetpack/v4/' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #1307.

Tax calculation was being kicked off even when core WC taxes were disabled, and on every admin page load. This was a side effect of having items in cart as an admin user, and by Jetpack's JITM request.

To test:
* Ensure that debug logging is enabled
* Ensure that you have items in a cart
* With tax calc **on** + automated taxes on - verify that no tax requests are logged while navigating the admin
* With tax calc **off** + automated taxes on - verify that no tax requests are logged while navigating the admin

(cc: @allendav)