### PR TITLE
Surface missing weight error directly in admin notice

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -96,7 +96,8 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 					if ( ! $product->has_weight() ) {
 						return new WP_Error(
 							'product_missing_weight',
-							sprintf( "Product ( ID: %d ) did not include a weight. Shipping rates cannot be calculated.", $product->get_id() )
+							sprintf( "Product ( ID: %d ) did not include a weight. Shipping rates cannot be calculated.", $product->get_id() ),
+							array( 'product_id' => $product->get_id() )
 						);
 					}
 

--- a/classes/class-wc-connect-error-notice.php
+++ b/classes/class-wc-connect-error-notice.php
@@ -60,7 +60,7 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 				$product_name = WC_Connect_Compatibility::instance()->get_product_name( wc_get_product( $product_id ) );
 
 				$message = sprintf(
-					__( 'An error occurred in WooCommerce Services: <strong><a href="%s">%s</a> did not include a weight.</strong> Shipping rates cannot be calculated.', 'woocommerce-services' ),
+					__( '<strong>%2$s does not have have a weight defined.</strong><br />Shipping rates cannot be calculated. <a href="%1$s">Add a weight for %2$s</a> so your customers can purchase this item.', 'woocommerce-services' ),
 					get_edit_post_link( $product_id ), $product_name
 				);
 			} else {

--- a/classes/class-wc-connect-error-notice.php
+++ b/classes/class-wc-connect-error-notice.php
@@ -55,9 +55,8 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 
 			$error = $this->notice_enabled();
 			if ( is_wp_error( $error ) && 'product_missing_weight' === $error->get_error_code() ) {
-				$matches = array();
-				preg_match( '/ID:\s([0-9]+)/', $error->get_error_message(), $matches );
-				$product_id = $matches[1];
+				$error_data = $error->get_error_data();
+				$product_id = $error_data['product_id'];
 				$product_name = WC_Connect_Compatibility::instance()->get_product_name( wc_get_product( $product_id ) );
 
 				$message = sprintf(

--- a/classes/class-wc-connect-error-notice.php
+++ b/classes/class-wc-connect-error-notice.php
@@ -75,10 +75,16 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 					$link_status, $link_dismiss
 				);
 			}
+
+			$allowed_html = array(
+				'a' => array( 'href' => array() ),
+				'strong' => array(),
+				'br' => array(),
+			);
 ?>
 			<div class='notice notice-error' style="position: relative;">
 				<a href="<?php echo esc_url( $link_dismiss ); ?>" style="text-decoration: none;" class="notice-dismiss" title="<?php esc_attr_e( 'Dismiss this notice', 'woocommerce-services' ); ?>"></a>
-				<p><?php echo $message; ?></p>
+				<p><?php echo wp_kses( $message, $allowed_html ); ?></p>
 			</div>
 <?php
 			echo "";

--- a/classes/class-wc-connect-error-notice.php
+++ b/classes/class-wc-connect-error-notice.php
@@ -57,7 +57,13 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 			if ( is_wp_error( $error ) && 'product_missing_weight' === $error->get_error_code() ) {
 				$error_data = $error->get_error_data();
 				$product_id = $error_data['product_id'];
-				$product_name = WC_Connect_Compatibility::instance()->get_product_name( wc_get_product( $product_id ) );
+				$product = wc_get_product( $product_id );
+				$product_name = WC_Connect_Compatibility::instance()->get_product_name( $product );
+
+				if ( $product->has_weight() ) {
+					$this->disable_notice();
+					return;
+				}
 
 				$message = sprintf(
 					__( '<strong>%2$s does not have have a weight defined.</strong><br />Shipping rates cannot be calculated. <a href="%1$s">Add a weight for %2$s</a> so your customers can purchase this item.', 'woocommerce-services' ),

--- a/classes/class-wc-connect-error-notice.php
+++ b/classes/class-wc-connect-error-notice.php
@@ -66,7 +66,7 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 				}
 
 				$message = sprintf(
-					__( '<strong>%2$s does not have have a weight defined.</strong><br />Shipping rates cannot be calculated. <a href="%1$s">Add a weight for %2$s</a> so your customers can purchase this item.', 'woocommerce-services' ),
+					__( '<strong>%2$s does not have a weight defined.</strong><br />Shipping rates cannot be calculated. <a href="%1$s">Add a weight for %2$s</a> so your customers can purchase this item.', 'woocommerce-services' ),
 					get_edit_post_link( $product_id ), $product_name
 				);
 			} else {

--- a/classes/class-wc-connect-error-notice.php
+++ b/classes/class-wc-connect-error-notice.php
@@ -72,7 +72,7 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 			} else {
 				$message = sprintf(
 					__( 'An error occurred in WooCommerce Services. Details are logged <a href="%s">here</a>.', 'woocommerce-services' ),
-					$link_status, $link_dismiss
+					$link_status
 				);
 			}
 

--- a/classes/class-wc-connect-error-notice.php
+++ b/classes/class-wc-connect-error-notice.php
@@ -23,8 +23,8 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 			return self::$inst;
 		}
 
