### PR TITLE
Added rate request caching

### DIFF
--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -340,8 +340,9 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				'wcs_rates_%s',
 				md5( serialize( array( $services, $package, $custom_boxes, $predefined_boxes ) ) )
 			);
+			$debug_mode = 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' );
 			$response_body = wp_cache_get( $cache_key );
-			if ( false !== $response_body ) {
+			if ( ! $debug_mode && false !== $response_body ) {
 				$this->debug( 'Rates response retrieved from cache' );
 			} else {
 				$response_body = $this->api_client->get_shipping_rates( $services, $package, $custom_boxes, $predefined_boxes );


### PR DESCRIPTION
Separated out of #1361

Adds request scope caching of the rates returned by the server. WC core implements effective caching when the shipping debug mode is disabled, but enabling it results in at least 4 requests sent to the server. This change will limit it to 2.

To test:
* enable debug mode in `WooCommerce > Settings > Shipping > Shipping Options`
* navigate to checkout
* you should see less rate requests processed by the server with this change (this can be observed by monitoring the server's console output)
* There's a new debug message for when a rates response is retrieved from cache
![screen shot 2018-04-03 at 19 49 22](https://user-images.githubusercontent.com/800604/38269339-25419e02-3778-11e8-9313-1bd19cd9236e.png)
