### PR TITLE
Updated the versions matrix to test our code in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ matrix:
 # Clones WordPress and configures our testing environment.
 before_script: bash tests/bin/install-wc-tests.sh wordpress_test root '' localhost $WP_VERSION $WC_VERSION
 
+script: phpunit --version
+
 sudo: false
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@
 # Tell Travis CI we're using PHP
 language: php
 
-# Next we define our matrix of build configurations to test against.
-
+# Define our matrix of build configurations to test against.
 matrix:
   include:
    - php: 5.2
@@ -33,26 +32,12 @@ matrix:
      env: WP_VERSION=4.4 WC_VERSION=2.6.14
    - php: 7.2
      env: WP_VERSION=latest WC_VERSION=3.3.3
-
-# Cache the NPM dependencies
-cache:
-  directories:
-    - node_modules
-    - "$HOME/.nvm"
-
-# Use an updated Node runtime
-# See: http://entulho.fiatjaf.alhur.es/guias/how-to-use-node-along-with-other-language-on-travis-ci/
-install:
-    - . $HOME/.nvm/nvm.sh
-    - nvm install 8.9.3
-    - nvm use 8.9.3
-    - npm install
+     # Run the JS tests in a separate container
+   - language: node_js
+     before_script: ""
 
 # Clones WordPress and configures our testing environment.
-before_script:
-    - bash tests/bin/install-wc-tests.sh wordpress_test root '' localhost $WP_VERSION $WC_VERSION
-
-script: phpunit && npm test
+before_script: bash tests/bin/install-wc-tests.sh wordpress_test root '' localhost $WP_VERSION $WC_VERSION
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,16 +30,16 @@ matrix:
      env: WP_VERSION=latest WC_VERSION=3.0.3
    - php: 7.2
      env: WP_VERSION=4.4 WC_VERSION=2.6.14
+     script: curl -sSfL -o ~/.phpenv/versions/7.2/bin/phpunit https://phar.phpunit.de/phpunit-6.4.phar && phpunit
    - php: 7.2
      env: WP_VERSION=latest WC_VERSION=3.3.3
+     script: curl -sSfL -o ~/.phpenv/versions/7.2/bin/phpunit https://phar.phpunit.de/phpunit-6.4.phar && phpunit
      # Run the JS tests in a separate container
    - language: node_js
      before_script: ""
 
 # Clones WordPress and configures our testing environment.
 before_script: bash tests/bin/install-wc-tests.sh wordpress_test root '' localhost $WP_VERSION $WC_VERSION
-
-script: phpunit --version
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,11 @@ matrix:
      env: WP_VERSION=latest WC_VERSION=3.0.3
    - php: 7.2
      env: WP_VERSION=4.4 WC_VERSION=2.6.14
-     script: curl -sSfL -o ~/.phpenv/versions/7.2/bin/phpunit https://phar.phpunit.de/phpunit-6.4.phar && phpunit
+     # Older versions of WP are not compatible with PHPUnit 6+. Manually install PHPUnit 5.
+     script: curl -sSfL -o ~/.phpenv/versions/7.2/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar && phpunit
    - php: 7.2
      env: WP_VERSION=latest WC_VERSION=3.3.3
+     # Not even the latest WP version is compatible with PHPUnit 7. Manually install PHPUnit 6.
      script: curl -sSfL -o ~/.phpenv/versions/7.2/bin/phpunit https://phar.phpunit.de/phpunit-6.4.phar && phpunit
      # Run the JS tests in a separate container
    - language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,7 @@
 # Tell Travis CI we're using PHP
 language: php
 
-# PHP version used in first build configuration.
-php:
-    - 7.2
-
-# WordPress version used in first build configuration.
-env:
-    - WP_VERSION=latest WC_VERSION=3.3.3
-
-# Next we define our matrix of additional build configurations to test against.
-# The versions listed above will automatically create our first configuration,
-# so it doesn't need to be re-defined below.
-
-# WP_VERSION specifies the tag to use. The way these tests are configured to run
-# requires at least WordPress 3.8. Specify "master" to test against SVN trunk.
+# Next we define our matrix of build configurations to test against.
 
 matrix:
   include:
