### PR TITLE
Add personal data erasure

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -252,6 +252,16 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		/**
+		 * Gets the shipping label status (refund status, tracking code, etc)
+		 *
+		 * @param $order_id integer
+		 * @return object|WP_Error
+		 */
+		public function anonymize_order( $order_id ) {
+			return $this->request( 'POST', '/privacy/order/' . $order_id . '/anonymize' );
+		}
+
+		/**
 		 * Request a refund for a given shipping label
 		 *
 		 * @param $label_id integer

--- a/classes/class-wc-connect-privacy.php
+++ b/classes/class-wc-connect-privacy.php
@@ -85,10 +85,6 @@ class WC_Connect_Privacy {
 		}
 
 		foreach ( $labels as $label_idx => $label ) {
-			if ( ! isset( $label['tracking'] ) ) {
-				continue;
-			}
-			$items_removed = true;
 			$labels[ $label_idx ]['tracking'] = '';
 			$labels[ $label_idx ]['status'] = 'ANONYMIZED';
 		}

--- a/classes/class-wc-connect-privacy.php
+++ b/classes/class-wc-connect-privacy.php
@@ -90,6 +90,7 @@ class WC_Connect_Privacy {
 			}
 			$items_removed = true;
 			$labels[ $label_idx ]['tracking'] = '';
+			$labels[ $label_idx ]['status'] = 'ANONYMIZED';
 		}
 
 		$this->api_client->anonymize_order( $order_id );

--- a/classes/class-wc-connect-privacy.php
+++ b/classes/class-wc-connect-privacy.php
@@ -15,6 +15,7 @@ class WC_Connect_Privacy {
 
 		add_action( 'admin_init', array( $this, 'add_privacy_message' ) );
 		add_filter( 'woocommerce_privacy_export_order_personal_data', array( $this, 'label_data_exporter' ), 10, 2 );
+		add_action( 'woocommerce_privacy_before_remove_order_personal_data', array( $this, 'label_data_eraser' ) );
 	}
 
 	/**
@@ -64,5 +65,26 @@ class WC_Connect_Privacy {
 		}
 
 		return $personal_data;
+	}
+
+	/**
+	 * Hooks into woocommerce_privacy_before_remove_order_personal_data to remove WCS personal data from orders
+	 * @param Object  $order
+	 */
+	public function label_data_eraser( $order ) {
+		$order_id = $order->get_id();
+		$labels = $this->settings_store->get_label_order_meta_data( $order_id );
+		$found_personal_data = false;
+
+		foreach ( $labels as $label_idx => $label ) {
+			if ( ! isset( $label['tracking'] ) ) {
+				continue;
+			}
+			$items_removed = true;
+			$labels[ $label_idx ]['tracking'] = '';
+		}
+
+		//TODO: call server
+		update_post_meta( $order_id, 'wc_connect_labels', $labels );
 	}
 }

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -612,7 +612,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$paypal_ec             = new WC_Connect_PayPal_EC( $api_client, $nux );
 			$label_reports         = new WC_Connect_Label_Reports( $settings_store );
 
-			new WC_Connect_Privacy( $settings_store );
+			new WC_Connect_Privacy( $settings_store, $api_client );
 
 			$this->set_logger( $logger );
 			$this->set_shipping_logger( $shipping_logger );


### PR DESCRIPTION
Erases personal data (tracking numbers) from the client database and calls the server to erase the same data.

Note: the affected labels will currently disappear from the order page. A separate Calypso PR will follow which will render the anonymized labels in the log, but not show the reprint link.

To test:
* Make sure you're using WordPress 4.9.6+
* Use the latest [WooCommerce code](https://github.com/woocommerce/woocommerce)
* Use the server PR - 1089-gh-woocommerce-connect-server
* Set WooCommerce to erase the order data by navigating to `WooCommerce > Settings > Accounts & Privacy` and enabling the `Remove personal data from orders` checkbox
* Place an order with an email address
* Purchase a label for that order 
* Navigate to `Tools > Erase Personal Data` and erase the data using the email with which the order was placed
* The labels should have their tracking number removed in the database and status set to `ANONYMIZED`
* Same should happen on the server, the label image cache should not exist for the affected labels