### PR TITLE
 Forward specific address normalization errors, as success response

### DIFF
--- a/classes/class-wc-rest-connect-address-normalization-controller.php
+++ b/classes/class-wc-rest-connect-address-normalization-controller.php
@@ -39,7 +39,7 @@ class WC_REST_Connect_Address_Normalization_Controller extends WC_REST_Connect_B
 			$this->logger->log( 'Address validation errors: ' . implode( '; ', array_values( (array) $response->field_errors ) ), __CLASS__ );
 			return array(
 				'success' => true,
-				'fieldErrors' => $response->field_errors,
+				'field_errors' => $response->field_errors,
 			);
 		}
 

--- a/classes/class-wc-rest-connect-address-normalization-controller.php
+++ b/classes/class-wc-rest-connect-address-normalization-controller.php
@@ -35,18 +35,13 @@ class WC_REST_Connect_Address_Normalization_Controller extends WC_REST_Connect_B
 			return $error;
 		}
 
-		if ( isset( $response->error ) ) {
-			$error = new WP_Error(
-				$response->error->code,
-				$response->error->message,
-				array(
-					'status' => 400,
-					'message' => $response->error->message,
-					'fieldErrors' => $response->fieldErrors,
-				)
+		if ( isset( $response->fieldErrors ) ) {
+			$response = array(
+				'success' => true,
+				'fieldErrors' => $response->fieldErrors,
 			);
-			$this->logger->log( $error, __CLASS__ );
-			return $error;
+			$this->logger->log( $response, __CLASS__ );
+			return $response;
 		}
 
 		$response->normalized->name = $name;

--- a/classes/class-wc-rest-connect-address-normalization-controller.php
+++ b/classes/class-wc-rest-connect-address-normalization-controller.php
@@ -39,7 +39,11 @@ class WC_REST_Connect_Address_Normalization_Controller extends WC_REST_Connect_B
 			$error = new WP_Error(
 				$response->error->code,
 				$response->error->message,
-				array( 'message' => $response->error->message, 'fieldErrors' => $response->fieldErrors )
+				array(
+					'status' => 400,
+					'message' => $response->error->message,
+					'fieldErrors' => $response->fieldErrors,
+				)
 			);
 			$this->logger->log( $error, __CLASS__ );
 			return $error;

--- a/classes/class-wc-rest-connect-address-normalization-controller.php
+++ b/classes/class-wc-rest-connect-address-normalization-controller.php
@@ -36,12 +36,11 @@ class WC_REST_Connect_Address_Normalization_Controller extends WC_REST_Connect_B
 		}
 
 		if ( isset( $response->fieldErrors ) ) {
-			$response = array(
+			$this->logger->log( 'Address validation errors: ' . implode( '; ', array_values( (array) $response->fieldErrors ) ), __CLASS__ );
+			return array(
 				'success' => true,
 				'fieldErrors' => $response->fieldErrors,
 			);
-			$this->logger->log( $response, __CLASS__ );
-			return $response;
 		}
 
 		$response->normalized->name = $name;

--- a/classes/class-wc-rest-connect-address-normalization-controller.php
+++ b/classes/class-wc-rest-connect-address-normalization-controller.php
@@ -35,11 +35,11 @@ class WC_REST_Connect_Address_Normalization_Controller extends WC_REST_Connect_B
 			return $error;
 		}
 
-		if ( isset( $response->fieldErrors ) ) {
-			$this->logger->log( 'Address validation errors: ' . implode( '; ', array_values( (array) $response->fieldErrors ) ), __CLASS__ );
+		if ( isset( $response->field_errors ) ) {
+			$this->logger->log( 'Address validation errors: ' . implode( '; ', array_values( (array) $response->field_errors ) ), __CLASS__ );
 			return array(
 				'success' => true,
-				'fieldErrors' => $response->fieldErrors,
+				'fieldErrors' => $response->field_errors,
 			);
 		}
 

--- a/classes/class-wc-rest-connect-address-normalization-controller.php
+++ b/classes/class-wc-rest-connect-address-normalization-controller.php
@@ -39,7 +39,7 @@ class WC_REST_Connect_Address_Normalization_Controller extends WC_REST_Connect_B
 			$error = new WP_Error(
 				$response->error->code,
 				$response->error->message,
-				array( 'message' => $response->error->message )
+				array( 'message' => $response->error->message, 'fieldErrors' => $response->fieldErrors )
 			);
 			$this->logger->log( $error, __CLASS__ );
 			return $error;


### PR DESCRIPTION
In the event of address normalization validation errors, passes specific address field validation errors back to the client. ~(Depends on server branch `add/address-normalization-field-errors`.)~

Also, changes this response from an error to a success response (to match the WCS server response): the data only gets passed back to the WP.com client in the event of a successful request.