### PR TITLE
Update Calypso dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,13 +1,13 @@
 {
   "name": "woocommerce-services",
-  "version": "1.13.0",
+  "version": "1.13.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "10.0.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.9.tgz",
-      "integrity": "sha512-ekJ3mXJcJP+Nn5kC6eCmWPND/fHx/Ga12Lz0IJgTfGz1ge7OCIR5xcDY5tcYgnyM1kWsVDRH2bguxkGcNj39AQ==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.2.tgz",
+      "integrity": "sha512-bjk1RIeZBCe/WukrFToIVegOf91Pebr8cXYBwLBIsfiGWVQ+ifwWsT59H3RxrWzWrzd1l/Amk1/ioY5Fq3/bpA==",
       "dev": true
     },
     "abab": {
@@ -266,7 +266,7 @@
       "dev": true,
       "requires": {
         "archiver-utils": "1.3.0",
-        "async": "2.6.0",
+        "async": "2.6.1",
         "buffer-crc32": "0.2.13",
         "glob": "7.1.2",
         "lodash": "4.17.10",
@@ -277,9 +277,9 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
             "lodash": "4.17.10"
@@ -504,7 +504,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000840",
+        "caniuse-db": "1.0.30000844",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -517,8 +517,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000840",
-            "electron-to-chromium": "1.3.45"
+            "caniuse-db": "1.0.30000844",
+            "electron-to-chromium": "1.3.48"
           }
         }
       }
@@ -1334,7 +1334,7 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "3.2.7",
+        "browserslist": "3.2.8",
         "invariant": "2.2.4",
         "semver": "5.5.0"
       }
@@ -1663,15 +1663,6 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.1"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1793,12 +1784,12 @@
       }
     },
     "browserslist": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.7.tgz",
-      "integrity": "sha512-oYVLxFVqpX9uMhOIQBLtZL+CX4uY8ZpWcjNTaxyWl5rO8yA9SSNikFnAfvk8J3P/7z3BZwNmEqFKaJoYltj3MQ==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+      "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "requires": {
-        "caniuse-lite": "1.0.30000840",
-        "electron-to-chromium": "1.3.45"
+        "caniuse-lite": "1.0.30000844",
+        "electron-to-chromium": "1.3.48"
       }
     },
     "buffer": {
@@ -1937,7 +1928,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000840",
+        "caniuse-db": "1.0.30000844",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -1948,22 +1939,22 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000840",
-            "electron-to-chromium": "1.3.45"
+            "caniuse-db": "1.0.30000844",
+            "electron-to-chromium": "1.3.48"
           }
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000840",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000840.tgz",
-      "integrity": "sha1-aNWg8GlMkhgLDYLnINcPjmE2ZgQ=",
+      "version": "1.0.30000844",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000844.tgz",
+      "integrity": "sha1-vKV5jNoraTHWgQDC1p5V+zOMu0E=",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000840",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000840.tgz",
-      "integrity": "sha512-Lw6AaouV6lh7TgIdQtLiUFKKO2mtDnZFkzCq5/V6tqs4ZI0OGVSDCEt1uegZ3OOBEBUYuVw3Hhr9DQSbgVofFA=="
+      "version": "1.0.30000844",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000844.tgz",
+      "integrity": "sha512-UpKQE7y6dLHhlv75UyBCRiun34Q+bmxyX3zS+ve9M07YG52tRafOvop9N9d5jC+sikKuG7UMweJKJNts4FVehA=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -2031,7 +2022,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.2.3",
+        "fsevents": "1.2.4",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -2234,9 +2225,9 @@
       }
     },
     "colors": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
-      "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+      "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw==",
       "dev": true
     },
     "colors-mini": {
@@ -2580,26 +2571,6 @@
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "dev": true,
-      "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        }
-      }
-    },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -2713,7 +2684,7 @@
         "postcss-discard-empty": "2.1.0",
         "postcss-discard-overridden": "0.1.1",
         "postcss-discard-unused": "2.2.3",
-        "postcss-filter-plugins": "2.0.2",
+        "postcss-filter-plugins": "2.0.3",
         "postcss-merge-idents": "2.1.7",
         "postcss-merge-longhand": "2.0.2",
         "postcss-merge-rules": "2.1.2",
@@ -3159,9 +3130,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.45",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.45.tgz",
-      "integrity": "sha1-RYrBscXHYM6IEaFtK/vZfsMLr7g="
+      "version": "1.3.48",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",
+      "integrity": "sha1-07DYWTgUBE4JLs4hCPw6ya6kuQA="
     },
     "elliptic": {
       "version": "6.4.0",
@@ -3644,9 +3615,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.11.0.tgz",
-      "integrity": "sha1-Fa7qN6Z0mdhI6OmBgG1GJ7VQOBY=",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.12.0.tgz",
+      "integrity": "sha1-2tMXgSktZmSyUxf9BJ0uKy8CIF0=",
       "dev": true,
       "requires": {
         "contains-path": "0.1.0",
@@ -4270,16 +4241,16 @@
       "integrity": "sha1-dW7076gVXDaBgz+8NNpTuUF0bWw=",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
+        "async": "2.6.1",
         "loader-utils": "1.1.0",
         "schema-utils": "0.3.0",
         "webpack-sources": "1.1.0"
       },
       "dependencies": {
         "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
             "lodash": "4.17.10"
@@ -4465,9 +4436,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
-      "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+      "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
       "dev": true,
       "requires": {
         "debug": "3.1.0"
@@ -4572,14 +4543,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
-      "integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "dev": true,
       "optional": true,
       "requires": {
         "nan": "2.10.0",
-        "node-pre-gyp": "0.9.1"
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -4660,7 +4631,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.4.2",
+          "version": "0.5.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -4838,7 +4809,7 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.9.1",
+          "version": "0.10.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4849,7 +4820,7 @@
             "nopt": "4.0.1",
             "npm-packlist": "1.1.10",
             "npmlog": "4.1.2",
-            "rc": "1.2.6",
+            "rc": "1.2.7",
             "rimraf": "2.6.2",
             "semver": "5.5.0",
             "tar": "4.4.1"
@@ -4947,12 +4918,12 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.6",
+          "version": "1.2.7",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
+            "deep-extend": "0.5.1",
             "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
@@ -5146,9 +5117,9 @@
       }
     },
     "gaze": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
-      "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+      "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
       "dev": true,
       "requires": {
         "globule": "1.2.0"
@@ -5477,18 +5448,6 @@
         "minimalistic-assert": "1.0.1"
       }
     },
-    "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "dev": true,
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
-      }
-    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -5505,12 +5464,6 @@
         "minimalistic-assert": "1.0.1",
         "minimalistic-crypto-utils": "1.0.1"
       }
-    },
-    "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
-      "dev": true
     },
     "hoist-non-react-statics": {
       "version": "2.5.0",
@@ -5598,9 +5551,9 @@
       }
     },
     "http-parser-js": {
-      "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.12.tgz",
-      "integrity": "sha1-uc+/Sizybw/DSxDKFImid3HjR08=",
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
+      "integrity": "sha1-O9bW/ebjFyyTNMOzO2wZPYD+ETc=",
       "dev": true
     },
     "http-proxy": {
@@ -5610,7 +5563,7 @@
       "dev": true,
       "requires": {
         "eventemitter3": "3.1.0",
-        "follow-redirects": "1.4.1",
+        "follow-redirects": "1.5.0",
         "requires-port": "1.0.0"
       }
     },
@@ -6548,9 +6501,9 @@
       "integrity": "sha1-coueFHXyrvR0fvk+J4cTqEiQQPo="
     },
     "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.5.tgz",
+      "integrity": "sha512-aUnNwqMOXw3yvErjMPSQu6qIIzUmT1e5KcU1OZxRDU1g/am6mzBvcrmLAYwzmB59BHPrh5/tKaiF4OPhqRWESQ==",
       "dev": true
     },
     "js-tokens": {
@@ -6592,7 +6545,7 @@
         "html-encoding-sniffer": "1.0.2",
         "nwmatcher": "1.4.4",
         "parse5": "1.5.1",
-        "request": "2.85.0",
+        "request": "2.87.0",
         "sax": "1.2.4",
         "symbol-tree": "3.2.2",
         "tough-cookie": "2.3.4",
@@ -6711,7 +6664,7 @@
         "bluebird": "3.5.1",
         "body-parser": "1.18.3",
         "chokidar": "1.7.0",
-        "colors": "1.2.5",
+        "colors": "1.3.0",
         "combine-lists": "1.0.1",
         "connect": "3.6.6",
         "core-js": "2.5.6",
@@ -6874,7 +6827,7 @@
       "integrity": "sha512-2cyII34jfrAabbI2+4Rk4j95Nazl98FvZQhgSiqKUDarT317rxfv/EdzZ60CyATN4PQxJdO5ucR5bOOXkEVrXw==",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
+        "async": "2.6.1",
         "babel-runtime": "6.26.0",
         "loader-utils": "1.1.0",
         "lodash": "4.17.10",
@@ -6883,9 +6836,9 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
             "lodash": "4.17.10"
@@ -7325,12 +7278,6 @@
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
       }
-    },
-    "macaddress": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
-      "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
-      "dev": true
     },
     "make-dir": {
       "version": "1.3.0",
@@ -7876,7 +7823,7 @@
         "nopt": "3.0.6",
         "npmlog": "4.1.2",
         "osenv": "0.1.5",
-        "request": "2.85.0",
+        "request": "2.87.0",
         "rimraf": "2.6.2",
         "semver": "5.3.0",
         "tar": "2.2.1",
@@ -7943,7 +7890,7 @@
         "async-foreach": "0.1.3",
         "chalk": "1.1.3",
         "cross-spawn": "3.0.1",
-        "gaze": "1.1.2",
+        "gaze": "1.1.3",
         "get-stdin": "4.0.1",
         "glob": "7.1.2",
         "in-publish": "2.0.0",
@@ -7955,7 +7902,7 @@
         "nan": "2.10.0",
         "node-gyp": "3.6.2",
         "npmlog": "4.1.2",
-        "request": "2.85.0",
+        "request": "2.87.0",
         "sass-graph": "2.2.4",
         "stdout-stream": "1.4.0"
       },
