### PR TITLE
Restore error logging whether ordinary logging is enabled or not

### DIFF
--- a/classes/class-wc-connect-logger.php
+++ b/classes/class-wc-connect-logger.php
@@ -99,7 +99,7 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 		 */
 		public function error( $message, $context = '' ) {
 			WC_Connect_Error_Notice::instance()->enable_notice();
-			$this->log( $message, $context );
+			$this->log( $message, $context, true );
 		}
 
 		/**
@@ -108,14 +108,14 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 		 * @param string $message Message to log
 		 * @param string $context Optional context (e.g. a class or function name)
 		 */
-		public function log( $message, $context = '' ) {
+		public function log( $message, $context = '', $force = false ) {
 			$log_message = $this->format_message( $message, $context );
 
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 				error_log( $log_message );
 			}
 
-			if ( ! $this->is_logging_enabled() ) {
+			if ( ! $this->is_logging_enabled() && ! $force ) {
 				return;
 			}
 


### PR DESCRIPTION
Restores the original behavior of the logger's `error` method, which logs the message whether "debug" logging is enabled or not. This fixes a broken UX when an error isn't logged but the admin notice directing the merchant to view the error still appears.

Background:
- https://github.com/Automattic/woocommerce-services/pull/803 added a bit of indirection to `log` calls, in which most uses of the `log` method were called via a `debug` method, but an `error` method was used in the shipping rate case, to show a "An error has occurred" notice and log the message regardless of whether "Debug Logging" is enabled.
- https://github.com/Automattic/woocommerce-services/pull/1303 switched `debug` calls back to `log` (as part of introducing a new, separate `debug` feature) which is used by `error`, and brought the check for whether logging is enabled directly into the `log` method. (If the latter was done to intentionally avoid logging on errors unless logging is enabled, the approach in this PR can be changed.)