### PR TITLE
Taxes - Moved the total price calulation until after the taxes are added

### DIFF
--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -268,12 +268,6 @@ class WC_Connect_TaxJar_Integration {
 			'line_items' => $line_items,
 		) );
 
-		if ( class_exists( 'WC_Cart_Totals' ) ) { // Woo 3.2+
-			do_action( 'woocommerce_cart_reset', $wc_cart_object, false );
-			do_action( 'woocommerce_before_calculate_totals', $wc_cart_object );
-			new WC_Cart_Totals( $wc_cart_object );
-		}
-
 		foreach ( $this->line_items as $line_item_key => $line_item ) {
 			if ( isset( $cart_taxes[ $this->rate_ids[ $line_item_key ] ] ) ) {
 				$cart_taxes[ $this->rate_ids[ $line_item_key ] ] += $line_item->tax_collectable;
@@ -300,6 +294,12 @@ class WC_Connect_TaxJar_Integration {
 			if ( isset( $this->line_items[ $line_item_key ] ) ) {
 				$wc_cart_object->cart_contents[ $cart_item_key ]['line_tax'] = $this->line_items[ $line_item_key ]->tax_collectable;
 			}
+		}
+
+		if ( class_exists( 'WC_Cart_Totals' ) ) { // Woo 3.2+
+			do_action( 'woocommerce_cart_reset', $wc_cart_object, false );
+			do_action( 'woocommerce_before_calculate_totals', $wc_cart_object );
+			new WC_Cart_Totals( $wc_cart_object );
 		}
 	}
 


### PR DESCRIPTION
Fixes #1309

`WC_Connect_TaxJar_Integration` was telling WC to calculate the totals using the old data, and then modifying some of the rows that came back as a result of that calculation but not updating the grand total. This in turn would lead to prices+taxes not adding up.

To test:
* have a store set in NC
* add a Flat Rate shipping method and set the tax status to none
* enable automated taxes
* checkout an item to an NC address
* the taxes row should not include the shipping tax and the total should be correct
* set the shipping method to taxable
* the taxes row on checkout should include the shipping tax and the total should be correct