@@ -8433,7 +8380,7 @@
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
-        "@types/node": "10.0.9"
+        "@types/node": "10.1.2"
       }
     },
     "parsejson": {
@@ -8671,7 +8618,7 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "js-base64": "2.4.3",
+        "js-base64": "2.4.5",
         "source-map": "0.5.7",
         "supports-color": "3.2.3"
       },
@@ -8766,13 +8713,12 @@
       }
     },
     "postcss-filter-plugins": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
-      "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.3.tgz",
+      "integrity": "sha512-T53GVFsdinJhgwm7rg1BzbeBRomOg9y5MBVhGcsV0CxurUdVj1UlPdKtn7aqYA/c/QVkzKMjq2bSV5dKG5+AwQ==",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18",
-        "uniqid": "4.1.1"
+        "postcss": "5.2.18"
       }
     },
     "postcss-load-config": {
@@ -8858,8 +8804,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000840",
-            "electron-to-chromium": "1.3.45"
+            "caniuse-db": "1.0.30000844",
+            "electron-to-chromium": "1.3.48"
           }
         }
       }
@@ -9859,9 +9805,9 @@
       }
     },
     "request": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "dev": true,
       "requires": {
         "aws-sign2": "0.7.0",
@@ -9872,7 +9818,6 @@
         "forever-agent": "0.6.1",
         "form-data": "2.3.2",
         "har-validator": "5.0.3",
-        "hawk": "6.0.2",
         "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
@@ -9882,7 +9827,6 @@
         "performance-now": "2.1.0",
         "qs": "6.5.1",
         "safe-buffer": "5.1.2",
-        "stringstream": "0.0.5",
         "tough-cookie": "2.3.4",
         "tunnel-agent": "0.6.0",
         "uuid": "3.2.1"
@@ -10181,7 +10125,7 @@
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "2.4.3",
+        "js-base64": "2.4.5",
         "source-map": "0.4.4"
       },
       "dependencies": {
@@ -10418,7 +10362,7 @@
       "integrity": "sha1-2HNX+TugQEyJudUOKeRoE4L3ZtY=",
       "dev": true,
       "requires": {
-        "colors": "1.2.5",
+        "colors": "1.3.0",
         "diff": "3.2.0",
         "formatio": "1.1.1",
         "lolex": "1.6.0",
@@ -10544,15 +10488,6 @@
             "is-buffer": "1.1.6"
           }
         }
-      }
-    },
-    "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.1"
       }
     },
     "socket.io": {
@@ -10978,12 +10913,6 @@
       "requires": {
         "safe-buffer": "5.1.2"
       }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -11489,15 +11418,6 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
-    "uniqid": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
-      "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
-      "dev": true,
-      "requires": {
-        "macaddress": "0.2.8"
-      }
-    },
     "uniqs": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
@@ -11551,9 +11471,9 @@
       }
     },
     "upath": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.5.tgz",
-      "integrity": "sha512-qbKn90aDQ0YEwvXoLqj0oiuUYroLX2lVHZ+b+xwjozFasAOC4GneDq5+OaIG5Zj+jFmbz/uO+f7a9qxjktJQww==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+      "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
       "dev": true
     },
     "uri-js": {
@@ -11772,7 +11692,7 @@
             "anymatch": "2.0.0",
             "async-each": "1.0.1",
             "braces": "2.3.2",
-            "fsevents": "1.2.3",
+            "fsevents": "1.2.4",
             "glob-parent": "3.1.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
@@ -11780,7 +11700,7 @@
             "normalize-path": "2.1.1",
             "path-is-absolute": "1.0.1",
             "readdirp": "2.1.0",
-            "upath": "1.0.5"
+            "upath": "1.1.0"
           }
         },
         "glob-parent": {
@@ -11846,7 +11766,7 @@
         "acorn-dynamic-import": "2.0.2",
         "ajv": "4.11.8",
         "ajv-keywords": "1.5.1",
-        "async": "2.6.0",
+        "async": "2.6.1",
         "enhanced-resolve": "3.4.1",
         "interpret": "1.1.0",
         "json-loader": "0.5.7",
@@ -11866,9 +11786,9 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
             "lodash": "4.17.10"
@@ -12017,7 +11937,7 @@
             "anymatch": "2.0.0",
             "async-each": "1.0.1",
             "braces": "2.3.2",
-            "fsevents": "1.2.3",
+            "fsevents": "1.2.4",
             "glob-parent": "3.1.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
@@ -12025,7 +11945,7 @@
             "normalize-path": "2.1.1",
             "path-is-absolute": "1.0.1",
             "readdirp": "2.1.0",
-            "upath": "1.0.5"
+            "upath": "1.1.0"
           }
         },
         "cliui": {
@@ -12192,7 +12112,7 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": "0.4.12",
+        "http-parser-js": "0.4.13",
         "websocket-extensions": "0.1.3"
       }
     },
@@ -12285,7 +12205,7 @@
       "dev": true
     },
     "wp-calypso": {
-      "version": "github:automattic/wp-calypso#2ad41412b9488bb154145ac6fc4c2876b98c5317",
+      "version": "github:automattic/wp-calypso#14c09cc79ca71e53eca5f0cce3e2c58682ac3384",
       "requires": {
         "@babel/cli": "7.0.0-beta.44",
         "@babel/core": "7.0.0-beta.44",
@@ -12306,7 +12226,6 @@
         "babel-plugin-add-module-exports": "0.2.1",
         "babel-plugin-transform-class-properties": "6.24.1",
         "babel-plugin-transform-export-extensions": "6.22.0",
-        "babel-plugin-transform-imports": "1.4.1",
         "blob": "0.0.4",
         "body-parser": "1.17.2",
         "bounding-client-rect": "1.0.5",
@@ -12347,7 +12266,7 @@
         "escape-string-regexp": "1.0.3",
         "events": "1.0.2",
         "exports-loader": "0.6.2",
-        "express": "4.13.3",
+        "express": "4.16.3",
         "express-useragent": "1.0.7",
         "filesize": "3.2.1",
         "flag-icon-css": "2.3.0",
@@ -12869,7 +12788,7 @@
           "requires": {
             "@babel/helper-plugin-utils": "7.0.0-beta.44",
             "@babel/helper-regex": "7.0.0-beta.44",
-            "regexpu-core": "4.1.3"
+            "regexpu-core": "4.1.5"
           }
         },
         "@babel/plugin-syntax-async-generators": {
@@ -13021,7 +12940,7 @@
           "requires": {
             "@babel/helper-plugin-utils": "7.0.0-beta.44",
             "@babel/helper-regex": "7.0.0-beta.44",
-            "regexpu-core": "4.1.3"
+            "regexpu-core": "4.1.5"
           }
         },
         "@babel/plugin-transform-duplicate-keys": {
@@ -13208,7 +13127,7 @@
           "requires": {
             "@babel/helper-plugin-utils": "7.0.0-beta.44",
             "@babel/helper-regex": "7.0.0-beta.44",
-            "regexpu-core": "4.1.3"
+            "regexpu-core": "4.1.5"
           }
         },
         "@babel/polyfill": {
@@ -13364,9 +13283,21 @@
             "to-fast-properties": "2.0.0"
           }
         },
+        "@mrmlnc/readdir-enhanced": {
+          "version": "2.2.1",
+          "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+          "requires": {
+            "call-me-maybe": "1.0.1",
+            "glob-to-regexp": "0.3.0"
+          }
+        },
+        "@nodelib/fs.stat": {
+          "version": "1.0.2",
+          "integrity": "sha512-vCpf75JDcdomXvUd7Rn6DfYAVqPAFI66FVjxiWGwh85OLdvfo3paBoPJaam5keIYRyUolnS7SleS/ZPCidCvzw=="
+        },
         "@types/node": {
-          "version": "10.0.8",
-          "integrity": "sha512-MFFKFv2X4iZy/NFl1m1E8uwE1CR96SGwJjgHma09PLtqOWoj3nqeJHMG+P/EuJGVLvC2I6MdQRQsr4TcRduIow=="
+          "version": "10.1.2",
+          "integrity": "sha512-bjk1RIeZBCe/WukrFToIVegOf91Pebr8cXYBwLBIsfiGWVQ+ifwWsT59H3RxrWzWrzd1l/Amk1/ioY5Fq3/bpA=="
         },
         "JSONStream": {
           "version": "0.8.4",
@@ -13385,11 +13316,11 @@
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "accepts": {
-          "version": "1.2.13",
-          "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
+          "version": "1.3.5",
+          "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
           "requires": {
             "mime-types": "2.1.18",
-            "negotiator": "0.5.3"
+            "negotiator": "0.6.1"
           }
         },
         "acorn": {
@@ -13696,16 +13627,16 @@
           "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
         },
         "async-kit": {
-          "version": "2.2.3",
-          "integrity": "sha1-JkdRonndxfWbQZY4uAWuLEmFj7c=",
+          "version": "2.2.4",
+          "integrity": "sha512-LuWbpSYdTwrGv5MWhsUY69UaQAc3AYMwf/LwTupotu/ubb/1TjDd03WK1eoMXRK/s3bmi4aUkKY0TmxYQgRrmw==",
           "requires": {
-            "nextgen-events": "0.9.9",
-            "tree-kit": "0.5.26"
+            "nextgen-events": "0.14.6",
+            "tree-kit": "0.5.27"
           },
           "dependencies": {
             "nextgen-events": {
-              "version": "0.9.9",
-              "integrity": "sha1-OaivxKK4RTiMV+LGu5cWcRmGo6A="
+              "version": "0.14.6",
+              "integrity": "sha512-Ln9d5Midoah7RCxFk8z9tAAcRW/VkB4wZ61Nnw8aqM1/lb/WfPAnlzpLGYRghEjwZdXQNQedTfD/gclYMeI0eQ=="
             }
           }
         },
@@ -13726,7 +13657,7 @@
           "integrity": "sha1-a8vQOKM3xwYn5/zkQ4+lgYjwk3s=",
           "requires": {
             "browserslist": "1.3.6",
-            "caniuse-db": "1.0.30000839",
+            "caniuse-db": "1.0.30000844",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -13737,7 +13668,7 @@
               "version": "1.3.6",
               "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
               "requires": {
-                "caniuse-db": "1.0.30000839"
+                "caniuse-db": "1.0.30000844"
               }
             }
           }
