### PR TITLE
Added a warning about erased labels to the erasure page

### DIFF
--- a/classes/class-wc-connect-privacy.php
+++ b/classes/class-wc-connect-privacy.php
@@ -62,7 +62,7 @@ class WC_Connect_Privacy {
 		}
 
 		?>
-			<div class='notice notice-warning' style="position: relative;">
+			<div class="notice notice-warning" style="position: relative;">
 				<p><?php esc_html_e( 'Warning: Erasing personal data will cause the ability to reprint or refund WooCommerce Services shipping labels to be lost on the affected orders.', 'woocommerce-services' ); ?></p>
 			</div>
 		<?php

--- a/classes/class-wc-connect-privacy.php
+++ b/classes/class-wc-connect-privacy.php
@@ -51,8 +51,8 @@ class WC_Connect_Privacy {
 	 * If WooCommerce order data erasure is enabled, display a warning on the erasure page
 	 */
 	public function add_erasure_notice() {
-		global $pagenow;
-		if ( ( $pagenow !== 'tools.php' ) || ( $_GET['page'] !== 'remove_personal_data' ) ) {
+		$screen = get_current_screen();
+		if ( 'tools_page_remove_personal_data' !== $screen->id ) {
 			return;
 		}
 

--- a/classes/class-wc-connect-privacy.php
+++ b/classes/class-wc-connect-privacy.php
@@ -63,7 +63,7 @@ class WC_Connect_Privacy {
 
 		?>
 			<div class='notice notice-warning' style="position: relative;">
-				<p><?php esc_html_e( 'Warning: Erasing personal data will cause the ability to reprint or refund WooCommerce Services shipping labels to be lost on the affected orders.', 'woocommerce-services' ) ?></p>
+				<p><?php esc_html_e( 'Warning: Erasing personal data will cause the ability to reprint or refund WooCommerce Services shipping labels to be lost on the affected orders.', 'woocommerce-services' ); ?></p>
 			</div>
 		<?php
 	}

--- a/classes/class-wc-connect-privacy.php
+++ b/classes/class-wc-connect-privacy.php
@@ -20,6 +20,7 @@ class WC_Connect_Privacy {
 		$this->api_client = $api_client;
 
 		add_action( 'admin_init', array( $this, 'add_privacy_message' ) );
+		add_action( 'admin_notices', array( $this, 'add_erasure_notice' ) );
 		add_filter( 'woocommerce_privacy_export_order_personal_data', array( $this, 'label_data_exporter' ), 10, 2 );
 		add_action( 'woocommerce_privacy_before_remove_order_personal_data', array( $this, 'label_data_eraser' ) );
 	}
@@ -44,6 +45,27 @@ class WC_Connect_Privacy {
 		);
 
 		wp_add_privacy_policy_content( $title, $content );
+	}
+
+	/**
+	 * If WooCommerce order data erasure is enabled, display a warning on the erasure page
+	 */
+	public function add_erasure_notice() {
+		global $pagenow;
+		if ( ( $pagenow !== 'tools.php' ) || ( $_GET['page'] !== 'remove_personal_data' ) ) {
+			return;
+		}
+
+		$erasure_enabled = wc_string_to_bool( get_option( 'woocommerce_erasure_request_removes_order_data', 'no' ) );
+		if ( ! $erasure_enabled ) {
+			return;
+		}
+
+		?>
+			<div class='notice notice-warning' style="position: relative;">
+				<p><?php esc_html_e( 'Warning: Erasing personal data will cause the ability to reprint or refund WooCommerce Services shipping labels to be lost on the affected orders.', 'woocommerce-services' ) ?></p>
+			</div>
+		<?php
 	}
 
 	/**


### PR DESCRIPTION
Adds the following warning to the erasure page:
![screen shot 2018-05-23 at 15 08 40](https://user-images.githubusercontent.com/800604/40429783-64eed156-5e9b-11e8-851f-9d2accdec938.png)

To test:
* use WordPress 4.9.6 or later
* use WooCommerce `master` branch
* enable order data erasure under `WooCommerce > Settings > Accounts & Privacy`
* navigate to `Tools > Export personal data`
* the notice should be visible
* the notice should not be visible when order data erasure is disabled