### PR TITLE
Add privacy policy message

### DIFF
--- a/classes/class-wc-connect-privacy.php
+++ b/classes/class-wc-connect-privacy.php
@@ -13,7 +13,8 @@ class WC_Connect_Privacy extends WC_Abstract_Privacy {
 		return wpautop(
 			sprintf(
 				wp_kses(
-					__( 'By using this extension, you may be storing personal data or sharing data with external services. <a href="%s" target="_blank">Learn more about how this works, including what you may want to include in your privacy policy.</a>', 'woocommerce-services' )
+					__( 'By using this extension, you may be storing personal data or sharing data with external services. <a href="%s" target="_blank">Learn more about how this works, including what you may want to include in your privacy policy.</a>', 'woocommerce-services' ),
+					array( 'a' => array( 'href' => array() ) )
 				),
 				'https://jetpack.com/support/for-your-privacy-policy/#woocommerce-services'
 			)

--- a/classes/class-wc-connect-privacy.php
+++ b/classes/class-wc-connect-privacy.php
@@ -14,7 +14,7 @@ class WC_Connect_Privacy extends WC_Abstract_Privacy {
 			sprintf(
 				wp_kses(
 					__( 'By using this extension, you may be storing personal data or sharing data with external services. <a href="%s" target="_blank">Learn more about how this works, including what you may want to include in your privacy policy.</a>', 'woocommerce-services' ),
-					array( 'a' => array( 'href' => array() ) )
+					array( 'a' => array( 'href' => array(), 'target' => array() ) )
 				),
 				'https://jetpack.com/support/for-your-privacy-policy/#woocommerce-services'
 			)

--- a/classes/class-wc-connect-privacy.php
+++ b/classes/class-wc-connect-privacy.php
@@ -12,8 +12,10 @@ class WC_Connect_Privacy extends WC_Abstract_Privacy {
 	public function get_privacy_message() {
 		return wpautop(
 			sprintf(
-				__( 'By using this extension, you may be storing personal data or sharing data with an external services. <a href="%s" target="_blank">Learn more about how this works, including what you may want to include in your privacy policy.</a>', 'woocommerce-services' ),
-				'https://jetpack.com/support/what-data-does-jetpack-sync/#woocommerce-services'
+				wp_kses(
+					__( 'By using this extension, you may be storing personal data or sharing data with external services. <a href="%s" target="_blank">Learn more about how this works, including what you may want to include in your privacy policy.</a>', 'woocommerce-services' )
+				),
+				'https://jetpack.com/support/for-your-privacy-policy/#woocommerce-services'
 			)
 		);
 	}

--- a/classes/class-wc-connect-privacy.php
+++ b/classes/class-wc-connect-privacy.php
@@ -1,0 +1,22 @@
+<?php
+
+if ( ! class_exists( 'WC_Abstract_Privacy' ) ) {
+	return;
+}
+
+class WC_Connect_Privacy extends WC_Abstract_Privacy {
+	public function __construct() {
+		parent::__construct( 'WooCommerce Services' );
+	}
+
+	public function get_privacy_message() {
+		return wpautop(
+			sprintf(
+				__( 'By using this extension, you may be storing personal data or sharing data with an external services. <a href="%s" target="_blank">Learn more about how this works, including what you may want to include in your privacy policy.</a>', 'woocommerce-services' ),
+				'https://jetpack.com/support/what-data-does-jetpack-sync/#woocommerce-services'
+			)
+		);
+	}
+}
+
+new WC_Connect_Privacy();

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -590,6 +590,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			require_once( plugin_basename( 'classes/class-wc-connect-stripe.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-paypal-ec.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-label-reports.php' ) );
+			require_once( plugin_basename( 'classes/class-wc-connect-privacy.php' ) );
 
 			$core_logger           = new WC_Logger();
 			$logger                = new WC_Connect_Logger( $core_logger );


### PR DESCRIPTION
Fixes #1383 

To test:
* Either use the latest [WordPress Core SVN trunk](https://develop.svn.wordpress.org/trunk/) or latest [master WordPress Core from GitHub](https://github.com/WordPress/WordPress)
* Use the latest [WooCommerce code](https://github.com/woocommerce/woocommerce)
* In wp-admin under `Tools > Privacy` you should be able to designate and edit a privacy page
* When editing the privacy page, click "check out our guide" (in notice)
* the following snippet should appear among the others:
<img width="704" alt="screen shot 2018-05-03 at 12 25 21" src="https://user-images.githubusercontent.com/800604/39573922-18290b4e-4ecd-11e8-8ca9-4a4773aabc95.png"> The link points to https://jetpack.com/support/for-your-privacy-policy/#woocommerce-services
