### PR TITLE
Refresh service schemas when specific WooCommerce settings are updated

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -663,11 +663,15 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				}
 			}
 
-			add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
+			// Changing the postcode, currency, weight or dimension units affect the returned schema from the server.
+			// Make sure to update the service schemas when these options change.
+			// TODO: Add other options that change the schema here, or figure out a way to do it automatically.
 			add_action( 'update_option_woocommerce_store_postcode',  array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
 			add_action( 'update_option_woocommerce_currency', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
 			add_action( 'update_option_woocommerce_weight_unit', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
 			add_action( 'update_option_woocommerce_dimension_unit', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
+
+			add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
 			add_action( 'wc_connect_fetch_service_schemas', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
 			add_filter( 'woocommerce_hidden_order_itemmeta', array( $this, 'hide_wc_connect_package_meta_data' ) );
 			add_filter( 'is_protected_meta', array( $this, 'hide_wc_connect_order_meta_data' ), 10, 3 );

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -664,7 +664,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 
 			add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
-			add_action( 'woocommerce_settings_saved', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
+			add_action( 'update_option_woocommerce_store_postcode',  array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
+			add_action( 'update_option_woocommerce_currency', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
+			add_action( 'update_option_woocommerce_weight_unit', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
+			add_action( 'update_option_woocommerce_dimension_unit', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
 			add_action( 'wc_connect_fetch_service_schemas', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
 			add_filter( 'woocommerce_hidden_order_itemmeta', array( $this, 'hide_wc_connect_package_meta_data' ) );
 			add_filter( 'is_protected_meta', array( $this, 'hide_wc_connect_order_meta_data' ), 10, 3 );

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -666,10 +666,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			// Changing the postcode, currency, weight or dimension units affect the returned schema from the server.
 			// Make sure to update the service schemas when these options change.
 			// TODO: Add other options that change the schema here, or figure out a way to do it automatically.
-			add_action( 'update_option_woocommerce_store_postcode',  array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
-			add_action( 'update_option_woocommerce_currency', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
-			add_action( 'update_option_woocommerce_weight_unit', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
-			add_action( 'update_option_woocommerce_dimension_unit', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
+			add_action( 'update_option_woocommerce_store_postcode',  array( $this, 'queue_service_schema_refresh' ) );
+			add_action( 'update_option_woocommerce_currency', array( $this, 'queue_service_schema_refresh' ) );
+			add_action( 'update_option_woocommerce_weight_unit', array( $this, 'queue_service_schema_refresh' ) );
+			add_action( 'update_option_woocommerce_dimension_unit', array( $this, 'queue_service_schema_refresh' ) );
 
 			add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
 			add_action( 'wc_connect_fetch_service_schemas', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
@@ -692,6 +692,19 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			$this->taxjar->init();
 			$this->paypal_ec->init();
+		}
+
+		/**
+		 * Queue up a service schema refresh (on shutdown) if there isn't one already.
+		 */
+		public function queue_service_schema_refresh() {
+			$schemas_store = $this->get_service_schemas_store();
+
+			if ( has_action( 'shutdown', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) ) ) {
+				return;
+			}
+
+			add_action( 'shutdown', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
 		}
 
 		public function tos_rest_init() {


### PR DESCRIPTION
Fixes #1273.

Refresh service schemas when the following options are updated: store post code, currency, weight unit, and dimension unit.

**To Test:**

- Load this branch
- Enable logging
- Make sure your frequent fetch flag is NOT enabled
- Change any one of the mentioned settings via `wp-admin`
- Observe that a fetch_service_schemas_from_connect_server event is logged in the logs
- Change any one of the mentioned settings via the REST API
- Observe that a fetch_service_schemas_from_connect_server event is logged in the logs