### PR TITLE
Added personal data export functionality

### DIFF
--- a/classes/class-wc-connect-privacy.php
+++ b/classes/class-wc-connect-privacy.php
@@ -5,10 +5,26 @@ if ( ! class_exists( 'WC_Abstract_Privacy' ) ) {
 }
 
 class WC_Connect_Privacy extends WC_Abstract_Privacy {
-	public function __construct() {
+	/**
+	 * @var WC_Connect_Service_Settings_Store
+	 */
+	protected $settings_store;
+
+	public function __construct( WC_Connect_Service_Settings_Store $settings_store ) {
 		parent::__construct( 'WooCommerce Services' );
+
+		$this->settings_store = $settings_store;
+
+		$this->add_exporter(
+			'woocommerce-services-labels',
+			__( 'WooCommerce Services Label Data', 'woocommerce-services' ),
+			array( $this, 'label_data_exporter' )
+		);
 	}
 
+	/**
+	 * Gets the privacy message to display in the admin panel
+	 */
 	public function get_privacy_message() {
 		return wpautop(
 			sprintf(
@@ -20,6 +36,68 @@ class WC_Connect_Privacy extends WC_Abstract_Privacy {
 			)
 		);
 	}
-}
 
-new WC_Connect_Privacy();
+	/**
+	 * Gets the customer's orders by page
+	 * @param string  $email_address
+	 * @param int     $page
+	 * @return array WP_Post
+	 */
+	private function get_orders_page( $email_address, $page ) {
+		$user = get_user_by( 'email', $email_address ); // Check if user has an ID in the DB to load stored personal data.
+		$order_query    = array(
+			'limit'          => 10,
+			'page'           => $page,
+		);
+		if ( $user instanceof WP_User ) {
+			$order_query['customer_id'] = (int) $user->ID;
+		} else {
+			$order_query['billing_email'] = $email_address;
+		}
+		return wc_get_orders( $order_query );
+	}
+
+	/**
+	 * Handle exporting data for orders
+	 * @param string  $email_address
+	 * @param int     $page
+	 * @return array
+	 */
+	public function label_data_exporter( $email_address, $page = 1 ) {
+		$data_to_export = array();
+
+		$orders = $this->get_orders_page( $email_address, $page );
+		$done = empty( $orders );
+
+		foreach ( $orders as $order ) {
+			$order_id = $order->get_id();
+			$labels = $this->settings_store->get_label_order_meta_data( $order_id );
+
+			foreach ( $labels as $label ) {
+				if ( empty( $label['tracking'] ) ) {
+					continue;
+				}
+				$data_to_export[] = array(
+					'group_id'    => 'woocommerce_orders',
+					'group_label' => __( 'Orders', 'woocommerce-services' ),
+					'item_id'     => 'order-' . $order_id,
+					'data'        => array(
+						array(
+							'name'  => __( 'Shipping label service', 'woocommerce-services' ),
+							'value' => $label['service_name'],
+						),
+						array(
+							'name'  => __( 'Shipping label tracking number', 'woocommerce-services' ),
+							'value' => $label['tracking'],
+						),
+					),
+				);
+			}
+		}
+
+		return array(
+			'data' => $data_to_export,
+			'done' => $done,
+		);
+	}
+}

--- a/classes/class-wc-connect-privacy.php
+++ b/classes/class-wc-connect-privacy.php
@@ -1,32 +1,32 @@
 <?php
 
-if ( ! class_exists( 'WC_Abstract_Privacy' ) ) {
+if ( class_exists( 'WC_Connect_Privacy' ) ) {
 	return;
 }
 
-class WC_Connect_Privacy extends WC_Abstract_Privacy {
+class WC_Connect_Privacy {
 	/**
 	 * @var WC_Connect_Service_Settings_Store
 	 */
 	protected $settings_store;
 
 	public function __construct( WC_Connect_Service_Settings_Store $settings_store ) {
-		parent::__construct( 'WooCommerce Services' );
-
 		$this->settings_store = $settings_store;
 
-		$this->add_exporter(
-			'woocommerce-services-labels',
-			__( 'WooCommerce Services Label Data', 'woocommerce-services' ),
-			array( $this, 'label_data_exporter' )
-		);
+		add_action( 'admin_init', array( $this, 'add_privacy_message' ) );
+		add_filter( 'woocommerce_privacy_export_order_personal_data', array( $this, 'label_data_exporter' ), 10, 2 );
 	}
 
 	/**
 	 * Gets the privacy message to display in the admin panel
 	 */
-	public function get_privacy_message() {
-		return wpautop(
+	public function add_privacy_message() {
+		if ( ! function_exists( 'wp_add_privacy_policy_content' ) ) {
+			return;
+		}
+
+		$title = __( 'WooCommerce Services', 'woocommerce-services' );
+		$content = wpautop(
 			sprintf(
 				wp_kses(
 					__( 'By using this extension, you may be storing personal data or sharing data with external services. <a href="%s" target="_blank">Learn more about how this works, including what you may want to include in your privacy policy.</a>', 'woocommerce-services' ),
@@ -35,69 +35,34 @@ class WC_Connect_Privacy extends WC_Abstract_Privacy {
 				'https://jetpack.com/support/for-your-privacy-policy/#woocommerce-services'
 			)
 		);
+
+		wp_add_privacy_policy_content( $title, $content );
 	}
 
 	/**
-	 * Gets the customer's orders by page
-	 * @param string  $email_address
-	 * @param int     $page
-	 * @return array WP_Post
-	 */
-	private function get_orders_page( $email_address, $page ) {
-		$user = get_user_by( 'email', $email_address ); // Check if user has an ID in the DB to load stored personal data.
-		$order_query    = array(
-			'limit'          => 10,
-			'page'           => $page,
-		);
-		if ( $user instanceof WP_User ) {
-			$order_query['customer_id'] = (int) $user->ID;
-		} else {
-			$order_query['billing_email'] = $email_address;
-		}
-		return wc_get_orders( $order_query );
-	}
-
-	/**
-	 * Handle exporting data for orders
-	 * @param string  $email_address
-	 * @param int     $page
+	 * Filter for woocommerce_privacy_export_order_personal_data that adds WCS personal data to the exported orders
+	 * @param array  $personal_data
+	 * @param object $order
 	 * @return array
 	 */
-	public function label_data_exporter( $email_address, $page = 1 ) {
-		$data_to_export = array();
+	public function label_data_exporter( $personal_data, $order ) {
+		$order_id = $order->get_id();
+		$labels = $this->settings_store->get_label_order_meta_data( $order_id );
 
-		$orders = $this->get_orders_page( $email_address, $page );
-		$done = empty( $orders );
-
-		foreach ( $orders as $order ) {
-			$order_id = $order->get_id();
-			$labels = $this->settings_store->get_label_order_meta_data( $order_id );
-
-			foreach ( $labels as $label ) {
-				if ( empty( $label['tracking'] ) ) {
-					continue;
-				}
-				$data_to_export[] = array(
-					'group_id'    => 'woocommerce_orders',
-					'group_label' => __( 'Orders', 'woocommerce-services' ),
-					'item_id'     => 'order-' . $order_id,
-					'data'        => array(
-						array(
-							'name'  => __( 'Shipping label service', 'woocommerce-services' ),
-							'value' => $label['service_name'],
-						),
-						array(
-							'name'  => __( 'Shipping label tracking number', 'woocommerce-services' ),
-							'value' => $label['tracking'],
-						),
-					),
-				);
+		foreach ( $labels as $label ) {
+			if ( empty( $label['tracking'] ) ) {
+				continue;
 			}
+			$personal_data[] = array(
+				'name'  => __( 'Shipping label service', 'woocommerce-services' ),
+				'value' => $label['service_name'],
+			);
+			$personal_data[] = array(
+				'name'  => __( 'Shipping label tracking number', 'woocommerce-services' ),
+				'value' => $label['tracking'],
+			);
 		}
 
-		return array(
-			'data' => $data_to_export,
-			'done' => $done,
-		);
+		return $personal_data;
 	}
 }

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -612,9 +612,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$paypal_ec             = new WC_Connect_PayPal_EC( $api_client, $nux );
 			$label_reports         = new WC_Connect_Label_Reports( $settings_store );
 
-			if ( class_exists( 'WC_Connect_Privacy' ) ) {
-				new WC_Connect_Privacy( $settings_store );
-			}
+			new WC_Connect_Privacy( $settings_store );
 
 			$this->set_logger( $logger );
 			$this->set_shipping_logger( $shipping_logger );

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -612,6 +612,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$paypal_ec             = new WC_Connect_PayPal_EC( $api_client, $nux );
 			$label_reports         = new WC_Connect_Label_Reports( $settings_store );
 
+			if ( class_exists( 'WC_Connect_Privacy' ) ) {
+				new WC_Connect_Privacy( $settings_store );
+			}
+
 			$this->set_logger( $logger );
 			$this->set_shipping_logger( $shipping_logger );
 			$this->set_api_client( $api_client );


### PR DESCRIPTION
Fixes #1384 

Adds the label tracking numbers to the personal data exports:
<img width="923" alt="screen shot 2018-05-09 at 13 35 08" src="https://user-images.githubusercontent.com/800604/39814972-684bbb6a-538e-11e8-9baf-818f030b57be.png">

To test:
* Either use the latest [WordPress Core SVN trunk](https://develop.svn.wordpress.org/trunk/) or latest [master WordPress Core from GitHub](https://github.com/WordPress/WordPress)
* Use the latest [WooCommerce code](https://github.com/woocommerce/woocommerce)
* Under `Tools > Export personal data` you should be able to initiate the personal data export for a given email address
* Export the data for orders that have labels with tracking numbers purchased
* The data should include the tracking number

