### PR TITLE
Added integration with WooCommerce Shipment Tracking

### DIFF
--- a/classes/class-wc-connect-extension-compatibility.php
+++ b/classes/class-wc-connect-extension-compatibility.php
@@ -1,0 +1,41 @@
+<?php
+
+if ( ! class_exists( 'WC_Connect_Extension_Compatibility' ) ) {
+	class WC_Connect_Extension_Compatibility {
+		/**
+		 * Function called when a new tracking number is added to the order
+		 *
+		 * @param $order_id - order ID
+		 * @param $carrier_id - carrier ID, as returned on the label objects returned by the server
+		 * @param $tracking_number - tracking number string
+		 */
+		public static function on_new_tracking_number( $order_id, $carrier_id, $tracking_number ) {
+			//call WooCommerce Shipment Tracking if it's installed
+			if ( function_exists( 'wc_st_add_tracking_number' ) ) {
+				//note: the only carrier ID we use at the moment is 'usps', which is the same in WC_ST, but this might require a mapping
+				wc_st_add_tracking_number( $order_id, $tracking_number, $carrier_id );
+			}
+		}
+
+		/**
+		 * Checks if WooCommerce Services should email the tracking details, or if another extension is taking care of that already
+		 *
+		 * @param $order_id - order ID
+		 * @return boolean true if WCS should send the tracking info, false otherwise
+		 */
+		public static function should_email_tracking_details( $order_id ) {
+			if ( function_exists( 'wc_shipment_tracking' ) ) {
+				$shipment_tracking = wc_shipment_tracking();
+				if ( property_exists( $shipment_tracking, 'actions' )
+					&& method_exists( $shipment_tracking->actions, 'get_tracking_items' ) ) {
+					$shipment_tracking_items = $shipment_tracking->actions->get_tracking_items( $order_id );
+					if ( ! empty( $shipment_tracking_items ) ) {
+						return false;
+					}
+				}
+			}
+
+			return true;
+		}
+	}
+}

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -248,6 +248,11 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				if ( $label_data['label_id'] === $new_label_data->label_id ) {
 					$result = array_merge( $label_data, (array) $new_label_data );
 					$labels_data[ $index ] = $result;
+
+					if ( ! isset( $label_data['tracking'] )
+						&& isset( $result['tracking'] ) ) {
+							WC_Connect_Extension_Compatibility::on_new_tracking_number( $order_id, $result['carrier_id'], $result['tracking'] );
+					}
 				}
 			}
 			update_post_meta( $order_id, 'wc_connect_labels', $labels_data );

--- a/client/apps/shipping-label/index.js
+++ b/client/apps/shipping-label/index.js
@@ -12,6 +12,7 @@ import notices from 'state/notices/reducer';
 import reducer from 'woocommerce/woocommerce-services/state/shipping-label/reducer';
 import packagesReducer from 'woocommerce/woocommerce-services/state/packages/reducer';
 import labelSettingsReducer from 'woocommerce/woocommerce-services/state/label-settings/reducer';
+import reduxMiddleware from './redux-middleware';
 import { combineReducers } from 'state/utils';
 
 export default ( { orderId } ) => ( {
@@ -55,6 +56,10 @@ export default ( { orderId } ) => ( {
 
 	getStateKey() {
 		return `wcs-label-${ orderId }`;
+	},
+
+	getMiddleware() {
+		return reduxMiddleware;
 	},
 
 	View: () => (

--- a/client/apps/shipping-label/redux-middleware.js
+++ b/client/apps/shipping-label/redux-middleware.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+//from calypso
+import {
+	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_EXIT_PRINTING_FLOW,
+} from 'woocommerce/woocommerce-services/state/action-types';
+
+const middlewareActions = {
+	[  WOOCOMMERCE_SERVICES_SHIPPING_LABEL_EXIT_PRINTING_FLOW ]: () => {
+		window.wc_shipment_tracking_refresh && window.wc_shipment_tracking_refresh();
+	},
+};
+
+export default () => ( next ) => ( action ) => {
+	// let the action go to the reducers
+	next( action );
+
+	const middlewareAction = middlewareActions[ action.type ];
+	if ( ! middlewareAction ) {
+		return;
+	}
+
+	// perform the action
+	setTimeout( () => middlewareAction( action ) );
+};

--- a/client/apps/shipping-label/redux-middleware.js
+++ b/client/apps/shipping-label/redux-middleware.js
@@ -3,11 +3,14 @@
  */
 //from calypso
 import {
-	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_EXIT_PRINTING_FLOW,
+	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_PURCHASE_RESPONSE,
 } from 'woocommerce/woocommerce-services/state/action-types';
 
 const middlewareActions = {
-	[  WOOCOMMERCE_SERVICES_SHIPPING_LABEL_EXIT_PRINTING_FLOW ]: () => {
+	[  WOOCOMMERCE_SERVICES_SHIPPING_LABEL_PURCHASE_RESPONSE ]: ( { error } ) => {
+		if ( error ) {
+			return;
+		}
 		window.wc_shipment_tracking_refresh && window.wc_shipment_tracking_refresh();
 	},
 };
@@ -22,5 +25,5 @@ export default () => ( next ) => ( action ) => {
 	}
 
 	// perform the action
-	setTimeout( () => middlewareAction( action ) );
+	middlewareAction( action );
 };

--- a/client/main.js
+++ b/client/main.js
@@ -66,7 +66,10 @@ Array.from( document.getElementsByClassName( 'wcc-root' ) ).forEach( ( container
 		Route.getReducer(),
 		{ ...serverState, ...persistedState },
 		compose(
-			applyMiddleware( thunk.withExtraArgument( args ) ),
+			applyMiddleware(
+				thunk.withExtraArgument( args ),
+				Route.getMiddleware ? Route.getMiddleware() : () => ( next ) => ( action ) => next( action ),
+			),
 			window.devToolsExtension ? window.devToolsExtension() : f => f
 		)
 	);

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -36,6 +36,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once( plugin_basename( 'classes/class-wc-connect-options.php' ) );
 require_once( plugin_basename( 'classes/class-wc-connect-jetpack.php' ) );
+require_once( plugin_basename( 'classes/class-wc-connect-extension-compatibility.php' ) );
 
 if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
@@ -879,8 +880,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function add_tracking_info_to_emails( $order, $sent_to_admin, $plain_text ) {
 			$id = WC_Connect_Compatibility::instance()->get_order_id( $order );
 
-			// Abort if no id was passed or if the order is not marked as 'completed'
-			if ( ! $id || ! $order->has_status( 'completed' ) ) {
+			// Abort if no id was passed, if the order is not marked as 'completed' or if another extension is handling the emailing
+			if ( ! $id
+				|| ! $order->has_status( 'completed' )
+				|| ! WC_Connect_Extension_Compatibility::should_email_tracking_details( $id ) ) {
 				return;
 			}
 


### PR DESCRIPTION
Fixes #1156 

Automatically adds the tracking number when a new label is purchased and checks for WooCommerce Shipment Tracking existence when sending the "order complete" email. If WCST is going to append its data to the email, WCS will not do that.

Will need PR 87 to be shipped on the `woocommerce-shipment-tracking` repo to be fully functional, but will work without it. The PR allows us to refresh the tracking data without reloading the page.

I also wanted to lay some ground work for future integration with other official WooCommerce extensions:
* added a static `WC_Connect_Extension_Compatibility` class which should contain the PHP integration code
* added per-JS-app Redux middleware. It allows to listen for actions and extend them beyond just modifying the state, which could give us more flexibility without needing to go to Calypso with every change