### PR TITLE
Include warning message in response upon failure to retrieve payment methods

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -108,12 +108,6 @@
 		font-size: 13px;
 	}
 
-	// Global notices
-
-	.notice.is-warning {
-		margin-bottom: 0;
-	}
-
 	.global-notices {
 		z-index: z-index( 'root', '.is-section-woocommerce .global-notices' ) !important; // Make sure notices are shown on top of modals
 		top: 16px;

--- a/classes/class-wc-connect-payment-methods-store.php
+++ b/classes/class-wc-connect-payment-methods-store.php
@@ -47,6 +47,7 @@ if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 			$this->update_payment_methods( $payment_methods );
 
 			$this->potentially_update_selected_payment_method_from_payment_methods( $payment_methods );
+			return true;
 		}
 
 		protected function potentially_update_selected_payment_method_from_payment_methods( $payment_methods ) {

--- a/classes/class-wc-connect-payment-methods-store.php
+++ b/classes/class-wc-connect-payment-methods-store.php
@@ -28,19 +28,24 @@ if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 
 		}
 
+		/**
+		 * Fetch stored payment methods from server and store in options.
+		 *
+		 * @return bool Were payment methods successfully retrieved?
+		 */
 		public function fetch_payment_methods_from_connect_server() {
 
 			$response_body = $this->api_client->get_payment_methods();
 
 			if ( is_wp_error( $response_body ) ) {
 				$this->logger->log( $response_body, __FUNCTION__ );
-				return;
+				return false;
 			}
 
 			$payment_methods = $this->get_payment_methods_from_response_body( $response_body );
 			if ( is_wp_error( $payment_methods ) ) {
 				$this->logger->log( $payment_methods, __FUNCTION__ );
-				return;
+				return false;
 			}
 
 			// If we made it this far, it is safe to store the object

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -45,7 +45,7 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 				'master_user_login' => is_a( $master_user, 'WP_User' ) ? $master_user->user_login : '',
 				'master_user_email' => $email,
 				'payment_methods' => $this->payment_methods_store->get_payment_methods(),
-				'warnings' => ! $payment_methods_fetched ? array( 'payment_methods' => 'Encountered an error while retrieving stored payment methods.' ) : array(),
+				'warnings' => array( 'payment_methods' => $payment_methods_fetched ? false : 'Encountered an error while retrieving stored payment methods.' ),
 			),
 		), 200 );
 	}

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -45,7 +45,7 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 				'master_user_login' => is_a( $master_user, 'WP_User' ) ? $master_user->user_login : '',
 				'master_user_email' => $email,
 				'payment_methods' => $this->payment_methods_store->get_payment_methods(),
-				'warnings' => array( 'payment_methods' => $payment_methods_fetched ? false : 'Encountered an error while retrieving stored payment methods.' ),
+				'warnings' => array( 'payment_methods' => $payment_methods_fetched ? false : __( 'There was a problem fetching your saved credit cards.', 'woocommerce-services' ) ),
 			),
 		), 200 );
 	}

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -24,7 +24,7 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 
 	public function get() {
 		// Always get a fresh copy when hitting this endpoint
-		$this->payment_methods_store->fetch_payment_methods_from_connect_server();
+		$payment_methods_fetched = $this->payment_methods_store->fetch_payment_methods_from_connect_server();
 
 		$master_user = WC_Connect_Jetpack::get_master_user();
 		if ( is_a( $master_user, 'WP_User' ) ) {
@@ -45,7 +45,8 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 				'master_user_login' => is_a( $master_user, 'WP_User' ) ? $master_user->user_login : '',
 				'master_user_email' => $email,
 				'payment_methods' => $this->payment_methods_store->get_payment_methods(),
-			)
+				'warnings' => ! $payment_methods_fetched ? array( 'payment_methods' => 'WooCommerce Services encountered an error while retrieving stored payment methods. Please refresh to try again.' ) : array(),
+			),
 		), 200 );
 	}
 

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -45,7 +45,7 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 				'master_user_login' => is_a( $master_user, 'WP_User' ) ? $master_user->user_login : '',
 				'master_user_email' => $email,
 				'payment_methods' => $this->payment_methods_store->get_payment_methods(),
-				'warnings' => ! $payment_methods_fetched ? array( 'payment_methods' => 'Encountered an error while retrieving stored payment methods. Please refresh to try again.' ) : array(),
+				'warnings' => ! $payment_methods_fetched ? array( 'payment_methods' => 'Encountered an error while retrieving stored payment methods.' ) : array(),
 			),
 		), 200 );
 	}

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -23,8 +23,13 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 	}
 
 	public function get() {
-		// Always get a fresh copy when hitting this endpoint
-		$payment_methods_fetched = $this->payment_methods_store->fetch_payment_methods_from_connect_server();
+		// Always get a fresh list of payment methods when hitting this endpoint
+		$payment_methods_warning = false;
+		$payment_methods_success = $this->payment_methods_store->fetch_payment_methods_from_connect_server();
+
+		if ( ! $payment_methods_success ) {
+			$payment_methods_warning = __( 'There was a problem fetching your saved credit cards.', 'woocommerce-services' );
+		}
 
 		$master_user = WC_Connect_Jetpack::get_master_user();
 		if ( is_a( $master_user, 'WP_User' ) ) {
@@ -45,7 +50,7 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 				'master_user_login' => is_a( $master_user, 'WP_User' ) ? $master_user->user_login : '',
 				'master_user_email' => $email,
 				'payment_methods' => $this->payment_methods_store->get_payment_methods(),
-				'warnings' => array( 'payment_methods' => $payment_methods_fetched ? false : __( 'There was a problem fetching your saved credit cards.', 'woocommerce-services' ) ),
+				'warnings' => array( 'payment_methods' => $payment_methods_warning ),
 			),
 		), 200 );
 	}

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -28,7 +28,7 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 		$payment_methods_success = $this->payment_methods_store->fetch_payment_methods_from_connect_server();
 
 		if ( ! $payment_methods_success ) {
-			$payment_methods_warning = __( 'There was a problem fetching your saved credit cards.', 'woocommerce-services' );
+			$payment_methods_warning = __( 'There was a problem updating your saved credit cards.', 'woocommerce-services' );
 		}
 
 		$master_user = WC_Connect_Jetpack::get_master_user();

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -45,7 +45,7 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 				'master_user_login' => is_a( $master_user, 'WP_User' ) ? $master_user->user_login : '',
 				'master_user_email' => $email,
 				'payment_methods' => $this->payment_methods_store->get_payment_methods(),
-				'warnings' => ! $payment_methods_fetched ? array( 'payment_methods' => 'WooCommerce Services encountered an error while retrieving stored payment methods. Please refresh to try again.' ) : array(),
+				'warnings' => ! $payment_methods_fetched ? array( 'payment_methods' => 'Encountered an error while retrieving stored payment methods. Please refresh to try again.' ) : array(),
 			),
 		), 200 );
 	}


### PR DESCRIPTION
Returns the following message if payment methods could not be fetched when requesting label settings:

<img width="686" alt="screen shot 2018-03-14 at 4 58 57 pm" src="https://user-images.githubusercontent.com/1867547/37430608-040afabe-27a9-11e8-963a-28fc37020776.png">

This is to notify the merchant if their payment methods were not updated in the current page load, as implemented in https://github.com/Automattic/wp-calypso/pull/23307.

To test, make WCS unreachable by setting `WOOCOMMERCE_CONNECT_SERVER_URL` to a URL in which there is no WCS server, and load the label settings page.