### PR TITLE
Fix crash when there's an error requesting taxes from the WCS proxy.

### DIFF
--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -182,6 +182,15 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	/**
+	 * @param $message
+	 */
+	public function _error( $message ) {
+		$formatted_message = is_scalar( $message ) ? $message : json_encode( $message );
+
+		$this->logger->error( $formatted_message, 'WCS Tax' );
+	}
+
+	/**
 	 * Wrapper to avoid calling calculate_totals() for admin carts.
 	 *
 	 * @param $wc_cart_object
@@ -685,11 +694,11 @@ class WC_Connect_TaxJar_Integration {
 		) );
 
 		if ( is_wp_error( $response ) ) {
-			return new WP_Error( 'request', __( 'There was an error retrieving the tax rates. Please check your server configuration.' ) );
+			$this->_error( 'Error retrieving the tax rates. Received (' . $response->get_error_code() . '): ' . $response->get_error_message() );
 		} elseif ( 200 == $response['response']['code'] ) {
 			return $response;
 		} else {
-			$this->_log( 'Received (' . $response['response']['code'] . '): ' . $response['body'] );
+			$this->_error( 'Error retrieving the tax rates. Received (' . $response['response']['code'] . '): ' . $response['body'] );
 		}
 	}
 


### PR DESCRIPTION
"Fixes" https://wordpress.org/support/topic/php-fatal-error-site-very-slow-when-activated-with-taxjar/

It won't fix the problem, but at least the merchant will get a real error message instead of a full crash.

The problem is that, before, `smartcalcs_request` could either:
* Return a response object (associative array).
* Return a `WP_Error`.
* Return nothing (`NULL`).

The function that calls `smartcalcs_request` would only check that `isset($response)`, so if the response is a `WP_Error` it would be treated as a normal response and the whole thing would crash when accessed like an associative array.

The solution is to make sure that `smartcalcs_request` returns either a regular response, or nothing (`NULL`). I added some error logging so errors will be written in the WCS logger even if logging is turned off.

Since this part was rewritten (to remove the `tlc_transient`), I don't think the original `taxjar` integration is vulnerable to this error.