### PR TITLE
Add package and product measurements to shipping rate debug messages

### DIFF
--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -395,7 +395,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 							);
 						}
 
-						$package_summaries[] = sprintf( '%s (%s)', $package_name, $package_measurements ) . '<ul><li>' . implode( '</li><li>', $item_summaries ) . '</li></ul>';
+						$package_summaries[] = sprintf( '%s (%s)', $package_name, $package_measurements )
+							. '<ul><li>' . implode( '</li><li>', $item_summaries ) . '</li></ul>';
 					}
 
 					$packaging_info = implode( ', ', $package_summaries );

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -378,14 +378,16 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 						}
 
 						if ( ! property_exists( $rate_package, 'box_id' ) ) {
-							$package_name = __( 'Unknown package', 'woocommerce-services' );
+							$package_name = __( '📦 Unknown package', 'woocommerce-services' );
 						} else if ( 'individual' === $rate_package->box_id ) {
-							$package_name = __( 'Individual packaging', 'woocommerce-services' );
+							$package_name = __( '📦 Individual packaging', 'woocommerce-services' );
 						} else if (
 							isset( $packaging_lookup[ $rate_package->box_id ] ) &&
 							isset( $packaging_lookup[ $rate_package->box_id ]['name'] )
 						) {
-							$package_name = $packaging_lookup[ $rate_package->box_id ]['name'];
+							$is_letter = isset( $packaging_lookup[ $rate_package->box_id ]['is_letter'] ) && $packaging_lookup[ $rate_package->box_id ]['is_letter'];
+							$icon = $is_letter ? '✉️' : '📦';
+							$package_name = $icon . ' ' . $packaging_lookup[ $rate_package->box_id ]['name'];
 							$package_measurements = sprintf(
 								$measurements_format,
 								$rate_package->length,

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -373,7 +373,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 									$package_item->height,
 									$package_item->weight
 								);
-								$item_summaries[] = sprintf( '%s (%s)', $item_name, $item_measurements );
+								$item_summaries[] = sprintf( '<strong>%s</strong> (%s)', $item_name, $item_measurements );
 							}
 						}
 
@@ -395,7 +395,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 							);
 						}
 
-						$package_summaries[] = sprintf( '%s (%s)', $package_name, $package_measurements )
+						$package_summaries[] = sprintf( '<strong>%s</strong> (%s)', $package_name, $package_measurements )
 							. '<ul><li>' . implode( '</li><li>', $item_summaries ) . '</li></ul>';
 					}
 
@@ -421,7 +421,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 						} else {
 							$this->debug(
 								sprintf(
-									'Received rate: %s (%s)<br/><ul><li>%s</li></ul>',
+									'Received rate: <strong>%s</strong> (%s)<br/><ul><li>%s</li></ul>',
 									$rate_to_add['label'],
 									wc_price( $rate->rate ),
 									implode( '</li><li>', $package_summaries )


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/1163#issuecomment-368528627

Enhances shipping rate front-end debug messages by adding dimensions and weight for packages and their products:

<img width="806" alt="screen shot 2018-03-01 at 4 34 46 pm" src="https://user-images.githubusercontent.com/1867547/36870916-860591c2-1d6e-11e8-8be8-e9ef02f19dba.png">