@@ -13968,7 +13899,7 @@
           "integrity": "sha512-rEdN/jevSuX0IQKcUqwqOGa0gDNis4jGY52Rq53aizfDGPwQYNJq+f9NCMT1HUhtUZhYSjvfGUfHQWBRT1/icA==",
           "requires": {
             "babel-plugin-istanbul": "4.1.6",
-            "babel-preset-jest": "22.4.3"
+            "babel-preset-jest": "22.4.4"
           }
         },
         "babel-loader": {
@@ -14025,8 +13956,8 @@
           }
         },
         "babel-plugin-jest-hoist": {
-          "version": "22.4.3",
-          "integrity": "sha512-zhvv4f6OTWy2bYevcJftwGCWXMFe7pqoz41IhMi4xna7xNsX5NygdagsrE0y6kkfuXq8UalwvPwKTyAxME2E/g=="
+          "version": "22.4.4",
+          "integrity": "sha512-DUvGfYaAIlkdnygVIEl0O4Av69NtuQWcrjMOv6DODPuhuGLDnbsARz3AwiiI/EkIMMlxQDUcrZ9yoyJvTNjcVQ=="
         },
         "babel-plugin-jscript": {
           "version": "1.0.4",
@@ -14363,7 +14294,7 @@
               "version": "2.0.0",
               "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
               "requires": {
-                "regenerate": "1.3.3",
+                "regenerate": "1.4.0",
                 "regjsgen": "0.2.0",
                 "regjsparser": "0.1.5"
               }
@@ -14418,16 +14349,6 @@
           "requires": {
             "babel-plugin-syntax-flow": "6.18.0",
             "babel-runtime": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-imports": {
-          "version": "1.4.1",
-          "integrity": "sha512-o7EqCZFj0pKUUDwYDZLTRSg1wNMN69p31l3Sf1+ujTFjWUq+/plAUJ04kO1kn5oLVaHbwLi2F4jQbIHFTN2t+A==",
-          "requires": {
-            "babel-types": "6.26.0",
-            "lodash.camelcase": "4.3.0",
-            "lodash.kebabcase": "4.1.1",
-            "lodash.snakecase": "4.1.1"
           }
         },
         "babel-plugin-transform-object-rest-spread": {
@@ -14551,10 +14472,10 @@
           }
         },
         "babel-preset-jest": {
-          "version": "22.4.3",
-          "integrity": "sha512-a+M3LTEXTq3gxv0uBN9Qm6ahUl7a8pj923nFbCUdqFUSsf3YrX8Uc+C3MEwji5Af3LiQjSC7w4ooYewlz8HRTA==",
+          "version": "22.4.4",
+          "integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
           "requires": {
-            "babel-plugin-jest-hoist": "22.4.3",
+            "babel-plugin-jest-hoist": "22.4.4",
             "babel-plugin-syntax-object-rest-spread": "6.13.0"
           }
         },
@@ -14920,13 +14841,6 @@
           "version": "1.0.0",
           "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
         },
-        "boom": {
-          "version": "4.3.1",
-          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        },
         "bounding-client-rect": {
           "version": "1.0.5",
           "integrity": "sha1-meLNJgLQfyLqO+7kIFNFBP1EJM8=",
@@ -15042,8 +14956,8 @@
           "version": "3.2.7",
           "integrity": "sha512-oYVLxFVqpX9uMhOIQBLtZL+CX4uY8ZpWcjNTaxyWl5rO8yA9SSNikFnAfvk8J3P/7z3BZwNmEqFKaJoYltj3MQ==",
           "requires": {
-            "caniuse-lite": "1.0.30000839",
-            "electron-to-chromium": "1.3.45"
+            "caniuse-lite": "1.0.30000844",
+            "electron-to-chromium": "1.3.47"
           }
         },
         "bser": {
@@ -15169,6 +15083,10 @@
             }
           }
         },
