### PR TITLE
Removed transform-react-remove-prop-types plugin

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-services",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1178,11 +1178,6 @@
         "babel-plugin-syntax-jsx": "6.18.0",
         "babel-runtime": "6.26.0"
       }
-    },
-    "babel-plugin-transform-react-remove-prop-types": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.3.3.tgz",
-      "integrity": "sha1-0J9IualQOmnBztObOCXC9F0pMzw="
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "babel": "^6.23.0",
     "babel-core": "^6.25.1",
     "babel-loader": "^7.1.1",
-    "babel-plugin-transform-react-remove-prop-types": "^0.3.2",
     "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.23.0",
     "babel-preset-stage-1": "^6.22.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -150,9 +150,6 @@ const config = {
 };
 
 if ( isProd || isI18n ) {
-
-	babelSettings.plugins.push( 'transform-react-remove-prop-types' );
-
 	config.plugins.push( new webpack.LoaderOptionsPlugin( { minimize: true } ) );
 
 	config.plugins.push( new webpack.DefinePlugin( {


### PR DESCRIPTION
Some of the Calypso's components rely on PropTypes in their code (for example the clipboard button).

`transform-react-remove-prop-types` Babel plugin removes the PropTypes when `npm run dist` is executed, which might lead to unexpected side effects that can only be observed in the compiled JS.

To test:
* run `npm run dist`
* ensure the plugin is using the compiled JS (comment out the line `define( 'WOOCOMMERCE_CONNECT_DEV_SERVER_URL', 'http://localhost:8085/' );` in the dev plugin)
* verify that the plugin status page loads
* other areas of the plugin should work as well