### PR TITLE
Remove extensionsMiddleware, use the plain wpcomApiMiddleware instead

### DIFF
--- a/client/apps/shipping-label/index.js
+++ b/client/apps/shipping-label/index.js
@@ -15,12 +15,10 @@ import labelSettingsReducer from 'woocommerce/woocommerce-services/state/label-s
 import reduxMiddleware from './redux-middleware';
 import ordersReducer from 'woocommerce/state/sites/orders/reducer';
 import { combineReducers } from 'state/utils';
-import { addHandlers } from 'state/data-layer/extensions-middleware';
 import orders from 'woocommerce/state/data-layer/orders';
+import { middleware as rawWpcomApiMiddleware } from 'state/data-layer/wpcom-api-middleware';
 
 export default ( { orderId } ) => {
-	addHandlers( 'woocommerce', orders );
-
 	return {
 		getReducer() {
 			return combineReducers( {
@@ -75,8 +73,8 @@ export default ( { orderId } ) => {
 			return `wcs-label-${ orderId }`;
 		},
 
-		getMiddleware() {
-			return reduxMiddleware;
+		getMiddlewares() {
+			return [ reduxMiddleware, rawWpcomApiMiddleware( orders ) ];
 		},
 
 		View: () => (

--- a/client/main.js
+++ b/client/main.js
@@ -23,8 +23,7 @@ import PrintTestLabel from './apps/print-test-label';
 import Packages from './apps/packages';
 import PluginStatus from './apps/plugin-status';
 import { setNonce, setBaseURL } from 'api/request';
-import wpcomApiMiddleware from 'state/data-layer/wpcom-api-middleware.js';
-import extensionsMiddleware from 'state/data-layer/extensions-middleware.js';
+import wpcomApiMiddleware from 'state/data-layer/wpcom-api-middleware';
 import localApiMiddleware from 'lib/local-api-middleware';
 
 if ( global.wcConnectData ) {
@@ -72,11 +71,10 @@ Array.from( document.getElementsByClassName( 'wcc-root' ) ).forEach( ( container
 		thunk.withExtraArgument( args ),
 		wpcomApiMiddleware,
 		localApiMiddleware,
-		extensionsMiddleware,
 	];
 
-	if ( _.isFunction( Route.getMiddleware ) ) {
-		middlewares.push( Route.getMiddleware() );
+	if ( _.isFunction( Route.getMiddlewares ) ) {
+		middlewares.push.apply( middlewares, Route.getMiddlewares() );
 	}
 
 	const enhancers = [


### PR DESCRIPTION
I managed to fix this without touching `wp-calypso`.

**The bug:** In the `self-help` page, you can't interact with the debugging toggles.

**The cause:** We're using Calypso's `extensions-middleware` to load some `woocommerce`-related data-layer handlers. That middleware maintains a global state, so when it's called 2 times with different Redux stores, the first one will be overwritten. That means that the second Redux store (in this case, the `print-test-label` section) will receive all the Redux actions, including the ones that don't correspond with that "app".

**The solution:** Avoid `extensions-middleware`. Its only purpose is to allow extensions (which in Calypso are different chunks loaded on-demand) to register handlers **after** the Redux store is configured. We don't need that, since we know ahead of time which handlers we'll need for a given "app". I've changed it to use the plain `wpcom-api-middleware` instead.

PS: To test, try the `self-help` page and check that both sections (self-help and print-test-label) work. Also try opening the `Rates` step on the Buy Label modal and check that the user-selected rate appears correctly.