### PR TITLE
Added labels reports section

### DIFF
--- a/classes/class-wc-connect-compatibility-wc26.php
+++ b/classes/class-wc-connect-compatibility-wc26.php
@@ -24,6 +24,17 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC26' ) ) {
 		}
 
 		/**
+		 * Get admin url for a given order
+		 *
+		 * @param WC_Order $order
+		 *
+		 * @return string
+		 */
+		public function get_edit_order_url( WC_Order $order ) {
+			return get_admin_url( null, 'post.php?post=' . $this->get_order_id( $order ) . '&action=edit' );
+		}
+
+		/**
 		 * Get the payment method for a given Order.
 		 *
 		 * @param WC_Order $order

--- a/classes/class-wc-connect-compatibility-wc30.php
+++ b/classes/class-wc-connect-compatibility-wc30.php
@@ -24,6 +24,17 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC30' ) ) {
 		}
 
 		/**
+		 * Get admin url for a given order
+		 *
+		 * @param WC_Order $order
+		 *
+		 * @return string
+		 */
+		public function get_edit_order_url( WC_Order $order ) {
+			return $order->get_edit_order_url();
+		}
+
+		/**
 		 * Get the payment method for a given Order.
 		 *
 		 * @param WC_Order $order

--- a/classes/class-wc-connect-compatibility.php
+++ b/classes/class-wc-connect-compatibility.php
@@ -59,6 +59,15 @@ if ( ! class_exists( 'WC_Connect_Compatibility' ) ) {
 		abstract public function get_order_id( WC_Order $order );
 
 		/**
+		 * Get admin url for a given order
+		 *
+		 * @param WC_Order $order
+		 *
+		 * @return string
+		 */
+		abstract public function get_edit_order_url( WC_Order $order );
+
+		/**
 		 * Get the payment method for a given Order.
 		 *
 		 * @param WC_Order $order

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 			?>
 			<a
 				href="#"
-				download="report-<?php echo esc_attr( $current_range ); ?>-<?php echo date_i18n( 'Y-m-d', current_time( 'timestamp' ) ); ?>.csv"
+				download="report-shipping-labels-<?php echo esc_attr( $current_range ); ?>-<?php echo date_i18n( 'Y-m-d', current_time( 'timestamp' ) ); ?>.csv"
 				class="export_csv"
 				data-export="table"
 			>

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -4,7 +4,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 	include_once( WC()->plugin_path() . '/includes/admin/reports/class-wc-admin-report.php' );
 
 	class WC_Connect_Label_Reports extends WC_Admin_Report {
-		const LABELS_CACHE_KEY = 'wcs_label_reports';
+		const LABELS_TRANSIENT_KEY = 'wcs_label_reports';
 
 		/**
 		 * @var WC_Connect_Service_Settings_Store
@@ -60,10 +60,11 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 		}
 
 		private function query_labels() {
-			$all_labels =  wp_cache_get( self::LABELS_CACHE_KEY );
+			$all_labels =  get_transient( self::LABELS_TRANSIENT_KEY );
 			if ( false === $all_labels ) {
 				$all_labels = $this->get_all_labels();
-				wp_cache_set( self::LABELS_CACHE_KEY, $all_labels, '', 1800 );
+				//set transient with ttl of 30 minutes
+				set_transient( self::LABELS_TRANSIENT_KEY, $all_labels, '', 1800 );
 			}
 
 			// translate timestamps to JS timestapms

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -4,6 +4,8 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 	include_once( WC()->plugin_path() . '/includes/admin/reports/class-wc-admin-report.php' );
 
 	class WC_Connect_Label_Reports extends WC_Admin_Report {
+		const LABELS_CACHE_KEY = 'wcs_label_reports';
+
 		/**
 		 * @var WC_Connect_Service_Settings_Store
 		 */
