### PR TITLE
Order fulfillment options when purchasing label

### DIFF
--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -52,16 +52,15 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		public function get_account_settings() {
 			$default = array(
 				'selected_payment_method_id' => 0,
-				'enabled' => true,
+				'enabled'                    => true,
+				'email_receipts'             => true,
+				'mark_orders_complete'       => true,
+				'email_tracking_info'        => true,
 			);
 
 			$result = WC_Connect_Options::get_option( 'account_settings', $default );
 			$result['paper_size'] = $this->get_preferred_paper_size();
 			$result = array_merge( $default, $result );
-
-			if ( ! isset( $result['email_receipts'] ) ) {
-				$result['email_receipts'] = true;
-			}
 
 			return $result;
 		}

--- a/client/apps/shipping-label/style.scss
+++ b/client/apps/shipping-label/style.scss
@@ -32,11 +32,6 @@
 	font-size: 15px;
 }
 
-.label-purchase-modal__option-email-customer,
-.label-purchase-modal__option-mark-order-fulfilled {
-	display: none;
-}
-
 .order-activity-log {
 	.foldable-card .foldable-card__content {
 		padding-left: 0;

--- a/client/apps/shipping-label/view-wrapper.js
+++ b/client/apps/shipping-label/view-wrapper.js
@@ -151,12 +151,6 @@ class ShippingLabelViewWrapper extends Component {
 			siteId,
 		} = this.props;
 
-		// We don't support automatically emailing the customer
-		// or marking the order as fulfilled
-		// once the order is fulfilled
-		this.props.setEmailDetailsOption( orderId, siteId, false );
-		this.props.setFulfillOrderOption( orderId, siteId, false );
-
 		this.props.openPrintingFlow( orderId, siteId );
 	};
 


### PR DESCRIPTION
Fixes #1274.

This PR shows the "mark order fulfilled" and "email details to customer" checkboxes on the label modal:

![screen shot 2018-06-08 at 4 35 09 pm](https://user-images.githubusercontent.com/63922/41183938-718aa632-6b3a-11e8-8cba-93c07a36dae9.png)
 
It also adds the backend provisions for store-wide defaults for these - view in Calypso:

![screen shot 2018-06-08 at 3 55 50 pm](https://user-images.githubusercontent.com/63922/41183954-8611e2c8-6b3a-11e8-82a6-5ac1152db885.png)

_Note: Without landing the Calypso PR and updating the dependency here, the "email details" checkbox is effectively inert._

**To test:**
- Check out https://github.com/Automattic/wp-calypso/pull/25400 and `npm link` it
- Verify that checkboxes on the order screen default to the values set store-wide
- Verify that the "mark order fulfilled" checkbox changes the order from "processing" to "complete" when purchasing a label
- Verify that the "email details" checkbox is hidden when "mark fulfilled" is unchecked
- Verify that tracking info is in "completed order" email and no customer note is created when "email details" is checked
- Verify that transitioning an order to "complete" outside of the labels flow sends tracking info if the order has labels and the store-wide setting for "email details" is checked