@@ -44,7 +31,8 @@ matrix:
      env: WP_VERSION=latest WC_VERSION=3.0.3
    - php: 7.2
      env: WP_VERSION=4.4 WC_VERSION=2.6.14
-     # 7.2 / latest / 3.3 already included above as first build.
+   - php: 7.2
+     env: WP_VERSION=latest WC_VERSION=3.3.3
 
 # Cache the NPM dependencies
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ php:
 
 # WordPress version used in first build configuration.
 env:
-    - WP_VERSION=latest
-    - wC_VERSION=3.3.3
+    - WP_VERSION=latest WC_VERSION=3.3.3
 
 # Next we define our matrix of additional build configurations to test against.
 # The versions listed above will automatically create our first configuration,

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,16 @@ language: php
 
 # PHP version used in first build configuration.
 php:
-    - 5.6
+    - 7.2
 
 # WordPress version used in first build configuration.
 env:
     - WP_VERSION=latest
+    - wC_VERSION=3.3.3
 
 # Next we define our matrix of additional build configurations to test against.
 # The versions listed above will automatically create our first configuration,
 # so it doesn't need to be re-defined below.
-
-# Test WP trunk/master and two latest versions on minimum (5.2).
-# Test WP latest two versions (4.4, 4.4) on most popular (5.5, 5.6).
-# Test WP latest stable (4.4) on other supported PHP (5.3, 5.4).
-# Test WP trunk/master on edge platforms (7.0, hhvm, PHP nightly).
 
 # WP_VERSION specifies the tag to use. The way these tests are configured to run
 # requires at least WordPress 3.8. Specify "master" to test against SVN trunk.
@@ -26,36 +22,30 @@ env:
 matrix:
   include:
    - php: 5.2
-     env: WP_VERSION=latest WC_VERSION=2.6.14
+     env: WP_VERSION=4.4 WC_VERSION=2.6.14
      sudo: true
      dist: precise
    - php: 5.2
-     env: WP_VERSION=4.4 WC_VERSION=2.6.14
+     env: WP_VERSION=latest WC_VERSION=3.3.3
      sudo: true
      dist: precise
    - php: 5.3
-     env: WP_VERSION=latest WC_VERSION=2.6.14
-     sudo: true
-     dist: precise
-   - php: 5.3
-     env: WP_VERSION=4.4 WC_VERSION=2.6.14
+     env: WP_VERSION=4.5 WC_VERSION=3.2.6
      sudo: true
      dist: precise
    - php: 5.4
+     env: WP_VERSION=4.6 WC_VERSION=3.1.2
+   - php: 5.5
+     env: WP_VERSION=4.7 WC_VERSION=3.0.9
+   - php: 5.6
+     env: WP_VERSION=4.8 WC_VERSION=2.6.14
+   - php: 7.0
      env: WP_VERSION=latest WC_VERSION=2.6.14
-   - php: 5.4
-     env: WP_VERSION=4.4 WC_VERSION=2.6.14
-   - php: 5.5
-     env: WP_VERSION=latest WC_VERSION=2.6.14
-   - php: 5.5
-     env: WP_VERSION=4.4 WC_VERSION=2.6.14
-   - php: 5.5
+   - php: 7.1
      env: WP_VERSION=latest WC_VERSION=3.0.3
-     # 5.6 / master already included above as first build.
-   - php: 5.6
+   - php: 7.2
      env: WP_VERSION=4.4 WC_VERSION=2.6.14
-   - php: 5.6
-     env: WP_VERSION=4.4 WC_VERSION=3.0.3
+     # 7.2 / latest / 3.3 already included above as first build.
 
 # Cache the NPM dependencies
 cache:

