### PR TITLE
Fix too many rate requests

### DIFF
--- a/classes/class-wc-connect-functions.php
+++ b/classes/class-wc-connect-functions.php
@@ -1,0 +1,23 @@
+<?php
+
+if ( ! class_exists( 'WC_Connect_Functions' ) ) {
+	class WC_Connect_Functions {
+		/**
+		 * Checks if the potentially expensive Shipping/Tax API requests should be sent
+		 * based on the context in which they are initialized
+		 * @return bool true if the request can be sent, false otherwise
+		 */
+		public static function should_send_cart_api_request() {
+			return ! (
+				// Skip for carts loaded from session in the dashboard
+				( is_admin() && did_action( 'woocommerce_cart_loaded_from_session' ) ) ||
+				// Skip during Jetpack API requests
+				( false !== strpos( $_SERVER['REQUEST_URI'], 'jetpack/v4/' ) ) ||
+				// Skip during REST API or XMLRPC requests
+				( defined( 'REST_REQUEST' ) || defined( 'REST_API_REQUEST' ) || defined( 'XMLRPC_REQUEST' ) ) ||
+				// Skip during Jetpack REST API proxy requests
+				( isset( $_GET['rest_route'] ) && isset( $_GET['_for'] ) && ( 'jetpack' === $_GET['_for'] ) )
+			);
+		}
+	}
+}

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -262,6 +262,9 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		}
 
 		public function calculate_shipping( $package = array() ) {
+			if ( ! WC_Connect_Functions::should_send_cart_api_request() ) {
+				return;
+			}
 
 			$this->debug( sprintf(
 				'WooCommerce Services debug mode is on - to hide these messages, turn debug mode off in the <a href="%s" style="text-decoration: underline;">settings</a>.',

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -281,23 +281,7 @@ class WC_Connect_TaxJar_Integration {
 	 * @param $wc_cart_object
 	 */
 	public function maybe_calculate_totals( $wc_cart_object ) {
-		// Skip for carts loaded from session in the dashboard
-		if ( is_admin() && did_action( 'woocommerce_cart_loaded_from_session' ) ) {
-			return;
-		}
-
-		// Skip during Jetpack API requests
-		if ( false !== strpos( $_SERVER['REQUEST_URI'], 'jetpack/v4/' ) ) {
-			return;
-		}
-
-		// Skip during REST API or XMLRPC requests
-		if ( defined( 'REST_REQUEST' ) || defined( 'REST_API_REQUEST' ) || defined( 'XMLRPC_REQUEST' ) ) {
-			return;
-		}
-
-		// Skip during Jetpack REST API proxy requests
-		if ( isset( $_GET['rest_route'] ) && isset( $_GET['_for'] ) && ( 'jetpack' === $_GET['_for'] ) ) {
+		if ( ! WC_Connect_Functions::should_send_cart_api_request() ) {
 			return;
 		}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -34,9 +34,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-require_once( plugin_basename( 'classes/class-wc-connect-options.php' ) );
-require_once( plugin_basename( 'classes/class-wc-connect-jetpack.php' ) );
 require_once( plugin_basename( 'classes/class-wc-connect-extension-compatibility.php' ) );
+require_once( plugin_basename( 'classes/class-wc-connect-functions.php' ) );
+require_once( plugin_basename( 'classes/class-wc-connect-jetpack.php' ) );
+require_once( plugin_basename( 'classes/class-wc-connect-options.php' ) );
 
 if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 


### PR DESCRIPTION
Fixes #1360 

* Copied the solution from #1308 to skip the requests when not on the checkout page or the request is a Jetpack request
* ~~added rates response memory caching - requests can attempt to calculate rates more than once and our code would send the rates request every time for this~~

To test:
* enable debug mode in `WooCommerce > Settings > Shipping > Shipping Options` to ensure that rates are not cached
* WP Admin requests and non-checkout AJAX requests should not generate a rate request - this can be checked either by monitoring the server console output or placing a debug breakpoint in `class-wc-connect-shipping-method.php`
* checkout rates should display and update when cart contents/address are updated
* ~~only one rates request should be sent per WP request - added a debug message to monitor when a request has been retrieved from cache~~