### PR TITLE
Tweaks to generic API error messaging

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -376,8 +376,8 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 					return new WP_Error( 'wcc_server_error', 'The WooCommerce Services API could not be reached.' );
 				} elseif ( 500 == $response_code ) {
 					return new WP_Error( 'wcc_server_error', 'The WooCommerce Services API encountered an error. Please try again.' );
-				} elseif ( 200 != $response_code ) {
-					return new WP_Error( 'wcc_server_error', sprintf( 'The WooCommerce Services API returned HTTP status code: %d', $response_code ) );
+				} elseif ( 400 <= $response_code ) {
+					return new WP_Error( 'wcc_server_error', 'The WooCommerce Services API could not process the request.' );
 				}
 				return $response;
 			}
@@ -387,15 +387,9 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				$response_body = json_decode( $response_body );
 			}
 
-			if ( 200 != $response_code ) {
+			if ( 400 <= $response_code ) {
 				if ( empty( $response_body ) ) {
-					return new WP_Error(
-						'wcc_server_empty_response',
-						sprintf(
-							'The WooCommerce Services API returned HTTP status code %d and an empty response body.',
-							$response_code
-						)
-					);
+					return new WP_Error( 'wcc_server_empty_response', 'The WooCommerce Services API could not process the request.' );
 				}
 
 				$error   = property_exists( $response_body, 'error' ) ? $response_body->error : '';
@@ -406,16 +400,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 					return new WP_Error( 'wcc_server_error_response', 'The WooCommerce Services API encountered an error. Please try again.' );
 				}
 
-				return new WP_Error(
-					'wcc_server_error_response',
-					sprintf(
-						'The WooCommerce Services API returned HTTP status code %d: %s. %s',
-						$response_code,
-						$error,
-						$message
-					),
-					$data
-				);
+				return new WP_Error( 'wcc_server_error_response', $message, $data );
 			}
 
 			return $response_body;

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -376,6 +376,8 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 					return new WP_Error( 'wcc_server_error', 'The WooCommerce Services API could not be reached.' );
 				} elseif ( 500 == $response_code ) {
 					return new WP_Error( 'wcc_server_error', 'The WooCommerce Services API encountered an error. Please try again.' );
+				} elseif ( 500 < $response_code ) {
+					return new WP_Error( 'wcc_server_error', 'The WooCommerce Services API is unavailable. Please try again in just a moment.' );
 				} elseif ( 400 <= $response_code ) {
 					return new WP_Error( 'wcc_server_error', 'The WooCommerce Services API could not process the request.' );
 				}
@@ -398,6 +400,8 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 
 				if ( 500 == $response_code ) {
 					return new WP_Error( 'wcc_server_error_response', 'The WooCommerce Services API encountered an error. Please try again.' );
+				} elseif ( 500 < $response_code ) {
+					return new WP_Error( 'wcc_server_error_response', 'The WooCommerce Services API is unavailable. Please try again in just a moment.' );
 				}
 
 				return new WP_Error( 'wcc_server_error_response', $message, $data );

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -373,7 +373,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			$content_type = wp_remote_retrieve_header( $response, 'content-type' );
 			if ( false === strpos( $content_type, 'application/json' ) ) {
 				if ( ! $response_code ) {
-					return new WP_Error( 'wcc_server_error', 'The WooCommerce Services API could not be reached. Please make sure your server can make requests to api.woocommerce.com, and try again.' );
+					return new WP_Error( 'wcc_server_error', 'The WooCommerce Services API could not be reached.' );
 				} elseif ( 500 == $response_code ) {
 					return new WP_Error( 'wcc_server_error', 'The WooCommerce Services API encountered an error. Please try again.' );
 				} elseif ( 200 != $response_code ) {

--- a/client/api/request.js
+++ b/client/api/request.js
@@ -47,6 +47,15 @@ const _request = ( url, data, method, namespace = '' ) => {
 				return;
 			}
 
+			if ( 403 === response.status ) {
+				throw {
+					data: {
+						message: __( 'Please check the security configuration of your host, and make sure ' +
+							'requests can be made to the WooCommerce Services API (192.0.96.246).' ),
+					},
+				};
+			}
+
 			throw json;
 		} );
 	} );

--- a/client/api/request.js
+++ b/client/api/request.js
@@ -47,15 +47,6 @@ const _request = ( url, data, method, namespace = '' ) => {
 				return;
 			}
 
