### PR TITLE
Fix the PHP warning on the status page when logs are empty

### DIFF
--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -249,13 +249,13 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 
 			$line_count = count( $data->tail );
 			if ( $line_count < 1 ) {
-				$log_tail = __( 'Log is empty', 'woocommerce-services' );
+				$log_tail = array( __( 'Log is empty', 'woocommerce-services' ) );
 			} else {
 				$log_tail = $data->tail;
 			}
 
 			return array(
-				'tail' => implode( $log_tail, '' ),
+				'tail' => implode( $log_tail ),
 				'url'  => $url = add_query_arg(
 					array(
 						'page'     => 'wc-status',


### PR DESCRIPTION
Fixes #1405 

To test:
* either delete the WCS logs (by default they are located in `wp-content/uploads/wc-logs`) or change `$line_count` to 0 in `class-wc-connect-help-view.php`
* open the status page
* the log components should read `Log is empty` and no warnings should be shown 