### PR TITLE
Don't show "add method to zone" pointer if shipping was opted into

### DIFF
--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -113,6 +113,23 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			return array();
 		}
 
+		/**
+		 * Dismiss a WP pointer for the current user.
+		 *
+		 * @param string $pointer_to_dismiss Pointer ID to dismiss for the current user
+		 */
+		public function dismiss_pointer( $pointer_to_dismiss ) {
+			$dismissed_pointers = $this->get_dismissed_pointers();
+
+			if ( in_array( $pointer_to_dismiss, $dismissed_pointers, true ) ) {
+				return;
+			}
+
+			$dismissed_pointers[] = $pointer_to_dismiss;
+			$dismissed_data = implode( ',', $dismissed_pointers );
+			update_user_meta( get_current_user_id(), 'dismissed_wp_pointers', $dismissed_data );
+		}
+
 		public function register_add_service_to_zone_pointer( $pointers ) {
 			$pointers[] = array(
 				'id' => 'wc_services_add_service_to_zone',
@@ -149,9 +166,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 
 			// If the user is not new to labels, we should just dismiss this pointer
 			if ( ! $this->is_new_labels_user() ) {
-				$dismissed_pointers[] = 'wc_services_labels_metabox';
-				$dismissed_data = implode( ',', $dismissed_pointers );
-				update_user_meta( get_current_user_id(), 'dismissed_wp_pointers', $dismissed_data );
+				$this->dismiss_pointer( 'wc_services_labels_metabox' );
 				return $pointers;
 			}
 

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -159,11 +159,6 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		}
 
 		public function register_order_page_labels_pointer( $pointers ) {
-			$dismissed_pointers = $this->get_dismissed_pointers();
-			if ( in_array( 'wc_services_labels_metabox', $dismissed_pointers, true ) ) {
-				return $pointers;
-			}
-
 			// If the user is not new to labels, we should just dismiss this pointer
 			if ( ! $this->is_new_labels_user() ) {
 				$this->dismiss_pointer( 'wc_services_labels_metabox' );

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -483,6 +483,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$instance_id = $zone->add_shipping_method( $method->method_id );
 			$zone->save();
 
+			// Dismiss the "add a method to zone" pointer
+			$this->nux->dismiss_pointer( 'wc_services_add_service_to_zone' );
+
 			$instance = WC_Shipping_Zones::get_shipping_method( $instance_id );
 			if ( empty( $instance ) ) {
 				return;


### PR DESCRIPTION
Fixes #1334.

Don’t show the shipping method NUX pointer if shipping was opted into in the core Setup Wizard.

To test:
* Set up a new WooCommerce store using the OBW
* Opt in to either domestic or international live rates
* Connect Jetpack
* Verify that the "add a WCS method" pointer *does not* show on the Shipping settings page