### PR TITLE
Save defaults when adding new WCS shipping method

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -473,6 +473,13 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			return $defaults;
 		}
 
+		public function save_defaults_to_shipping_method( $instance_id, $service_id, $zone_id ) {
+			$shipping_method = WC_Shipping_Zones::get_shipping_method( $instance_id );
+			$schema   = $shipping_method->get_service_schema();
+			$defaults = (object) $this->get_service_schema_defaults( $schema->service_settings );
+			WC_Connect_Options::update_shipping_method_option( 'form_settings', $defaults, $service_id, $instance_id );
+		}
+
 		protected function add_method_to_shipping_zone( $zone_id, $method_id ) {
 			$method = $this->get_service_schemas_store()->get_service_schema_by_id( $method_id );
 			if ( empty( $method ) ) {
@@ -485,15 +492,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			// Dismiss the "add a method to zone" pointer
 			$this->nux->dismiss_pointer( 'wc_services_add_service_to_zone' );
-
-			$instance = WC_Shipping_Zones::get_shipping_method( $instance_id );
-			if ( empty( $instance ) ) {
-				return;
-			}
-
-			$schema   = $instance->get_service_schema();
-			$defaults = (object) $this->get_service_schema_defaults( $schema->service_settings );
-			WC_Connect_Options::update_shipping_method_option( 'form_settings', $defaults, $method->method_id, $instance_id );
 		}
 
 		public function init_core_wizard_shipping_config() {
@@ -655,6 +653,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				add_action( 'wc_connect_service_init', array( $this, 'init_service' ), 10, 2 );
 				add_action( 'wc_connect_service_admin_options', array( $this, 'localize_and_enqueue_service_script' ), 10, 2 );
 				add_action( 'woocommerce_shipping_zone_method_added', array( $this, 'shipping_zone_method_added' ), 10, 3 );
+				add_action( 'wc_connect_shipping_zone_method_added', array( $this, 'save_defaults_to_shipping_method' ), 10, 3 );
 				add_action( 'woocommerce_shipping_zone_method_deleted', array( $this, 'shipping_zone_method_deleted' ), 10, 3 );
 				add_action( 'woocommerce_shipping_zone_method_status_toggled', array( $this, 'shipping_zone_method_status_toggled' ), 10, 4 );
 


### PR DESCRIPTION
Fixes #966 

This PR saves the default settings of a shipping method when it's added to a zone, using the `wc_connect_shipping_zone_method_added` hook.

Note that the settings for FedEx are not yet complete, so they'll cause an error.

This also works on Calypso because a zone shipping method is created, and then it's updated with the valous provided by the user, so there's no possibility of a race condition (can see some of the code in [`getSaveZoneActionListSteps`](https://github.com/Automattic/wp-calypso/blob/39a6bcd9cac5aa2e9d8b7b875cc999e52a4126b7/client/extensions/woocommerce/state/data-layer/ui/shipping-zones/index.js#L370)).

**Question for design:**
Should we save the default settings without prompting the user to review them?

## Steps to test:
1. start with no zones, and no shipping methods
2. see that no rates are available on cart
3. add live rates shipping methods in the OBW at `wp-admin/index.php?page=wc-setup&step=shipping`
4. go to the cart and see that there are rates returned for domenstic US addresses and international addresses
5. see also that the shipping methods were added in the options table: e.g. `woocommerce_wc_services_usps_#_form_settings`
6. add another USPS shipping method, see that it was added in the DB and is being used on the cart page
7. see the same steps work with a store in Canada

![add-a-shipping-method](https://user-images.githubusercontent.com/11487924/41207678-e31edf1c-6ce7-11e8-8600-a54d27bcd8f3.gif)