+        "call-me-maybe": {
+          "version": "1.0.1",
+          "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+        },
         "caller-path": {
           "version": "0.1.0",
           "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
@@ -15211,12 +15129,12 @@
           }
         },
         "caniuse-db": {
-          "version": "1.0.30000839",
-          "integrity": "sha1-VahuQCx0rhcUlwe+o+o5lSIjNJc="
+          "version": "1.0.30000844",
+          "integrity": "sha1-vKV5jNoraTHWgQDC1p5V+zOMu0E="
         },
         "caniuse-lite": {
-          "version": "1.0.30000839",
-          "integrity": "sha512-gJZIfmkuy84agOeAZc7WJOexZhisZaBSFk96gkGM6TkH7+1mBfr/MSPnXC8lO0g7guh/ucbswYjruvDbzc6i0g=="
+          "version": "1.0.30000844",
+          "integrity": "sha512-UpKQE7y6dLHhlv75UyBCRiun34Q+bmxyX3zS+ve9M07YG52tRafOvop9N9d5jC+sikKuG7UMweJKJNts4FVehA=="
         },
         "capture-exit": {
           "version": "1.2.0",
@@ -15406,7 +15324,7 @@
             "normalize-path": "2.1.1",
             "path-is-absolute": "1.0.1",
             "readdirp": "2.1.0",
-            "upath": "1.0.5"
+            "upath": "1.1.0"
           },
           "dependencies": {
             "anymatch": {
@@ -15885,7 +15803,7 @@
           "integrity": "sha512-9ljtIROIjPIUmMRqO+XuDITDoV8xRrZmA0jcEq6p2hg2+wY9wGmLfreAZGIL72IzUfdEDZaU8+Vjidg1fBQ8GQ==",
           "requires": {
             "argv": "0.0.2",
-            "request": "2.85.0",
+            "request": "2.87.0",
             "urlgrey": "0.4.4"
           }
         },
@@ -16024,8 +15942,8 @@
           }
         },
         "compare-versions": {
-          "version": "3.1.0",
-          "integrity": "sha512-4hAxDSBypT/yp2ySFD346So6Ragw5xmBn/e/agIGl3bZr6DLUqnoRZPusxKrXdYRZpgexO9daejmIenlq/wrIQ=="
+          "version": "3.2.1",
+          "integrity": "sha512-2y2nHcopMG/NAyk6vWXlLs86XeM9sik4jmx1tKIgzMi9/RQ2eo758RGpxQO3ErihHmg0RlQITPqgz73y6s7quA=="
         },
         "component-bind": {
           "version": "1.0.0",
@@ -16162,8 +16080,8 @@
           "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
         },
         "content-disposition": {
-          "version": "0.5.0",
-          "integrity": "sha1-QoT+auBjCHRjnkToCkGMKTQTXp4="
+          "version": "0.5.2",
+          "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
         },
         "content-type": {
           "version": "1.0.4",
@@ -16382,22 +16300,6 @@
             "lru-cache": "4.1.3",
             "shebang-command": "1.2.0",
             "which": "1.3.0"
-          }
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-              "requires": {
-                "hoek": "4.2.1"
-              }
-            }
           }
         },
         "crypto-browserify": {
@@ -16862,8 +16764,8 @@
           }
         },
         "destroy": {
-          "version": "1.0.3",
-          "integrity": "sha1-tDO0ck5x/YVR2YhRdIUcX8N34sk="
+          "version": "1.0.4",
+          "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
         },
         "detect-conflict": {
           "version": "1.0.1",
@@ -16939,7 +16841,7 @@
           "integrity": "sha1-GJLRC2Gpo1at2/K2FJM+gfi7ODQ=",
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000839",
+            "caniuse-db": "1.0.30000844",
             "css-rule-stream": "1.1.0",
             "duplexer2": "0.0.2",
             "jsonfilter": "1.1.2",
@@ -16956,8 +16858,8 @@
               "version": "1.7.7",
               "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
               "requires": {
-                "caniuse-db": "1.0.30000839",
-                "electron-to-chromium": "1.3.45"
+                "caniuse-db": "1.0.30000844",
+                "electron-to-chromium": "1.3.47"
               }
             },
             "isarray": {
@@ -17173,8 +17075,8 @@
           "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
         },
         "electron-to-chromium": {
-          "version": "1.3.45",
-          "integrity": "sha1-RYrBscXHYM6IEaFtK/vZfsMLr7g="
+          "version": "1.3.47",
+          "integrity": "sha1-dk6IfKkQTQGgrI6r7n38DizhQQQ="
         },
         "elegant-spinner": {
           "version": "1.0.1",
@@ -17561,8 +17463,8 @@
           }
         },
         "escape-html": {
-          "version": "1.0.2",
-          "integrity": "sha1-130y+pjjjC9BroXpJ44ODmuhAiw="
+          "version": "1.0.3",
+          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
         },
         "escape-regexp": {
           "version": "0.0.1",
@@ -17756,8 +17658,8 @@
           }
         },
         "eslint-config-wpcalypso": {
-          "version": "3.0.0",
-          "integrity": "sha512-AyKNbVrITBicI9zfz5F3Y2q8DrmVvLW7NG7YEN9sYHlh08208qelBbbx6xHAcbmmeBk4N/rqLpNoEOX0bkmzvw=="
+          "version": "4.0.0",
+          "integrity": "sha512-l8P1rGPatEIWdytCj0QoNKjcTiujBsfMFsCMI5BOORK6UBU7FX8UpesBF9N+OT5aJ5IV9G/v1Mq4uqFVVVBkEg=="
         },
         "eslint-eslines": {
           "version": "1.0.0",
@@ -18024,8 +17926,8 @@
           "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
         },
         "etag": {
-          "version": "1.7.0",
-          "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg="
+          "version": "1.8.1",
+          "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
         },
         "event-emitter": {
           "version": "0.3.5",
@@ -18161,51 +18063,125 @@
           }
         },
         "express": {
-          "version": "4.13.3",
-          "integrity": "sha1-3bLx+0UCvzNZjSsDKwN5YMpsgKM=",
+          "version": "4.16.3",
+          "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
           "requires": {
-            "accepts": "1.2.13",
+            "accepts": "1.3.5",
             "array-flatten": "1.1.1",
-            "content-disposition": "0.5.0",
+            "body-parser": "1.18.2",
+            "content-disposition": "0.5.2",
             "content-type": "1.0.4",
-            "cookie": "0.1.3",
+            "cookie": "0.3.1",
             "cookie-signature": "1.0.6",
-            "debug": "2.2.0",
-            "depd": "1.0.1",
-            "escape-html": "1.0.2",
-            "etag": "1.7.0",
-            "finalhandler": "0.4.0",
-            "fresh": "0.3.0",
-            "merge-descriptors": "1.0.0",
+            "debug": "2.6.9",
+            "depd": "1.1.2",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "finalhandler": "1.1.1",
+            "fresh": "0.5.2",
+            "merge-descriptors": "1.0.1",
             "methods": "1.1.2",
             "on-finished": "2.3.0",
             "parseurl": "1.3.2",
             "path-to-regexp": "0.1.7",
-            "proxy-addr": "1.0.10",
-            "qs": "4.0.0",
-            "range-parser": "1.0.3",
-            "send": "0.13.0",
-            "serve-static": "1.10.3",
+            "proxy-addr": "2.0.3",
+            "qs": "6.5.1",
+            "range-parser": "1.2.0",
+            "safe-buffer": "5.1.1",
+            "send": "0.16.2",
+            "serve-static": "1.13.2",
+            "setprototypeof": "1.1.0",
+            "statuses": "1.4.0",
             "type-is": "1.6.16",
-            "utils-merge": "1.0.0",
-            "vary": "1.0.1"
+            "utils-merge": "1.0.1",
+            "vary": "1.1.2"
           },
           "dependencies": {
+            "body-parser": {
+              "version": "1.18.2",
+              "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+              "requires": {
+                "bytes": "3.0.0",
+                "content-type": "1.0.4",
+                "debug": "2.6.9",
+                "depd": "1.1.2",
+                "http-errors": "1.6.3",
+                "iconv-lite": "0.4.19",
+                "on-finished": "2.3.0",
+                "qs": "6.5.1",
+                "raw-body": "2.3.2",
+                "type-is": "1.6.16"
+              }
+            },
+            "bytes": {
+              "version": "3.0.0",
+              "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+            },
             "cookie": {
-              "version": "0.1.3",
-              "integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU="
+              "version": "0.3.1",
+              "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
             },
             "cookie-signature": {
               "version": "1.0.6",
               "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
             },
-            "depd": {
-              "version": "1.0.1",
-              "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo="
+            "debug": {
+              "version": "2.6.9",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
             },
-            "qs": {
-              "version": "4.0.0",
-              "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc="
+            "iconv-lite": {
+              "version": "0.4.19",
+              "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+            },
+            "ms": {
+              "version": "2.0.0",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            },
+            "raw-body": {
+              "version": "2.3.2",
+              "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+              "requires": {
+                "bytes": "3.0.0",
+                "http-errors": "1.6.2",
+                "iconv-lite": "0.4.19",
+                "unpipe": "1.0.0"
+              },
+              "dependencies": {
+                "depd": {
+                  "version": "1.1.1",
+                  "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+                },
+                "http-errors": {
+                  "version": "1.6.2",
+                  "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+                  "requires": {
+                    "depd": "1.1.1",
+                    "inherits": "2.0.3",
+                    "setprototypeof": "1.0.3",
+                    "statuses": "1.4.0"
+                  }
+                },
+                "setprototypeof": {
+                  "version": "1.0.3",
+                  "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+                }
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+            },
+            "statuses": {
+              "version": "1.4.0",
+              "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
             }
           }
         },
@@ -18295,6 +18271,281 @@
         "fast-deep-equal": {
           "version": "1.1.0",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+        },
+        "fast-glob": {
+          "version": "2.2.2",
+          "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
+          "requires": {
+            "@mrmlnc/readdir-enhanced": "2.2.1",
+            "@nodelib/fs.stat": "1.0.2",
+            "glob-parent": "3.1.0",
+            "is-glob": "4.0.0",
+            "merge2": "1.2.2",
+            "micromatch": "3.1.10"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "4.0.0",
+              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+            },
+            "braces": {
+              "version": "2.3.2",
+              "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+              "requires": {
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.2",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "2.6.9",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "expand-brackets": {
+              "version": "2.1.4",
+              "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+              "requires": {
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                  "requires": {
+                    "is-descriptor": "0.1.6"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "0.1.6",
+                  "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "0.1.4",
+                  "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "is-descriptor": {
+                  "version": "0.1.6",
+                  "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                  "requires": {
+                    "is-accessor-descriptor": "0.1.6",
+                    "is-data-descriptor": "0.1.4",
+                    "kind-of": "5.1.0"
+                  }
+                },
+                "kind-of": {
+                  "version": "5.1.0",
+                  "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                }
+              }
+            },
+            "extglob": {
+              "version": "2.0.4",
+              "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+              "requires": {
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                  "requires": {
+                    "is-descriptor": "1.0.2"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+              "requires": {
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "glob-parent": {
+              "version": "3.1.0",
+              "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+              "requires": {
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
+              },
+              "dependencies": {
+                "is-glob": {
+                  "version": "3.1.0",
+                  "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                  "requires": {
+                    "is-extglob": "2.1.1"
+                  }
+                }
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-extglob": {
+              "version": "2.1.1",
+              "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+            },
+            "is-glob": {
+              "version": "4.0.0",
+              "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+              "requires": {
+                "is-extglob": "2.1.1"
+              }
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+              "requires": {
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.9",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
@@ -18473,13 +18724,33 @@
           }
         },
         "finalhandler": {
-          "version": "0.4.0",
-          "integrity": "sha1-llpS2ejQXSuFdUhUH7ibU6JJfZs=",
+          "version": "1.1.1",
+          "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
           "requires": {
-            "debug": "2.2.0",
-            "escape-html": "1.0.2",
+            "debug": "2.6.9",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
             "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "statuses": "1.4.0",
             "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            },
+            "statuses": {
+              "version": "1.4.0",
+              "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+            }
           }
         },
         "find-cache-dir": {
@@ -18653,8 +18924,8 @@
           }
         },
         "fresh": {
-          "version": "0.3.0",
-          "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
+          "version": "0.5.2",
+          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
         },
         "from": {
           "version": "0.1.7",
@@ -19572,7 +19843,7 @@
             "omggif": "1.0.9",
             "parse-data-uri": "0.2.0",
             "pngjs": "2.3.1",
-            "request": "2.85.0",
+            "request": "2.87.0",
             "through": "2.3.8"
           }
         },
@@ -19680,6 +19951,10 @@
             "is-glob": "2.0.1"
           }
         },
+        "glob-to-regexp": {
+          "version": "0.3.0",
+          "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
+        },
         "global": {
           "version": "4.3.2",
           "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
@@ -19774,7 +20049,7 @@
           "version": "1.0.1",
           "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
           "requires": {
-            "sparkles": "1.0.0"
+            "sparkles": "1.0.1"
           }
         },
         "good-listener": {
@@ -19991,7 +20266,7 @@
           "version": "0.1.0",
           "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
           "requires": {
-            "sparkles": "1.0.0"
+            "sparkles": "1.0.1"
           }
         },
         "has-symbol-support-x": {
@@ -20083,16 +20358,6 @@
             }
           }
         },
-        "hawk": {
-          "version": "6.0.2",
-          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.1",
-            "sntp": "2.1.0"
-          }
-        },
         "he": {
           "version": "0.5.0",
           "integrity": "sha1-LAX/rvkLaOhg8/0rVO9YCYknfuI="
@@ -20105,10 +20370,6 @@
             "minimalistic-assert": "1.0.1",
             "minimalistic-crypto-utils": "1.0.1"
           }
