### PR TITLE
Status page: REST API check and toggle state error handling

### DIFF
--- a/client/api/request.js
+++ b/client/api/request.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { translate as __ } from 'i18n-calypso';
+import React from 'react';
 import { startsWith, endsWith } from 'lodash';
 
 /**
@@ -51,9 +52,8 @@ const _request = ( url, data, method, namespace = '' ) => {
 
 			if ( 403 === response.status ) {
 				const message = __(
-					'The request was not fulfilled. ' +
-					'Please see the status page for diagnostics: ' +
-					'WooCommerce » Status » WooCommerce Services.'
+					'The request was not fulfilled. Please see the {{a}}status page{{/a}} for diagnostics.',
+					{ components: { a: <a href="?page=wc-status&tab=connect" /> } }
 				);
 				throw { data: { message } };
 			}

--- a/client/api/request.js
+++ b/client/api/request.js
@@ -53,7 +53,7 @@ const _request = ( url, data, method, namespace = '' ) => {
 			if ( 403 === response.status ) {
 				const message = __(
 					'The request was not fulfilled. Please see the {{a}}status page{{/a}} for diagnostics.',
-					{ components: { a: <a href="?page=wc-status&tab=connect" /> } }
+					{ components: { a: <a href="admin.php?page=wc-status&tab=connect" /> } }
 				);
 				throw { data: { message } };
 			}

--- a/client/api/request.js
+++ b/client/api/request.js
@@ -49,6 +49,15 @@ const _request = ( url, data, method, namespace = '' ) => {
 				return;
 			}
 
+			if ( 403 === response.status ) {
+				const message = __(
+					'The request was not fulfilled. ' +
+					'Please see the status page for diagnostics: ' +
+					'WooCommerce » Status » WooCommerce Services.'
+				);
+				throw { data: { message } };
+			}
+
 			throw json;
 		} );
 	} );

--- a/client/apps/plugin-status/indicator.js
+++ b/client/apps/plugin-status/indicator.js
@@ -41,7 +41,7 @@ const Indicator = ( { title, subtitle, state, message, children } ) => {
 
 	return (
 		<FormFieldset>
-			<FormLegend>
+			<FormLegend className="plugin-status__indicator-title">
 				<span>{ title }</span>
 				{ renderSubTitle( subtitle ) }
 			</FormLegend>

--- a/client/apps/plugin-status/state/actions.js
+++ b/client/apps/plugin-status/state/actions.js
@@ -79,14 +79,14 @@ export const checkRestApi = () => ( dispatch, getState ) => {
 			dispatch( {
 				type: PLUGIN_STATUS_REST_RESPONSE,
 				success: true,
-				message: translate( 'Can manage settings and print shipping labels' ),
+				message: translate( 'WooCommerce REST API is working properly' ),
 			} );
 		} )
 		.catch( () => {
 			dispatch( {
 				type: PLUGIN_STATUS_REST_RESPONSE,
 				success: false,
-				message: translate( 'Cannot manage settings or print shipping labels' ),
+				message: translate( 'Encountered an issue with the WooCommerce REST API' ),
 			} );
 		} );
 };

--- a/client/apps/plugin-status/state/actions.js
+++ b/client/apps/plugin-status/state/actions.js
@@ -82,7 +82,7 @@ export const checkRestApi = () => ( dispatch, getState ) => {
 				message: translate( 'Can manage settings and print shipping labels' ),
 			} );
 		} )
-		.catch( ( error ) => {
+		.catch( () => {
 			dispatch( {
 				type: PLUGIN_STATUS_REST_RESPONSE,
 				success: false,

--- a/client/apps/plugin-status/state/actions.js
+++ b/client/apps/plugin-status/state/actions.js
@@ -12,6 +12,8 @@ import * as NoticeActions from 'state/notices/actions';
 
 export const PLUGIN_STATUS_DEBUG_TOGGLE = 'PLUGIN_STATUS_DEBUG_TOGGLE';
 export const PLUGIN_STATUS_LOGGING_TOGGLE = 'PLUGIN_STATUS_LOGGING_TOGGLE';
+export const PLUGIN_STATUS_REST_REQUEST = 'PLUGIN_STATUS_REST_REQUEST';
+export const PLUGIN_STATUS_REST_RESPONSE = 'PLUGIN_STATUS_REST_RESPONSE';
 
 export const toggleLogging = ( value ) => ( {
 	type: PLUGIN_STATUS_LOGGING_TOGGLE,
@@ -43,5 +45,32 @@ export const save = () => ( dispatch, getState ) => {
 			if ( _.isObject( error ) ) {
 				dispatch( NoticeActions.errorNotice( translate( 'There was a problem when saving your preferences. Please try again.' ) ) );
 			}
+		} );
+};
+
+export const checkRestApi = () => ( dispatch, getState ) => {
+	dispatch( { type: PLUGIN_STATUS_REST_REQUEST } );
+
+	const state = getState().status;
+
+	const data = {
+		wcc_debug_on: state.debug_enabled,
+		wcc_logging_on: state.logging_enabled,
+	};
+
+	api.post( api.url.selfHelp(), data )
+		.then( () => {
+			dispatch( {
+				type: PLUGIN_STATUS_REST_RESPONSE,
+				success: true,
+				message: translate( 'Can manage settings and print shipping labels' ),
+			} );
+		} )
+		.catch( ( error ) => {
+			dispatch( {
+				type: PLUGIN_STATUS_REST_RESPONSE,
+				success: false,
+				message: translate( 'Cannot manage settings or print shipping labels' ),
+			} );
 		} );
 };

--- a/client/apps/plugin-status/state/actions.js
+++ b/client/apps/plugin-status/state/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import _ from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -49,11 +48,7 @@ export const save = () => ( dispatch, getState ) => {
 			}
 		} )
 		.catch( ( error ) => {
-			if ( _.isString( error ) ) {
-				dispatch( NoticeActions.errorNotice( error ) );
-			} else if ( _.isObject( error ) ) {
-				dispatch( NoticeActions.errorNotice( translate( 'There was a problem when saving your preferences. Please try again.' ) ) );
-			}
+			dispatch( NoticeActions.errorNotice( error ) );
 
 			if ( state.debug_saving ) {
 				dispatch( setDebug( ! state.debug_enabled, false ) );

--- a/client/apps/plugin-status/state/reducer.js
+++ b/client/apps/plugin-status/state/reducer.js
@@ -2,24 +2,24 @@
  * Internal dependencies
  */
 import {
-	PLUGIN_STATUS_DEBUG_TOGGLE,
-	PLUGIN_STATUS_LOGGING_TOGGLE,
+	PLUGIN_STATUS_SET_DEBUG,
+	PLUGIN_STATUS_SET_LOGGING,
 	PLUGIN_STATUS_REST_REQUEST,
 	PLUGIN_STATUS_REST_RESPONSE,
 } from './actions';
 
 const reducer = {
-	[ PLUGIN_STATUS_DEBUG_TOGGLE ]: ( state, { value } ) => {
-		return {
-			...state,
+	[ PLUGIN_STATUS_SET_DEBUG ]: ( state, { value, saving } ) => {
+		return { ...state,
 			debug_enabled: value,
+			debug_saving: saving,
 		};
 	},
 
-	[ PLUGIN_STATUS_LOGGING_TOGGLE ]: ( state, { value } ) => {
-		return {
-			...state,
+	[ PLUGIN_STATUS_SET_LOGGING ]: ( state, { value, saving } ) => {
+		return { ...state,
 			logging_enabled: value,
+			logging_saving: saving,
 		};
 	},
 

--- a/client/apps/plugin-status/state/reducer.js
+++ b/client/apps/plugin-status/state/reducer.js
@@ -4,6 +4,8 @@
 import {
 	PLUGIN_STATUS_DEBUG_TOGGLE,
 	PLUGIN_STATUS_LOGGING_TOGGLE,
+	PLUGIN_STATUS_REST_REQUEST,
+	PLUGIN_STATUS_REST_RESPONSE,
 } from './actions';
 
 const reducer = {
@@ -18,6 +20,29 @@ const reducer = {
 		return {
 			...state,
 			logging_enabled: value,
+		};
+	},
+
+	[ PLUGIN_STATUS_REST_REQUEST ]: ( state ) => {
+		return { ...state,
+			health_items: { ...state.health_items,
+				rest_api: {
+					state: 'warning',
+					message: 'Checking REST API health...',
+				},
+			},
+		};
+	},
+
+	[ PLUGIN_STATUS_REST_RESPONSE ]: ( state, { success, message } ) => {
+		return {
+			...state,
+			health_items: { ...state.health_items,
+				rest_api: {
+					state: success ? 'success' : 'error',
+					message,
+				},
+			},
 		};
 	},
 };

--- a/client/apps/plugin-status/style.scss
+++ b/client/apps/plugin-status/style.scss
@@ -1,3 +1,7 @@
+.plugin-status__indicator-title {
+	margin-bottom: 2px;
+}
+
 .plugin-status__indicator {
 	margin-top: 4px;
 	margin-bottom: 4px;

--- a/client/apps/plugin-status/view.js
+++ b/client/apps/plugin-status/view.js
@@ -19,39 +19,41 @@ import ServicesStatusView from './services';
 import SettingsGroupCard from 'woocommerce/woocommerce-services/components/settings-group-card';
 import Toggle from 'components/toggle';
 import {
-	toggleLogging,
-	toggleDebug,
+	setLogging,
+	setDebug,
 	save,
 } from './state/actions';
 
-const StatusView = ( { actions, loggingEnabled, debugEnabled, translate } ) => {
+const StatusView = ( { actions, loggingEnabled, loggingSaving, debugEnabled, debugSaving, translate } ) => {
 	return (
 		<div>
 			<GlobalNotices id="notices" notices={ notices.list } />
 			<HealthView />
 			<ServicesStatusView />
 			<SettingsGroupCard heading={ translate( 'Debug' ) }>
-			<Toggle
+				<Toggle
 					id="wcs-toggle-debug"
 					checked={ debugEnabled }
+					disabled={ debugSaving }
 					title={ translate( 'Debug' ) }
 					description={ translate( 'Display troubleshooting information on the Cart and Checkout pages.' ) }
 					trueText={ translate( 'Enabled' ) }
 					falseText={ translate( 'Disabled' ) }
 					saveOnToggle={ true }
 					saveForm={ actions.save }
-					updateValue={ actions.toggleDebug }
+					updateValue={ actions.setDebug }
 				/>
 				<Toggle
 					id="wcs-toggle-logging"
 					checked={ loggingEnabled }
+					disabled={ loggingSaving }
 					title={ translate( 'Logging' ) }
 					description={ translate( 'Write diagnostic messages to log files. Helpful when contacting support.' ) }
 					trueText={ translate( 'Enabled' ) }
 					falseText={ translate( 'Disabled' ) }
 					saveOnToggle={ true }
 					saveForm={ actions.save }
-					updateValue={ actions.toggleLogging }
+					updateValue={ actions.setLogging }
 				/>
 				<LogView
 					logKey="shipping"
@@ -90,12 +92,14 @@ const StatusView = ( { actions, loggingEnabled, debugEnabled, translate } ) => {
 export default connect(
 	( state ) => ( {
 		loggingEnabled: Boolean( state.status.logging_enabled ),
+		loggingSaving: Boolean( state.status.logging_saving ),
 		debugEnabled: Boolean( state.status.debug_enabled ),
+		debugSaving: Boolean( state.status.debug_saving ),
 	} ),
 	( dispatch ) => ( {
 		actions: bindActionCreators( {
-			toggleLogging,
-			toggleDebug,
+			setLogging,
+			setDebug,
 			save,
 		}, dispatch ),
 	} )

--- a/client/components/toggle/index.js
+++ b/client/components/toggle/index.js
@@ -23,6 +23,7 @@ class Toggle extends Component {
 		falseText: PropTypes.string.isRequired,
 		saveOnToggle: PropTypes.bool,
 		checked: PropTypes.bool,
+		disabled: PropTypes.bool,
 		saveForm: PropTypes.func,
 		updateValue: PropTypes.func,
 		className: PropTypes.string,
@@ -59,6 +60,7 @@ class Toggle extends Component {
 			trueText,
 			falseText,
 			checked,
+			disabled,
 			placeholder,
 			className,
 		} = this.props;
@@ -71,6 +73,7 @@ class Toggle extends Component {
 					name={ id }
 					placeholder={ placeholder }
 					checked={ checked }
+					disabled={ disabled }
 					onChange={ this.handleChangeEvent }
 				/>
 				{ this.renderToggleText( checked ? trueText : falseText ) }


### PR DESCRIPTION
Add a health check to the status page, that (in contrast with the existing checks) is added by the client dynamically, to verify the ability to make REST API requests.

In addition, improve the state management of the toggles on this page (in case of REST API failure), by disabling controls while saving, and reverting the state if saving failed.

&nbsp; | Success | Failure
-- | -- | --
REST API check | ![rest-api-check-succeeded](https://user-images.githubusercontent.com/1867547/38447608-5fabed44-39cc-11e8-89a3-0a1f6819f05e.gif) | ![rest-api-check-failed](https://user-images.githubusercontent.com/1867547/38447610-63c09e20-39cc-11e8-9802-57df1f442fa6.gif)
Debug toggle | ![debug-toggle-succeeded](https://user-images.githubusercontent.com/1867547/38447615-69bd730c-39cc-11e8-9a48-de32306f3312.gif) | ![debug-toggle-failed](https://user-images.githubusercontent.com/1867547/38447618-6ac9bb48-39cc-11e8-919f-14a9dd60c721.gif)

Also, if the failure was a 403 (which encodes a rejection of the request that is inexplicable by the client), show a notice:

<img width="751" alt="screen shot 2018-04-06 at 7 06 28 pm" src="https://user-images.githubusercontent.com/1867547/38447818-cd610706-39cd-11e8-91c9-bfda81d67d59.png">

Can test failure cases by adding a filter (e.g. in `attach_hooks`):
```
add_filter( 'rest_authentication_errors', function() {
    $message = 'REST API is disabled.';
    return new WP_Error(
        'rest_api_disabled',
        $message,
        array( 'status' => 403, 'message' => $message )
    );
} );
```

Thoughts / concerns:
- Title and messages need editing
- Should we suggest checking the JS console in the event of failure?
- Should we check for `page=wc-status&tab=connect` in the request module, and omit Status page directions in this case?