--- a/tests/bin/install-wc-tests.sh
+++ b/tests/bin/install-wc-tests.sh
@@ -13,7 +13,7 @@ WP_VERSION=${5-latest}
 WC_VERSION=${6-"2.6.14"}
 
 install_wc() {
-	git clone --depth=1 --branch=$WC_VERSION https://github.com/woocommerce/woocommerce.git /tmp/woocommerce
+	wget -q -O- https://github.com/woocommerce/woocommerce/archive/${WC_VERSION}.tar.gz | tar xvz -C /tmp/woocommerce
 }
 
 install_wp() {

--- a/tests/bin/install-wc-tests.sh
+++ b/tests/bin/install-wc-tests.sh
@@ -13,7 +13,8 @@ WP_VERSION=${5-latest}
 WC_VERSION=${6-"2.6.14"}
 
 install_wc() {
-	wget -q -O- https://github.com/woocommerce/woocommerce/archive/${WC_VERSION}.tar.gz | tar xvz -C /tmp/woocommerce
+	mkdir /tmp/woocommerce
+	wget -q -O- https://github.com/woocommerce/woocommerce/archive/${WC_VERSION}.tar.gz | tar xvz -C /tmp/woocommerce --strip-components=1
 }
 
 install_wp() {

--- a/tests/bin/install-wc-tests.sh
+++ b/tests/bin/install-wc-tests.sh
@@ -13,8 +13,7 @@ WP_VERSION=${5-latest}
 WC_VERSION=${6-"2.6.14"}
 
 install_wc() {
-	mkdir /tmp/woocommerce
-	wget -q -O- https://github.com/woocommerce/woocommerce/archive/${WC_VERSION}.tar.gz | tar xvz -C /tmp/woocommerce --strip-components=1
+	git clone --depth=1 --branch=$WC_VERSION https://github.com/woocommerce/woocommerce.git /tmp/woocommerce
 }
 
 install_wp() {

--- a/tests/php/test_class-wc-connect-api-client.php
+++ b/tests/php/test_class-wc-connect-api-client.php
@@ -27,10 +27,12 @@ class WP_Test_WC_Connect_API_Client extends WC_Unit_Test_Case {
 		WC_Helper_Product::delete_product( $this->product->get_id() );
 	}
 
-	public function test_build_shipment_contents_simple_product_no_dimensions() {
+	public function test_build_shipment_contents_simple_product_no_weight() {
 		$this->product = WC_Helper_Product::create_simple_product();
+		$product_id = $this->product->get_id();
+		update_post_meta( $product_id, '_weight', '' );
 
-		WC()->cart->add_to_cart( $this->product->get_id(), 1 );
+		WC()->cart->add_to_cart( $product_id, 1 );
 
 		$actual = $this->api_client->build_shipment_contents( array( 'contents' => WC()->cart->get_cart() ) );
 


### PR DESCRIPTION
Closes #780

The new build matrix includes a variety of these versions:
WordPress:
- 4.4 (earliest supported by WooCommerce 2.6)
- 4.5
- 4.6
- 4.7
- 4.8
- `latest` (4.9 at the moment of writing this)

WooCommerce:
- 2.6.14 (earliest supported by WCS for now)
- 3.0.9
- 3.1.3
- 3.2.6
- 3.3.3 (latest)

PHP:
- 5.2 (earliest we support)
- 5.3
- 5.4
- 5.5
- 5.6
- 7.0
- 7.1
- 7.2 (latest)

I added a sensible matrix so we don't hog TravisCI resources for no reason. I made sure that these situations are covered:
- Earliest PHP version with latest WC and WP versions.
- Earliest PHP, WC and WP versions.
- Latest PHP versions with earliest WC and WP versions.
- Latest PHP, WC and WP versions.
- Earliest WC version with latest WP version.
- Earliest WP version with latest WC version.

If you ask me, that's already overkill, but the new matrix is slightly shorter than before (1 case less), so I think that's OK. Thoughts?

No testing instructions, just check that CI passes.