-        },
-        "hoek": {
-          "version": "4.2.1",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
         },
         "hoist-non-react-statics": {
           "version": "1.2.0",
@@ -20591,8 +20852,8 @@
           "integrity": "sha1-ge9X/l0FgUzVjCSDYyqZwwoOgIc="
         },
         "ipaddr.js": {
-          "version": "1.0.5",
-          "integrity": "sha1-X6eM8wG4JceKvDBC2BJyMEnqI8c="
+          "version": "1.6.0",
+          "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
         },
         "irregular-plurals": {
           "version": "1.4.0",
@@ -21038,8 +21299,8 @@
           "version": "1.3.1",
           "integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
           "requires": {
-            "async": "2.6.0",
-            "compare-versions": "3.1.0",
+            "async": "2.6.1",
+            "compare-versions": "3.2.1",
             "fileset": "2.0.3",
             "istanbul-lib-coverage": "1.2.0",
             "istanbul-lib-hook": "1.2.0",
@@ -21053,10 +21314,10 @@
           },
           "dependencies": {
             "async": {
-              "version": "2.6.0",
-              "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+              "version": "2.6.1",
+              "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
               "requires": {
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
               }
             },
             "debug": {
@@ -21076,6 +21337,10 @@
                 "rimraf": "2.6.2",
                 "source-map": "0.5.7"
               }
+            },
+            "lodash": {
+              "version": "4.17.10",
+              "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
             },
             "ms": {
               "version": "2.0.0",
@@ -21209,7 +21474,7 @@
           "integrity": "sha512-wD7dXWtfaQAgbNVsjFqzmuhg6nzwGsTRVea3FpSJ7GURhG+J536fw4mdoLB01DgiEozDDeF1ZMR/UlUszTsCrg==",
           "requires": {
             "import-local": "1.0.0",
-            "jest-cli": "22.4.3"
+            "jest-cli": "22.4.4"
           },
           "dependencies": {
             "ansi-regex": {
@@ -21259,8 +21524,8 @@
               "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
             },
             "jest-cli": {
-              "version": "22.4.3",
-              "integrity": "sha512-IiHybF0DJNqZPsbjn4Cy4vcqcmImpoFwNFnkehzVw8lTUSl4axZh5DHewu5bdpZF2Y5gUqFKYzH0FH4Qx2k+UA==",
+              "version": "22.4.4",
+              "integrity": "sha512-I9dsgkeyjVEEZj9wrGrqlH+8OlNob9Iptyl+6L5+ToOLJmHm4JwOPatin1b2Bzp5R5YRQJ+oiedx7o1H7wJzhA==",
               "requires": {
                 "ansi-escapes": "3.1.0",
                 "chalk": "2.4.1",
@@ -21274,18 +21539,18 @@
                 "istanbul-lib-instrument": "1.10.1",
                 "istanbul-lib-source-maps": "1.2.3",
                 "jest-changed-files": "22.4.3",
-                "jest-config": "22.4.3",
+                "jest-config": "22.4.4",
                 "jest-environment-jsdom": "22.4.3",
                 "jest-get-type": "22.4.3",
                 "jest-haste-map": "22.4.3",
                 "jest-message-util": "22.4.3",
                 "jest-regex-util": "22.4.3",
                 "jest-resolve-dependencies": "22.4.3",
-                "jest-runner": "22.4.3",
-                "jest-runtime": "22.4.3",
+                "jest-runner": "22.4.4",
+                "jest-runtime": "22.4.4",
                 "jest-snapshot": "22.4.3",
                 "jest-util": "22.4.3",
-                "jest-validate": "22.4.3",
+                "jest-validate": "22.4.4",
                 "jest-worker": "22.4.3",
                 "micromatch": "2.3.11",
                 "node-notifier": "5.2.1",
@@ -21365,19 +21630,19 @@
           }
         },
         "jest-config": {
-          "version": "22.4.3",
-          "integrity": "sha512-KSg3EOToCgkX+lIvenKY7J8s426h6ahXxaUFJxvGoEk0562Z6inWj1TnKoGycTASwiLD+6kSYFALcjdosq9KIQ==",
+          "version": "22.4.4",
+          "integrity": "sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
           "requires": {
             "chalk": "2.4.1",
             "glob": "7.1.2",
             "jest-environment-jsdom": "22.4.3",
             "jest-environment-node": "22.4.3",
             "jest-get-type": "22.4.3",
-            "jest-jasmine2": "22.4.3",
+            "jest-jasmine2": "22.4.4",
             "jest-regex-util": "22.4.3",
             "jest-resolve": "22.4.3",
             "jest-util": "22.4.3",
-            "jest-validate": "22.4.3",
+            "jest-validate": "22.4.4",
             "pretty-format": "22.4.3"
           },
           "dependencies": {
@@ -21488,8 +21753,8 @@
           }
         },
         "jest-jasmine2": {
-          "version": "22.4.3",
-          "integrity": "sha512-yZCPCJUcEY6R5KJB/VReo1AYI2b+5Ky+C+JA1v34jndJsRcLpU4IZX4rFJn7yDTtdNbO/nNqg+3SDIPNH2ecnw==",
+          "version": "22.4.4",
+          "integrity": "sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==",
           "requires": {
             "chalk": "2.4.1",
             "co": "4.6.0",
@@ -21501,7 +21766,7 @@
             "jest-message-util": "22.4.3",
             "jest-snapshot": "22.4.3",
             "jest-util": "22.4.3",
-            "source-map-support": "0.5.5"
+            "source-map-support": "0.5.6"
           },
           "dependencies": {
             "chalk": {
@@ -21522,8 +21787,8 @@
               "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
             },
             "source-map-support": {
-              "version": "0.5.5",
-              "integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
+              "version": "0.5.6",
+              "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
               "requires": {
                 "buffer-from": "1.0.0",
                 "source-map": "0.6.1"
@@ -21702,17 +21967,17 @@
           }
         },
         "jest-runner": {
-          "version": "22.4.3",
-          "integrity": "sha512-U7PLlQPRlWNbvOHWOrrVay9sqhBJmiKeAdKIkvX4n1G2tsvzLlf77nBD28GL1N6tGv4RmuTfI8R8JrkvCa+IBg==",
+          "version": "22.4.4",
+          "integrity": "sha512-5S/OpB51igQW9xnkM5Tgd/7ZjiAuIoiJAVtvVTBcEBiXBIFzWM3BAMPBM19FX68gRV0KWyFuGKj0EY3M3aceeQ==",
           "requires": {
             "exit": "0.1.2",
-            "jest-config": "22.4.3",
+            "jest-config": "22.4.4",
             "jest-docblock": "22.4.3",
             "jest-haste-map": "22.4.3",
-            "jest-jasmine2": "22.4.3",
+            "jest-jasmine2": "22.4.4",
             "jest-leak-detector": "22.4.3",
             "jest-message-util": "22.4.3",
-            "jest-runtime": "22.4.3",
+            "jest-runtime": "22.4.4",
             "jest-util": "22.4.3",
             "jest-worker": "22.4.3",
             "throat": "4.1.0"
@@ -21728,22 +21993,22 @@
           }
         },
         "jest-runtime": {
-          "version": "22.4.3",
-          "integrity": "sha512-Eat/esQjevhx9BgJEC8udye+FfoJ2qvxAZfOAWshYGS22HydHn5BgsvPdTtt9cp0fSl5LxYOFA1Pja9Iz2Zt8g==",
+          "version": "22.4.4",
+          "integrity": "sha512-WRTj9m///npte1YjuphCYX7GRY/c2YvJImU9t7qOwFcqHr4YMzmX6evP/3Sehz5DKW2Vi8ONYPCFWe36JVXxfw==",
           "requires": {
             "babel-core": "6.26.3",
-            "babel-jest": "22.4.3",
+            "babel-jest": "22.4.4",
             "babel-plugin-istanbul": "4.1.6",
             "chalk": "2.4.1",
             "convert-source-map": "1.5.1",
             "exit": "0.1.2",
             "graceful-fs": "4.1.11",
-            "jest-config": "22.4.3",
+            "jest-config": "22.4.4",
             "jest-haste-map": "22.4.3",
             "jest-regex-util": "22.4.3",
             "jest-resolve": "22.4.3",
             "jest-util": "22.4.3",
-            "jest-validate": "22.4.3",
+            "jest-validate": "22.4.4",
             "json-stable-stringify": "1.0.1",
             "micromatch": "2.3.11",
             "realpath-native": "1.0.0",
@@ -21783,11 +22048,11 @@
               }
             },
             "babel-jest": {
-              "version": "22.4.3",
-              "integrity": "sha512-BgSjmtl3mW3i+VeVHEr9d2zFSAT66G++pJcHQiUjd00pkW+voYXFctIm/indcqOWWXw5a1nUpR1XWszD9fJ1qg==",
+              "version": "22.4.4",
+              "integrity": "sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==",
               "requires": {
                 "babel-plugin-istanbul": "4.1.6",
-                "babel-preset-jest": "22.4.3"
+                "babel-preset-jest": "22.4.4"
               }
             },
             "babylon": {
@@ -21979,11 +22244,11 @@
           }
         },
         "jest-validate": {
-          "version": "22.4.3",
-          "integrity": "sha512-CfFM18W3GSP/xgmA4UouIx0ljdtfD2mjeBC6c89Gg17E44D4tQhAcTrZmf9djvipwU30kSTnk6CzcxdCCeSXfA==",
+          "version": "22.4.4",
+          "integrity": "sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==",
           "requires": {
             "chalk": "2.4.1",
-            "jest-config": "22.4.3",
+            "jest-config": "22.4.4",
             "jest-get-type": "22.4.3",
             "leven": "2.1.0",
             "pretty-format": "22.4.3"
@@ -22024,8 +22289,8 @@
           "integrity": "sha1-Epi4i5COfH91AeuMGmHxrIM3tTE="
         },
         "js-base64": {
-          "version": "2.4.3",
-          "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
+          "version": "2.4.5",
+          "integrity": "sha512-aUnNwqMOXw3yvErjMPSQu6qIIzUmT1e5KcU1OZxRDU1g/am6mzBvcrmLAYwzmB59BHPrh5/tKaiF4OPhqRWESQ=="
         },
         "js-tokens": {
           "version": "3.0.2",
@@ -22061,7 +22326,7 @@
             "babel-preset-stage-1": "6.24.1",
             "babel-register": "6.26.0",
             "babylon": "6.18.0",
-            "colors": "1.2.5",
+            "colors": "1.3.0",
             "es6-promise": "3.3.1",
             "flow-parser": "0.72.0",
             "lodash": "4.17.5",
@@ -22148,8 +22413,8 @@
               "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
             },
             "colors": {
-              "version": "1.2.5",
-              "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg=="
+              "version": "1.3.0",
+              "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
             },
             "core-js": {
               "version": "1.2.7",
@@ -22263,7 +22528,7 @@
             "nwmatcher": "1.4.4",
             "parse5": "4.0.0",
             "pn": "1.1.0",
-            "request": "2.85.0",
+            "request": "2.87.0",
             "request-promise-native": "1.0.5",
             "sax": "1.2.4",
             "symbol-tree": "3.2.2",
@@ -22918,10 +23183,6 @@
             "lodash.keys": "3.1.2"
           }
         },
-        "lodash.camelcase": {
-          "version": "4.3.0",
-          "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-        },
         "lodash.clonedeep": {
           "version": "4.5.0",
           "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
@@ -22961,10 +23222,6 @@
         "lodash.istypedarray": {
           "version": "3.0.6",
           "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I="
-        },
-        "lodash.kebabcase": {
-          "version": "4.1.1",
-          "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY="
         },
         "lodash.keys": {
           "version": "3.1.2",
@@ -23011,10 +23268,6 @@
         "lodash.restparam": {
           "version": "3.6.1",
           "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-        },
-        "lodash.snakecase": {
-          "version": "4.1.1",
-          "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40="
         },
         "lodash.sortby": {
           "version": "4.7.0",
@@ -23411,8 +23664,8 @@
           "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
         },
         "merge-descriptors": {
-          "version": "1.0.0",
-          "integrity": "sha1-IWnPdTjhsMyH+4jhUC2EdLv3mGQ="
+          "version": "1.0.1",
+          "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
         },
         "merge-stream": {
           "version": "1.0.1",
@@ -23420,6 +23673,10 @@
           "requires": {
             "readable-stream": "2.3.6"
           }
+        },
+        "merge2": {
+          "version": "1.2.2",
+          "integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg=="
         },
         "methods": {
           "version": "1.1.2",
@@ -23453,8 +23710,8 @@
           }
         },
         "mime": {
-          "version": "1.3.4",
-          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+          "version": "1.4.1",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
         },
         "mime-db": {
           "version": "1.33.0",
@@ -23512,7 +23769,7 @@
             "from2": "2.3.0",
             "parallel-transform": "1.1.0",
             "pump": "2.0.1",
-            "pumpify": "1.5.0",
+            "pumpify": "1.5.1",
             "stream-each": "1.2.2",
             "through2": "2.0.3"
           }
@@ -23723,8 +23980,8 @@
           }
         },
         "negotiator": {
-          "version": "0.5.3",
-          "integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g="
+          "version": "0.6.1",
+          "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
         },
         "neo-async": {
           "version": "1.8.2",
@@ -23744,6 +24001,10 @@
         "nextgen-events": {
           "version": "0.10.2",
           "integrity": "sha512-P6efDoVOOJjVLOhwINq+aqhC2B3a9IxojbWMn9fTv2coDiyRaaGLSgWsm84wQHlQeuqVgqiLEE+xiHXf3EVN6w=="
+        },
+        "nice-try": {
+          "version": "1.0.4",
+          "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
         },
         "nock": {
           "version": "8.0.0",
@@ -23798,7 +24059,7 @@
             "nopt": "3.0.6",
             "npmlog": "4.1.2",
             "osenv": "0.1.5",
-            "request": "2.85.0",
+            "request": "2.87.0",
             "rimraf": "2.6.2",
             "semver": "5.3.0",
             "tar": "2.2.1",
@@ -23895,7 +24156,7 @@
             "nan": "2.10.0",
             "node-gyp": "3.6.2",
             "npmlog": "4.1.2",
-            "request": "2.85.0",
+            "request": "2.87.0",
             "sass-graph": "2.2.4",
             "stdout-stream": "1.4.0"
           },
@@ -24644,7 +24905,7 @@
           "version": "3.0.3",
           "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
           "requires": {
-            "@types/node": "10.0.8"
+            "@types/node": "10.1.2"
           }
         },
         "parsejson": {
@@ -24860,7 +25121,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           },
@@ -25356,11 +25617,11 @@
           "integrity": "sha1-8/zKCm/gZzanulcpZgaWF8EwtIE="
         },
         "proxy-addr": {
-          "version": "1.0.10",
-          "integrity": "sha1-DUCoL4Afw1VWfS7LZe/j8HfxIcU=",
+          "version": "2.0.3",
+          "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
           "requires": {
             "forwarded": "0.1.2",
-            "ipaddr.js": "1.0.5"
+            "ipaddr.js": "1.6.0"
           }
         },
         "prr": {
@@ -25398,8 +25659,8 @@
           }
         },
         "pumpify": {
-          "version": "1.5.0",
-          "integrity": "sha512-UWi0klDoq8xtVzlMRgENV9F7iCTZExaJQSQL187UXsxpk9NnrKGqTqqUNYAKGOzucSOxs2+jUnRNI+rLviPhJg==",
+          "version": "1.5.1",
+          "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
           "requires": {
             "duplexify": "3.6.0",
             "inherits": "2.0.3",
@@ -25502,8 +25763,8 @@
           }
         },
         "range-parser": {
-          "version": "1.0.3",
-          "integrity": "sha1-aHKCNTXGkuLCoBA4Jq/YLC4P8XU="
+          "version": "1.2.0",
+          "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
         },
         "raw-body": {
           "version": "2.2.0",
@@ -26068,7 +26329,7 @@
                 "html-encoding-sniffer": "1.0.2",
                 "nwmatcher": "1.4.4",
                 "parse5": "1.5.1",
-                "request": "2.85.0",
+                "request": "2.87.0",
                 "sax": "1.2.4",
                 "symbol-tree": "3.2.2",
                 "tough-cookie": "2.3.4",
@@ -26693,14 +26954,14 @@
           "integrity": "sha1-41VEoQ/NnJ47qWCDrBbHAjlPQAk="
         },
         "regenerate": {
-          "version": "1.3.3",
-          "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+          "version": "1.4.0",
+          "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
         },
         "regenerate-unicode-properties": {
-          "version": "5.1.3",
-          "integrity": "sha512-Yjy6t7jFQczDhYE+WVm7pg6gWYE258q4sUkk9qDErwXJIqx7jU9jGrMFHutJK/SRfcg7MEkXjGaYiVlOZyev/A==",
+          "version": "6.0.0",
+          "integrity": "sha512-BvXxRS7RfVWxtm7vrq+0I0j7sqZ1zeSC+yzf5HS0qLnKcZPX541gFEGB39LvGuKHrkyKXrzXug+oC7xkM1Zovw==",
           "requires": {
-            "regenerate": "1.3.3"
+            "regenerate": "1.4.0"
           }
         },
         "regenerator": {
@@ -26775,7 +27036,7 @@
           "requires": {
             "esprima": "2.7.3",
             "recast": "0.10.43",
-            "regenerate": "1.3.3",
+            "regenerate": "1.4.0",
             "regjsgen": "0.2.0",
             "regjsparser": "0.1.5"
           },
@@ -26826,13 +27087,13 @@
           }
         },
         "regexpu-core": {
-          "version": "4.1.3",
-          "integrity": "sha512-mB+njEzO7oezA57IbQxxd6fVPOeWKDmnGvJ485CwmfNchjHe5jWwqKepapmzUEj41yxIAqOg+C4LbXuJlkiO8A==",
+          "version": "4.1.5",
+          "integrity": "sha512-3xo5pFze1F8oR4F9x3aFbdtdxAxQ9WBX6gXfLgeBt7KpDI0+oDF7WVntnhsPKqobU/GAYc2pmx+y3z0JI1+z3w==",
           "requires": {
-            "regenerate": "1.3.3",
-            "regenerate-unicode-properties": "5.1.3",
-            "regjsgen": "0.3.0",
-            "regjsparser": "0.2.1",
+            "regenerate": "1.4.0",
+            "regenerate-unicode-properties": "6.0.0",
+            "regjsgen": "0.4.0",
+            "regjsparser": "0.3.0",
             "unicode-match-property-ecmascript": "1.0.3",
             "unicode-match-property-value-ecmascript": "1.0.1"
           }
@@ -26845,12 +27106,12 @@
           }
         },
         "regjsgen": {
-          "version": "0.3.0",
-          "integrity": "sha1-DuSj6SdkMM2iXx54nqbBW4ewy0M="
+          "version": "0.4.0",
+          "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA=="
         },
         "regjsparser": {
-          "version": "0.2.1",
-          "integrity": "sha1-w3h1U/rwTndcMCEC7zRtmVAA7Bw=",
+          "version": "0.3.0",
+          "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
           "requires": {
             "jsesc": "0.5.0"
           },
@@ -26918,8 +27179,8 @@
           "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
         },
         "request": {
-          "version": "2.85.0",
-          "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+          "version": "2.87.0",
+          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
           "requires": {
             "aws-sign2": "0.7.0",
             "aws4": "1.7.0",
@@ -26929,7 +27190,6 @@
             "forever-agent": "0.6.1",
             "form-data": "2.3.2",
             "har-validator": "5.0.3",
-            "hawk": "6.0.2",
             "http-signature": "1.2.0",
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
@@ -26939,7 +27199,6 @@
             "performance-now": "2.1.0",
             "qs": "6.5.1",
             "safe-buffer": "5.1.2",
-            "stringstream": "0.0.5",
             "tough-cookie": "2.3.4",
             "tunnel-agent": "0.6.0",
             "uuid": "3.2.1"
@@ -27191,7 +27450,7 @@
             "capture-exit": "1.2.0",
             "exec-sh": "0.2.1",
             "fb-watchman": "2.0.0",
-            "fsevents": "1.2.3",
+            "fsevents": "1.2.4",
             "micromatch": "3.1.10",
             "minimist": "1.2.0",
             "walker": "1.0.7",
@@ -27370,12 +27629,12 @@
               }
             },
             "fsevents": {
-              "version": "1.2.3",
-              "integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
+              "version": "1.2.4",
+              "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
               "optional": true,
               "requires": {
                 "nan": "2.10.0",
-                "node-pre-gyp": "0.9.1"
+                "node-pre-gyp": "0.10.0"
               },
               "dependencies": {
                 "abbrev": {
@@ -27444,8 +27703,8 @@
                   }
                 },
                 "deep-extend": {
-                  "version": "0.4.2",
-                  "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+                  "version": "0.5.1",
+                  "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
                   "optional": true
                 },
                 "delegates": {
@@ -27600,8 +27859,8 @@
                   }
                 },
                 "node-pre-gyp": {
-                  "version": "0.9.1",
-                  "integrity": "sha1-8RwHUW3ZL4cZnbx+GDjqt81WyeA=",
+                  "version": "0.10.0",
+                  "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
                   "optional": true,
                   "requires": {
                     "detect-libc": "1.0.3",
@@ -27610,7 +27869,7 @@
                     "nopt": "4.0.1",
                     "npm-packlist": "1.1.10",
                     "npmlog": "4.1.2",
-                    "rc": "1.2.6",
+                    "rc": "1.2.7",
                     "rimraf": "2.6.2",
                     "semver": "5.5.0",
                     "tar": "4.4.1"
@@ -27696,11 +27955,11 @@
                   "optional": true
                 },
                 "rc": {
-                  "version": "1.2.6",
-                  "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
+                  "version": "1.2.7",
+                  "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
                   "optional": true,
                   "requires": {
-                    "deep-extend": "0.4.2",
+                    "deep-extend": "0.5.1",
                     "ini": "1.3.5",
                     "minimist": "1.2.0",
                     "strip-json-comments": "2.0.1"
@@ -28006,7 +28265,7 @@
           "version": "0.2.3",
           "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
           "requires": {
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.4.4"
           },
           "dependencies": {
@@ -28039,38 +28298,38 @@
           }
         },
         "send": {
-          "version": "0.13.0",
-          "integrity": "sha1-UY+SGusFYK7H3KspkLFM9vPM5d4=",
+          "version": "0.16.2",
+          "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
           "requires": {
-            "debug": "2.2.0",
-            "depd": "1.0.1",
-            "destroy": "1.0.3",
-            "escape-html": "1.0.2",
-            "etag": "1.7.0",
-            "fresh": "0.3.0",
-            "http-errors": "1.3.1",
-            "mime": "1.3.4",
-            "ms": "0.7.1",
+            "debug": "2.6.9",
+            "depd": "1.1.2",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "1.6.3",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
             "on-finished": "2.3.0",
-            "range-parser": "1.0.3",
-            "statuses": "1.2.1"
+            "range-parser": "1.2.0",
+            "statuses": "1.4.0"
           },
           "dependencies": {
-            "depd": {
-              "version": "1.0.1",
-              "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo="
-            },
-            "http-errors": {
-              "version": "1.3.1",
-              "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
+            "debug": {
+              "version": "2.6.9",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "requires": {
-                "inherits": "2.0.1",
-                "statuses": "1.2.1"
+                "ms": "2.0.0"
               }
             },
+            "ms": {
+              "version": "2.0.0",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            },
             "statuses": {
-              "version": "1.2.1",
-              "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg="
+              "version": "1.4.0",
+              "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
             }
           }
         },
@@ -28086,52 +28345,13 @@
           "integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ=="
         },
         "serve-static": {
-          "version": "1.10.3",
-          "integrity": "sha1-zlpuzTEB/tXsCYJ9rCKpwpv7BTU=",
+          "version": "1.13.2",
+          "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
           "requires": {
+            "encodeurl": "1.0.2",
             "escape-html": "1.0.3",
             "parseurl": "1.3.2",
-            "send": "0.13.2"
-          },
-          "dependencies": {
-            "destroy": {
-              "version": "1.0.4",
-              "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-            },
-            "escape-html": {
-              "version": "1.0.3",
-              "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-            },
-            "http-errors": {
-              "version": "1.3.1",
-              "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-              "requires": {
-                "inherits": "2.0.1",
-                "statuses": "1.2.1"
-              }
-            },
-            "send": {
-              "version": "0.13.2",
-              "integrity": "sha1-dl52B8gFVFK7pvCwUllTUJhgNt4=",
-              "requires": {
-                "debug": "2.2.0",
-                "depd": "1.1.2",
-                "destroy": "1.0.4",
-                "escape-html": "1.0.3",
-                "etag": "1.7.0",
-                "fresh": "0.3.0",
-                "http-errors": "1.3.1",
-                "mime": "1.3.4",
-                "ms": "0.7.1",
-                "on-finished": "2.3.0",
-                "range-parser": "1.0.3",
-                "statuses": "1.2.1"
-              }
-            },
-            "statuses": {
-              "version": "1.2.1",
-              "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg="
-            }
+            "send": "0.16.2"
           }
         },
         "set-blocking": {
@@ -28364,13 +28584,6 @@
             "kind-of": "3.2.2"
           }
         },
-        "sntp": {
-          "version": "2.1.0",
-          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        },
         "social-logos": {
           "version": "2.0.0",
           "integrity": "sha1-5x71006P0BSpRaI+VdBu+k4Ctr0="
@@ -28513,8 +28726,8 @@
           "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
         },
         "sparkles": {
-          "version": "1.0.0",
-          "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
+          "version": "1.0.1",
+          "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw=="
         },
         "spawn-sync": {
           "version": "1.0.15",
@@ -28735,8 +28948,8 @@
           "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4="
         },
         "string-kit": {
-          "version": "0.6.17",
-          "integrity": "sha512-c1r25H8wmVY0sQbQp/40E2B/Gz05z15MfUlR9NsAyerhBHVGhnj50R1KKn19fkYSpJbfllgpRmeunhsMFjlKPg==",
+          "version": "0.6.18",
+          "integrity": "sha512-G/nR5FBUcVkFagf0ckMPCnV8UIlldTa60LaYPR4bZ6MtAj6o03cQcJK9TqoU13dOy52Sjt/XqY+bO7iJcJ+chw==",
           "requires": {
             "xregexp": "4.1.1"
           }
@@ -28798,10 +29011,6 @@
         "stringset": {
           "version": "0.2.1",
           "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU="
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -28869,8 +29078,8 @@
               "version": "1.7.7",
               "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
               "requires": {
-                "caniuse-db": "1.0.30000839",
-                "electron-to-chromium": "1.3.45"
+                "caniuse-db": "1.0.30000844",
+                "electron-to-chromium": "1.3.47"
               }
             },
             "chalk": {
@@ -29093,7 +29302,7 @@
             "form-data": "1.0.0-rc4",
             "formidable": "1.2.1",
             "methods": "1.1.2",
-            "mime": "1.3.4",
+            "mime": "1.4.1",
             "qs": "6.5.1",
             "readable-stream": "2.3.6"
           },
@@ -29247,12 +29456,12 @@
           "version": "1.13.13",
           "integrity": "sha512-6A8b5OJd9oMLvbfPIaRr4F+FBnuH4/sQQPlVCnhbuQ+EwAyUbFB9Z+KTuivtmbWOUErXIYtlQ8t36+YBz5T2vA==",
           "requires": {
-            "async-kit": "2.2.3",
+            "async-kit": "2.2.4",
             "get-pixels": "3.3.0",
             "ndarray": "1.0.18",
             "nextgen-events": "0.10.2",
-            "string-kit": "0.6.17",
-            "tree-kit": "0.5.26"
+            "string-kit": "0.6.18",
+            "tree-kit": "0.5.27"
           }
         },
         "test-exclude": {
@@ -29517,17 +29726,21 @@
           "version": "1.1.5",
           "integrity": "sha512-BklxWyBW9EsRC6neZPuwwV6L1iRkGwe8sFWUcI1g+3DS3JajW/zJKo2t6j2a72bXngv9a4xyDHpn1EpXM9VWDw==",
           "requires": {
-            "async": "2.6.0",
+            "async": "2.6.1",
             "loader-runner": "2.3.0",
             "loader-utils": "1.1.0"
           },
           "dependencies": {
             "async": {
-              "version": "2.6.0",
-              "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+              "version": "2.6.1",
+              "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
               "requires": {
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
               }
+            },
+            "lodash": {
+              "version": "4.17.10",
+              "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
             }
           }
         },
@@ -29704,8 +29917,8 @@
           "integrity": "sha1-moxDxIonW9stVaRa1B0KJI8xit8="
         },
         "tree-kit": {
-          "version": "0.5.26",
-          "integrity": "sha1-hXHIb6JNHbdU5bDLOn4J9B50qN8="
+          "version": "0.5.27",
+          "integrity": "sha512-0AtAzYDYaKSzeEPK3SI72lg/io5jrBxnT1gIRxEQasJycpQf5iXGh6YAl1kkh9wHmLlNRhDx0oj+GZEQHVe+cw=="
         },
         "trim": {
           "version": "0.0.1",
@@ -30107,8 +30320,8 @@
           }
         },
         "upath": {
-          "version": "1.0.5",
-          "integrity": "sha512-qbKn90aDQ0YEwvXoLqj0oiuUYroLX2lVHZ+b+xwjozFasAOC4GneDq5+OaIG5Zj+jFmbz/uO+f7a9qxjktJQww=="
+          "version": "1.1.0",
+          "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw=="
         },
         "update-notifier": {
           "version": "0.3.2",
@@ -30240,8 +30453,8 @@
           }
         },
         "utils-merge": {
-          "version": "1.0.0",
-          "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+          "version": "1.0.1",
+          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
         },
         "uuid": {
           "version": "3.2.1",
@@ -30264,8 +30477,8 @@
           }
         },
         "vary": {
-          "version": "1.0.1",
-          "integrity": "sha1-meSYFWaihhGN+yuBc1ffeZM3bRA="
+          "version": "1.1.2",
+          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
         },
         "verror": {
           "version": "1.10.0",
@@ -30860,8 +31073,8 @@
               "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
             },
             "colors": {
-              "version": "1.2.5",
-              "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg=="
+              "version": "1.3.0",
+              "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
             },
             "esprima": {
               "version": "4.0.0",
@@ -30877,7 +31090,7 @@
                 "babel-preset-stage-1": "6.24.1",
                 "babel-register": "6.26.0",
                 "babylon": "6.18.0",
-                "colors": "1.2.5",
+                "colors": "1.3.0",
                 "flow-parser": "0.72.0",
                 "lodash": "4.17.5",
                 "micromatch": "2.3.11",
@@ -30923,34 +31136,6 @@
             "ws": "4.1.0"
           },
           "dependencies": {
-            "accepts": {
-              "version": "1.3.5",
-              "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-              "requires": {
-                "mime-types": "2.1.18",
-                "negotiator": "0.6.1"
-              }
-            },
-            "body-parser": {
-              "version": "1.18.2",
-              "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
-              "requires": {
-                "bytes": "3.0.0",
-                "content-type": "1.0.4",
-                "debug": "2.6.9",
-                "depd": "1.1.2",
-                "http-errors": "1.6.3",
-                "iconv-lite": "0.4.19",
-                "on-finished": "2.3.0",
-                "qs": "6.5.1",
-                "raw-body": "2.3.2",
-                "type-is": "1.6.16"
-              }
-            },
-            "bytes": {
-              "version": "3.0.0",
-              "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
-            },
             "chalk": {
               "version": "2.4.1",
               "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
@@ -30964,219 +31149,20 @@
               "version": "2.15.1",
               "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
             },