@@ -58,7 +60,11 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 		}
 
 		private function query_labels() {
-			$all_labels = $this->get_all_labels();
+			$all_labels =  wp_cache_get( self::LABELS_CACHE_KEY );
+			if ( false === $all_labels ) {
+				$all_labels = $this->get_all_labels();
+				wp_cache_set( self::LABELS_CACHE_KEY, $all_labels, '', 1800 );
+			}
 
 			// translate timestamps to JS timestapms
 			$start_date = $this->start_date * 1000;

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -88,10 +88,10 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 					continue;
 				}
 
-				//ignore labels with complete or requested refunds, but not the rejected ones
+				//ignore labels with complete refunds
 				if ( isset( $label['refund'] ) ) {
 					$refund = ( array ) $label['refund'];
-					if ( isset( $refund['status'] ) && 'rejected' !== $refund['status'] ) {
+					if ( isset( $refund['status'] ) && 'completed' === $refund['status'] ) {
 						continue;
 					}
 				}
@@ -129,6 +129,21 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 			return '<a href="' . WC_Connect_Compatibility::instance()->get_edit_order_url( $order ) . '">' . $order->get_order_number( $order ) . '</a>';
 		}
 
+		private function get_label_refund_status( $label ) {
+			if ( ! isset( $label['refund'] ) ) {
+				return '';
+			}
+
+			$refund = ( array ) $label['refund'];
+
+			if ( isset( $refund['status'] ) &&
+				( 'rejected' === $refund['status'] || 'complete' === $refund['status'] ) ) {
+				return '';
+			}
+
+			return __( 'Requested', 'woocommerce-services' );
+		}
+
 		/**
 		 * Get the main chart.
 		 */
@@ -151,6 +166,9 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 						<th>
 							<?php esc_html_e( 'Service', 'woocommerce-services' ); ?>
 						</th>
+						<th>
+							<?php esc_html_e( 'Refund', 'woocommerce-services' ); ?>
+						</th>
 					</tr>
 				</thead>
 				<?php if ( ! empty( $labels ) ) : ?>
@@ -169,6 +187,9 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 								<td>
 									<?php echo $label['service_name']; ?>
 								</td>
+								<td>
+									<?php echo $this->get_label_refund_status( $label ); ?>
+								</td>
 							</tr>
 						<?php endforeach; ?>
 					</tbody>
@@ -186,6 +207,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 							<th>
 								<?php echo wc_price( $total ); ?>
 							</th>
+							<th></th>
 							<th></th>
 						</tr>
 				<?php else : ?>

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -137,7 +137,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 						<?php foreach ( $labels as $label ) : ?>
 							<tr>
 								<th scope="row">
-									<?php echo date_i18n( get_option( 'date_format' ) . ' g:i a', $label['created'] / 1000 ); ?>
+									<?php echo get_date_from_gmt( date( 'Y-m-d H:i:s', $label['created'] / 1000 ) ); ?>
 								</th>
 								<td>
 									<a href="<?php echo admin_url( 'post.php?post=' . $label['order_id'] . '&action=edit' ); ?>">

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 		}
 
 		private function compare_label_dates_desc( $label_a, $label_b ) {
-			return $label_b['created'] <=> $label_a['created'];
+			return $label_b['created'] - $label_a['created'];
 		}
 
 		private function get_all_labels() {

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -64,7 +64,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 			if ( false === $all_labels ) {
 				$all_labels = $this->get_all_labels();
 				//set transient with ttl of 30 minutes
-				set_transient( self::LABELS_TRANSIENT_KEY, $all_labels, '', 1800 );
+				set_transient( self::LABELS_TRANSIENT_KEY, $all_labels, 1800 );
 			}
 
 			// translate timestamps to JS timestapms

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -119,6 +119,28 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 			return '<a href="' . WC_Connect_Compatibility::instance()->get_edit_order_url( $order ) . '">' . WC_Connect_Compatibility::instance()->get_order_id( $order ) . '</a>';
 		}
 
