### PR TITLE
Adapt order page link to label settings' new section slug

### DIFF
--- a/client/apps/settings/components/settings-form/settings-item.js
+++ b/client/apps/settings/components/settings-form/settings-item.js
@@ -117,7 +117,7 @@ class SettingsItem extends Component {
 							'Add and edit saved packages using the {{a}}Packaging Manager{{/a}}.',
 							{
 								components: {
-									a: <a href="admin.php?page=wc-settings&tab=shipping&section=package-settings" />,
+									a: <a href="admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings" />,
 								},
 							}
 						) }

--- a/client/apps/shipping-label/view-wrapper.js
+++ b/client/apps/shipping-label/view-wrapper.js
@@ -99,7 +99,11 @@ class ShippingLabelViewWrapper extends Component {
 		return (
 			<Notice isCompact showDismiss={ false } className="shipping-label__payment inline">
 				<p>{ translate( 'To purchase shipping labels, you will first need to add a credit card.' ) }</p>
-				<p><a href="admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings">{ translate( 'Add a credit card' ) }</a></p>
+				<p>
+					<a href="admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings">
+						{ translate( 'Add a credit card' ) }
+					</a>
+				</p>
 			</Notice>
 		);
 	};

--- a/client/apps/shipping-label/view-wrapper.js
+++ b/client/apps/shipping-label/view-wrapper.js
@@ -75,7 +75,7 @@ class ShippingLabelViewWrapper extends Component {
 						} ) }
 					</p>
 					<p>
-						<a href={ `admin.php?page=wc-settings&tab=shipping&section=label-settings&from_order=${ orderId }` }>
+						<a href={ `admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings&from_order=${ orderId }` }>
 							{ translate( 'Manage cards' ) }
 						</a>
 					</p>
@@ -88,7 +88,7 @@ class ShippingLabelViewWrapper extends Component {
 				<Notice isCompact={ true } showDismiss={ false } className="shipping-label__payment inline">
 					<p>{ translate( 'To purchase shipping labels, you will first need to select a credit card.' ) }</p>
 					<p>
-						<a href={ `admin.php?page=wc-settings&tab=shipping&section=label-settings&from_order=${ orderId }` }>
+						<a href={ `admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings&from_order=${ orderId }` }>
 							{ translate( 'Select a credit card' ) }
 						</a>
 					</p>
@@ -99,7 +99,7 @@ class ShippingLabelViewWrapper extends Component {
 		return (
 			<Notice isCompact showDismiss={ false } className="shipping-label__payment inline">
 				<p>{ translate( 'To purchase shipping labels, you will first need to add a credit card.' ) }</p>
-				<p><a href="admin.php?page=wc-settings&tab=shipping&section=label-settings">{ translate( 'Add a credit card' ) }</a></p>
+				<p><a href="admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings">{ translate( 'Add a credit card' ) }</a></p>
 			</Notice>
 		);
 	};


### PR DESCRIPTION
Adjusts links to label settings, which moved to a new section in https://github.com/Automattic/woocommerce-services/pull/1328 causing the "Manage Cards" link to lead to an empty WooCommerce Settings screen.