-			if ( 403 === response.status ) {
-				throw {
-					data: {
-						message: __( 'Please check the security configuration of your host, and make sure ' +
-							'requests can be made to the WooCommerce Services API (192.0.96.246).' ),
-					},
-				};
-			}
-
 			throw json;
 		} );
 	} );


### PR DESCRIPTION
_Aims to make sure error messaging is adequate in all cases where the server couldn't be reached or returns a `500` status._

### Generic message

#### If the server couldn't be reached

Instead of:

<img width="613" alt="screen shot 2018-02-06 at 6 09 09 pm" src="https://user-images.githubusercontent.com/1867547/37484617-6a645754-285f-11e8-8b1e-47fc99f9e04c.png">

...the API client responds with a more appropriate message — though if and how it shows up on the client depends on the context. Examples:

<img width="757" alt="screen shot 2018-03-15 at 11 23 17 am" src="https://user-images.githubusercontent.com/1867547/37472808-54aeb7a4-2843-11e8-9fda-e3a0c370d2a5.png">

<img width="804" alt="screen shot 2018-03-14 at 6 29 51 pm" src="https://user-images.githubusercontent.com/1867547/37434387-c486c1c2-27b5-11e8-9fdd-901f858b4ad3.png">

_Edit:_ this now says:
> The WooCommerce Services API encountered an error. Please try again.

The reference to the server is changed from "WooCommerce Services server" (kind of inelegant as a result of the renaming to "WooCommerce Services") to "WooCommerce Services API", based on a precedent in the connection test tool:
https://github.com/Automattic/woocommerce-services/blob/3624a2c7c6181667af76f316d7e7f65e47a51909/classes/class-wc-connect-debug-tools.php#L28-L35

<s>(Some discussion in p1521044361000197-slack-hydra of the suggestion to check whether requests can go out at all. If possible, we should consider only showing this if we have particular reason to believe this might be the case — perhaps only if no server requests have yet succeeded.)</s>

#### Internal server error

If a 500 error comes back, there is generally no information specific to the error we can communicate via the client, so instead of:

<img width="752" alt="screen shot 2018-03-15 at 2 43 57 pm" src="https://user-images.githubusercontent.com/1867547/37484625-712c5b9a-285f-11e8-90d4-f243601a76fc.png">

...we can simplify the message:

<img width="640" alt="screen shot 2018-03-15 at 1 43 50 pm" src="https://user-images.githubusercontent.com/1867547/37481110-4d35eb82-2857-11e8-97c2-ea1e5a865256.png">

Edit: other 5xx errors (such as 502 during server downtime) now yield:
> The WooCommerce Services API is unavailable. Please try again in just a moment.

#### 4xx errors

If available, the raw error message is passed through, without the HTTP status or meta-error message "Error: The WooCommerce Services server returned [...]":

<img width="583" alt="screen shot 2018-02-13 at 2 38 49 pm" src="https://user-images.githubusercontent.com/1867547/36170065-416d94a0-10cc-11e8-8305-3149323af3f9.png">

### <s>Error communication per context</s>

<s>Manually tested all relevant cases by searching for `$this->api_client->` in the codebase. Some e2e tests might be helpful so as to be confident errors are and will continue to be properly communicated.</s>

To test global notices:

- For _internal server error_ message, can point payment proxy on local server to a URL where there is no server responding, and then trigger any of these:
  - Label status fetch on order page load
  - Label refund request

- For _unreachable server_ message, can set `WOOCOMMERCE_CONNECT_SERVER_URL` to a URL where there is no WCS server responding, and then trigger any of the above, or:
  - Shipping rate fetch (on cart/checkout page, with debug mode enabled) 
  - Label rate fetch
  - Label purchase request

<s>TODO:
- Show some error if manual service schema fetch fails
- TaxJar proxy fails silently if WCS down. Might best be addressed by https://github.com/Automattic/woocommerce-services/issues/1313
- PPEC gives only an unhelpful message if WCS proxy is down: https://cloudup.com/c3OTHZxIMaj
- Test print shows a print dialog with only a `WP_Error` in JSON form. Show a notice instead
</s>

_Edit:_ now captured in https://github.com/Automattic/woocommerce-services/issues/1364

<s>Also:
- On failure to fetch payment methods, might want to communicate more about how it failed</s>