### PR TITLE
Update shipping label endpoint to support return labels

### DIFF
--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -40,11 +40,9 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 
 		$service_names = array();
 		foreach ( $settings[ 'packages' ] as $index => $package ) {
-			if ( isset( $package[ 'service_name' ] ) ) {
-				$service_names[] = $package[ 'service_name' ];
-				unset( $package[ 'service_name' ] );
-				$settings[ 'packages' ][ $index ] = $package;
-			}
+			$service_names[] = $package[ 'service_name' ];
+			unset( $package[ 'service_name' ] );
+			$settings[ 'packages' ][ $index ] = $package;
 		}
 
 		$response = $this->api_client->send_shipping_label_request( $settings );
@@ -86,7 +84,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 			);
 
 			$package = $settings[ 'packages' ][ $index ];
-			$box_id = isset( $package[ 'box_id' ] ) && $package[ 'box_id' ];
+			$box_id = $package[ 'box_id' ];
 			if ( 'individual' === $box_id ) {
 				$label_meta[ 'package_name' ] = __( 'Individual packaging', 'woocommerce-services' );
 			} else if ( isset( $package_lookup[ $box_id ] ) ) {

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -84,7 +84,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 			);
 
 			$package = $settings[ 'packages' ][ $index ];
-			$box_id = $package[ 'box_id' ];
+			$box_id = isset( $package[ 'box_id' ] ) && $package[ 'box_id' ];
 			$label_meta[ 'box_id' ] = $box_id;
 			if ( 'individual' === $box_id ) {
 				$label_meta[ 'package_name' ] = __( 'Individual packaging', 'woocommerce-services' );
@@ -94,20 +94,22 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 				$label_meta[ 'package_name' ] = __( 'Unknown package', 'woocommerce-services' );
 			}
 
-			$product_names = array();
-			foreach ( $package[ 'products' ] as $product_id ) {
-				$product = wc_get_product( $product_id );
+			if ( isset( $package[ 'products' ] ) ) {
+				$product_names = array();
+				foreach ( $package[ 'products' ] as $product_id ) {
+					$product = wc_get_product( $product_id );
 
-				if ( $product ) {
-					$product_names[] = $product->get_title();
-				} else {
-					$order = wc_get_order( $order_id );
-					$product_names[] = WC_Connect_Compatibility::instance()->get_product_name_from_order( $product_id, $order );
+					if ( $product ) {
+						$product_names[] = $product->get_title();
+					} else {
+						$order = wc_get_order( $order_id );
+						$product_names[] = WC_Connect_Compatibility::instance()->get_product_name_from_order( $product_id, $order );
+					}
 				}
-			}
 
-			$label_meta[ 'product_ids' ] = $package[ 'products' ];
-			$label_meta[ 'product_names' ] = $product_names;
+				$label_meta[ 'product_ids' ] = $package[ 'products' ];
+				$label_meta[ 'product_names' ] = $product_names;
+			}
 
 			array_unshift( $purchased_labels_meta, $label_meta );
 		}

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -82,6 +82,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 				'carrier_id' => $label_data->label->carrier_id,
 				'service_name' => $service_names[ $index ],
 				'status' => $label_data->label->status,
+				'returning_label_id' => $label_data->label->returning_label_id,
 			);
 
 			$package = $settings[ 'packages' ][ $index ];

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -85,6 +85,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 
 			$package = $settings[ 'packages' ][ $index ];
 			$box_id = $package[ 'box_id' ];
+			$label_meta[ 'box_id' ] = $box_id;
 			if ( 'individual' === $box_id ) {
 				$label_meta[ 'package_name' ] = __( 'Individual packaging', 'woocommerce-services' );
 			} else if ( isset( $package_lookup[ $box_id ] ) ) {
@@ -105,6 +106,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 				}
 			}
 
+			$label_meta[ 'product_ids' ] = $package[ 'products' ];
 			$label_meta[ 'product_names' ] = $product_names;
 
 			array_unshift( $purchased_labels_meta, $label_meta );

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -40,9 +40,11 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 
 		$service_names = array();
 		foreach ( $settings[ 'packages' ] as $index => $package ) {
-			$service_names[] = $package[ 'service_name' ];
-			unset( $package[ 'service_name' ] );
-			$settings[ 'packages' ][ $index ] = $package;
+			if ( isset( $package[ 'service_name' ] ) ) {
+				$service_names[] = $package[ 'service_name' ];
+				unset( $package[ 'service_name' ] );
+				$settings[ 'packages' ][ $index ] = $package;
+			}
 		}
 
 		$response = $this->api_client->send_shipping_label_request( $settings );
@@ -83,7 +85,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 			);
 
 			$package = $settings[ 'packages' ][ $index ];
-			$box_id = $package[ 'box_id' ];
+			$box_id = isset( $package[ 'box_id' ] ) && $package[ 'box_id' ];
 			if ( 'individual' === $box_id ) {
 				$label_meta[ 'package_name' ] = __( 'Individual packaging', 'woocommerce-services' );
 			} else if ( isset( $package_lookup[ $box_id ] ) ) {


### PR DESCRIPTION
Adapt shipping label endpoint to the case of a return label being purchased:
- pass back label ID being returned
- allow for missing <s>`service_name` and</s> `box_id` and `products` in shipping label endpoint

**Support for return labels on server required for release.**