### PR TITLE
Respond with real HTTP errors when the shipping settings can't be validated

### DIFF
--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -447,22 +447,12 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			if ( ! empty( $instance ) ) {
 				$service_schema = $this->service_schemas_store->get_service_schema_by_instance_id( $instance );
 				if ( ! $service_schema ) {
-					wp_send_json_error(
-						array(
-							'error' => 'bad_instance_id',
-							'message' => __( 'An invalid service instance was received.', 'woocommerce-services' )
-						)
-					);
+					return new WP_Error( 'bad_instance_id', __( 'An invalid service instance was received.', 'woocommerce-services' ) );
 				}
 			} else {
 				$service_schema = $this->service_schemas_store->get_service_schema_by_method_id( $id );
 				if ( ! $service_schema ) {
-					wp_send_json_error(
-						array(
-							'error' => 'bad_service_id',
-							'message' => __( 'An invalid service ID was received.', 'woocommerce-services' )
-						)
-					);
+					return new WP_Error( 'bad_service_id', __( 'An invalid service ID was received.', 'woocommerce-services' ) );
 				}
 			}
 
@@ -471,13 +461,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 
 			if ( is_wp_error( $response_body ) ) {
 				// TODO - handle multiple error messages when the validation endpoint can return them
-				wp_send_json_error(
-					array(
-						'error'   => 'validation_failure',
-					 	'message' => $response_body->get_error_message(),
-						'data'    => $response_body->get_error_data(),
-					)
-				);
+				return $response_body;
 			}
 
 			// On success, save the settings to the database and exit

--- a/classes/class-wc-rest-connect-services-controller.php
+++ b/classes/class-wc-rest-connect-services-controller.php
@@ -82,10 +82,7 @@ class WC_REST_Connect_Services_Controller extends WC_REST_Connect_Base_Controlle
 					__( 'Unable to update service settings. Validation failed. %s', 'woocommerce-services' ),
 					$validation_result->get_error_message()
 				),
-				array_merge(
-					array( 'status' => 400 ),
-					$validation_result->get_error_data()
-				)
+				array( 'status' => 400 )
 			);
 			$this->logger->log( $error, __CLASS__ );
 			return $error;


### PR DESCRIPTION
There's more context in https://github.com/Automattic/wp-calypso/pull/25101

We had an error in which service schema validation would fail in the server if the adjustment fields were touched in any way. The error has been fixed (something something `coerceValues`), but I dug deeper on "Why doesn't this fail in Calypso"?

In Calypso, a validation failure in the plugin side will happily show a "success" notice, but the shipping method won't be updated at all. That's because the Calypso HTTP layer logic checks for non-200 HTTP responses to trigger the error notice, and the plugin responds with a `HTTP 200` response with `{ success: false }` in the body.

This PR changes the plugin logic so it responds with a real HTTP error. All our other REST endpoints already return a `WP_Error` on failure, this one was the only one that used the `{ success: false }` trick.

To test:
- With this branch of the plugin installed on your site, go to Calypso (can be `wordpress.com` or a local install).
- Go to the Shipping settings, and add or edit a USPS shipping method.
- Before saving, stop your local Hydra server (or make the `WOOCOMMERCE_CONNECT_SERVER_URL` constant to point to a non-existing server).
- Save the changes in Calypso.
- Check that you get an error notice. Before, it would just fail silently and display a Success notice.