### PR TITLE
Fixes the "Save changes" button on USPS/Canada settings staying in "busy" state after failing validation

### DIFF
--- a/client/apps/settings/view-wrapper.js
+++ b/client/apps/settings/view-wrapper.js
@@ -48,10 +48,12 @@ class ViewWrapper extends Component {
 		};
 		const failureAction = ( dispatch, getState, { error } ) => {
 			this.setState( { isSaving: false } );
-			dispatch( errorNotice( isString( error )
-				? error
-				: translate( 'There was a problem with one or more entries. Please fix the errors below and try saving again.' )
-			) );
+			if ( error ) {
+				dispatch( errorNotice( isString( error )
+					? error
+					: translate( 'There was a problem with one or more entries. Please fix the errors below and try saving again.' )
+				) );
+			}
 		};
 
 		this.setState( { isSaving: true } );
@@ -116,6 +118,7 @@ const saveChanges = ( successAction, failureAction ) => ( dispatch, getState ) =
 	// Trigger a full validation
 	dispatch( closeShippingZoneMethod( siteId ) );
 	if ( getCurrentlyOpenShippingZoneMethod( getState() ) ) {
+		dispatch( failureAction );
 		return;
 	}
 	dispatch( openShippingZoneMethod( siteId, method.id ) );

--- a/client/apps/settings/view-wrapper.js
+++ b/client/apps/settings/view-wrapper.js
@@ -115,12 +115,14 @@ const saveChanges = ( successAction, failureAction ) => ( dispatch, getState ) =
 	const siteId = getSelectedSiteId( getState() );
 	const method = getCurrentlyOpenShippingZoneMethod( getState() );
 
-	// Trigger a full validation
+	// Close the shipping method to trigger a full validation
 	dispatch( closeShippingZoneMethod( siteId ) );
 	if ( getCurrentlyOpenShippingZoneMethod( getState() ) ) {
+		// If there's still a shipping method marked as "opened", it means that the full validation triggered by closing it failed
 		dispatch( failureAction );
 		return;
 	}
+	// Open the shipping method again in case the user wants to keep editing it
 	dispatch( openShippingZoneMethod( siteId, method.id ) );
 
 	dispatch(


### PR DESCRIPTION
If there are invalid fields when you open the USPS/Canada settings form, but you haven't interacted with those fields, then they won't show any error until you click "Save changes". Clicking that button will trigger a full validation and show an error notice if it fails (the logic of that is in `wp-calypso`, including the error notice). Since all that logic is in `wp-calypso`, the `<ViewWrapper>` component's state wasn't being updated, so it would keep showing the `busy` animation forever.

To reproduce:
* Get to the service settings page having some fields be incorrect. The easiest way is to change the Store base address to have an invalid ZIP code, and then add a new shipping method (it will take that bogus ZIP code as default).
* Interact with any other field (such as the title, or services list).
* Click the `Save changes` button.
* In `master`, you'll see the error notice but the button will keep being "busy". With this change, it will become disabled but it will be clickable again once you fix the errors.