### PR TITLE
Add customer selected shipping method to rates step.

### DIFF
--- a/client/api/request.js
+++ b/client/api/request.js
@@ -11,9 +11,11 @@ import parseJson from 'lib/utils/parse-json';
 
 let nonce;
 export const setNonce = ( _nonce ) => nonce = _nonce;
+export const getNonce = () => nonce;
 
 let baseURL;
 export const setBaseURL = ( _baseURL ) => baseURL = _baseURL;
+export const getBaseURL = () => baseURL;
 
 const _request = ( url, data, method, namespace = '' ) => {
 	const request = {

--- a/client/apps/shipping-label/index.js
+++ b/client/apps/shipping-label/index.js
@@ -48,7 +48,23 @@ export default ( { orderId } ) => {
 		},
 
 		getInitialState() {
-			return {};
+			return {
+				extensions: {
+					woocommerce: {
+						sites: {
+							1: {
+								orders: {
+									notes: {
+										isLoading: {
+											[ orderId ]: false,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			};
 		},
 
 		getStateForPersisting() {

--- a/client/apps/shipping-label/index.js
+++ b/client/apps/shipping-label/index.js
@@ -13,56 +13,58 @@ import reducer from 'woocommerce/woocommerce-services/state/shipping-label/reduc
 import packagesReducer from 'woocommerce/woocommerce-services/state/packages/reducer';
 import labelSettingsReducer from 'woocommerce/woocommerce-services/state/label-settings/reducer';
 import reduxMiddleware from './redux-middleware';
+import ordersReducer from 'woocommerce/state/sites/orders/reducer';
 import { combineReducers } from 'state/utils';
+import { addHandlers } from 'state/data-layer/extensions-middleware';
+import orders from 'woocommerce/state/data-layer/orders';
 
-export default ( { orderId } ) => ( {
-	getReducer() {
-		return combineReducers( {
-			extensions: combineReducers( {
-				woocommerce: combineReducers( {
-					woocommerceServices: combineReducers( {
-						1: combineReducers( {
-							shippingLabel: reducer,
-							packages: packagesReducer,
-							labelSettings: labelSettingsReducer,
+export default ( { orderId } ) => {
+	addHandlers( 'woocommerce', orders );
+
+	return {
+		getReducer() {
+			return combineReducers( {
+				extensions: combineReducers( {
+					woocommerce: combineReducers( {
+						woocommerceServices: combineReducers( {
+							1: combineReducers( {
+								shippingLabel: reducer,
+								packages: packagesReducer,
+								labelSettings: labelSettingsReducer,
+							} ),
 						} ),
-					} ),
-					sites: combineReducers( {
-						1: combineReducers( {
-							orders: combineReducers( {
-								notes: combineReducers( {
-									isLoading: () => ( { [ orderId ]: false } ),
-									isLoaded: () => ( { [ orderId ]: true } ),
-								} ),
+						sites: combineReducers( {
+							1: combineReducers( {
+								orders: ordersReducer,
 							} ),
 						} ),
 					} ),
 				} ),
-			} ),
-			notices,
-			ui: () => ( {
-				selectedSiteId: 1,
-			} ),
-		} );
-	},
+				notices,
+				ui: () => ( {
+					selectedSiteId: 1,
+				} ),
+			} );
+		},
 
-	getInitialState() {
-		return {};
-	},
+		getInitialState() {
+			return {};
+		},
 
-	getStateForPersisting() {
-		return null; //do not persist any state for labels
-	},
+		getStateForPersisting() {
+			return null; //do not persist any state for labels
+		},
 
-	getStateKey() {
-		return `wcs-label-${ orderId }`;
-	},
+		getStateKey() {
+			return `wcs-label-${ orderId }`;
+		},
 
-	getMiddleware() {
-		return reduxMiddleware;
-	},
+		getMiddleware() {
+			return reduxMiddleware;
+		},
 
-	View: () => (
-		<ShippingLabelViewWrapper orderId={ orderId } />
-	),
-} );
+		View: () => (
+			<ShippingLabelViewWrapper orderId={ orderId } />
+		),
+	};
+};

--- a/client/apps/shipping-label/view-wrapper.js
+++ b/client/apps/shipping-label/view-wrapper.js
@@ -37,11 +37,20 @@ import ActivityLog from 'woocommerce/app/order/order-activity-log/events';
 import {
 	getActivityLogEvents,
 } from 'woocommerce/state/sites/orders/activity-log/selectors';
+import { fetchOrder } from 'woocommerce/state/sites/orders/actions';
 
 class ShippingLabelViewWrapper extends Component {
 	static propTypes = {
 		orderId: PropTypes.number.isRequired,
 	};
+
+	componentDidMount() {
+		const { siteId, orderId } = this.props;
+
+		if ( siteId && orderId ) {
+			this.props.fetchOrder( siteId, orderId );
+		}
+	}
 
 	renderPaymentInfo = () => {
 		const {
@@ -197,6 +206,7 @@ export default connect(
 			openPrintingFlow,
 			setEmailDetailsOption,
 			setFulfillOrderOption,
+			fetchOrder,
 		}, dispatch ),
 	} ),
 )( localize( ShippingLabelViewWrapper ) );

--- a/client/calypso-stubs/config.js
+++ b/client/calypso-stubs/config.js
@@ -3,6 +3,7 @@
 
 const data = {
 	env: ( process && process.env.NODE_ENV ) || 'development',
+	wpcom_concierge_schedule_id: 1,
 };
 
 const d = ( key ) => {

--- a/client/calypso-stubs/extensions/woocommerce/state/sites/http-request.js
+++ b/client/calypso-stubs/extensions/woocommerce/state/sites/http-request.js
@@ -1,0 +1,121 @@
+/** @format */
+
+/**
+ * This stub replaces /client/extensions/woocommerce/state/sites/http-request.js
+ *
+ * It's main purpose is to replace WPCOM HTTP actions with vanilla
+ * HTTP actions that don't use the Jetpack proxy.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/http/actions';
+import { getNonce, getBaseURL } from 'api/request';
+import { extendAction } from 'state/utils';
+
+/**
+ * Returns a proper HTTP_REQUEST action (http data layer) for dispatching requests
+ * in data-layer handlers.
+ * The resulting data will be in the form of `{ API data }`
+ * @param {String} method HTTP Request Method
+ * @param {String} path The WC API path to make a request to (after /wc/v#)
+ * @param {Number} siteId Site ID to make the request to
+ * @param {Object} body HTTP Body for POST and PUT Requests
+ * @param {Object} action The original requesting action
+ * @param {String} namespace Namespace to be pre-pended to path (e.g. /wc/v2)
+ * @return {Object} HTTP_REQUEST Action
+ */
+const _request = ( method, path, siteId, body, action, namespace ) => {
+	const baseURL = getBaseURL();
+
+	if ( namespace && ! namespace.endsWith( '/' ) ) {
+		namespace += '/';
+	}
+	if ( -1 !== baseURL.indexOf( '?' ) ) {
+		path = path.replace( '?', '&' );
+	}
+
+	// Extend the HTTP_REQUEST action with a flag that the request
+	// was altered to hit the local WC API rather than the Jetpack proxy.
+	return extendAction( http(
+		{
+			url: baseURL + namespace + path,
+			method,
+			headers: [
+				[ 'X-WP-Nonce', getNonce() ],
+				[ 'Content-Type', 'application/json' ],
+			],
+			body: body && JSON.stringify( body ),
+			withCredentials: true,
+		},
+		action
+	), { meta: { localApiRequest: true } } );
+};
+
+/**
+ * Prepares a request action that will return the body and headers.
+ * The resulting data will be in the form of `{ data: { status: <code>, body: { API data }, headers: { API response headers } } }`
+ * @param {String} method HTTP Request Method
+ * @param {String} path The WC API path to make a request to (after /wc/v#)
+ * @param {Number} siteId Site ID to make the request to
+ * @param {Object} body HTTP Body for POST and PUT Requests
+ * @param {Object} action The original requesting action
+ * @param {String} namespace Namespace to be pre-pended to path (e.g. /wc/v2)
+ * @return {Object} WPCOM_HTTP_REQUEST Action
+ */
+const _requestWithHeaders = ( method, path, siteId, body, action, namespace ) => {
+	return _request( method, path + '&_envelope', siteId, body, action, namespace );
+};
+
+/**
+ * Provides a wrapper over the http data-layer, made specifically for making requests to
+ * WooCommerce endpoints without repeating things like /wc/v3.
+ * @param {Number} siteId Site ID to make the request to
+ * @param {Object} action The original requesting action
+ * @param {String} namespace Namespace to be pre-pended to path. Defaults to wc/v2
+ * @return {Object} An object with the properties "get", "post", "put" and "del", which are functions to
+ * make an HTTP GET, POST, PUT and DELETE request, respectively.
+ */
+export default ( siteId, action, namespace = 'wc/v2' ) => ( {
+	/**
+	 * Sends a GET request to the API
+	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json/wc/v#/" prefix
+	 * @return {Object} WPCOM_HTTP_REQUEST Action with `data = { API data }`
+	 */
+	get: path => _request( 'GET', path, siteId, null, action, namespace ),
+
+	/**
+	 * Sends a GET request to the API that will return with headers
+	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json-/wc/v#/" prefix
+	 * @return {Object} WPCOM_HTTP_REQUEST Action with `data = { status: <code>, body: { API data }, headers: { API response headers } }`
+	 */
+	getWithHeaders: path => _requestWithHeaders( 'GET', path, siteId, null, action, namespace ),
+
+	/**
+	 * Sends a POST request to the API
+	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json/wc/v#/" prefix
+	 * @param {Object} body Payload to send
+	 * @return {Object} WPCOM_HTTP_REQUEST Action
+	 */
+	post: ( path, body ) => _request( 'POST', path, siteId, body || {}, action, namespace ),
+
+	/**
+	 * Sends a PUT request to the API.
+	 * Note that the underlying request will be a POST, with an special URL parameter to
+	 * be interpreted by the WPCOM server as a PUT request.
+	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json/wc/v#/" prefix
+	 * @param {Object} body Payload to send
+	 * @return {Object} WPCOM_HTTP_REQUEST Action
+	 */
+	put: ( path, body ) => _request( 'PUT', path, siteId, body || {}, action, namespace ),
+
+	/**
+	 * Sends a DELETE request to the API.
+	 * Note that the underlying request will be a POST, with an special URL parameter to
+	 * be interpreted by the WPCOM server as a DELETE request.
+	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json/wc/v#/" prefix
+	 * @return {Object} WPCOM_HTTP_REQUEST Action
+	 */
+	del: path => _request( 'DELETE', path, siteId, null, action, namespace ),
+} );

--- a/client/lib/local-api-middleware.js
+++ b/client/lib/local-api-middleware.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import _ from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { HTTP_REQUEST } from 'state/action-types';
+
+const actionsToModify = [];
+
+/**
+ * Look for Jetpack proxy requests that were localized as
+ * indicated by the `meta.localApiRequest` flag.
+ *
+ * Modify their `dataLayer` meta to mimic the Jetpack proxy.
+ *
+ * @returns {Function} middleware function
+ */
+export default () => ( next ) => ( action ) => {
+	if (
+		HTTP_REQUEST === action.type &&
+		_.get( action, 'meta.localApiRequest' ) &&
+		_.has( action, 'onSuccess.type' )
+	) {
+		// This request was a Jetpack proxy request that
+		// was rewritten to hit the local WC API.
+		actionsToModify.push( _.get( action, 'onSuccess.type' ) );
+	} else if (
+		-1 !== actionsToModify.indexOf( action.type ) &&
+		_.has( action, 'meta.dataLayer.data.body' )
+	) {
+		// The WooCommerce middleware expects this response from the
+		// Jetpack REST API proxy, which nests the body under `data`.
+		action.meta.dataLayer.data.data = action.meta.dataLayer.data.body;
+		delete action.meta.dataLayer.data.body;
+
+		// Don't process this action again.
+		const actionIndex = actionsToModify.indexOf( action.type );
+		actionsToModify.splice( actionIndex, 1 );
+	}
+
+	return next( action );
+};

--- a/client/main.js
+++ b/client/main.js
@@ -22,6 +22,8 @@ import AccountSettings from './apps/account-settings';
 import PrintTestLabel from './apps/print-test-label';
 import Packages from './apps/packages';
 import { setNonce, setBaseURL } from 'api/request';
+import wpcomApiMiddleware from 'state/data-layer/wpcom-api-middleware.js';
+import extensionsMiddleware from 'state/data-layer/extensions-middleware.js';
 
 if ( global.wcConnectData ) {
 	setNonce( global.wcConnectData.nonce );
@@ -61,18 +63,24 @@ Array.from( document.getElementsByClassName( 'wcc-root' ) ).forEach( ( container
 	const persistedState = storageUtils.getWithExpiry( persistedStateKey );
 	storageUtils.remove( persistedStateKey );
 	const serverState = Route.getInitialState();
+	const initialState = { ...serverState, ...persistedState };
 
-	const store = createStore(
-		Route.getReducer(),
-		{ ...serverState, ...persistedState },
-		compose(
-			applyMiddleware(
-				thunk.withExtraArgument( args ),
-				Route.getMiddleware ? Route.getMiddleware() : () => ( next ) => ( action ) => next( action ),
-			),
-			window.devToolsExtension ? window.devToolsExtension() : f => f
-		)
-	);
+	const middlewares = [
+		thunk.withExtraArgument( args ),
+		wpcomApiMiddleware,
+		extensionsMiddleware,
+	];
+
+	if ( _.isFunction( Route.getMiddleware ) ) {
+		middlewares.push( Route.getMiddleware() );
+	}
+
+	const enhancers = [
+		applyMiddleware( ...middlewares ),
+		window.devToolsExtension && window.devToolsExtension(),
+	].filter( Boolean );
+
+	const store = compose( ...enhancers )( createStore )( Route.getReducer(), initialState );
 
 	if ( Route.getInitialAction ) {
 		store.dispatch( Route.getInitialAction() );

--- a/client/main.js
+++ b/client/main.js
@@ -24,6 +24,7 @@ import Packages from './apps/packages';
 import { setNonce, setBaseURL } from 'api/request';
 import wpcomApiMiddleware from 'state/data-layer/wpcom-api-middleware.js';
 import extensionsMiddleware from 'state/data-layer/extensions-middleware.js';
+import localApiMiddleware from 'lib/local-api-middleware';
 
 if ( global.wcConnectData ) {
 	setNonce( global.wcConnectData.nonce );
@@ -68,6 +69,7 @@ Array.from( document.getElementsByClassName( 'wcc-root' ) ).forEach( ( container
 	const middlewares = [
 		thunk.withExtraArgument( args ),
 		wpcomApiMiddleware,
+		localApiMiddleware,
 		extensionsMiddleware,
 	];
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2321,6 +2321,12 @@
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
     "content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
@@ -2395,11 +2401,6 @@
           "dev": true
         }
       }
-    },
-    "cpf_cnpj": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/cpf_cnpj/-/cpf_cnpj-0.2.0.tgz",
-      "integrity": "sha1-oDLBkkKjjoNj7c5OeLsfvp1mSqU="
     },
     "crc": {
       "version": "3.5.0",
@@ -3442,6 +3443,16 @@
       "integrity": "sha512-m/G31U8K2U5qV/u/BOHSTNtJGOBDR7Y84rH5hRBMhg/jWcXnJCEPy1sA0tFKfPL1GMJkJOosRVGTdMqMjiZJoQ==",
       "dev": true
     },
+    "eslint-import-resolver-node": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "resolve": "1.5.0"
+      }
+    },
     "eslint-loader": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-1.9.0.tgz",
@@ -3453,6 +3464,120 @@
         "object-assign": "4.1.1",
         "object-hash": "1.2.0",
         "rimraf": "2.6.2"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
+      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "pkg-dir": "1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2"
+          }
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz",
+      "integrity": "sha1-JgAu+/ylmJtyiKwEdQi9JPIXsWk=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "0.3.2",
+        "eslint-module-utils": "2.1.1",
+        "has": "1.0.1",
+        "lodash": "4.17.5",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "2.0.0"
+      },
+      "dependencies": {
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-jest": {
@@ -12629,7 +12754,7 @@
       "dev": true
     },
     "wp-calypso": {
-      "version": "github:automattic/wp-calypso#fde036a9ba30c5e1e92434d2f9f66f45a7ff654c",
+      "version": "github:automattic/wp-calypso#a8fbbafc0abde1ffbe2c05bd07810037808ec433",
       "requires": {
         "assets-webpack-plugin": "3.5.1",
         "async": "0.9.0",
@@ -12693,7 +12818,7 @@
         "fuse.js": "2.6.1",
         "get-video-id": "2.1.4",
         "globby": "6.1.0",
-        "gridicons": "2.1.2",
+        "gridicons": "2.1.3",
         "happypack": "4.0.0",
         "hard-source-webpack-plugin": "0.3.12",
         "hash.js": "1.1.3",
@@ -12718,7 +12843,7 @@
         "markdown-loader": "2.0.1",
         "marked": "0.3.9",
         "mkdirp": "0.5.1",
-        "moment": "2.19.2",
+        "moment": "2.21.0",
         "morgan": "1.2.0",
         "ms": "0.7.1",
         "name-all-modules-plugin": "1.0.1",
@@ -12726,6 +12851,7 @@
         "notifications-panel": "2.1.5",
         "npm-run-all": "4.0.2",
         "page": "1.6.4",
+        "path-browserify": "0.0.0",
         "percentage-regex": "3.0.0",
         "phone": "git+https://github.com/Automattic/node-phone.git#6be6549b03137f2cca01e202250bf2590750119e",
         "photon": "2.0.1",
@@ -12736,6 +12862,7 @@
         "q": "1.0.1",
         "qrcode.react": "0.7.2",
         "qs": "4.0.0",
+        "querystring": "0.2.0",
         "react": "16.2.0",
         "react-click-outside": "2.3.1",
         "react-day-picker": "6.2.1",
@@ -12764,13 +12891,14 @@
         "tween.js": "16.3.1",
         "twemoji": "2.3.0",
         "uglifyjs-webpack-plugin": "1.2.0",
-        "uuid": "2.0.1",
+        "url": "0.11.0",
+        "uuid": "3.2.1",
         "valid-url": "1.0.9",
         "walk": "2.3.4",
         "webpack": "3.10.0",
         "webpack-dev-middleware": "1.11.0",
         "webpack-hot-middleware": "2.15.0",
-        "wpcom": "5.4.0",
+        "wpcom": "5.4.1",
         "wpcom-oauth": "0.3.3",
         "wpcom-proxy-request": "5.0.0",
         "wpcom-xhr-request": "1.1.1"
@@ -12820,25 +12948,25 @@
           "version": "7.0.0-beta.40",
           "integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
           "requires": {
-            "chalk": "2.3.1",
+            "chalk": "2.3.2",
             "esutils": "2.0.2",
             "js-tokens": "3.0.2"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "version": "3.2.1",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "requires": {
                 "color-convert": "1.9.1"
               }
             },
             "chalk": {
-              "version": "2.3.1",
-              "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+              "version": "2.3.2",
+              "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
               "requires": {
-                "ansi-styles": "3.2.0",
+                "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "5.2.0"
+                "supports-color": "5.3.0"
               }
             },
             "escape-string-regexp": {
@@ -12850,8 +12978,8 @@
               "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
             },
             "supports-color": {
-              "version": "5.2.0",
-              "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+              "version": "5.3.0",
+              "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
               "requires": {
                 "has-flag": "3.0.0"
               }
@@ -12914,12 +13042,12 @@
           "version": "4.1.0",
           "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
           "requires": {
-            "acorn": "5.4.1"
+            "acorn": "5.5.0"
           },
           "dependencies": {
             "acorn": {
-              "version": "5.4.1",
-              "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ=="
+              "version": "5.5.0",
+              "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g=="
             }
           }
         },
@@ -12945,7 +13073,7 @@
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "requires": {
             "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
+            "fast-deep-equal": "1.1.0",
             "fast-json-stable-stringify": "2.0.0",
             "json-schema-traverse": "0.3.1"
           }
@@ -13029,7 +13157,7 @@
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "requires": {
             "delegates": "1.0.0",
-            "readable-stream": "2.3.4"
+            "readable-stream": "2.3.5"
           },
           "dependencies": {
             "inherits": {
@@ -13037,8 +13165,8 @@
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -13093,6 +13221,10 @@
         "arr-flatten": {
           "version": "1.1.0",
           "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+        },
+        "arr-union": {
+          "version": "3.1.0",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
         },
         "array-differ": {
           "version": "1.0.0",
@@ -13196,6 +13328,10 @@
             "mkdirp": "0.5.1"
           }
         },
+        "assign-symbols": {
+          "version": "1.0.0",
+          "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+        },
         "ast-traverse": {
           "version": "0.1.1",
           "integrity": "sha1-ac8rg4bxnc2hux4F1o/jWdiJfeY="
@@ -13246,12 +13382,16 @@
           "version": "0.4.0",
           "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
+        "atob": {
+          "version": "2.0.3",
+          "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10="
+        },
         "autoprefixer": {
           "version": "6.3.5",
           "integrity": "sha1-a8vQOKM3xwYn5/zkQ4+lgYjwk3s=",
           "requires": {
             "browserslist": "1.3.6",
-            "caniuse-db": "1.0.30000810",
+            "caniuse-db": "1.0.30000812",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -13513,11 +13653,11 @@
           }
         },
         "babel-jest": {
-          "version": "22.4.0",
-          "integrity": "sha512-A/safCd5jSf1D98XoHCN3YYuGurtUPntuPh8b7UxsLNfEp/QC8UwdL+VEGSLN5Fk3+tS/Jdbf5NK/T2it8RGYw==",
+          "version": "22.4.1",
+          "integrity": "sha512-rEdN/jevSuX0IQKcUqwqOGa0gDNis4jGY52Rq53aizfDGPwQYNJq+f9NCMT1HUhtUZhYSjvfGUfHQWBRT1/icA==",
           "requires": {
             "babel-plugin-istanbul": "4.1.5",
-            "babel-preset-jest": "22.2.0"
+            "babel-preset-jest": "22.4.1"
           }
         },
         "babel-loader": {
@@ -13573,8 +13713,8 @@
           }
         },
         "babel-plugin-jest-hoist": {
-          "version": "22.2.0",
-          "integrity": "sha512-NwicD5n1YQaj6sM3PVULdPBDk1XdlWvh8xBeUJg3nqZwp79Vofb8Q7GOVeWoZZ/RMlMuJMMrEAgSQl/p392nLA=="
+          "version": "22.4.1",
+          "integrity": "sha512-gmj5FvFflXSnRapWmF/jDjx5Lof1kX0OwXibCxMOx38V3CFMOnTxLTUrAFfLkhCey3FJvv0ACvv/+h4nzFRxhg=="
         },
         "babel-plugin-jscript": {
           "version": "1.0.4",
@@ -14076,8 +14216,8 @@
               "version": "2.11.3",
               "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
               "requires": {
-                "caniuse-lite": "1.0.30000810",
-                "electron-to-chromium": "1.3.33"
+                "caniuse-lite": "1.0.30000812",
+                "electron-to-chromium": "1.3.35"
               }
             },
             "semver": {
@@ -14147,10 +14287,10 @@
           }
         },
         "babel-preset-jest": {
-          "version": "22.2.0",
-          "integrity": "sha512-p61cPMGYlSgfNScn1yQuVnLguWE4bjhB/br4KQDMbYZG+v6ryE5Ch7TKukjA6mRuIQj1zhyou7Sbpqrh4/N6Pg==",
+          "version": "22.4.1",
+          "integrity": "sha512-gW3+spyB8fkSAI9fX+41BQMwar5LjR+nyKa2QRvK22snxnI29+jJVAMfId+osucFJzJJvhlvzKWnfwX8Omodvg==",
           "requires": {
-            "babel-plugin-jest-hoist": "22.2.0",
+            "babel-plugin-jest-hoist": "22.4.1",
             "babel-plugin-syntax-object-rest-spread": "6.13.0"
           }
         },
@@ -14283,6 +14423,36 @@
           "version": "1.0.0",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
+        "base": {
+          "version": "0.11.2",
+          "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+          "requires": {
+            "cache-base": "1.0.1",
+            "class-utils": "0.3.6",
+            "component-emitter": "1.2.1",
+            "define-property": "1.0.0",
+            "isobject": "3.0.1",
+            "mixin-deep": "1.3.1",
+            "pascalcase": "0.1.1"
+          },
+          "dependencies": {
+            "component-emitter": {
+              "version": "1.2.1",
+              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+            },
+            "define-property": {
+              "version": "1.0.0",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
         "base62": {
           "version": "0.1.1",
           "integrity": "sha1-e0F0wvlESXU7EcJlHAg9qEGnsIQ="
@@ -14342,7 +14512,7 @@
           "version": "1.2.1",
           "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
           "requires": {
-            "readable-stream": "2.3.4"
+            "readable-stream": "2.3.5"
           },
           "dependencies": {
             "inherits": {
@@ -14350,8 +14520,8 @@
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -14549,7 +14719,7 @@
           "version": "1.3.6",
           "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
           "requires": {
-            "caniuse-db": "1.0.30000810"
+            "caniuse-db": "1.0.30000812"
           }
         },
         "bser": {
@@ -14625,6 +14795,31 @@
             }
           }
         },
+        "cache-base": {
+          "version": "1.0.1",
+          "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+          "requires": {
+            "collection-visit": "1.0.0",
+            "component-emitter": "1.2.1",
+            "get-value": "2.0.6",
+            "has-value": "1.0.0",
+            "isobject": "3.0.1",
+            "set-value": "2.0.0",
+            "to-object-path": "0.3.0",
+            "union-value": "1.0.0",
+            "unset-value": "1.0.0"
+          },
+          "dependencies": {
+            "component-emitter": {
+              "version": "1.2.1",
+              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
         "caller-path": {
           "version": "0.1.0",
           "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
@@ -14667,12 +14862,12 @@
           }
         },
         "caniuse-db": {
-          "version": "1.0.30000810",
-          "integrity": "sha1-vSWDDEHvq2Qzmi44H0lnc0PIRQk="
+          "version": "1.0.30000812",
+          "integrity": "sha1-KcKN1pJ+5D6MKrZI5SNqyRbJfWk="
         },
         "caniuse-lite": {
-          "version": "1.0.30000810",
-          "integrity": "sha512-/0Q00Oie9C72P8zQHtFvzmkrMC3oOFUnMWjCy5F2+BE8lzICm91hQPhh0+XIsAFPKOe2Dh3pKgbRmU3EKxfldA=="
+          "version": "1.0.30000812",
+          "integrity": "sha512-j+l55ayQ9BO4Sy9iVfbf99+G+4ddAmkXoiEt73WCW4vJ83usrlHzDkFEnNXe5/swkVqE7YBm5i8M2uRXlx9vWg=="
         },
         "cardinal": {
           "version": "1.0.0",
@@ -14843,6 +15038,7 @@
         "chokidar": {
           "version": "1.7.0",
           "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+          "optional": true,
           "requires": {
             "anymatch": "1.3.2",
             "async-each": "1.0.1",
@@ -14857,11 +15053,13 @@
           "dependencies": {
             "is-extglob": {
               "version": "1.0.0",
-              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+              "optional": true
             },
             "is-glob": {
               "version": "2.0.1",
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+              "optional": true,
               "requires": {
                 "is-extglob": "1.0.0"
               }
@@ -14876,7 +15074,7 @@
           "version": "1.3.1",
           "integrity": "sha1-0Nx2Kk2SYFG3UBatY8EAyv+dHYQ=",
           "requires": {
-            "moment": "2.19.2"
+            "moment": "2.21.0"
           }
         },
         "ci-info": {
@@ -14898,6 +15096,74 @@
         "cjk-regex": {
           "version": "1.0.2",
           "integrity": "sha512-NwSMtwULPLk8Ka9DEUcoFXhMRnV/bpyKDnoyDiVw/Qy5przhvHTvXLcsKaOmx13o8J4XEsPVT1baoCUj5zQs3w=="
+        },
+        "class-utils": {
+          "version": "0.3.6",
+          "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+          "requires": {
+            "arr-union": "3.1.0",
+            "define-property": "0.2.5",
+            "isobject": "3.0.1",
+            "static-extend": "0.1.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+            }
+          }
         },
         "classnames": {
           "version": "1.1.1",
@@ -14951,13 +15217,13 @@
           "version": "0.1.7",
           "integrity": "sha512-x/Q52iLSZsRrRb2ePmTsVYXrGcrPQ8G4yRAY7QpMlumxAfPVrnDOH2X6Z5s8qsAX7AA7YuIi8AXFrvH0wWEesA==",
           "requires": {
-            "marked": "0.3.16",
+            "marked": "0.3.17",
             "marked-terminal": "2.0.0"
           },
           "dependencies": {
             "marked": {
-              "version": "0.3.16",
-              "integrity": "sha512-diLiAxHidES67uJ1P5unXBUB4CyOFwodKrctuK0U4Ogw865N9Aw4dLmY0BK0tGKOy3xvkdMGgUXPD6W9z1Ne0Q=="
+              "version": "0.3.17",
+              "integrity": "sha512-+AKbNsjZl6jFfLPwHhWmGTqE009wTKn3RTmn9K8oUKHrX/abPJjtcRtXpYB/FFrwPJRUA86LX/de3T0knkPCmQ=="
             }
           }
         },
@@ -15019,6 +15285,14 @@
         "collapse-white-space": {
           "version": "1.0.3",
           "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw="
+        },
+        "collection-visit": {
+          "version": "1.0.0",
+          "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+          "requires": {
+            "map-visit": "1.0.0",
+            "object-visit": "1.0.1"
+          }
         },
         "color-convert": {
           "version": "1.9.1",
@@ -15215,12 +15489,12 @@
           "integrity": "sha1-JeTBbDdoq/dcWmW8YXYfSVBVtFk=",
           "requires": {
             "graceful-fs": "3.0.11",
-            "js-yaml": "3.10.0",
+            "js-yaml": "3.11.0",
             "mkdirp": "0.5.1",
             "object-assign": "2.1.1",
             "osenv": "0.1.5",
             "user-home": "1.1.1",
-            "uuid": "2.0.1",
+            "uuid": "2.0.3",
             "xdg-basedir": "1.0.1"
           },
           "dependencies": {
@@ -15234,6 +15508,10 @@
             "object-assign": {
               "version": "2.1.1",
               "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+            },
+            "uuid": {
+              "version": "2.0.3",
+              "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
             }
           }
         },
@@ -15259,6 +15537,10 @@
         "constants-browserify": {
           "version": "1.0.0",
           "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
+        },
+        "contains-path": {
+          "version": "0.1.0",
+          "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
         },
         "content-disposition": {
           "version": "0.5.0",
@@ -15307,6 +15589,10 @@
             "rimraf": "2.6.2",
             "run-queue": "1.0.3"
           }
+        },
+        "copy-descriptor": {
+          "version": "0.1.1",
+          "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
         },
         "copy-webpack-plugin": {
           "version": "4.0.1",
@@ -15358,7 +15644,7 @@
           "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
           "requires": {
             "is-directory": "0.3.1",
-            "js-yaml": "3.10.0",
+            "js-yaml": "3.11.0",
             "parse-json": "3.0.0",
             "require-from-string": "2.0.1"
           },
@@ -15371,6 +15657,10 @@
               }
             }
           }
+        },
+        "cpf_cnpj": {
+          "version": "0.2.0",
+          "integrity": "sha1-oDLBkkKjjoNj7c5OeLsfvp1mSqU="
         },
         "crc32": {
           "version": "0.2.2",
@@ -15667,6 +15957,10 @@
           "version": "1.2.0",
           "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
         },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+        },
         "decompress-response": {
           "version": "3.3.0",
           "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
@@ -15723,6 +16017,20 @@
           "requires": {
             "foreach": "2.0.5",
             "object-keys": "1.0.11"
+          }
+        },
+        "define-property": {
+          "version": "2.0.2",
+          "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+          "requires": {
+            "is-descriptor": "1.0.2",
+            "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
           }
         },
         "defined": {
@@ -15845,13 +16153,13 @@
           "version": "4.7.1",
           "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
           "requires": {
-            "acorn": "5.4.1",
+            "acorn": "5.5.0",
             "defined": "1.0.0"
           },
           "dependencies": {
             "acorn": {
-              "version": "5.4.1",
-              "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ=="
+              "version": "5.5.0",
+              "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g=="
             }
           }
         },
@@ -15885,7 +16193,7 @@
           "integrity": "sha1-GJLRC2Gpo1at2/K2FJM+gfi7ODQ=",
           "requires": {
             "browserslist": "1.3.6",
-            "caniuse-db": "1.0.30000810",
+            "caniuse-db": "1.0.30000812",
             "css-rule-stream": "1.1.0",
             "duplexer2": "0.0.2",
             "jsonfilter": "1.1.2",
@@ -15987,18 +16295,18 @@
           }
         },
         "duplexify": {
-          "version": "3.5.3",
-          "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
+          "version": "3.5.4",
+          "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
           "requires": {
             "end-of-stream": "1.4.1",
             "inherits": "2.0.1",
-            "readable-stream": "2.3.4",
+            "readable-stream": "2.3.5",
             "stream-shift": "1.0.0"
           },
           "dependencies": {
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -16073,8 +16381,8 @@
           "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
         },
         "electron-to-chromium": {
-          "version": "1.3.33",
-          "integrity": "sha1-vwBwPWKnxlI4E2V4w1LWxcBCpUU="
+          "version": "1.3.35",
+          "integrity": "sha1-aTwXz7k4QdOMtZuN8BnRfjVphfA="
         },
         "elliptic": {
           "version": "6.4.0",
@@ -16254,14 +16562,14 @@
             "lodash": "4.17.5",
             "object.assign": "4.1.0",
             "object.values": "1.0.4",
-            "prop-types": "15.6.0",
+            "prop-types": "15.6.1",
             "react-reconciler": "0.7.0",
             "react-test-renderer": "16.2.0"
           },
           "dependencies": {
             "prop-types": {
-              "version": "15.6.0",
-              "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+              "version": "15.6.1",
+              "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
               "requires": {
                 "fbjs": "0.8.16",
                 "loose-envify": "1.3.1",
@@ -16276,12 +16584,12 @@
           "requires": {
             "lodash": "4.17.5",
             "object.assign": "4.1.0",
-            "prop-types": "15.6.0"
+            "prop-types": "15.6.1"
           },
           "dependencies": {
             "prop-types": {
-              "version": "15.6.0",
-              "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+              "version": "15.6.1",
+              "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
               "requires": {
                 "fbjs": "0.8.16",
                 "loose-envify": "1.3.1",
@@ -16437,19 +16745,19 @@
           "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
         },
         "escodegen": {
-          "version": "1.9.0",
-          "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+          "version": "1.9.1",
+          "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
           "requires": {
             "esprima": "3.1.3",
             "estraverse": "4.2.0",
             "esutils": "2.0.2",
             "optionator": "0.8.1",
-            "source-map": "0.5.7"
+            "source-map": "0.6.1"
           },
           "dependencies": {
             "source-map": {
-              "version": "0.5.7",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "version": "0.6.1",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
               "optional": true
             }
           }
@@ -16460,7 +16768,7 @@
           "requires": {
             "es6-map": "0.1.5",
             "es6-weak-map": "2.0.2",
-            "esrecurse": "4.2.0",
+            "esrecurse": "4.2.1",
             "estraverse": "4.2.0"
           }
         },
@@ -16487,7 +16795,7 @@
             "debug": "2.2.0",
             "doctrine": "1.5.0",
             "escope": "3.6.0",
-            "espree": "3.5.3",
+            "espree": "3.5.4",
             "estraverse": "4.2.0",
             "esutils": "2.0.2",
             "file-entry-cache": "2.0.0",
@@ -16498,7 +16806,7 @@
             "inquirer": "0.12.0",
             "is-my-json-valid": "2.17.1",
             "is-resolvable": "1.1.0",
-            "js-yaml": "3.10.0",
+            "js-yaml": "3.11.0",
             "json-stable-stringify": "1.0.1",
             "levn": "0.3.0",
             "lodash": "4.17.5",
@@ -16608,6 +16916,149 @@
           "version": "0.0.6",
           "integrity": "sha1-9MXWe+pmYx6cXgnK/ZMsbMMAdcM="
         },
+        "eslint-import-resolver-node": {
+          "version": "0.3.2",
+          "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+          "requires": {
+            "debug": "2.6.9",
+            "resolve": "1.5.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "eslint-module-utils": {
+          "version": "2.1.1",
+          "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+          "requires": {
+            "debug": "2.6.9",
+            "pkg-dir": "1.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "find-up": {
+              "version": "1.1.2",
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+              "requires": {
+                "pinkie-promise": "2.0.1"
+              }
+            },
+            "pkg-dir": {
+              "version": "1.0.0",
+              "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+              "requires": {
+                "find-up": "1.1.2"
+              }
+            }
+          }
+        },
+        "eslint-plugin-import": {
+          "version": "2.9.0",
+          "integrity": "sha1-JgAu+/ylmJtyiKwEdQi9JPIXsWk=",
+          "requires": {
+            "builtin-modules": "1.1.1",
+            "contains-path": "0.1.0",
+            "debug": "2.6.9",
+            "doctrine": "1.5.0",
+            "eslint-import-resolver-node": "0.3.2",
+            "eslint-module-utils": "2.1.1",
+            "has": "1.0.1",
+            "lodash": "4.17.5",
+            "minimatch": "3.0.4",
+            "read-pkg-up": "2.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "doctrine": {
+              "version": "1.5.0",
+              "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+              "requires": {
+                "esutils": "2.0.2",
+                "isarray": "1.0.0"
+              }
+            },
+            "load-json-file": {
+              "version": "2.0.0",
+              "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "strip-bom": "3.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            },
+            "path-type": {
+              "version": "2.0.0",
+              "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+              "requires": {
+                "pify": "2.3.0"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+            },
+            "read-pkg": {
+              "version": "2.0.0",
+              "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+              "requires": {
+                "load-json-file": "2.0.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "2.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "2.0.0",
+              "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+              "requires": {
+                "find-up": "2.1.0",
+                "read-pkg": "2.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+            }
+          }
+        },
         "eslint-plugin-jest": {
           "version": "21.2.0",
           "integrity": "sha512-pe7JWoZiXWHfVCBArxX5o3laRZp24tkBSeIHImJJyX2mDIqzlrXkUGkfbC6tPKER3WbcQ3YxKDMgp8uqt8fjfw=="
@@ -16652,16 +17103,16 @@
           "integrity": "sha1-Yg2GbvSGGzMR91dm1SqFcrs8YzY="
         },
         "espree": {
-          "version": "3.5.3",
-          "integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
+          "version": "3.5.4",
+          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
           "requires": {
-            "acorn": "5.4.1",
+            "acorn": "5.5.0",
             "acorn-jsx": "3.0.1"
           },
           "dependencies": {
             "acorn": {
-              "version": "5.4.1",
-              "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ=="
+              "version": "5.5.0",
+              "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g=="
             }
           }
         },
@@ -16670,11 +17121,10 @@
           "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
         },
         "esrecurse": {
-          "version": "4.2.0",
-          "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+          "version": "4.2.1",
+          "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
           "requires": {
-            "estraverse": "4.2.0",
-            "object-assign": "4.1.1"
+            "estraverse": "4.2.0"
           }
         },
         "estraverse": {
@@ -16795,7 +17245,7 @@
           "version": "22.4.0",
           "integrity": "sha512-Fiy862jT3qc70hwIHwwCBNISmaqBrfWKKrtqyMJ6iwZr+6KXtcnHojZFtd63TPRvRl8EQTJ+YXYy2lK6/6u+Hw==",
           "requires": {
-            "ansi-styles": "3.2.0",
+            "ansi-styles": "3.2.1",
             "jest-diff": "22.4.0",
             "jest-get-type": "22.1.0",
             "jest-matcher-utils": "22.4.0",
@@ -16804,8 +17254,8 @@
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "version": "3.2.1",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "requires": {
                 "color-convert": "1.9.1"
               }
@@ -16885,6 +17335,23 @@
           "version": "3.0.1",
           "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
         },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "requires": {
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "requires": {
+                "is-plain-object": "2.0.4"
+              }
+            }
+          }
+        },
         "extglob": {
           "version": "0.3.2",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
@@ -16928,8 +17395,8 @@
           }
         },
         "fast-deep-equal": {
-          "version": "1.0.0",
-          "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+          "version": "1.1.0",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
         },
         "fast-future": {
           "version": "1.0.2",
@@ -17022,8 +17489,8 @@
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -17045,7 +17512,7 @@
               "version": "2.0.3",
               "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
               "requires": {
-                "readable-stream": "2.3.4",
+                "readable-stream": "2.3.5",
                 "xtend": "4.0.1"
               }
             }
@@ -17184,12 +17651,12 @@
           "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
           "requires": {
             "inherits": "2.0.1",
-            "readable-stream": "2.3.4"
+            "readable-stream": "2.3.5"
           },
           "dependencies": {
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -17294,6 +17761,13 @@
           "version": "0.1.2",
           "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
         },
+        "fragment-cache": {
+          "version": "0.2.1",
+          "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+          "requires": {
+            "map-cache": "0.2.2"
+          }
+        },
         "fresh": {
           "version": "0.3.0",
           "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
@@ -17307,12 +17781,12 @@
           "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
           "requires": {
             "inherits": "2.0.1",
-            "readable-stream": "2.3.4"
+            "readable-stream": "2.3.5"
           },
           "dependencies": {
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -17372,7 +17846,7 @@
           "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
           "optional": true,
           "requires": {
-            "nan": "2.8.0",
+            "nan": "2.9.2",
             "node-pre-gyp": "0.6.39"
           },
           "dependencies": {
@@ -18255,6 +18729,10 @@
           "version": "3.0.0",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         },
+        "get-value": {
+          "version": "2.0.6",
+          "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+        },
         "get-video-id": {
           "version": "2.1.4",
           "integrity": "sha1-lyKhEi4bxlK2lUOIo8jLngv8XBs=",
@@ -18403,7 +18881,7 @@
           "version": "3.3.1",
           "integrity": "sha1-5dDtSvVfw+701WAHdp2YGSvLLso=",
           "requires": {
-            "duplexify": "3.5.3",
+            "duplexify": "3.5.4",
             "infinity-agent": "2.0.3",
             "is-redirect": "1.0.0",
             "is-stream": "1.1.0",
@@ -18433,12 +18911,12 @@
           "version": "0.10.5",
           "integrity": "sha512-Q7cx22DiLhwHsEfUnUip1Ww/Vfx7FS0w6+iHItNuN61+XpegHSa3k5U0+6M5BcpavQImBwFiy0z3uYwY7cXMLQ==",
           "requires": {
-            "iterall": "1.2.1"
+            "iterall": "1.2.2"
           }
         },
         "gridicons": {
-          "version": "2.1.2",
-          "integrity": "sha512-IDfjWa7QIla6KMRUUiv4TrOZsqjZWDvG0xfjw+a6/rgEaqxlPTJDRvTUXh96/TekXM440h+Mks1JGBwO9AD3zA==",
+          "version": "2.1.3",
+          "integrity": "sha512-3gvt0TAKUKt+BBJ0vboxuaSPriGfJP5aRIyxLPJzlVYzCd3mVHxHFMMzf9UUVb1tv/jzTicakHFo9a9YLTnZCw==",
           "requires": {
             "prop-types": "15.5.10"
           }
@@ -18484,8 +18962,8 @@
               "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
             },
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -18511,7 +18989,7 @@
               "version": "2.0.3",
               "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
               "requires": {
-                "readable-stream": "2.3.4",
+                "readable-stream": "2.3.5",
                 "xtend": "4.0.1"
               }
             }
@@ -18659,6 +19137,54 @@
         "has-unicode": {
           "version": "2.0.1",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+        },
+        "has-value": {
+          "version": "1.0.0",
+          "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "1.0.0",
+            "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
+        "has-values": {
+          "version": "1.0.0",
+          "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+          "requires": {
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "kind-of": {
+              "version": "4.0.0",
+              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
         },
         "hash-base": {
           "version": "2.0.2",
@@ -18827,12 +19353,12 @@
             "domutils": "1.7.0",
             "entities": "1.1.1",
             "inherits": "2.0.1",
-            "readable-stream": "2.3.4"
+            "readable-stream": "2.3.5"
           },
           "dependencies": {
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -19126,6 +19652,19 @@
           "version": "1.4.0",
           "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
         },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "6.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.2",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+            }
+          }
+        },
         "is-alphabetical": {
           "version": "1.0.1",
           "integrity": "sha1-x3B5zJHU76x3W+EDS/LSQ/lebwg="
@@ -19171,6 +19710,19 @@
             "ci-info": "1.1.2"
           }
         },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "6.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.2",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+            }
+          }
+        },
         "is-date-object": {
           "version": "1.0.1",
           "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
@@ -19178,6 +19730,21 @@
         "is-decimal": {
           "version": "1.0.1",
           "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI="
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.2",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+            }
+          }
         },
         "is-directory": {
           "version": "0.3.1",
@@ -19266,6 +19833,19 @@
             "kind-of": "3.2.2"
           }
         },
+        "is-odd": {
+          "version": "2.0.0",
+          "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+          "requires": {
+            "is-number": "4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "4.0.0",
+              "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+            }
+          }
+        },
         "is-path-cwd": {
           "version": "1.0.0",
           "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
@@ -19287,6 +19867,19 @@
         "is-plain-obj": {
           "version": "1.1.0",
           "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+          "requires": {
+            "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
         },
         "is-posix-bracket": {
           "version": "0.1.1",
@@ -19410,7 +20003,7 @@
             "esprima": "2.7.3",
             "glob": "5.0.15",
             "handlebars": "4.0.11",
-            "js-yaml": "3.10.0",
+            "js-yaml": "3.11.0",
             "mkdirp": "0.5.1",
             "nopt": "3.0.6",
             "once": "1.4.0",
@@ -19488,7 +20081,7 @@
             "istanbul-lib-report": "1.1.3",
             "istanbul-lib-source-maps": "1.2.3",
             "istanbul-reports": "1.1.4",
-            "js-yaml": "3.10.0",
+            "js-yaml": "3.11.0",
             "mkdirp": "0.5.1",
             "once": "1.4.0"
           },
@@ -19578,8 +20171,8 @@
           }
         },
         "iterall": {
-          "version": "1.2.1",
-          "integrity": "sha512-XH2awY4PboL5tG5i2P7wZ2E6oet/JkmEUpUhjcroXxBUy7bPsUOXRDMAAZe+rnH2azSXboqvyDIp5n2f7GtlCQ=="
+          "version": "1.2.2",
+          "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
         },
         "jed": {
           "version": "1.0.2",
@@ -19589,7 +20182,7 @@
           "version": "22.0.3",
           "integrity": "sha512-90H1wLqiNR3tLhQUgwhC6GWHfRCG+Da14m7vxD608Mt/QTKR0TA751D+QH09x5bvcrLfvxLtxArtA0VEC0ORow==",
           "requires": {
-            "jest-cli": "22.4.0"
+            "jest-cli": "22.4.2"
           },
           "dependencies": {
             "ansi-escapes": {
@@ -19601,8 +20194,8 @@
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
             },
             "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "version": "3.2.1",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "requires": {
                 "color-convert": "1.9.1"
               }
@@ -19612,12 +20205,12 @@
               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
             },
             "chalk": {
-              "version": "2.3.1",
-              "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+              "version": "2.3.2",
+              "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
               "requires": {
-                "ansi-styles": "3.2.0",
+                "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "5.2.0"
+                "supports-color": "5.3.0"
               }
             },
             "cliui": {
@@ -19654,11 +20247,11 @@
               "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
             },
             "jest-cli": {
-              "version": "22.4.0",
-              "integrity": "sha512-0JlBb/PvHGQZR2I9GZwsycHgWHhriBmvBWPaaPYUT186oiIIDY4ezDxFOFt2Ts0yNTRg3iY9mTyHsfWbT5VRWA==",
+              "version": "22.4.2",
+              "integrity": "sha512-ebo6ZWK2xDSs7LGnLvM16SZOIJ2dj0B6/oERmGcal32NHkks450nNfGrGTyOSPgJDgH8DFhVdBXgSamN7mtZ0Q==",
               "requires": {
                 "ansi-escapes": "3.0.0",
-                "chalk": "2.3.1",
+                "chalk": "2.3.2",
                 "exit": "0.1.2",
                 "glob": "7.1.2",
                 "graceful-fs": "4.1.11",
@@ -19669,18 +20262,18 @@
                 "istanbul-lib-instrument": "1.9.2",
                 "istanbul-lib-source-maps": "1.2.3",
                 "jest-changed-files": "22.2.0",
-                "jest-config": "22.4.0",
-                "jest-environment-jsdom": "22.4.0",
+                "jest-config": "22.4.2",
+                "jest-environment-jsdom": "22.4.1",
                 "jest-get-type": "22.1.0",
-                "jest-haste-map": "22.4.0",
+                "jest-haste-map": "22.4.2",
                 "jest-message-util": "22.4.0",
                 "jest-regex-util": "22.1.0",
                 "jest-resolve-dependencies": "22.1.0",
-                "jest-runner": "22.4.0",
-                "jest-runtime": "22.4.0",
+                "jest-runner": "22.4.2",
+                "jest-runtime": "22.4.2",
                 "jest-snapshot": "22.4.0",
-                "jest-util": "22.4.0",
-                "jest-validate": "22.4.0",
+                "jest-util": "22.4.1",
+                "jest-validate": "22.4.2",
                 "jest-worker": "22.2.2",
                 "micromatch": "2.3.11",
                 "node-notifier": "5.2.1",
@@ -19718,8 +20311,8 @@
               }
             },
             "supports-color": {
-              "version": "5.2.0",
-              "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+              "version": "5.3.0",
+              "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
               "requires": {
                 "has-flag": "3.0.0"
               }
@@ -19763,36 +20356,36 @@
           }
         },
         "jest-config": {
-          "version": "22.4.0",
-          "integrity": "sha512-hZs8qHjCybOpqni0Kwt40eAavYN/3KnJJwYxSJsBRedJ98IgGSiI18SjybCSccKayA7eHgw1A+dLkHcfI4LItQ==",
+          "version": "22.4.2",
+          "integrity": "sha512-oG31qYO73/3vj/Q8aM2RgzmHndTkz9nRk8ISybfuJqqbf0RW7OUjHVOZPLOUiwLWtz52Yq2HkjIblsyhbA7vrg==",
           "requires": {
-            "chalk": "2.3.1",
+            "chalk": "2.3.2",
             "glob": "7.1.2",
-            "jest-environment-jsdom": "22.4.0",
-            "jest-environment-node": "22.4.0",
+            "jest-environment-jsdom": "22.4.1",
+            "jest-environment-node": "22.4.1",
             "jest-get-type": "22.1.0",
-            "jest-jasmine2": "22.4.0",
+            "jest-jasmine2": "22.4.2",
             "jest-regex-util": "22.1.0",
-            "jest-resolve": "22.4.0",
-            "jest-util": "22.4.0",
-            "jest-validate": "22.4.0",
+            "jest-resolve": "22.4.2",
+            "jest-util": "22.4.1",
+            "jest-validate": "22.4.2",
             "pretty-format": "22.4.0"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "version": "3.2.1",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "requires": {
                 "color-convert": "1.9.1"
               }
             },
             "chalk": {
-              "version": "2.3.1",
-              "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+              "version": "2.3.2",
+              "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
               "requires": {
-                "ansi-styles": "3.2.0",
+                "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "5.2.0"
+                "supports-color": "5.3.0"
               }
             },
             "escape-string-regexp": {
@@ -19816,8 +20409,8 @@
               "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
             },
             "supports-color": {
-              "version": "5.2.0",
-              "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+              "version": "5.3.0",
+              "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
               "requires": {
                 "has-flag": "3.0.0"
               }
@@ -19828,26 +20421,26 @@
           "version": "22.4.0",
           "integrity": "sha512-+/t20WmnkOkB8MOaGaPziI8zWKxquMvYw4Ub+wOzi7AUhmpFXz43buWSxVoZo4J5RnCozpGbX3/FssjJ5KV9Nw==",
           "requires": {
-            "chalk": "2.3.1",
+            "chalk": "2.3.2",
             "diff": "3.4.0",
             "jest-get-type": "22.1.0",
             "pretty-format": "22.4.0"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "version": "3.2.1",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "requires": {
                 "color-convert": "1.9.1"
               }
             },
             "chalk": {
-              "version": "2.3.1",
-              "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+              "version": "2.3.2",
+              "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
               "requires": {
-                "ansi-styles": "3.2.0",
+                "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "5.2.0"
+                "supports-color": "5.3.0"
               }
             },
             "escape-string-regexp": {
@@ -19859,8 +20452,8 @@
               "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
             },
             "supports-color": {
-              "version": "5.2.0",
-              "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+              "version": "5.3.0",
+              "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
               "requires": {
                 "has-flag": "3.0.0"
               }
@@ -19875,20 +20468,20 @@
           }
         },
         "jest-environment-jsdom": {
-          "version": "22.4.0",
-          "integrity": "sha512-SAUCte4KFLaD2YhYwHFVEI2GkR4BHqHJsnbFgmQMGgHnZ2CfjSZE8Bnb+jlarbxIG4GXl31+2e9rjBpzbY9gKQ==",
+          "version": "22.4.1",
+          "integrity": "sha512-x/JzAoH+dWPBnIMv5OQKiIR0TYf6UvbRjsIuDZ11yDFXkHKGJZg6jNnLAsokAm3cq9kUa2hH5BPUC9XU4n1ELQ==",
           "requires": {
             "jest-mock": "22.2.0",
-            "jest-util": "22.4.0",
+            "jest-util": "22.4.1",
             "jsdom": "11.6.2"
           }
         },
         "jest-environment-node": {
-          "version": "22.4.0",
-          "integrity": "sha512-ihSKa2MU5jkAhmRJ17FU4nisbbfW6spvl6Jtwmm5W9kmTVa2sa9UoHWbOWAb7HXuLi3PGGjzTfEt5o3uIzisnQ==",
+          "version": "22.4.1",
+          "integrity": "sha512-wj9+zzfRgnUbm5VwFOCGgG1QmbucUyrjPKBKUJdLW8K5Ss5zrNc1k+v6feZhFg6sS3ZGnjgtIyklaxEARxu+LQ==",
           "requires": {
             "jest-mock": "22.2.0",
-            "jest-util": "22.4.0"
+            "jest-util": "22.4.1"
           }
         },
         "jest-file-exists": {
@@ -19900,8 +20493,8 @@
           "integrity": "sha512-nD97IVOlNP6fjIN5i7j5XRH+hFsHL7VlauBbzRvueaaUe70uohrkz7pL/N8lx/IAwZRTJ//wOdVgh85OgM7g3w=="
         },
         "jest-haste-map": {
-          "version": "22.4.0",
-          "integrity": "sha512-znYomZ+GaRcuFLQz7hmwQOfLkHY2Y2Aoyd29ZcXLrwBEWts5U/c7lFsqo54XUJUlMhrM5M2IOaAUWjZ1CRqAOQ==",
+          "version": "22.4.2",
+          "integrity": "sha512-EdQADHGXRqHJYAr7q9B9YYHZnrlcMwhx1+DnIgc9uN05nCW3RvGCxJ91MqWXcC1AzatLoSv7SNd0qXMp2jKBDA==",
           "requires": {
             "fb-watchman": "2.0.0",
             "graceful-fs": "4.1.11",
@@ -19922,11 +20515,10 @@
           }
         },
         "jest-jasmine2": {
-          "version": "22.4.0",
-          "integrity": "sha512-oL7bNLfEL9jPVjmiwqQuwrAJ/5ddmKHSpns0kCpAmv1uQ47Q5aC9zBTXZbDWP5GVbVHj2hbYtNbkwTiXJr0e8w==",
+          "version": "22.4.2",
+          "integrity": "sha512-KZaIHpXQ0AIlvQJFCU0uoXxtz5GG47X14r9upMe7VXE55UazoMZBFnQb9TX2HoYX2/AxJYnjHuvwKVCFqOrEtw==",
           "requires": {
-            "callsites": "2.0.0",
-            "chalk": "2.3.1",
+            "chalk": "2.3.2",
             "co": "4.6.0",
             "expect": "22.4.0",
             "graceful-fs": "4.1.11",
@@ -19935,27 +20527,24 @@
             "jest-matcher-utils": "22.4.0",
             "jest-message-util": "22.4.0",
             "jest-snapshot": "22.4.0",
+            "jest-util": "22.4.1",
             "source-map-support": "0.5.3"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "version": "3.2.1",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "requires": {
                 "color-convert": "1.9.1"
               }
             },
-            "callsites": {
-              "version": "2.0.0",
-              "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
-            },
             "chalk": {
-              "version": "2.3.1",
-              "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+              "version": "2.3.2",
+              "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
               "requires": {
-                "ansi-styles": "3.2.0",
+                "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "5.2.0"
+                "supports-color": "5.3.0"
               }
             },
             "escape-string-regexp": {
@@ -19978,8 +20567,8 @@
               }
             },
             "supports-color": {
-              "version": "5.2.0",
-              "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+              "version": "5.3.0",
+              "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
               "requires": {
                 "has-flag": "3.0.0"
               }
@@ -20004,25 +20593,25 @@
           "version": "22.4.0",
           "integrity": "sha512-03m3issxUXpWMwDYTfmL8hRNewUB0yCRTeXPm+eq058rZxLHD9f5NtSSO98CWHqe4UyISIxd9Ao9iDVjHWd2qg==",
           "requires": {
-            "chalk": "2.3.1",
+            "chalk": "2.3.2",
             "jest-get-type": "22.1.0",
             "pretty-format": "22.4.0"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "version": "3.2.1",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "requires": {
                 "color-convert": "1.9.1"
               }
             },
             "chalk": {
-              "version": "2.3.1",
-              "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+              "version": "2.3.2",
+              "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
               "requires": {
-                "ansi-styles": "3.2.0",
+                "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "5.2.0"
+                "supports-color": "5.3.0"
               }
             },
             "escape-string-regexp": {
@@ -20034,8 +20623,8 @@
               "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
             },
             "supports-color": {
-              "version": "5.2.0",
-              "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+              "version": "5.3.0",
+              "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
               "requires": {
                 "has-flag": "3.0.0"
               }
@@ -20111,26 +20700,26 @@
           "integrity": "sha512-eyCJB0T3hrlpFF2FqQoIB093OulP+1qvATQmD3IOgJgMGqPL6eYw8TbC5P/VCWPqKhGL51xvjIIhow5eZ2wHFw==",
           "requires": {
             "@babel/code-frame": "7.0.0-beta.40",
-            "chalk": "2.3.1",
+            "chalk": "2.3.2",
             "micromatch": "2.3.11",
             "slash": "1.0.0",
             "stack-utils": "1.0.1"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "version": "3.2.1",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "requires": {
                 "color-convert": "1.9.1"
               }
             },
             "chalk": {
-              "version": "2.3.1",
-              "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+              "version": "2.3.2",
+              "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
               "requires": {
-                "ansi-styles": "3.2.0",
+                "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "5.2.0"
+                "supports-color": "5.3.0"
               }
             },
             "escape-string-regexp": {
@@ -20142,8 +20731,8 @@
               "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
             },
             "supports-color": {
-              "version": "5.2.0",
-              "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+              "version": "5.3.0",
+              "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
               "requires": {
                 "has-flag": "3.0.0"
               }
@@ -20159,27 +20748,27 @@
           "integrity": "sha512-on0LqVS6Xeh69sw3d1RukVnur+lVOl3zkmb0Q54FHj9wHoq6dbtWqb3TSlnVUyx36hqjJhjgs/QLqs07Bzu72Q=="
         },
         "jest-resolve": {
-          "version": "22.4.0",
-          "integrity": "sha512-Vs/5VeJEHLpB0ubpYuU9QpBjcCUZRHoHnoV58ZC+N3EXyMJr/MgoqUNpo4OHGQERWlUpvl4YLAAO5uxSMF2VIg==",
+          "version": "22.4.2",
+          "integrity": "sha512-P1hSfcc2HJYT5t+WPu/11OfFMa7m8pBb2Gf2vm6W9OVs7YTXQ5RCC3nDqaYZQaTqxEM1ZZaTcQGcE6U2xMOsqQ==",
           "requires": {
             "browser-resolve": "1.11.2",
-            "chalk": "2.3.1"
+            "chalk": "2.3.2"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "version": "3.2.1",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "requires": {
                 "color-convert": "1.9.1"
               }
             },
             "chalk": {
-              "version": "2.3.1",
-              "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+              "version": "2.3.2",
+              "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
               "requires": {
-                "ansi-styles": "3.2.0",
+                "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "5.2.0"
+                "supports-color": "5.3.0"
               }
             },
             "escape-string-regexp": {
@@ -20191,8 +20780,8 @@
               "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
             },
             "supports-color": {
-              "version": "5.2.0",
-              "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+              "version": "5.3.0",
+              "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
               "requires": {
                 "has-flag": "3.0.0"
               }
@@ -20207,18 +20796,18 @@
           }
         },
         "jest-runner": {
-          "version": "22.4.0",
-          "integrity": "sha512-x5QJQrSQs/oaZq2UxtKJxCjGq3fNF7guKRLxAIS39QIaRSAynS4agniMyvHMnLaYsBh6yzUea2SDeNHayQh+TQ==",
+          "version": "22.4.2",
+          "integrity": "sha512-W4vwgiVQS0NyXt8hgpw7i0YUtsfoChiQcoHWBJeq2ocV4VF2osEZx8HYgpH5HfNe1Cb5LZeZWxX8Dr3hesbGFg==",
           "requires": {
             "exit": "0.1.2",
-            "jest-config": "22.4.0",
+            "jest-config": "22.4.2",
             "jest-docblock": "22.4.0",
-            "jest-haste-map": "22.4.0",
-            "jest-jasmine2": "22.4.0",
+            "jest-haste-map": "22.4.2",
+            "jest-jasmine2": "22.4.2",
             "jest-leak-detector": "22.4.0",
             "jest-message-util": "22.4.0",
-            "jest-runtime": "22.4.0",
-            "jest-util": "22.4.0",
+            "jest-runtime": "22.4.2",
+            "jest-util": "22.4.1",
             "jest-worker": "22.2.2",
             "throat": "4.1.0"
           },
@@ -20233,22 +20822,22 @@
           }
         },
         "jest-runtime": {
-          "version": "22.4.0",
-          "integrity": "sha512-aixL2DIXoFQ2ubnurzK4kbNXLl3+m0m7wIBb5VWaJdl1/3nV1UCSjZ9/dJZzpWGGfXsoGw2RZd8sS0nS5s+tdw==",
+          "version": "22.4.2",
+          "integrity": "sha512-9/Fxbj99cqxI7o2nTNzevnI38eDBstkwve8ZeaAD/Kz0fbU3i3eRv2QPEmzbmyCyBvUWxCT7BzNLTzTqH1+pyA==",
           "requires": {
             "babel-core": "6.25.0",
-            "babel-jest": "22.4.0",
+            "babel-jest": "22.4.1",
             "babel-plugin-istanbul": "4.1.5",
-            "chalk": "2.3.1",
+            "chalk": "2.3.2",
             "convert-source-map": "1.5.1",
             "exit": "0.1.2",
             "graceful-fs": "4.1.11",
-            "jest-config": "22.4.0",
-            "jest-haste-map": "22.4.0",
+            "jest-config": "22.4.2",
+            "jest-haste-map": "22.4.2",
             "jest-regex-util": "22.1.0",
-            "jest-resolve": "22.4.0",
-            "jest-util": "22.4.0",
-            "jest-validate": "22.4.0",
+            "jest-resolve": "22.4.2",
+            "jest-util": "22.4.1",
+            "jest-validate": "22.4.2",
             "json-stable-stringify": "1.0.1",
             "micromatch": "2.3.11",
             "realpath-native": "1.0.0",
@@ -20263,8 +20852,8 @@
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
             },
             "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "version": "3.2.1",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "requires": {
                 "color-convert": "1.9.1"
               }
@@ -20274,12 +20863,12 @@
               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
             },
             "chalk": {
-              "version": "2.3.1",
-              "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+              "version": "2.3.2",
+              "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
               "requires": {
-                "ansi-styles": "3.2.0",
+                "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "5.2.0"
+                "supports-color": "5.3.0"
               }
             },
             "cliui": {
@@ -20332,8 +20921,8 @@
               "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
             },
             "supports-color": {
-              "version": "5.2.0",
-              "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+              "version": "5.3.0",
+              "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
               "requires": {
                 "has-flag": "3.0.0"
               }
@@ -20386,7 +20975,7 @@
           "version": "22.4.0",
           "integrity": "sha512-6Zz4F9G1Nbr93kfm5h3A2+OkE+WGpgJlskYE4iSNN2uYfoTL5b9W6aB9Orpx+ueReHyqmy7HET7Z3EmYlL3hKw==",
           "requires": {
-            "chalk": "2.3.1",
+            "chalk": "2.3.2",
             "jest-diff": "22.4.0",
             "jest-matcher-utils": "22.4.0",
             "mkdirp": "0.5.1",
@@ -20395,19 +20984,19 @@
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "version": "3.2.1",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "requires": {
                 "color-convert": "1.9.1"
               }
             },
             "chalk": {
-              "version": "2.3.1",
-              "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+              "version": "2.3.2",
+              "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
               "requires": {
-                "ansi-styles": "3.2.0",
+                "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "5.2.0"
+                "supports-color": "5.3.0"
               }
             },
             "escape-string-regexp": {
@@ -20419,8 +21008,8 @@
               "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
             },
             "supports-color": {
-              "version": "5.2.0",
-              "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+              "version": "5.3.0",
+              "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
               "requires": {
                 "has-flag": "3.0.0"
               }
@@ -20428,20 +21017,21 @@
           }
         },
         "jest-util": {
-          "version": "22.4.0",
-          "integrity": "sha512-652EArz3XScAGAUMhbny7FrFGlmJkp+56CO+9RTrKPtGfbtVDF2WB2D8G+6D6zorDmDW5hNtKNIGNdGfG2kj1g==",
+          "version": "22.4.1",
+          "integrity": "sha512-9ySBdJY2qVWpg0OvZbGcFXE2NgwccpZVj384E9bx7brKFc7l5anpqah15mseWcz7FLDk7/N+LyYgqFme7Rez2Q==",
           "requires": {
             "callsites": "2.0.0",
-            "chalk": "2.3.1",
+            "chalk": "2.3.2",
             "graceful-fs": "4.1.11",
             "is-ci": "1.1.0",
             "jest-message-util": "22.4.0",
-            "mkdirp": "0.5.1"
+            "mkdirp": "0.5.1",
+            "source-map": "0.6.1"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "version": "3.2.1",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "requires": {
                 "color-convert": "1.9.1"
               }
@@ -20451,12 +21041,12 @@
               "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
             },
             "chalk": {
-              "version": "2.3.1",
-              "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+              "version": "2.3.2",
+              "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
               "requires": {
-                "ansi-styles": "3.2.0",
+                "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "5.2.0"
+                "supports-color": "5.3.0"
               }
             },
             "escape-string-regexp": {
@@ -20467,9 +21057,13 @@
               "version": "3.0.0",
               "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
             },
+            "source-map": {
+              "version": "0.6.1",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+            },
             "supports-color": {
-              "version": "5.2.0",
-              "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+              "version": "5.3.0",
+              "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
               "requires": {
                 "has-flag": "3.0.0"
               }
@@ -20477,30 +21071,30 @@
           }
         },
         "jest-validate": {
-          "version": "22.4.0",
-          "integrity": "sha512-l5JwbIAso8jGp/5/Dy86BCVjOra/Rb81wyXcFTGa4VxbtIh4AEOp2WixgprHLwp+YlUrHugZwaGyuagjB+iB+A==",
+          "version": "22.4.2",
+          "integrity": "sha512-TLOgc/EULFBjMCAqZp5OdVvjxV16DZpfthd/UyPzM6lRmgWluohNVemAdnL3JvugU1s2Q2npcIqtbOtiPjaZ0A==",
           "requires": {
-            "chalk": "2.3.1",
-            "jest-config": "22.4.0",
+            "chalk": "2.3.2",
+            "jest-config": "22.4.2",
             "jest-get-type": "22.1.0",
             "leven": "2.1.0",
             "pretty-format": "22.4.0"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "version": "3.2.1",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "requires": {
                 "color-convert": "1.9.1"
               }
             },
             "chalk": {
-              "version": "2.3.1",
-              "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+              "version": "2.3.2",
+              "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
               "requires": {
-                "ansi-styles": "3.2.0",
+                "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "5.2.0"
+                "supports-color": "5.3.0"
               }
             },
             "escape-string-regexp": {
@@ -20516,8 +21110,8 @@
               "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
             },
             "supports-color": {
-              "version": "5.2.0",
-              "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+              "version": "5.3.0",
+              "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
               "requires": {
                 "has-flag": "3.0.0"
               }
@@ -20548,8 +21142,8 @@
           "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
         },
         "js-yaml": {
-          "version": "3.10.0",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "version": "3.11.0",
+          "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
           "requires": {
             "argparse": "1.0.10",
             "esprima": "4.0.0"
@@ -20745,7 +21339,7 @@
           "integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
           "requires": {
             "abab": "1.0.4",
-            "acorn": "5.4.1",
+            "acorn": "5.5.0",
             "acorn-globals": "4.1.0",
             "array-equal": "1.0.0",
             "browser-process-hrtime": "0.1.2",
@@ -20753,7 +21347,7 @@
             "cssom": "0.3.2",
             "cssstyle": "0.2.37",
             "domexception": "1.0.1",
-            "escodegen": "1.9.0",
+            "escodegen": "1.9.1",
             "html-encoding-sniffer": "1.0.2",
             "left-pad": "1.2.0",
             "nwmatcher": "1.4.3",
@@ -20763,34 +21357,29 @@
             "request-promise-native": "1.0.5",
             "sax": "1.2.4",
             "symbol-tree": "3.2.2",
-            "tough-cookie": "2.3.3",
+            "tough-cookie": "2.3.4",
             "w3c-hr-time": "1.0.1",
             "webidl-conversions": "4.0.2",
             "whatwg-encoding": "1.0.3",
             "whatwg-url": "6.4.0",
-            "ws": "4.0.0",
+            "ws": "4.1.0",
             "xml-name-validator": "3.0.0"
           },
           "dependencies": {
             "acorn": {
-              "version": "5.4.1",
-              "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ=="
+              "version": "5.5.0",
+              "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g=="
             },
             "parse5": {
               "version": "4.0.0",
               "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
             },
-            "ultron": {
-              "version": "1.1.1",
-              "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
-            },
             "ws": {
-              "version": "4.0.0",
-              "integrity": "sha512-QYslsH44bH8O7/W2815u5DpnCpXWpEK44FmaHffNwgJI4JMaSZONgPBTOfrxJ29mXKbXak+LsJ2uAkDTYq2ptQ==",
+              "version": "4.1.0",
+              "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
               "requires": {
                 "async-limiter": "1.0.0",
-                "safe-buffer": "5.1.1",
-                "ultron": "1.1.1"
+                "safe-buffer": "5.1.1"
               }
             }
           }
@@ -21432,6 +22021,10 @@
             "tmpl": "1.0.4"
           }
         },
+        "map-cache": {
+          "version": "0.2.2",
+          "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+        },
         "map-obj": {
           "version": "1.0.1",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
@@ -21443,6 +22036,13 @@
         "map-values": {
           "version": "1.0.1",
           "integrity": "sha1-douOecAJvytk/ugG4ip7HEGQyZA="
+        },
+        "map-visit": {
+          "version": "1.0.0",
+          "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+          "requires": {
+            "object-visit": "1.0.1"
+          }
         },
         "markdown-escapes": {
           "version": "1.0.1",
@@ -21530,7 +22130,7 @@
           "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
           "requires": {
             "errno": "0.1.7",
-            "readable-stream": "2.3.4"
+            "readable-stream": "2.3.5"
           },
           "dependencies": {
             "inherits": {
@@ -21538,8 +22138,8 @@
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -21593,7 +22193,7 @@
           "version": "1.0.1",
           "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
           "requires": {
-            "readable-stream": "2.3.4"
+            "readable-stream": "2.3.5"
           },
           "dependencies": {
             "inherits": {
@@ -21601,8 +22201,8 @@
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -21713,7 +22313,7 @@
           "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
           "requires": {
             "concat-stream": "1.5.2",
-            "duplexify": "3.5.3",
+            "duplexify": "3.5.4",
             "end-of-stream": "1.4.1",
             "flush-write-stream": "1.0.2",
             "from2": "2.3.0",
@@ -21729,8 +22329,8 @@
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -21752,7 +22352,7 @@
               "version": "2.0.3",
               "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
               "requires": {
-                "readable-stream": "2.3.4",
+                "readable-stream": "2.3.5",
                 "xtend": "4.0.1"
               }
             }
@@ -21772,6 +22372,23 @@
             }
           }
         },
+        "mixin-deep": {
+          "version": "1.3.1",
+          "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+          "requires": {
+            "for-in": "1.0.2",
+            "is-extendable": "1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "requires": {
+                "is-plain-object": "2.0.4"
+              }
+            }
+          }
+        },
         "mkdirp": {
           "version": "0.5.1",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
@@ -21780,15 +22397,19 @@
           }
         },
         "moment": {
-          "version": "2.19.2",
-          "integrity": "sha512-Rf6jiHPEfxp9+dlzxPTmRHbvoFXsh2L/U8hOupUMpnuecHQmI6cF6lUbJl3QqKPko1u6ujO+FxtcajLVfLpAtA=="
+          "version": "2.21.0",
+          "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
         },
         "moment-timezone": {
           "version": "0.5.11",
           "integrity": "sha1-m3bAPY71FMfkJJp7vOZJ7tOe8p8=",
           "requires": {
-            "moment": "2.19.2"
+            "moment": "2.21.0"
           }
+        },
+        "moo": {
+          "version": "0.4.3",
+          "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw=="
         },
         "morgan": {
           "version": "1.2.0",
@@ -21852,8 +22473,40 @@
           "integrity": "sha1-Cr+2rYNXGLn7Te8GdOBmV6lUN1w="
         },
         "nan": {
-          "version": "2.8.0",
-          "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+          "version": "2.9.2",
+          "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw=="
+        },
+        "nanomatch": {
+          "version": "1.2.9",
+          "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+          "requires": {
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "fragment-cache": "0.2.1",
+            "is-odd": "2.0.0",
+            "is-windows": "1.0.2",
+            "kind-of": "6.0.2",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "4.0.0",
+              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+            }
+          }
         },
         "natives": {
           "version": "1.1.1",
@@ -21887,9 +22540,10 @@
           }
         },
         "nearley": {
-          "version": "2.11.1",
-          "integrity": "sha512-1azpqq1JvHKZNPEixS1jNEXf4kDilhFtr8AIZIGjP8N0TcAcUhKgi354niI5pM4JoOsMQ+H6vzCYWQa95LQjcw==",
+          "version": "2.12.1",
+          "integrity": "sha512-FQyYKOKm5DgqzJkR6C9GhlRoYdrcRKXJF2qi9Y/4K4Cd2BN4Sglven0LO3dR8w1BQ72Ty5s+/XzA/FtN9Gx50w==",
           "requires": {
+            "moo": "0.4.3",
             "nomnom": "1.6.2",
             "railroad-diagrams": "1.0.0",
             "randexp": "0.4.6",
@@ -21958,8 +22612,8 @@
           }
         },
         "node-abi": {
-          "version": "2.2.0",
-          "integrity": "sha512-FqVC0WNNL8fQWQK3GYTESfwZXZKDbSIiEEIvufq7HV6Lj0IDDZRVa4CU/KTA0JVlqY9eTDSuPiC8FS9UfGVuzA==",
+          "version": "2.3.0",
+          "integrity": "sha512-zwm6vU3SsVgw3e9fu48JBaRBCJGIvAgysDsqtf5+vEexFE71bEOtaMWb5zr/zODZNzTPtQlqUUpC79k68Hspow==",
           "requires": {
             "semver": "5.5.0"
           },
@@ -22059,7 +22713,7 @@
             "process": "0.11.10",
             "punycode": "1.4.1",
             "querystring-es3": "0.2.1",
-            "readable-stream": "2.3.4",
+            "readable-stream": "2.3.5",
             "stream-browserify": "2.0.1",
             "stream-http": "2.8.0",
             "string_decoder": "1.0.3",
@@ -22075,8 +22729,8 @@
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -22132,7 +22786,7 @@
             "lodash.mergewith": "4.6.1",
             "meow": "3.7.0",
             "mkdirp": "0.5.1",
-            "nan": "2.8.0",
+            "nan": "2.9.2",
             "node-gyp": "3.6.2",
             "npmlog": "4.1.2",
             "request": "2.83.0",
@@ -22285,7 +22939,7 @@
             "hosted-git-info": "2.5.0",
             "is-builtin-module": "1.0.0",
             "semver": "5.1.0",
-            "validate-npm-package-license": "3.0.1"
+            "validate-npm-package-license": "3.0.3"
           }
         },
         "normalize-path": {
@@ -22419,6 +23073,53 @@
           "version": "0.0.3",
           "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
         },
+        "object-copy": {
+          "version": "0.1.0",
+          "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+          "requires": {
+            "copy-descriptor": "0.1.1",
+            "define-property": "0.2.5",
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "requires": {
+                "kind-of": "3.2.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "requires": {
+                "kind-of": "3.2.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "5.1.0",
+                  "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                }
+              }
+            }
+          }
+        },
         "object-filter": {
           "version": "1.0.2",
           "integrity": "sha1-rwt5f/6+r4pSxmN87b6IFs/sG8g="
@@ -22430,6 +23131,19 @@
         "object-keys": {
           "version": "1.0.11",
           "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+        },
+        "object-visit": {
+          "version": "1.0.1",
+          "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+          "requires": {
+            "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
         },
         "object.assign": {
           "version": "4.1.0",
@@ -22465,6 +23179,19 @@
           "requires": {
             "for-own": "0.1.5",
             "is-extendable": "0.1.1"
+          }
+        },
+        "object.pick": {
+          "version": "1.3.0",
+          "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+          "requires": {
+            "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
           }
         },
         "object.values": {
@@ -22633,7 +23360,7 @@
           "requires": {
             "cyclist": "0.2.2",
             "inherits": "2.0.3",
-            "readable-stream": "2.3.4"
+            "readable-stream": "2.3.5"
           },
           "dependencies": {
             "inherits": {
@@ -22641,8 +23368,8 @@
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -22784,6 +23511,10 @@
             "upper-case-first": "1.1.2"
           }
         },
+        "pascalcase": {
+          "version": "0.1.1",
+          "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+        },
         "path": {
           "version": "0.12.7",
           "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
@@ -22802,6 +23533,10 @@
           "requires": {
             "sentence-case": "1.1.3"
           }
+        },
+        "path-dirname": {
+          "version": "1.0.2",
+          "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
         },
         "path-exists": {
           "version": "3.0.0",
@@ -22953,6 +23688,10 @@
           "version": "2.3.1",
           "integrity": "sha1-EdHhK5y2TWPjDBQ6Mw9MH1Z9qF8="
         },
+        "posix-character-classes": {
+          "version": "0.1.1",
+          "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+        },
         "postcss": {
           "version": "5.2.18",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
@@ -23048,19 +23787,19 @@
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "version": "3.2.1",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "requires": {
                 "color-convert": "1.9.1"
               }
             },
             "chalk": {
-              "version": "2.3.1",
-              "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+              "version": "2.3.2",
+              "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
               "requires": {
-                "ansi-styles": "3.2.0",
+                "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "5.2.0"
+                "supports-color": "5.3.0"
               }
             },
             "escape-string-regexp": {
@@ -23075,9 +23814,9 @@
               "version": "6.0.19",
               "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
               "requires": {
-                "chalk": "2.3.1",
+                "chalk": "2.3.2",
                 "source-map": "0.6.1",
-                "supports-color": "5.2.0"
+                "supports-color": "5.3.0"
               }
             },
             "source-map": {
@@ -23085,8 +23824,8 @@
               "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
             },
             "supports-color": {
-              "version": "5.2.0",
-              "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+              "version": "5.3.0",
+              "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
               "requires": {
                 "has-flag": "3.0.0"
               }
@@ -23126,19 +23865,19 @@
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "version": "3.2.1",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "requires": {
                 "color-convert": "1.9.1"
               }
             },
             "chalk": {
-              "version": "2.3.1",
-              "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+              "version": "2.3.2",
+              "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
               "requires": {
-                "ansi-styles": "3.2.0",
+                "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "5.2.0"
+                "supports-color": "5.3.0"
               }
             },
             "escape-string-regexp": {
@@ -23153,9 +23892,9 @@
               "version": "6.0.19",
               "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
               "requires": {
-                "chalk": "2.3.1",
+                "chalk": "2.3.2",
                 "source-map": "0.6.1",
-                "supports-color": "5.2.0"
+                "supports-color": "5.3.0"
               }
             },
             "source-map": {
@@ -23163,8 +23902,8 @@
               "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
             },
             "supports-color": {
-              "version": "5.2.0",
-              "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+              "version": "5.3.0",
+              "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
               "requires": {
                 "has-flag": "3.0.0"
               }
@@ -23202,7 +23941,7 @@
             "github-from-package": "0.0.0",
             "minimist": "1.2.0",
             "mkdirp": "0.5.1",
-            "node-abi": "2.2.0",
+            "node-abi": "2.3.0",
             "noop-logger": "0.1.1",
             "npmlog": "4.1.2",
             "os-homedir": "1.0.2",
@@ -23281,8 +24020,8 @@
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
             },
             "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "version": "3.2.1",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "requires": {
                 "color-convert": "1.9.1"
               }
@@ -23308,7 +24047,7 @@
               "version": "2.1.0",
               "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
               "requires": {
-                "ansi-styles": "3.2.0",
+                "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
                 "supports-color": "4.5.0"
               }
@@ -23371,7 +24110,7 @@
               "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
               "requires": {
                 "ansi-regex": "3.0.0",
-                "ansi-styles": "3.2.0"
+                "ansi-styles": "3.2.1"
               }
             },
             "semver": {
@@ -23411,7 +24150,7 @@
           "integrity": "sha512-pvCxP2iODIIk9adXlo4S3GRj0BrJiil68kByAa1PrgG97c1tClh9dLMgp3Z6cHFZrclaABt0UH8PIhwHuFLqYA==",
           "requires": {
             "ansi-regex": "3.0.0",
-            "ansi-styles": "3.2.0"
+            "ansi-styles": "3.2.1"
           },
           "dependencies": {
             "ansi-regex": {
@@ -23419,8 +24158,8 @@
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
             },
             "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "version": "3.2.1",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "requires": {
                 "color-convert": "1.9.1"
               }
@@ -23540,7 +24279,7 @@
           "version": "1.4.0",
           "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
           "requires": {
-            "duplexify": "3.5.3",
+            "duplexify": "3.5.4",
             "inherits": "2.0.3",
             "pump": "2.0.1"
           },
@@ -23690,12 +24429,12 @@
             "fbjs": "0.8.16",
             "loose-envify": "1.3.1",
             "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
+            "prop-types": "15.6.1"
           },
           "dependencies": {
             "prop-types": {
-              "version": "15.6.0",
-              "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+              "version": "15.6.1",
+              "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
               "requires": {
                 "fbjs": "0.8.16",
                 "loose-envify": "1.3.1",
@@ -23832,7 +24571,7 @@
                 "doctrine": "1.5.0",
                 "es6-map": "0.1.5",
                 "escope": "3.6.0",
-                "espree": "3.5.3",
+                "espree": "3.5.4",
                 "estraverse": "4.2.0",
                 "esutils": "2.0.2",
                 "file-entry-cache": "1.3.1",
@@ -23843,7 +24582,7 @@
                 "inquirer": "0.12.0",
                 "is-my-json-valid": "2.17.1",
                 "is-resolvable": "1.1.0",
-                "js-yaml": "3.10.0",
+                "js-yaml": "3.11.0",
                 "json-stable-stringify": "1.0.1",
                 "levn": "0.3.0",
                 "lodash": "4.17.5",
@@ -23940,7 +24679,7 @@
                     "strip-ansi": "3.0.1",
                     "throat": "3.2.0",
                     "which": "1.3.0",
-                    "worker-farm": "1.5.2",
+                    "worker-farm": "1.5.4",
                     "yargs": "6.6.0"
                   }
                 }
@@ -24000,7 +24739,7 @@
                 "graceful-fs": "4.1.11",
                 "multimatch": "2.1.0",
                 "sane": "1.4.1",
-                "worker-farm": "1.5.2"
+                "worker-farm": "1.5.4"
               }
             },
             "jest-jasmine2": {
@@ -24121,14 +24860,14 @@
                 "content-type-parser": "1.0.2",
                 "cssom": "0.3.2",
                 "cssstyle": "0.2.37",
-                "escodegen": "1.9.0",
+                "escodegen": "1.9.1",
                 "html-encoding-sniffer": "1.0.2",
                 "nwmatcher": "1.4.3",
                 "parse5": "1.5.1",
                 "request": "2.83.0",
                 "sax": "1.2.4",
                 "symbol-tree": "3.2.2",
-                "tough-cookie": "2.3.3",
+                "tough-cookie": "2.3.4",
                 "webidl-conversions": "4.0.2",
                 "whatwg-encoding": "1.0.3",
                 "whatwg-url": "4.8.0",
@@ -24276,12 +25015,12 @@
           "integrity": "sha1-/CK4Cdt5I4bRRo0/RtclrZHgTbk=",
           "requires": {
             "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
+            "prop-types": "15.6.1"
           },
           "dependencies": {
             "prop-types": {
-              "version": "15.6.0",
-              "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+              "version": "15.6.1",
+              "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
               "requires": {
                 "fbjs": "0.8.16",
                 "loose-envify": "1.3.1",
@@ -24297,12 +25036,12 @@
             "fbjs": "0.8.16",
             "loose-envify": "1.3.1",
             "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
+            "prop-types": "15.6.1"
           },
           "dependencies": {
             "prop-types": {
-              "version": "15.6.0",
-              "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+              "version": "15.6.1",
+              "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
               "requires": {
                 "fbjs": "0.8.16",
                 "loose-envify": "1.3.1",
@@ -24352,12 +25091,12 @@
             "fbjs": "0.8.16",
             "loose-envify": "1.3.1",
             "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
+            "prop-types": "15.6.1"
           },
           "dependencies": {
             "prop-types": {
-              "version": "15.6.0",
-              "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+              "version": "15.6.1",
+              "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
               "requires": {
                 "fbjs": "0.8.16",
                 "loose-envify": "1.3.1",
@@ -24390,12 +25129,12 @@
           "requires": {
             "fbjs": "0.8.16",
             "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
+            "prop-types": "15.6.1"
           },
           "dependencies": {
             "prop-types": {
-              "version": "15.6.0",
-              "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+              "version": "15.6.1",
+              "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
               "requires": {
                 "fbjs": "0.8.16",
                 "loose-envify": "1.3.1",
@@ -24443,7 +25182,7 @@
           "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
           "requires": {
             "pinkie-promise": "2.0.1",
-            "readable-stream": "2.3.4"
+            "readable-stream": "2.3.5"
           },
           "dependencies": {
             "inherits": {
@@ -24451,8 +25190,8 @@
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -24535,7 +25274,7 @@
           "requires": {
             "graceful-fs": "4.1.11",
             "minimatch": "3.0.4",
-            "readable-stream": "2.3.4",
+            "readable-stream": "2.3.5",
             "set-immediate-shim": "1.0.1"
           },
           "dependencies": {
@@ -24544,8 +25283,8 @@
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -24714,6 +25453,14 @@
             "is-equal-shallow": "0.1.3"
           }
         },
+        "regex-not": {
+          "version": "1.0.2",
+          "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+          "requires": {
+            "extend-shallow": "3.0.2",
+            "safe-regex": "1.1.0"
+          }
+        },
         "regexpu": {
           "version": "1.3.0",
           "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
@@ -24867,7 +25614,7 @@
             "qs": "6.5.1",
             "safe-buffer": "5.1.1",
             "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
+            "tough-cookie": "2.3.4",
             "tunnel-agent": "0.6.0",
             "uuid": "3.2.1"
           },
@@ -24875,10 +25622,6 @@
             "qs": {
               "version": "6.5.1",
               "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
-            },
-            "uuid": {
-              "version": "3.2.1",
-              "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
             }
           }
         },
@@ -24895,7 +25638,7 @@
           "requires": {
             "request-promise-core": "1.1.1",
             "stealthy-require": "1.1.1",
-            "tough-cookie": "2.3.3"
+            "tough-cookie": "2.3.4"
           }
         },
         "require-directory": {
@@ -24945,6 +25688,10 @@
         "resolve-from": {
           "version": "1.0.1",
           "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+        },
+        "resolve-url": {
+          "version": "0.2.1",
+          "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
         },
         "restore-cursor": {
           "version": "1.0.1",
@@ -25003,14 +25750,14 @@
           "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
           "requires": {
             "lodash.flattendeep": "4.4.0",
-            "nearley": "2.11.1"
+            "nearley": "2.12.1"
           }
         },
         "rtlcss": {
           "version": "2.2.1",
           "integrity": "sha512-JjQ5DlrmwiItAjlmhoxrJq5ihgZcE0wMFxt7S17bIrt4Lw0WwKKFk+viRhvodB/0falyG/5fiO043ZDh6/aqTw==",
           "requires": {
-            "chalk": "2.3.1",
+            "chalk": "2.3.2",
             "findup": "0.1.5",
             "mkdirp": "0.5.1",
             "postcss": "6.0.19",
@@ -25018,19 +25765,19 @@
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+              "version": "3.2.1",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "requires": {
                 "color-convert": "1.9.1"
               }
             },
             "chalk": {
-              "version": "2.3.1",
-              "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+              "version": "2.3.2",
+              "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
               "requires": {
-                "ansi-styles": "3.2.0",
+                "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "5.2.0"
+                "supports-color": "5.3.0"
               }
             },
             "escape-string-regexp": {
@@ -25045,9 +25792,9 @@
               "version": "6.0.19",
               "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
               "requires": {
-                "chalk": "2.3.1",
+                "chalk": "2.3.2",
                 "source-map": "0.6.1",
-                "supports-color": "5.2.0"
+                "supports-color": "5.3.0"
               }
             },
             "source-map": {
@@ -25055,8 +25802,8 @@
               "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
             },
             "supports-color": {
-              "version": "5.2.0",
-              "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+              "version": "5.3.0",
+              "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
               "requires": {
                 "has-flag": "3.0.0"
               }
@@ -25088,6 +25835,13 @@
         "safe-buffer": {
           "version": "5.1.1",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+        },
+        "safe-regex": {
+          "version": "1.1.0",
+          "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+          "requires": {
+            "ret": "0.1.15"
+          }
         },
         "samsam": {
           "version": "1.1.2",
@@ -25177,15 +25931,15 @@
           "version": "0.4.5",
           "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
           "requires": {
-            "ajv": "6.1.1",
+            "ajv": "6.2.1",
             "ajv-keywords": "3.1.0"
           },
           "dependencies": {
             "ajv": {
-              "version": "6.1.1",
-              "integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
+              "version": "6.2.1",
+              "integrity": "sha1-KKarxJOiq+D7TIUHrK7bQ/pVBnE=",
               "requires": {
-                "fast-deep-equal": "1.0.0",
+                "fast-deep-equal": "1.1.0",
                 "fast-json-stable-stringify": "2.0.0",
                 "json-schema-traverse": "0.3.1"
               }
@@ -25332,9 +26086,35 @@
           "version": "2.0.0",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
         },
+        "set-getter": {
+          "version": "0.1.0",
+          "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
+          "requires": {
+            "to-object-path": "0.3.0"
+          }
+        },
         "set-immediate-shim": {
           "version": "1.0.1",
           "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+        },
+        "set-value": {
+          "version": "2.0.0",
+          "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "split-string": "3.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
         },
         "setimmediate": {
           "version": "1.0.5",
@@ -25441,6 +26221,114 @@
           "integrity": "sha1-DC8l4wUVjZoY09l3BmGH/vilpmo=",
           "requires": {
             "sentence-case": "1.1.3"
+          }
+        },
+        "snapdragon": {
+          "version": "0.8.1",
+          "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
+          "requires": {
+            "base": "0.11.2",
+            "debug": "2.2.0",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "map-cache": "0.2.2",
+            "source-map": "0.5.7",
+            "source-map-resolve": "0.5.1",
+            "use": "2.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+            }
+          }
+        },
+        "snapdragon-node": {
+          "version": "2.1.1",
+          "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+          "requires": {
+            "define-property": "1.0.0",
+            "isobject": "3.0.1",
+            "snapdragon-util": "3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
+        "snapdragon-util": {
+          "version": "3.0.1",
+          "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+          "requires": {
+            "kind-of": "3.2.2"
           }
         },
         "sntp": {
@@ -25554,6 +26442,17 @@
             "amdefine": "1.0.1"
           }
         },
+        "source-map-resolve": {
+          "version": "0.5.1",
+          "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+          "requires": {
+            "atob": "2.0.3",
+            "decode-uri-component": "0.2.0",
+            "resolve-url": "0.2.1",
+            "source-map-url": "0.4.0",
+            "urix": "0.1.0"
+          }
+        },
         "source-map-support": {
           "version": "0.3.2",
           "integrity": "sha1-c31ckB4LeP21OspxPSTyPMuxC+E=",
@@ -25570,24 +26469,37 @@
             }
           }
         },
+        "source-map-url": {
+          "version": "0.4.0",
+          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+        },
         "sparkles": {
           "version": "1.0.0",
           "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
         },
         "spdx-correct": {
-          "version": "1.0.2",
-          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+          "version": "3.0.0",
+          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "requires": {
-            "spdx-license-ids": "1.2.2"
+            "spdx-expression-parse": "3.0.0",
+            "spdx-license-ids": "3.0.0"
           }
         },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+        },
         "spdx-expression-parse": {
-          "version": "1.0.4",
-          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+          "version": "3.0.0",
+          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+          "requires": {
+            "spdx-exceptions": "2.1.0",
+            "spdx-license-ids": "3.0.0"
+          }
         },
         "spdx-license-ids": {
-          "version": "1.2.2",
-          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+          "version": "3.0.0",
+          "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
         },
         "specificity": {
           "version": "0.2.1",
@@ -25598,6 +26510,13 @@
           "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
           "requires": {
             "through": "2.3.8"
+          }
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+          "requires": {
+            "extend-shallow": "3.0.2"
           }
         },
         "split2": {
@@ -25644,6 +26563,68 @@
           "version": "1.0.0",
           "integrity": "sha1-0g+aYWu08MO5i5GSLSW2QKorxCU="
         },
+        "static-extend": {
+          "version": "0.1.2",
+          "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+          "requires": {
+            "define-property": "0.2.5",
+            "object-copy": "0.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+            }
+          }
+        },
         "statuses": {
           "version": "1.4.0",
           "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
@@ -25652,7 +26633,7 @@
           "version": "1.4.0",
           "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
           "requires": {
-            "readable-stream": "2.3.4"
+            "readable-stream": "2.3.5"
           },
           "dependencies": {
             "inherits": {
@@ -25660,8 +26641,8 @@
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -25694,12 +26675,12 @@
           "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
           "requires": {
             "inherits": "2.0.1",
-            "readable-stream": "2.3.4"
+            "readable-stream": "2.3.5"
           },
           "dependencies": {
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -25746,14 +26727,14 @@
           "requires": {
             "builtin-status-codes": "3.0.0",
             "inherits": "2.0.1",
-            "readable-stream": "2.3.4",
+            "readable-stream": "2.3.5",
             "to-arraybuffer": "1.0.1",
             "xtend": "4.0.1"
           },
           "dependencies": {
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -25973,7 +26954,7 @@
               "integrity": "sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=",
               "requires": {
                 "graceful-fs": "4.1.11",
-                "js-yaml": "3.10.0",
+                "js-yaml": "3.11.0",
                 "minimist": "1.2.0",
                 "object-assign": "4.1.1",
                 "os-homedir": "1.0.2",
@@ -26054,7 +27035,7 @@
             "methods": "1.1.2",
             "mime": "1.3.4",
             "qs": "6.5.1",
-            "readable-stream": "2.3.4"
+            "readable-stream": "2.3.5"
           },
           "dependencies": {
             "async": {
@@ -26079,8 +27060,8 @@
               "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
             },
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -26243,7 +27224,7 @@
           "requires": {
             "bl": "1.2.1",
             "end-of-stream": "1.4.1",
-            "readable-stream": "2.3.4",
+            "readable-stream": "2.3.5",
             "xtend": "4.0.1"
           },
           "dependencies": {
@@ -26252,8 +27233,8 @@
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "readable-stream": {
-              "version": "2.3.4",
-              "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+              "version": "2.3.5",
+              "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -26421,6 +27402,40 @@
           "version": "1.0.2",
           "integrity": "sha1-xyKQcWTvaxeBMsjmmTAhLRtKoWo="
         },
+        "to-object-path": {
+          "version": "0.3.0",
+          "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "to-regex": {
+          "version": "3.0.2",
+          "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+          "requires": {
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "regex-not": "1.0.2",
+            "safe-regex": "1.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "requires": {
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "requires": {
+                "kind-of": "3.2.2"
+              }
+            }
+          }
+        },
         "to-space-case": {
           "version": "1.0.0",
           "integrity": "sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=",
@@ -26438,8 +27453,8 @@
           }
         },
         "tough-cookie": {
-          "version": "2.3.3",
-          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+          "version": "2.3.4",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
           "requires": {
             "punycode": "1.4.1"
           }
@@ -26597,7 +27612,7 @@
             "source-map": "0.6.1",
             "uglify-es": "3.3.9",
             "webpack-sources": "1.1.0",
-            "worker-farm": "1.5.2"
+            "worker-farm": "1.5.4"
           },
           "dependencies": {
             "commander": {
@@ -26681,6 +27696,35 @@
             "x-is-string": "0.1.0"
           }
         },
+        "union-value": {
+          "version": "1.0.0",
+          "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+          "requires": {
+            "arr-union": "3.1.0",
+            "get-value": "2.0.6",
+            "is-extendable": "0.1.1",
+            "set-value": "0.4.3"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "set-value": {
+              "version": "0.4.3",
+              "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+              "requires": {
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "to-object-path": "0.3.0"
+              }
+            }
+          }
+        },
         "uniq": {
           "version": "1.0.1",
           "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
@@ -26758,6 +27802,46 @@
             }
           }
         },
+        "unset-value": {
+          "version": "1.0.0",
+          "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+          "requires": {
+            "has-value": "0.3.1",
+            "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+              "requires": {
+                "get-value": "2.0.6",
+                "has-values": "0.1.4",
+                "isobject": "2.1.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
+        "upath": {
+          "version": "1.0.4",
+          "integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw=="
+        },
         "update-notifier": {
           "version": "0.3.2",
           "integrity": "sha1-IqhzW6re8zIOLbko9pPaiY3Id3c=",
@@ -26797,6 +27881,10 @@
             "camelcase": "1.2.1"
           }
         },
+        "urix": {
+          "version": "0.1.0",
+          "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+        },
         "url": {
           "version": "0.11.0",
           "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
@@ -26808,6 +27896,80 @@
             "punycode": {
               "version": "1.3.2",
               "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+            }
+          }
+        },
+        "use": {
+          "version": "2.0.2",
+          "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
+          "requires": {
+            "define-property": "0.2.5",
+            "isobject": "3.0.1",
+            "lazy-cache": "2.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+            },
+            "lazy-cache": {
+              "version": "2.0.2",
+              "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+              "requires": {
+                "set-getter": "0.1.0"
+              }
             }
           }
         },
@@ -26843,19 +28005,19 @@
           "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
         },
         "uuid": {
-          "version": "2.0.1",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+          "version": "3.2.1",
+          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
         },
         "valid-url": {
           "version": "1.0.9",
           "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
         },
         "validate-npm-package-license": {
-          "version": "3.0.1",
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+          "version": "3.0.3",
+          "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
           "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
+            "spdx-correct": "3.0.0",
+            "spdx-expression-parse": "3.0.0"
           }
         },
         "vary": {
@@ -27019,20 +28181,286 @@
           }
         },
         "watchpack": {
-          "version": "1.4.0",
-          "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
+          "version": "1.5.0",
+          "integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
           "requires": {
-            "async": "2.6.0",
-            "chokidar": "1.7.0",
-            "graceful-fs": "4.1.11"
+            "chokidar": "2.0.2",
+            "graceful-fs": "4.1.11",
+            "neo-async": "2.5.0"
           },
           "dependencies": {
-            "async": {
-              "version": "2.6.0",
-              "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+            "anymatch": {
+              "version": "2.0.0",
+              "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
               "requires": {
-                "lodash": "4.17.5"
+                "micromatch": "3.1.9",
+                "normalize-path": "2.1.1"
               }
+            },
+            "arr-diff": {
+              "version": "4.0.0",
+              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+            },
+            "braces": {
+              "version": "2.3.1",
+              "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+              "requires": {
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "kind-of": "6.0.2",
+                "repeat-element": "1.1.2",
+                "snapdragon": "0.8.1",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                  "requires": {
+                    "is-descriptor": "1.0.2"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "chokidar": {
+              "version": "2.0.2",
+              "integrity": "sha512-l32Hw3wqB0L2kGVmSbK/a+xXLDrUEsc84pSgMkmwygHvD7ubRsP/vxxHa5BtB6oix1XLLVCHyYMsckRXxThmZw==",
+              "requires": {
+                "anymatch": "2.0.0",
+                "async-each": "1.0.1",
+                "braces": "2.3.1",
+                "fsevents": "1.1.3",
+                "glob-parent": "3.1.0",
+                "inherits": "2.0.1",
+                "is-binary-path": "1.0.1",
+                "is-glob": "4.0.0",
+                "normalize-path": "2.1.1",
+                "path-is-absolute": "1.0.1",
+                "readdirp": "2.1.0",
+                "upath": "1.0.4"
+              }
+            },
+            "debug": {
+              "version": "2.6.9",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "expand-brackets": {
+              "version": "2.1.4",
+              "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+              "requires": {
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.1",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                  "requires": {
+                    "is-descriptor": "0.1.6"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "0.1.6",
+                  "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                  "requires": {
+                    "is-accessor-descriptor": "0.1.6",
+                    "is-data-descriptor": "0.1.4",
+                    "kind-of": "5.1.0"
+                  }
+                },
+                "kind-of": {
+                  "version": "5.1.0",
+                  "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                }
+              }
+            },
+            "extglob": {
+              "version": "2.0.4",
+              "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+              "requires": {
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.1",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                  "requires": {
+                    "is-descriptor": "1.0.2"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+              "requires": {
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "glob-parent": {
+              "version": "3.1.0",
+              "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+              "requires": {
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
+              },
+              "dependencies": {
+                "is-glob": {
+                  "version": "3.1.0",
+                  "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                  "requires": {
+                    "is-extglob": "2.1.1"
+                  }
+                }
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-glob": {
+              "version": "4.0.0",
+              "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+              "requires": {
+                "is-extglob": "2.1.1"
+              }
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+            },
+            "micromatch": {
+              "version": "3.1.9",
+              "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
+              "requires": {
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.1",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.9",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.1",
+                "to-regex": "3.0.2"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            },
+            "neo-async": {
+              "version": "2.5.0",
+              "integrity": "sha512-nJmSswG4As/MkRq7QZFuH/sf/yuv8ODdMZrY4Bedjp77a5MK4A6s7YbBB64c9u79EBUOfXUXBvArmvzTD0X+6g=="
             }
           }
         },
@@ -27044,7 +28472,7 @@
           "version": "3.10.0",
           "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
           "requires": {
-            "acorn": "5.4.1",
+            "acorn": "5.5.0",
             "acorn-dynamic-import": "2.0.2",
             "ajv": "5.5.2",
             "ajv-keywords": "2.1.1",
@@ -27063,14 +28491,14 @@
             "supports-color": "4.5.0",
             "tapable": "0.2.8",
             "uglifyjs-webpack-plugin": "0.4.6",
-            "watchpack": "1.4.0",
+            "watchpack": "1.5.0",
             "webpack-sources": "1.1.0",
             "yargs": "8.0.2"
           },
           "dependencies": {
             "acorn": {
-              "version": "5.4.1",
-              "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ=="
+              "version": "5.5.0",
+              "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g=="
             },
             "ajv-keywords": {
               "version": "2.1.1",
@@ -27290,7 +28718,7 @@
           "version": "2.9.2",
           "integrity": "sha1-Y+2G63HMTNqG9o5oWoRTC6ASZEk=",
           "requires": {
-            "acorn": "5.4.1",
+            "acorn": "5.5.0",
             "chalk": "1.1.3",
             "commander": "2.14.1",
             "ejs": "2.5.7",
@@ -27300,20 +28728,20 @@
             "lodash": "4.17.5",
             "mkdirp": "0.5.1",
             "opener": "1.4.3",
-            "ws": "4.0.0"
+            "ws": "4.1.0"
           },
           "dependencies": {
             "accepts": {
-              "version": "1.3.4",
-              "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+              "version": "1.3.5",
+              "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
               "requires": {
                 "mime-types": "2.1.18",
                 "negotiator": "0.6.1"
               }
             },
             "acorn": {
-              "version": "5.4.1",
-              "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ=="
+              "version": "5.5.0",
+              "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g=="
             },
             "body-parser": {
               "version": "1.18.2",
@@ -27385,7 +28813,7 @@
               "version": "4.16.2",
               "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
               "requires": {
-                "accepts": "1.3.4",
+                "accepts": "1.3.5",
                 "array-flatten": "1.1.1",
                 "body-parser": "1.18.2",
                 "content-disposition": "0.5.2",
@@ -27529,10 +28957,6 @@
               "version": "2.0.0",
               "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             },
-            "ultron": {
-              "version": "1.1.1",
-              "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
-            },
             "utils-merge": {
               "version": "1.0.1",
               "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
@@ -27542,12 +28966,11 @@
               "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
             },
             "ws": {
-              "version": "4.0.0",
-              "integrity": "sha512-QYslsH44bH8O7/W2815u5DpnCpXWpEK44FmaHffNwgJI4JMaSZONgPBTOfrxJ29mXKbXak+LsJ2uAkDTYq2ptQ==",
+              "version": "4.1.0",
+              "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
               "requires": {
                 "async-limiter": "1.0.0",
-                "safe-buffer": "5.1.1",
-                "ultron": "1.1.1"
+                "safe-buffer": "5.1.1"
               }
             }
           }
@@ -27664,8 +29087,8 @@
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
         },
         "worker-farm": {
-          "version": "1.5.2",
-          "integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
+          "version": "1.5.4",
+          "integrity": "sha512-ITyClEvcfv0ozqJl1vmWFWhvI+OIrkbInYqkEPE50wFPXj8J9Gd3FYf8+CkZJXJJsQBYe+2DvmoK9Zhx5w8W+w==",
           "requires": {
             "errno": "0.1.7",
             "xtend": "4.0.1"
@@ -27686,8 +29109,8 @@
           }
         },
         "wpcom": {
-          "version": "5.4.0",
-          "integrity": "sha1-aRDXaX6ApLYTl6J/D0CREj7/vGU=",
+          "version": "5.4.1",
+          "integrity": "sha512-dahgmqzWsEOJywVVg+o5fQpfovkk/hajEo28GqLUu++NgsVHTo7K1CEmwBVSsicQcTOjHe/GHfq52hl6Ri1CVg==",
           "requires": {
             "babel-runtime": "6.26.0",
             "debug": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint": "3.16.0",
     "eslint-config-wpcalypso": "^2.0.0",
     "eslint-loader": "^1.6.1",
+    "eslint-plugin-import": "^2.9.0",
     "eslint-plugin-jest": "^21.2.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.1.0",
@@ -103,6 +104,6 @@
     "redux-thunk": "^2.2.0",
     "reselect": "^2.5.4",
     "whatwg-fetch": "^2.0.2",
-    "wp-calypso": "github:automattic/wp-calypso#fde036a9ba30c5e1e92434d2f9f66f45a7ff654c"
+    "wp-calypso": "github:automattic/wp-calypso#a8fbbafc0abde1ffbe2c05bd07810037808ec433"
   }
 }

--- a/tasks/i18njson.js
+++ b/tasks/i18njson.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console, import/no-nodejs-modules */
 const fs = require( 'fs' ),
 	globby = require( 'globby' ),
 	path = require( 'path' ),

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -1,5 +1,5 @@
-/* eslint-disable no-console */
-/*eslint no-process-exit: 0, no-undef: 0, strict: 0 */
+/* eslint-disable no-console, import/no-nodejs-modules */
+/* eslint no-process-exit: 0, no-undef: 0, strict: 0 */
 'use strict';
 require( 'shelljs/global' );
 const colors = require( 'colors' );


### PR DESCRIPTION
This PR seeks to add the functionality from this Calypso PR: https://github.com/Automattic/wp-calypso/pull/21229.

It adds the WooCommerce and WPCOM data-layer middleware to facilitate using the `woocommerce` state tree.

A Calypso stub and redux middleware were added to redirect Jetpack proxy requests to the local WC REST API and to modify the response for the WooCommerce data-layer middleware. _(`meta.dataLayer.data` vs `meta.dataLayer.body`)_

The stub+middleware combo will allow the use of any WooCommerce data-layer middleware that doesn't rely on https://github.com/woocommerce/wc-api-dev - e.g. can be requested over `/wc/v2`.

Visual changes in this PR:
![](https://camo.githubusercontent.com/ee609fc9b893a3a94ca961d91ed1f36dd6f47827/68747470733a2f2f636c6475702e636f6d2f71432d4a6d6a75454c4e2d3330303078333030302e706e67)