+		private function get_label_refund_status( $label ) {
+			if ( ! isset( $label['refund'] ) ) {
+				return '';
+			}
+
+			$refund = ( array ) $label['refund'];
+
+			if ( ! isset( $refund['status'] ) ) {
+				return __( 'Requested', 'woocommerce-services' );
+			}
+
+			if ( 'rejected' === $refund['status'] ) {
+				return __( 'Rejected', 'woocommerce-services' );
+			}
+
+			if ( 'complete' === $refund['status'] ) {
+				return __( 'Completed', 'woocommerce-services' );
+			}
+
+			return __( 'Requested', 'woocommerce-services' );
+		}
+
 		/**
 		 * Get the main chart.
 		 */
@@ -141,6 +163,9 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 						<th>
 							<?php esc_html_e( 'Service', 'woocommerce-services' ); ?>
 						</th>
+						<th>
+							<?php esc_html_e( 'Refund', 'woocommerce-services' ); ?>
+						</th>
 					</tr>
 				</thead>
 				<?php if ( ! empty( $labels ) ) : ?>
@@ -159,6 +184,9 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 								<td>
 									<?php echo $label['service_name']; ?>
 								</td>
+								<td>
+									<?php echo $this->get_label_refund_status( $label ); ?>
+								</td>
 							</tr>
 						<?php endforeach; ?>
 					</tbody>
@@ -176,6 +204,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 							<th>
 								<?php echo wc_price( $total ); ?>
 							</th>
+							<th></th>
 							<th></th>
 						</tr>
 				<?php else : ?>

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -116,7 +116,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 
 		private function get_order_url( $post_id ) {
 			$order = wc_get_order( $post_id );
-			return '<a href="' . WC_Connect_Compatibility::instance()->get_edit_order_url( $order ) . '">' . WC_Connect_Compatibility::instance()->get_order_id( $order ) . '</a>';
+			return '<a href="' . WC_Connect_Compatibility::instance()->get_edit_order_url( $order ) . '">' . $order->get_order_number( $order ) . '</a>';
 		}
 
 		private function get_label_refund_status( $label ) {

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -82,8 +82,17 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 					break;
 				}
 
-				if ( isset( $label['error'] ) || ! isset( $label['rate'] ) ) {
+				if ( isset( $label['error'] ) || //ignore the error labels
+					! isset( $label['rate'] ) ) { //labels where purchase hasn't completed for any reason
 					continue;
+				}
+
+				//ignore labels with complete or requested refunds, but not the rejected ones
+				if ( isset( $label['refund'] ) ) {
+					$refund = ( array ) $label['refund'];
+					if ( isset( $refund['status'] ) && 'rejected' !== $refund['status'] ) {
+						continue;
+					}
 				}
 
 				$results[] = $label;
@@ -119,28 +128,6 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 			return '<a href="' . WC_Connect_Compatibility::instance()->get_edit_order_url( $order ) . '">' . $order->get_order_number( $order ) . '</a>';
 		}
 
-		private function get_label_refund_status( $label ) {
-			if ( ! isset( $label['refund'] ) ) {
-				return '';
-			}
-
-			$refund = ( array ) $label['refund'];
-
-			if ( ! isset( $refund['status'] ) ) {
-				return __( 'Requested', 'woocommerce-services' );
-			}
-
-			if ( 'rejected' === $refund['status'] ) {
-				return __( 'Rejected', 'woocommerce-services' );
-			}
-
-			if ( 'complete' === $refund['status'] ) {
-				return __( 'Completed', 'woocommerce-services' );
-			}
-
-			return __( 'Requested', 'woocommerce-services' );
-		}
-
 		/**
 		 * Get the main chart.
 		 */
@@ -163,9 +150,6 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 						<th>
 							<?php esc_html_e( 'Service', 'woocommerce-services' ); ?>
 						</th>
-						<th>
-							<?php esc_html_e( 'Refund', 'woocommerce-services' ); ?>
-						</th>
 					</tr>
 				</thead>
 				<?php if ( ! empty( $labels ) ) : ?>
@@ -184,9 +168,6 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 								<td>
 									<?php echo $label['service_name']; ?>
 								</td>