-		public function enable_notice() {
-			WC_Connect_Options::update_option( 'error_notice', true );
+		public function enable_notice( $error = true ) {
+			WC_Connect_Options::update_option( 'error_notice', $error );
 		}
 
 		public function disable_notice() {
@@ -53,10 +53,23 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 			$link_status = admin_url( 'admin.php?page=wc-status&tab=connect' );
 			$link_dismiss = add_query_arg( array( 'wc-connect-error-notice' => 'disable' ) );
 
-			$message = sprintf(
-				__( 'An error occurred in WooCommerce Services. Details are logged <a href="%s">here</a>.', 'woocommerce-services' ),
-				$link_status, $link_dismiss
-			);
+			$error = $this->notice_enabled();
+			if ( is_wp_error( $error ) && 'product_missing_weight' === $error->get_error_code() ) {
+				$matches = array();
+				preg_match( '/ID:\s([0-9]+)/', $error->get_error_message(), $matches );
+				$product_id = $matches[1];
+				$product_name = WC_Connect_Compatibility::instance()->get_product_name( wc_get_product( $product_id ) );
+
+				$message = sprintf(
+					__( 'An error occurred in WooCommerce Services: <strong><a href="%s">%s</a> did not include a weight.</strong> Shipping rates cannot be calculated.', 'woocommerce-services' ),
+					get_edit_post_link( $product_id ), $product_name
+				);
+			} else {
+				$message = sprintf(
+					__( 'An error occurred in WooCommerce Services. Details are logged <a href="%s">here</a>.', 'woocommerce-services' ),
+					$link_status, $link_dismiss
+				);
+			}
 ?>
 			<div class='notice notice-error' style="position: relative;">
 				<a href="<?php echo esc_url( $link_dismiss ); ?>" style="text-decoration: none;" class="notice-dismiss" title="<?php esc_attr_e( 'Dismiss this notice', 'woocommerce-services' ); ?>"></a>

--- a/classes/class-wc-connect-logger.php
+++ b/classes/class-wc-connect-logger.php
@@ -98,7 +98,7 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 		 * @param string $context Optional context (e.g. a class or function name)
 		 */
 		public function error( $message, $context = '' ) {
-			WC_Connect_Error_Notice::instance()->enable_notice();
+			WC_Connect_Error_Notice::instance()->enable_notice( $message );
 			$this->log( $message, $context, true );
 		}
 


### PR DESCRIPTION
Addresses https://github.com/Automattic/woocommerce-services/issues/1376#issuecomment-382153745 by enhancing the admin notice — in the case of a shipping rate missing weight error — with a description and link to the relevant product:

<img width="895" alt="screen shot 2018-04-20 at 7 05 06 pm" src="https://user-images.githubusercontent.com/1867547/39077149-cac0ee34-44cd-11e8-8312-22ae74443696.png">

Questions:
- Should this code live somewhere other than `WC_Connect_Error_Notice`?
- Should clicking the link dismiss the notice?
- Are there other errors that should get a similar treatment?