### PR TITLE
Fix various styling inconsistencies

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -233,7 +233,6 @@
 	@import '../../client/apps/print-test-label/style';
 	@import '../../client/apps/settings/style';
 	@import '../../client/components/checkbox/style';
-	@import '../../client/components/error-notice/style';
 	@import '../../client/components/indicators/style';
 	@import '../../client/components/info-tooltip/style';
 	@import '../../client/components/loading-spinner/style';

--- a/client/apps/shipping-label/style.scss
+++ b/client/apps/shipping-label/style.scss
@@ -47,6 +47,10 @@
 		}
 	}
 
+	.foldable-card.card.order-activity-log__day-header {
+		margin: 0;
+	}
+
 	.order-activity-log__note-body {
 		margin-left: 0;
 		padding-left: 8px;

--- a/client/apps/shipping-label/style.scss
+++ b/client/apps/shipping-label/style.scss
@@ -32,14 +32,6 @@
 	font-size: 15px;
 }
 
-.label-purchase-modal__content {
-	.is-success, .is-error, .is-warning {
-		.gridicon {
-			margin-top: 1px;
-		}
-	}
-}
-
 .label-purchase-modal__option-email-customer,
 .label-purchase-modal__option-mark-order-fulfilled {
 	display: none;

--- a/client/components/error-notice/index.js
+++ b/client/components/error-notice/index.js
@@ -12,7 +12,6 @@ import Notice from 'components/notice';
 const ErrorNotice = ( { children, isWarning } ) => {
 	return (
 		<Notice
-			className="error-notice"
 			status={ isWarning ? 'is-warning' : 'is-error' }
 			showDismiss={ false }>
 			{ children }

--- a/client/components/error-notice/style.scss
+++ b/client/components/error-notice/style.scss
@@ -1,8 +1,0 @@
-.error-notice {
-	margin: -24px -24px 24px -24px;
-	width: inherit;
-
-	.notice__icon {
-		display: none;
-	}
-}


### PR DESCRIPTION
Before | After
-- | --
<img width="666" alt="screen shot 2018-03-19 at 7 02 57 pm" src="https://user-images.githubusercontent.com/1867547/37626880-2bfc59de-2ba8-11e8-885a-dd248e81b39f.png"> | <img width="670" alt="screen shot 2018-03-19 at 6 27 28 pm" src="https://user-images.githubusercontent.com/1867547/37626876-2ace46bc-2ba8-11e8-8935-171bca911c92.png">

https://github.com/Automattic/woocommerce-services/commit/c0d0d78a0f1947371fa5f443e702069530e16549: Removes custom styling for `ErrorNotice` component, which is only used in one place and looks the same without it except with icon showing: <img width="740" alt="screen shot 2018-03-19 at 6 23 48 pm" src="https://user-images.githubusercontent.com/1867547/37627079-20ff5814-2ba9-11e8-971a-aefac8122546.png">

---

Before | After
-- | --
<img width="675" alt="screen shot 2018-03-19 at 6 32 18 pm" src="https://user-images.githubusercontent.com/1867547/37626894-45566bd6-2ba8-11e8-9fb8-16dc40b0e6e9.png"> | <img width="671" alt="screen shot 2018-03-19 at 6 32 28 pm" src="https://user-images.githubusercontent.com/1867547/37626898-46fb6004-2ba8-11e8-9db1-a74fb369acc9.png">

https://github.com/Automattic/woocommerce-services/commit/311f9f0ae09effb7068abf678c3c55f0f7b071ab: Reverts https://github.com/Automattic/woocommerce-services/commit/171ffa0ef22dbb41ac96d1505beccb78cc4cf0cd, which was introduced to fix icon alignment in header [[#](https://github.com/Automattic/woocommerce-services/pull/1216#issuecomment-346091581)], but removing it doesn't appear to break it

---

Before | After
-- | --
<img width="297" alt="screen shot 2018-03-19 at 7 02 37 pm" src="https://user-images.githubusercontent.com/1867547/37626978-ad8aba22-2ba8-11e8-8d7f-43844ab727ae.png"> | <img width="295" alt="screen shot 2018-03-19 at 7 02 07 pm" src="https://user-images.githubusercontent.com/1867547/37626979-ae91ec42-2ba8-11e8-8919-16cc9ea3469a.png">

https://github.com/Automattic/woocommerce-services/commit/b92d07d9165fa62df32e4f6d614e06b6dcc0e5dc: Removes vertical margins that look out of place due to lack of horizontal margins in this context