-								<td>
-									<?php echo $this->get_label_refund_status( $label ); ?>
-								</td>
 							</tr>
 						<?php endforeach; ?>
 					</tbody>
@@ -204,7 +185,6 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 							<th>
 								<?php echo wc_price( $total ); ?>
 							</th>
-							<th></th>
 							<th></th>
 						</tr>
 				<?php else : ?>

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -1,0 +1,163 @@
+<?php
+
+if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
+	include_once( WC()->plugin_path() . '/includes/admin/reports/class-wc-admin-report.php' );
+
+	class WC_Connect_Label_Reports extends WC_Admin_Report {
+		/**
+		 * @var WC_Connect_Service_Settings_Store
+		 */
+		protected $settings_store;
+
+		public function __construct( WC_Connect_Service_Settings_Store $settings_store ) {
+			$this->settings_store = $settings_store;
+		}
+
+		public function get_export_button() {
+			$current_range = ! empty( $_GET['range'] ) ? sanitize_text_field( $_GET['range'] ) : '7day';
+			?>
+			<a
+				href="#"
+				download="report-<?php echo esc_attr( $current_range ); ?>-<?php echo date_i18n( 'Y-m-d', current_time( 'timestamp' ) ); ?>.csv"
+				class="export_csv"
+				data-export="table"
+			>
+				<?php _e( 'Export CSV', 'woocommerce-services' ); ?>
+			</a>
+			<?php
+		}
+
+		private function compare_label_dates_desc( $label_a, $label_b ) {
+			return $label_b['created'] <=> $label_a['created'];
+		}
+
+		private function get_all_labels() {
+			global $wpdb;
+			$query = "SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = 'wc_connect_labels'";
+			$db_results = $wpdb->get_results( $query );
+			$results = array();
+
+			foreach( $db_results as $meta ) {
+				$labels = maybe_unserialize( $meta->meta_value );
+
+				if ( ! is_array( $labels ) ) {
+					$labels = $this->settings_store->try_deserialize_labels_json( $meta->meta_value );
+				}
+
+				if ( empty( $labels ) ) {
+					continue;
+				}
+
+				foreach ( $labels as $label ) {
+					$results[] = array_merge( $label, array( 'order_id' => $meta->post_id ) );
+				}
+			}
+
+			usort( $results, array( $this, 'compare_label_dates_desc' ) );
+			return $results;
+		}
+
+		private function query_labels() {
+			$all_labels = $this->get_all_labels();
+
+			// translate timestamps to JS timestapms
+			$start_date = $this->start_date * 1000;
+			$end_date = $this->end_date * 1000;
+
+			$results = array();
+			foreach ( $all_labels as $label ) {
+				$created = $label['created'];
+				if ( $created > $end_date ) {
+					continue;
+				}
+
+				//labels are sorted in descending order, so if we reached the end, break the loop
+				if ( $created < $start_date ) {
+					break;
+				}
+
+				if ( isset( $label['error'] ) || ! isset( $label['rate'] ) ) {
+					continue;
+				}
+
+				$results[] = $label;
+			}
+
+			return $results;
+		}
+
+		public function output_report() {
+			$ranges = array(
+				'year'       => __( 'Year', 'woocommerce-services' ),
+				'last_month' => __( 'Last month', 'woocommerce-services' ),
+				'month'      => __( 'This month', 'woocommerce-services' ),
+				'7day'       => __( 'Last 7 days', 'woocommerce-services' ),
+			);
+
+			$current_range = ! empty( $_GET['range'] ) ? sanitize_text_field( $_GET['range'] ) : '7day';
+
+			if ( ! in_array( $current_range, array( 'custom', 'year', 'last_month', 'month', '7day' ) ) ) {
+				$current_range = '7day';
+			}
+
+			$this->check_current_range_nonce( $current_range );
+			$this->calculate_current_range( $current_range );
+
+			$hide_sidebar = true;
+
+			include( WC()->plugin_path() . '/includes/admin/views/html-report-by-date.php' );
+		}
+
+		/**
+		 * Get the main chart.
+		 */
+		public function get_main_chart() {
+			$labels = $this->query_labels();
+
+			?>
+			<table class="widefat">
+				<thead>
+					<tr>
+						<th><?php esc_html_e( 'Time', 'woocommerce-services' ); ?></th>
+						<th><?php esc_html_e( 'Order', 'woocommerce-services' ); ?></th>
+						<th><?php esc_html_e( 'Price', 'woocommerce-services' ); ?></th>
+						<th><?php esc_html_e( 'Service', 'woocommerce-services' ); ?></th>
+					</tr>
+				</thead>
+				<?php if ( ! empty( $labels ) ) : ?>
+					<tbody>
+						<?php
+						foreach ( $labels as $label ) {
+							?>
+							<tr>
+								<th scope="row"><?php echo date_i18n( get_option( 'date_format' ) . ' g:i a', $label['created'] / 1000 ); ?></th>
+								<td><a href="<?php echo admin_url( 'post.php?post=' . $label['order_id'] . '&action=edit' ); ?>"><?php echo $label['order_id']; ?></a></td>
+								<td><?php echo wc_price( $label['rate'] ); ?></td>
+								<td><?php echo $label['service_name'] ?></td>
+							</tr>
+							<?php
+						}
+						?>
+					</tbody>
+					<tfoot>
+						<?php
+							$total = array_sum( wp_list_pluck( $labels, 'rate' ) );
+						?>
+						<tr>
+							<th scope="row"><?php _e( 'Total', 'woocommerce-services' ); ?></th>
+							<th><?php echo count( $labels ); ?></th>
+							<th><?php echo wc_price( $total ); ?></th>
+							<th></th>
+						</tr>
+				<?php else : ?>
+					<tbody>
+						<tr>
+							<td><?php esc_html_e( 'No labels found for this period', 'woocommerce-services' ); ?></td>
+						</tr>
+					</tbody>
+				<?php endif; ?>
+			</table>
+			<?php
+		}
+	}
+}

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -37,7 +37,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 			$db_results = $wpdb->get_results( $query );
 			$results = array();
 
