### PR TITLE
Hide the tax settings and show a notice when automated taxes are enabled

### DIFF
--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -95,10 +95,13 @@ class WC_Connect_TaxJar_Integration {
 	 * @return array
 	 */
 	public function add_tax_settings( $tax_settings ) {
+		$enabled = $this->is_enabled();
+
 		$automated_taxes = array(
 			'title'    => __( 'Automated taxes', 'woocommerce-services' ),
 			'id'       => self::OPTION_NAME, // TODO: save in `wc_connect_options`?
 			'desc_tip' => __( 'Automate your sales tax calculations with WooCommerce Services, powered by Jetpack.', 'woocommerce-services' ),
+			'desc'     => $enabled ? '<p>' . __( 'Powered by WooCommerce Services ― Your tax rates and settings are automatically configured.', 'woocommerce-services' ) . '</p>' : '',
 			'default'  => 'no',
 			'type'     => 'select',
 			'class'    => 'wc-enhanced-select',
@@ -111,13 +114,9 @@ class WC_Connect_TaxJar_Integration {
 		// Insert the "automated taxes" setting at the top (under the section title)
 		array_splice( $tax_settings, 1, 0, array( $automated_taxes ) );
 
-		if ( $this->is_enabled() ) {
+		if ( $enabled ) {
 			// If the automated taxes are enabled, disable the settings that would be reverted in the original plugin
 			foreach ( $tax_settings as $index => $tax_setting ) {
-				if ( 'tax_options' === $tax_setting['id'] && 'title' === $tax_setting['type'] ) {
-					$tax_settings[$index]['desc'] = __( 'Powered by WooCommerce Services ― Your tax rates and settings are automatically configured.', 'woocommerce-services' );
-				}
-
 				if ( in_array( $tax_setting['id'], array( 'tax_options', 'woocommerce_tax_classes', self::OPTION_NAME ) ) ) {
 					continue;
 				}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -42,6 +42,10 @@ class WC_Connect_TaxJar_Integration {
 		// Add toggle for automated taxes to the core settings page
 		add_filter( 'woocommerce_tax_settings', array( $this, 'add_tax_settings' ) );
 
+		// Settings Page
+		add_action( 'woocommerce_sections_tax', array( $this, 'output_sections_before' ),  9 );
+		add_action( 'woocommerce_sections_tax', array( $this, 'output_sections_after' ),  11 );
+
 		// Bow out if we're not wanted
 		if ( ! $this->is_enabled() ) {
 			return;
@@ -101,10 +105,47 @@ class WC_Connect_TaxJar_Integration {
 			),
 		);
 
-		// Insert the "automated taxes" setting at the top (under the section title)
-		array_splice( $tax_settings, 1, 0, array( $automated_taxes ) );
+		if ( $this->is_enabled() ) {
+			// If the automated taxes are enabled, then don't show any other settings besides title and save button
+			array_splice( $tax_settings, 1, count( $tax_settings ) - 2, array( $automated_taxes ) );
+		} else {
+			// Insert the "automated taxes" setting at the top (under the section title)
+			array_splice( $tax_settings, 1, 0, array( $automated_taxes ) );
+		}
 
 		return $tax_settings;
+	}
+
+	/**
+	 * Hack to hide the tax sections for additional tax class rate tables.
+	 *
+	 */
+	public function output_sections_before() {
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
+		?>
+		<div class="updated">
+			<p>
+				<b><? esc_html_e( 'Powered by WooCommerce Services', 'woocommerce-services' ) ?></b>
+				<? esc_html_e( ' ― Your tax rates and settings are automatically configured.', 'woocommerce-services' ) ?>
+			</p>
+		</div>
+		<div style="display: none">
+		<?
+	}
+
+	/**
+	 * Hack to hide the tax sections for additional tax class rate tables.
+	 *
+	 */
+	public function output_sections_after() {
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
+		?></div><?
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -127,6 +127,7 @@ class WC_Connect_TaxJar_Integration {
 	/**
 	 * When automated taxes are enabled, overwrite core tax settings that might break the API integration
 	 * This is similar to the original plugin functionality where these options were reverted on page load
+	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/82bf7c58/includes/class-wc-taxjar-integration.php#L66-L91
 	 *
 	 * @param mixed $value - option value
 	 * @param array $option - option metadata
@@ -207,7 +208,6 @@ class WC_Connect_TaxJar_Integration {
 			return;
 		}
 
-		$this->configure_tax_settings();
 		$this->backup_existing_tax_rates();
 
 		WC_Connect_Options::update_option( self::ENV_SETUP_FLAG, false );
@@ -781,38 +781,6 @@ class WC_Connect_TaxJar_Integration {
 		} else {
 			$this->_log( 'Received (' . $response['response']['code'] . '): ' . $response['body'] );
 		}
-	}
-
-	/**
-	 * Configure WooCommerce core tax settings for TaxJar integration.
-	 *
-	 * Ported from TaxJar's plugin.
-	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/82bf7c58/includes/class-wc-taxjar-integration.php#L66-L91
-	 */
-	public function configure_tax_settings() {
-		// If TaxJar is enabled and a user disables taxes we renable them
-		update_option( 'woocommerce_calc_taxes', 'yes' );
-
-		// Users can set either billing or shipping address for tax rates but not shop
-		update_option( 'woocommerce_tax_based_on', 'shipping' );
-
-		// Rate calculations assume tax not included
-		update_option( 'woocommerce_prices_include_tax', 'no' );
-
-		// Use no special handling on shipping taxes, our API handles that
-		update_option( 'woocommerce_shipping_tax_class', '' );
-
-		// API handles rounding precision
-		update_option( 'woocommerce_tax_round_at_subtotal', 'no' );
-
-		// Rates are calculated in the cart assuming tax not included
-		update_option( 'woocommerce_tax_display_shop', 'excl' );
-
-		// TaxJar returns one total amount, not line item amounts
-		update_option( 'woocommerce_tax_display_cart', 'excl' );
-
-		// TaxJar returns one total amount, not line item amounts
-		update_option( 'woocommerce_tax_total_display', 'single' );
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -128,12 +128,12 @@ class WC_Connect_TaxJar_Integration {
 		?>
 		<div class="updated">
 			<p>
-				<b><? esc_html_e( 'Powered by WooCommerce Services', 'woocommerce-services' ) ?></b>
-				<? esc_html_e( ' ― Your tax rates and settings are automatically configured.', 'woocommerce-services' ) ?>
+				<b><?php esc_html_e( 'Powered by WooCommerce Services', 'woocommerce-services' ) ?></b>
+				<?php esc_html_e( ' ― Your tax rates and settings are automatically configured.', 'woocommerce-services' ) ?>
 			</p>
 		</div>
 		<div style="display: none">
-		<?
+		<?php
 	}
 
 	/**
@@ -145,7 +145,7 @@ class WC_Connect_TaxJar_Integration {
 			return;
 		}
 
-		?></div><?
+		?></div><?php
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -114,6 +114,10 @@ class WC_Connect_TaxJar_Integration {
 		if ( $this->is_enabled() ) {
 			// If the automated taxes are enabled, disable the settings that would be reverted in the original plugin
 			foreach ( $tax_settings as $index => $tax_setting ) {
+				if ( 'tax_options' === $tax_setting['id'] && 'title' === $tax_setting['type'] ) {
+					$tax_settings[$index]['desc'] = __( 'Powered by WooCommerce Services ― Your tax rates and settings are automatically configured.', 'woocommerce-services' );
+				}
+
 				if ( in_array( $tax_setting['id'], array( 'tax_options', 'woocommerce_tax_classes', self::OPTION_NAME ) ) ) {
 					continue;
 				}
@@ -175,14 +179,7 @@ class WC_Connect_TaxJar_Integration {
 		if ( ! $this->is_enabled() ) {
 			return;
 		}
-
 		?>
-		<div class="updated">
-			<p>
-				<b><?php esc_html_e( 'Powered by WooCommerce Services', 'woocommerce-services' ) ?></b>
-				<?php esc_html_e( ' ― Your tax rates and settings are automatically configured.', 'woocommerce-services' ) ?>
-			</p>
-		</div>
 		<div style="display: none">
 		<?php
 	}
@@ -194,7 +191,6 @@ class WC_Connect_TaxJar_Integration {
 		if ( ! $this->is_enabled() ) {
 			return;
 		}
-
 		?></div><?php
 	}
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -105,20 +105,30 @@ class WC_Connect_TaxJar_Integration {
 			),
 		);
 
+		// Insert the "automated taxes" setting at the top (under the section title)
+		array_splice( $tax_settings, 1, 0, array( $automated_taxes ) );
+
 		if ( $this->is_enabled() ) {
-			// If the automated taxes are enabled, then don't show any other settings besides title and save button
-			array_splice( $tax_settings, 1, count( $tax_settings ) - 2, array( $automated_taxes ) );
-		} else {
-			// Insert the "automated taxes" setting at the top (under the section title)
-			array_splice( $tax_settings, 1, 0, array( $automated_taxes ) );
+			// If the automated taxes are enabled, only show the settings that will not be overriden
+			$tax_settings = array_filter( $tax_settings, array( $this, 'tax_settings_filter' ) );
 		}
 
 		return $tax_settings;
 	}
 
 	/**
-	 * Hack to hide the tax sections for additional tax class rate tables.
+	 * Filter callback for tax settings when automated taxes are enabled
 	 *
+	 * @param $setting - woocommerce setting schema, see woocommerce/includes/admin/settings/views/settings-tax.php
+	 * @return boolean true if the setting control should be shown with automated taxes enabled, false otherwise
+	 */
+	private function tax_settings_filter( $setting ) {
+		//only show title, automated taxes control, additional tax classes and the save button
+		return in_array( $setting['id'], array( 'tax_options', 'woocommerce_tax_classes', self::OPTION_NAME ) );
+	}
+
+	/**
+	 * Hack to hide the tax sections for additional tax class rate tables.
 	 */
 	public function output_sections_before() {
 		if ( ! $this->is_enabled() ) {
@@ -138,7 +148,6 @@ class WC_Connect_TaxJar_Integration {
 
 	/**
 	 * Hack to hide the tax sections for additional tax class rate tables.
-	 *
 	 */
 	public function output_sections_after() {
 		if ( ! $this->is_enabled() ) {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -141,7 +141,7 @@ class WC_Connect_TaxJar_Integration {
 			case 'woocommerce_calc_taxes':
 				// If automated taxes are enabled and user disables taxes we re-enable them
 				return 'yes';
-			case 'woocommerce_calc_taxes':
+			case 'woocommerce_tax_based_on':
 				// Users can set either billing or shipping address for tax rates but not shop
 				return $value === 'billing' ? $value : 'shipping';
 			case 'woocommerce_prices_include_tax':


### PR DESCRIPTION
Fixes #1296
Fixes #1297

TaxJar shows all the options when enabled, but reverts them on save anyway. I decided to hide the options since they are always ignored when calculating the taxes.

<img width="849" alt="screen shot 2018-03-06 at 13 04 27" src="https://user-images.githubusercontent.com/800604/37034048-e7bdd774-213f-11e8-9f19-87fff172b339.png">
