### PR TITLE
Fix "Undefined variable: service_settings" error

### DIFF
--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -245,7 +245,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			return is_string( $preset_id );
 		}
 
-		private function check_and_handle_response_error( $response_body ) {
+		private function check_and_handle_response_error( $response_body, $service_settings ) {
 			if ( is_wp_error( $response_body ) ) {
 				$this->debug(
 					sprintf(
@@ -349,7 +349,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				$this->debug( 'Rates response retrieved from cache' );
 			} else {
 				$response_body = $this->api_client->get_shipping_rates( $services, $package, $custom_boxes, $predefined_boxes );
-				if ( $this->check_and_handle_response_error( $response_body ) ) {
+				if ( $this->check_and_handle_response_error( $response_body, $service_settings ) ) {
 					return;
 				}
 				wp_cache_set( $cache_key, $response_body, '', 3600 );


### PR DESCRIPTION
Fixes a PHP error that appears when the server cannot be reached.

To reproduce:
* Make sure the client cannot reach the server (for example stop the server if using a local env)
* Try to request rates
* Warnings will appear

To test:
* Repeat the reproduce steps
* No PHP warnings should appear

This might also require a point release since it breaks the fallback rate functionality :/