-			foreach( $db_results as $meta ) {
+			foreach ( $db_results as $meta ) {
 				$labels = maybe_unserialize( $meta->meta_value );
 
 				if ( ! is_array( $labels ) ) {
@@ -118,35 +118,55 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 			<table class="widefat">
 				<thead>
 					<tr>
-						<th><?php esc_html_e( 'Time', 'woocommerce-services' ); ?></th>
-						<th><?php esc_html_e( 'Order', 'woocommerce-services' ); ?></th>
-						<th><?php esc_html_e( 'Price', 'woocommerce-services' ); ?></th>
-						<th><?php esc_html_e( 'Service', 'woocommerce-services' ); ?></th>
+						<th>
+							<?php esc_html_e( 'Time', 'woocommerce-services' ); ?>
+						</th>
+						<th>
+							<?php esc_html_e( 'Order', 'woocommerce-services' ); ?>
+						</th>
+						<th>
+							<?php esc_html_e( 'Price', 'woocommerce-services' ); ?>
+						</th>
+						<th>
+							<?php esc_html_e( 'Service', 'woocommerce-services' ); ?>
+						</th>
 					</tr>
 				</thead>
 				<?php if ( ! empty( $labels ) ) : ?>
 					<tbody>
-						<?php
-						foreach ( $labels as $label ) {
-							?>
+						<?php foreach ( $labels as $label ) : ?>
 							<tr>
-								<th scope="row"><?php echo date_i18n( get_option( 'date_format' ) . ' g:i a', $label['created'] / 1000 ); ?></th>
-								<td><a href="<?php echo admin_url( 'post.php?post=' . $label['order_id'] . '&action=edit' ); ?>"><?php echo $label['order_id']; ?></a></td>
-								<td><?php echo wc_price( $label['rate'] ); ?></td>
-								<td><?php echo $label['service_name'] ?></td>
+								<th scope="row">
+									<?php echo date_i18n( get_option( 'date_format' ) . ' g:i a', $label['created'] / 1000 ); ?>
+								</th>
+								<td>
+									<a href="<?php echo admin_url( 'post.php?post=' . $label['order_id'] . '&action=edit' ); ?>">
+										<?php echo $label['order_id']; ?>
+									</a>
+								</td>
+								<td>
+									<?php echo wc_price( $label['rate'] ); ?>
+								</td>
+								<td>
+									<?php echo $label['service_name'] ?>
+								</td>
 							</tr>
-							<?php
-						}
-						?>
+						<?php endforeach; ?>
 					</tbody>
 					<tfoot>
 						<?php
 							$total = array_sum( wp_list_pluck( $labels, 'rate' ) );
 						?>
 						<tr>
-							<th scope="row"><?php _e( 'Total', 'woocommerce-services' ); ?></th>
-							<th><?php echo count( $labels ); ?></th>
-							<th><?php echo wc_price( $total ); ?></th>
+							<th scope="row">
+								<?php _e( 'Total', 'woocommerce-services' ); ?>
+							</th>
+							<th>
+								<?php echo count( $labels ); ?>
+							</th>
+							<th>
+								<?php echo wc_price( $total ); ?>
+							</th>
 							<th></th>
 						</tr>
 				<?php else : ?>

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -108,6 +108,11 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 			include( WC()->plugin_path() . '/includes/admin/views/html-report-by-date.php' );
 		}
 
+		private function get_order_url( $post_id ) {
+			$order = wc_get_order( $post_id );
+			return '<a href="' . WC_Connect_Compatibility::instance()->get_edit_order_url( $order ) . '">' . WC_Connect_Compatibility::instance()->get_order_id( $order ) . '</a>';
+		}
+
 		/**
 		 * Get the main chart.
 		 */
@@ -140,15 +145,13 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 									<?php echo get_date_from_gmt( date( 'Y-m-d H:i:s', $label['created'] / 1000 ) ); ?>
 								</th>
 								<td>
-									<a href="<?php echo admin_url( 'post.php?post=' . $label['order_id'] . '&action=edit' ); ?>">
-										<?php echo $label['order_id']; ?>
-									</a>
+									<?php echo $this->get_order_url( $label['order_id'] ); ?>
 								</td>
 								<td>
 									<?php echo wc_price( $label['rate'] ); ?>
 								</td>
 								<td>
-									<?php echo $label['service_name'] ?>
+									<?php echo $label['service_name']; ?>
 								</td>
 							</tr>
 						<?php endforeach; ?>

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -193,25 +193,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			return $json;
 		}
 
-		/**
-		 * Returns labels for the specific order ID
-		 *
-		 * @param $order_id
-		 *
-		 * @return array
-		 */
-		public function get_label_order_meta_data( $order_id ) {
-			$label_data = get_post_meta( ( int ) $order_id, 'wc_connect_labels', true );
-			//return an empty array if the data doesn't exist
-			if ( ! $label_data ) {
-				return array();
-			}
-
-			//labels stored as an array, return
-			if ( is_array( $label_data ) ) {
-				return $label_data;
-			}
-
+		public function try_deserialize_labels_json( $label_data ) {
 			//attempt to decode the JSON (legacy way of storing the labels data)
 			$decoded_labels = json_decode( $label_data, true );
 			if ( $decoded_labels ) {
@@ -231,6 +213,28 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			}
 
 			return array();
+		}
+
+		/**
+		 * Returns labels for the specific order ID
+		 *
+		 * @param $order_id
+		 *
+		 * @return array
+		 */
+		public function get_label_order_meta_data( $order_id ) {
+			$label_data = get_post_meta( ( int ) $order_id, 'wc_connect_labels', true );
+			//return an empty array if the data doesn't exist
+			if ( ! $label_data ) {
+				return array();
+			}
+
+			//labels stored as an array, return
+			if ( is_array( $label_data ) ) {
+				return $label_data;
+			}
+
+			return $this->try_deserialize_labels_json( $label_data );
 		}
 
 		/**

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -886,10 +886,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 */
 		public function reports_tabs( $reports ) {
 			$reports[ 'wcs_labels' ] = array(
-				'title' => __( 'Labels', 'woocommerce-services' ),
+				'title' => __( 'Shipping Labels', 'woocommerce-services' ),
 				'reports' => array(
 					'connect_labels'     => array(
-						'title'       => __( 'Labels', 'woocommerce' ),
+						'title'       => __( 'Shipping Labels', 'woocommerce-services' ),
 						'description' => '',
 						'hide_title'  => true,
 						'callback'    => array( $this->label_reports, 'output_report' ),

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -404,6 +404,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->paypal_ec = $paypal_ec;
 		}
 
+		public function set_label_reports( WC_Connect_Label_Reports $label_reports ) {
+			$this->label_reports = $label_reports;
+		}
+
 		/**
 		 * Load our textdomain
 		 *
@@ -584,6 +588,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			require_once( plugin_basename( 'classes/class-wc-connect-nux.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-stripe.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-paypal-ec.php' ) );
+			require_once( plugin_basename( 'classes/class-wc-connect-label-reports.php' ) );
 
 			$core_logger           = new WC_Logger();
 			$logger                = new WC_Connect_Logger( $core_logger );
@@ -603,6 +608,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$options               = new WC_Connect_Options();
 			$stripe                = new WC_Connect_Stripe( $api_client, $options, $payments_logger );
 			$paypal_ec             = new WC_Connect_PayPal_EC( $api_client, $nux );
+			$label_reports         = new WC_Connect_Label_Reports( $settings_store );
 
 			$this->set_logger( $logger );
 			$this->set_shipping_logger( $shipping_logger );
@@ -617,6 +623,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->set_taxjar( $taxjar );
 			$this->set_stripe( $stripe );
 			$this->set_paypal_ec( $paypal_ec );
+			$this->set_label_reports( $label_reports );
 		}
 
 		/**
@@ -677,6 +684,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'admin_init', array( $this, 'load_admin_dependencies' ) );
 			add_filter( 'wc_connect_shipping_service_settings', array( $this, 'shipping_service_settings' ), 10, 3 );
 			add_action( 'woocommerce_email_after_order_table', array( $this, 'add_tracking_info_to_emails' ), 10, 3 );
+			add_filter( 'woocommerce_admin_reports', array( $this, 'reports_tabs' ) );
 
 			$tracks = $this->get_tracks();
 			$tracks->init();
@@ -868,6 +876,28 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			do_action( 'enqueue_wc_connect_script',
 				'wc-connect-service-settings',
 				apply_filters( 'wc_connect_shipping_service_settings', array(), $method_id, $instance_id ) );
+		}
+
+		/**
+		 * Filter function for adding the report tabs
+		 *
+		 * @param array $reports - report tabs meta
+		 * @return array report tabs with WCS tabs added
+		 */
+		public function reports_tabs( $reports ) {
+			$reports[ 'wcs_labels' ] = array(
+				'title' => __( 'Labels', 'woocommerce-services' ),
+				'reports' => array(
+					'connect_labels'     => array(
+						'title'       => __( 'Labels', 'woocommerce' ),
+						'description' => '',
+						'hide_title'  => true,
+						'callback'    => array( $this->label_reports, 'output_report' ),
+					),
+				),
+			);
+
+			return $reports;
 		}
 
 		/**


### PR DESCRIPTION
Fixes #1277
Fixes #1327

Adds a simple reports page listing all labels successfully purchased during a selected time period:
<img width="1497" alt="screen shot 2018-03-22 at 16 37 24" src="https://user-images.githubusercontent.com/800604/37780586-56ead4ba-2def-11e8-865b-52e8563d1ba4.png">

The page can be accessed under `WooCommerce > Reports > Labels`
* Doesn't list labels with errors
* Labels are listed by package, so if two labels are purchased with one request, it will result in two rows
* Only lists time, price, order ID and service. Do we need to display any other data?