-            "content-disposition": {
-              "version": "0.5.2",
-              "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
-            },
-            "cookie": {
-              "version": "0.3.1",
-              "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-            },
-            "cookie-signature": {
-              "version": "1.0.6",
-              "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-            },
-            "debug": {
-              "version": "2.6.9",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "destroy": {
-              "version": "1.0.4",
-              "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-            },
-            "escape-html": {
-              "version": "1.0.3",
-              "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-            },
             "escape-string-regexp": {
               "version": "1.0.5",
               "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
             },
-            "etag": {
-              "version": "1.8.1",
-              "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-            },
-            "express": {
-              "version": "4.16.3",
-              "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
-              "requires": {
-                "accepts": "1.3.5",
-                "array-flatten": "1.1.1",
-                "body-parser": "1.18.2",
-                "content-disposition": "0.5.2",
-                "content-type": "1.0.4",
-                "cookie": "0.3.1",
-                "cookie-signature": "1.0.6",
-                "debug": "2.6.9",
-                "depd": "1.1.2",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
-                "finalhandler": "1.1.1",
-                "fresh": "0.5.2",
-                "merge-descriptors": "1.0.1",
-                "methods": "1.1.2",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.2",
-                "path-to-regexp": "0.1.7",
-                "proxy-addr": "2.0.3",
-                "qs": "6.5.1",
-                "range-parser": "1.2.0",
-                "safe-buffer": "5.1.1",
-                "send": "0.16.2",
-                "serve-static": "1.13.2",
-                "setprototypeof": "1.1.0",
-                "statuses": "1.4.0",
-                "type-is": "1.6.16",
-                "utils-merge": "1.0.1",
-                "vary": "1.1.2"
-              }
-            },
             "filesize": {
               "version": "3.6.1",
               "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
-            },
-            "finalhandler": {
-              "version": "1.1.1",
-              "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
-              "requires": {
-                "debug": "2.6.9",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.2",
-                "statuses": "1.4.0",
-                "unpipe": "1.0.0"
-              }
-            },
-            "fresh": {
-              "version": "0.5.2",
-              "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-            },
-            "iconv-lite": {
-              "version": "0.4.19",
-              "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-            },
-            "ipaddr.js": {
-              "version": "1.6.0",
-              "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
-            },
-            "merge-descriptors": {
-              "version": "1.0.1",
-              "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-            },
-            "mime": {
-              "version": "1.4.1",
-              "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
-            },
-            "ms": {
-              "version": "2.0.0",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            },
-            "negotiator": {
-              "version": "0.6.1",
-              "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
-            },
-            "proxy-addr": {
-              "version": "2.0.3",
-              "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
-              "requires": {
-                "forwarded": "0.1.2",
-                "ipaddr.js": "1.6.0"
-              }
-            },
-            "range-parser": {
-              "version": "1.2.0",
-              "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
-            },
-            "raw-body": {
-              "version": "2.3.2",
-              "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-              "requires": {
-                "bytes": "3.0.0",
-                "http-errors": "1.6.2",
-                "iconv-lite": "0.4.19",
-                "unpipe": "1.0.0"
-              },
-              "dependencies": {
-                "depd": {
-                  "version": "1.1.1",
-                  "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
-                },
-                "http-errors": {
-                  "version": "1.6.2",
-                  "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-                  "requires": {
-                    "depd": "1.1.1",
-                    "inherits": "2.0.3",
-                    "setprototypeof": "1.0.3",
-                    "statuses": "1.4.0"
-                  }
-                },
-                "setprototypeof": {
-                  "version": "1.0.3",
-                  "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
-                }
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-            },
-            "send": {
-              "version": "0.16.2",
-              "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-              "requires": {
-                "debug": "2.6.9",
-                "depd": "1.1.2",
-                "destroy": "1.0.4",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
-                "fresh": "0.5.2",
-                "http-errors": "1.6.3",
-                "mime": "1.4.1",
-                "ms": "2.0.0",
-                "on-finished": "2.3.0",
-                "range-parser": "1.2.0",
-                "statuses": "1.4.0"
-              }
-            },
-            "serve-static": {
-              "version": "1.13.2",
-              "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-              "requires": {
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "parseurl": "1.3.2",
-                "send": "0.16.2"
-              }
-            },
-            "statuses": {
-              "version": "1.4.0",
-              "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
-            },
-            "utils-merge": {
-              "version": "1.0.1",
-              "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-            },
-            "vary": {
-              "version": "1.1.2",
-              "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
             },
             "ws": {
               "version": "4.1.0",
               "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
               "requires": {
                 "async-limiter": "1.0.0",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -31213,7 +31199,7 @@
             "webpack-addons": "1.1.5",
             "webpack-fork-yeoman-generator": "1.1.1",
             "yargs": "9.0.1",
-            "yeoman-environment": "2.0.6"
+            "yeoman-environment": "2.1.1"
           },
           "dependencies": {
             "ansi-regex": {
@@ -31275,8 +31261,8 @@
               }
             },
             "colors": {
-              "version": "1.2.5",
-              "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg=="
+              "version": "1.3.0",
+              "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
             },
             "enhanced-resolve": {
               "version": "3.4.1",
@@ -31306,7 +31292,7 @@
                 "babel-preset-stage-1": "6.24.1",
                 "babel-register": "6.26.0",
                 "babylon": "6.18.0",
-                "colors": "1.2.5",
+                "colors": "1.3.0",
                 "flow-parser": "0.72.0",
                 "lodash": "4.17.5",
                 "micromatch": "2.3.11",
@@ -31483,7 +31469,7 @@
             "memory-fs": "0.4.1",
             "mime": "2.3.1",
             "path-is-absolute": "1.0.1",
-            "range-parser": "1.0.3",
+            "range-parser": "1.2.0",
             "url-join": "4.0.0",
             "webpack-log": "1.2.0"
           },
@@ -31498,7 +31484,7 @@
           "version": "1.1.1",
           "integrity": "sha512-TrLT6Bw6gl9rJA7iZw+YJ+4xHhEUzfOQB3tHpyINBFdZDmO0tlDW9MtMSMZ5rsUNjHxcEba5yuGaAW86J84j/w==",
           "requires": {
-            "async": "2.6.0",
+            "async": "2.6.1",
             "chalk": "1.0.0",
             "cli-table": "0.3.1",
             "cross-spawn": "5.1.0",
@@ -31530,10 +31516,16 @@
               "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
             },
             "async": {
-              "version": "2.6.0",
-              "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+              "version": "2.6.1",
+              "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
               "requires": {
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
+              },
+              "dependencies": {
+                "lodash": {
+                  "version": "4.17.10",
+                  "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+                }
               }
             },
             "cli-cursor": {
@@ -32068,24 +32060,30 @@
           "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
         },
         "yeoman-environment": {
-          "version": "2.0.6",
-          "integrity": "sha512-jzHBTTy8EPI4ImV8dpUMt+Q5zELkSU5xvGpndHcHudQ4tqN6YgIWaCGmRFl+HDchwRUkcgyjQ+n6/w5zlJBCPg==",
+          "version": "2.1.1",
+          "integrity": "sha512-IBLwCUrJrDxBYuwdYm1wuF3O/CR2LpXR0rFS684QOrU6x69DPPrsdd20dZOFaedZ/M9sON7po73WhO3I1CbgNQ==",
           "requires": {
             "chalk": "2.4.1",
+            "cross-spawn": "6.0.5",
             "debug": "3.1.0",
             "diff": "3.4.0",
             "escape-string-regexp": "1.0.3",
-            "globby": "6.1.0",
+            "globby": "8.0.1",
             "grouped-queue": "0.3.3",
-            "inquirer": "3.3.0",
+            "inquirer": "5.2.0",
             "is-scoped": "1.0.0",
-            "lodash": "4.17.5",
+            "lodash": "4.17.10",
             "log-symbols": "2.1.0",
             "mem-fs": "1.1.3",
+            "strip-ansi": "4.0.0",
             "text-table": "0.2.0",
-            "untildify": "3.0.2"
+            "untildify": "3.0.3"
           },
           "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+            },
             "chalk": {
               "version": "2.4.1",
               "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
@@ -32101,6 +32099,17 @@
                 }
               }
             },
+            "cross-spawn": {
+              "version": "6.0.5",
+              "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+              "requires": {
+                "nice-try": "1.0.4",
+                "path-key": "2.0.1",
+                "semver": "5.5.0",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
+              }
+            },
             "debug": {
               "version": "3.1.0",
               "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
@@ -32108,13 +32117,92 @@
                 "ms": "2.0.0"
               }
             },
+            "glob": {
+              "version": "7.1.2",
+              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+              "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.1",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
+            },
+            "globby": {
+              "version": "8.0.1",
+              "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+              "requires": {
+                "array-union": "1.0.2",
+                "dir-glob": "2.0.0",
+                "fast-glob": "2.2.2",
+                "glob": "7.1.2",
+                "ignore": "3.3.8",
+                "pify": "3.0.0",
+                "slash": "1.0.0"
+              }
+            },
+            "ignore": {
+              "version": "3.3.8",
+              "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg=="
+            },
+            "inquirer": {
+              "version": "5.2.0",
+              "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+              "requires": {
+                "ansi-escapes": "3.1.0",
+                "chalk": "2.4.1",
+                "cli-cursor": "2.1.0",
+                "cli-width": "2.2.0",
+                "external-editor": "2.2.0",
+                "figures": "2.0.0",
+                "lodash": "4.17.10",
+                "mute-stream": "0.0.7",
+                "run-async": "2.3.0",
+                "rxjs": "5.5.10",
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "through": "2.3.8"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+            },
+            "lodash": {
+              "version": "4.17.10",
+              "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+            },
             "ms": {
               "version": "2.0.0",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             },
+            "pify": {
+              "version": "3.0.0",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+            },
+            "semver": {
+              "version": "5.5.0",
+              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            },
             "untildify": {
-              "version": "3.0.2",
-              "integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E="
+              "version": "3.0.3",
+              "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -105,6 +105,6 @@
     "redux-thunk": "^2.2.0",
     "reselect": "^2.5.4",
     "whatwg-fetch": "^2.0.2",
-    "wp-calypso": "github:automattic/wp-calypso#2ad41412b9488bb154145ac6fc4c2876b98c5317"
+    "wp-calypso": "github:automattic/wp-calypso#14c09cc79ca71e53eca5f0cce3e2c58682ac3384"
   }
 }


### PR DESCRIPTION
Updates the Calypso dependency to the latest commit to bring back https://github.com/Automattic/wp-calypso/pull/25018 (display anonymized labels)

I checked the git logs on Calypso and it looks like there were no new standalone features or fixes since we released 1.13.0

To test:
* check that the JS admin areas work