### PR TITLE
Update Calypso to cc49f0a

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -34,9 +34,9 @@
       }
     },
     "@types/node": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.4.tgz",
-      "integrity": "sha512-YMLlzdeNnAyLrQew39IFRkMacAR5BqKGIEei9ZjdHsIZtv+ZWKYTu1i7QJhetxQ9ReXx8w5f+cixdHZG3zgMQA==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.5.tgz",
+      "integrity": "sha512-6lRwZN0Y3TuglwaaZN2XPocobmzLlhxcqDjKFjNYSsXG/TFAGYkCqkzZh4+ms8iTHHQE6gJXLHPV7TziVGeWhg==",
       "dev": true
     },
     "abab": {
@@ -1972,15 +1972,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000856",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000856.tgz",
-      "integrity": "sha1-++u5mr4VpWVPx3R+u1MVvf3jNY8=",
+      "version": "1.0.30000858",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000858.tgz",
+      "integrity": "sha1-FTyTSDUGQdxiTRUOwXQmLCrZheU=",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000856",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000856.tgz",
-      "integrity": "sha512-x3mYcApHMQemyaHuH/RyqtKCGIYTgEA63fdi+VBvDz8xUSmRiVWTLeyKcoGQCGG6UPR9/+4qG4OKrTa6aSQRKg=="
+      "version": "1.0.30000858",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000858.tgz",
+      "integrity": "sha512-oJRGfVfwHr0VKcoy2UqIoRmQcDOugnNAQsWYI3/JTzExrlzxSKtmLW1N4h+gmjgpYCEJthHmaIjok894H5il/g=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -3173,9 +3173,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.48",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",
-      "integrity": "sha1-07DYWTgUBE4JLs4hCPw6ya6kuQA="
+      "version": "1.3.50",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.50.tgz",
+      "integrity": "sha1-dDi3b5K0G5GfP73TUPvQdX2s3fc="
     },
     "elliptic": {
       "version": "6.4.0",
@@ -3658,9 +3658,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.12.0.tgz",
-      "integrity": "sha1-2tMXgSktZmSyUxf9BJ0uKy8CIF0=",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.13.0.tgz",
+      "integrity": "sha512-t6hGKQDMIt9N8R7vLepsYXgDfeuhp6ZJSgtrLEDxonpSubyxUZHjhm6LsAaZX8q6GYVxkbT3kTsV9G5mBCFR6A==",
       "dev": true,
       "requires": {
         "contains-path": "^0.1.0",
@@ -3753,15 +3753,15 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.9.1.tgz",
-      "integrity": "sha512-uvq+2ZkiqzjwF+pMZ8xqIC3pChV4KviPvvPIyQOvKWnjtvyW3iGfHIRqVumw05L3itby0QGmA4VdBA9m1OdMmg==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.10.0.tgz",
+      "integrity": "sha512-18rzWn4AtbSUxFKKM7aCVcj5LXOhOKdwBino3KKWy4psxfPW0YtIbE8WNRDUdyHFL50BeLb6qFd4vpvNYyp7hw==",
       "dev": true,
       "requires": {
         "doctrine": "^2.1.0",
-        "has": "^1.0.2",
+        "has": "^1.0.3",
         "jsx-ast-utils": "^2.0.1",
-        "prop-types": "^15.6.1"
+        "prop-types": "^15.6.2"
       },
       "dependencies": {
         "doctrine": {
@@ -3774,12 +3774,11 @@
           }
         },
         "prop-types": {
-          "version": "15.6.1",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-          "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
           "dev": true,
           "requires": {
-            "fbjs": "^0.8.16",
             "loose-envify": "^1.3.1",
             "object-assign": "^4.1.1"
           }
@@ -5860,9 +5859,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -5894,9 +5893,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
-      "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
     "import-local": {
@@ -7708,9 +7707,9 @@
           },
           "dependencies": {
             "postcss": {
-              "version": "6.0.22",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-              "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
               "dev": true,
               "requires": {
                 "chalk": "^2.4.1",
@@ -9166,9 +9165,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -9230,9 +9229,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -9294,9 +9293,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -9358,9 +9357,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -9746,11 +9745,10 @@
       },
       "dependencies": {
         "prop-types": {
-          "version": "15.6.1",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-          "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
           "requires": {
-            "fbjs": "^0.8.16",
             "loose-envify": "^1.3.1",
             "object-assign": "^4.1.1"
           }
@@ -9785,11 +9783,10 @@
       },
       "dependencies": {
         "prop-types": {
-          "version": "15.6.1",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-          "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
           "requires": {
-            "fbjs": "^0.8.16",
             "loose-envify": "^1.3.1",
             "object-assign": "^4.1.1"
           }
@@ -9810,11 +9807,10 @@
       },
       "dependencies": {
         "prop-types": {
-          "version": "15.6.1",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-          "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
           "requires": {
-            "fbjs": "^0.8.16",
             "loose-envify": "^1.3.1",
             "object-assign": "^4.1.1"
           }
@@ -12532,8 +12528,8 @@
       "dev": true
     },
     "wp-calypso": {
-      "version": "github:automattic/wp-calypso#2ed3e056afa2be61698fe6ab491668a6652bd51c",
-      "from": "github:automattic/wp-calypso#2ed3e056afa2be61698fe6ab491668a6652bd51c",
+      "version": "github:automattic/wp-calypso#cc49f0a87c039c2267395490a5ec8c5630d4b296",
+      "from": "github:automattic/wp-calypso#cc49f0a87c039c2267395490a5ec8c5630d4b296",
       "requires": {
         "@babel/cli": "7.0.0-beta.44",
         "@babel/core": "7.0.0-beta.44",
@@ -12545,8 +12541,8 @@
         "@babel/preset-react": "7.0.0-beta.44",
         "@babel/preset-stage-2": "7.0.0-beta.44",
         "@babel/runtime": "7.0.0-beta.44",
-        "autoprefixer": "8.6.2",
-        "autosize": "3.0.21",
+        "autoprefixer": "8.6.3",
+        "autosize": "4.0.2",
         "babel-core": "7.0.0-bridge.0",
         "babel-jest": "22.4.1",
         "babel-loader": "8.0.0-beta.3",
@@ -12562,7 +12558,7 @@
         "chokidar": "2.0.4",
         "chrono-node": "1.3.5",
         "circular-dependency-plugin": "5.0.2",
-        "classnames": "1.2.2",
+        "classnames": "2.2.6",
         "click-outside": "2.0.2",
         "clipboard": "1.7.1",
         "component-closest": "0.1.4",
@@ -12585,8 +12581,8 @@
         "doctrine": "2.1.0",
         "dom-helpers": "2.4.0",
         "dom-scroll-into-view": "1.2.1",
-        "dompurify": "1.0.2",
-        "draft-js": "0.10.4",
+        "dompurify": "1.0.5",
+        "draft-js": "0.10.5",
         "email-validator": "2.0.4",
         "emoji-text": "0.2.6",
         "escape-regexp": "0.0.1",
@@ -12599,92 +12595,89 @@
         "flag-icon-css": "2.9.0",
         "flux": "2.1.1",
         "fsevents": "1.2.4",
-        "fuse.js": "2.6.1",
+        "fuse.js": "2.7.4",
         "get-video-id": "2.1.7",
         "globby": "6.1.0",
         "gridicons": "3.0.1",
         "gzip-size": "4.1.0",
         "hash.js": "1.1.4",
         "he": "0.5.0",
-        "html-loader": "0.4.0",
-        "html-to-react": "1.3.1",
-        "i18n-calypso": "1.8.4",
-        "immutability-helper": "2.4.0",
+        "html-loader": "0.5.5",
+        "html-to-react": "1.3.3",
+        "i18n-calypso": "1.9.1",
+        "immutability-helper": "2.7.1",
         "immutable": "3.7.6",
-        "imports-loader": "0.6.5",
-        "inherits": "2.0.1",
+        "imports-loader": "0.8.0",
+        "inherits": "2.0.3",
         "is-my-json-valid": "2.17.2",
         "jquery": "1.12.3",
-        "json-loader": "0.5.4",
         "json-stable-stringify": "1.0.1",
-        "jsx-to-string": "1.3.1",
+        "jsx-to-string": "1.4.0",
         "key-mirror": "1.0.1",
         "keymaster": "1.6.2",
         "loader-utils": "1.1.0",
-        "localforage": "1.4.3",
+        "localforage": "1.7.2",
         "lodash": "4.17.10",
         "lru": "3.1.0",
-        "lunr": "0.5.7",
+        "lunr": "0.7.2",
         "markdown-loader": "3.0.0",
-        "marked": "0.3.9",
+        "marked": "0.4.0",
         "mkdirp": "0.5.1",
-        "moment": "2.21.0",
-        "morgan": "1.2.0",
-        "ms": "0.7.1",
+        "moment": "2.22.2",
+        "morgan": "1.9.0",
+        "ms": "0.7.3",
         "node-sass": "4.9.0",
         "notifications-panel": "2.1.10",
-        "npm-run-all": "4.0.2",
-        "object-path-immutable": "0.5.2",
+        "npm-run-all": "4.1.3",
+        "object-path-immutable": "0.5.3",
         "objectpath": "1.2.1",
         "page": "1.6.4",
-        "path-browserify": "0.0.0",
+        "path-browserify": "1.0.0",
         "percentage-regex": "3.0.0",
         "phone": "git+https://github.com/Automattic/node-phone.git#6be6549b03137f2cca01e202250bf2590750119e",
         "photon": "2.0.1",
-        "postcss-cli": "2.5.1",
-        "postcss-custom-properties": "6.2.0",
-        "prismjs": "1.6.0",
-        "prop-types": "15.6.1",
-        "q": "1.0.1",
-        "qrcode.react": "0.7.2",
-        "qs": "6.5.1",
-        "react": "16.4.0",
+        "postcss-cli": "2.6.0",
+        "postcss-custom-properties": "6.3.1",
+        "prismjs": "1.15.0",
+        "prop-types": "15.6.2",
+        "qrcode.react": "0.8.0",
+        "qs": "6.5.2",
+        "react": "16.4.1",
         "react-click-outside": "2.3.1",
         "react-day-picker": "6.2.1",
-        "react-dom": "16.4.0",
+        "react-dom": "16.4.1",
         "react-hot-loader": "1.3.1",
         "react-lazily-render": "1.0.1",
         "react-live": "1.10.1",
-        "react-modal": "3.1.11",
+        "react-modal": "3.4.5",
         "react-pure-render": "1.0.2",
         "react-redux": "5.0.7",
         "react-transition-group": "1.2.1",
-        "react-virtualized": "9.9.0",
+        "react-virtualized": "9.19.1",
         "redux": "4.0.0",
         "redux-form": "7.0.2",
-        "redux-thunk": "1.0.0",
-        "rtlcss": "2.2.1",
-        "semver": "5.1.0",
+        "redux-thunk": "1.0.3",
+        "rtlcss": "2.4.0",
+        "semver": "5.5.0",
         "social-logos": "2.0.0",
         "socket.io-client": "2.1.1",
         "source-map": "0.1.39",
-        "source-map-support": "0.3.2",
+        "source-map-support": "0.5.6",
         "store": "1.3.16",
-        "striptags": "2.1.1",
-        "superagent": "2.1.0",
+        "striptags": "2.2.1",
+        "superagent": "2.3.0",
         "textarea-caret": "3.1.0",
         "thread-loader": "1.1.5",
         "tinymce": "4.6.3",
         "to-title-case": "0.1.5",
-        "tracekit": "0.4.3",
+        "tracekit": "0.4.5",
         "twemoji": "2.3.0",
-        "uglifyjs-webpack-plugin": "1.2.4",
+        "uglifyjs-webpack-plugin": "1.2.6",
         "url": "0.11.0",
         "uuid": "3.2.1",
         "valid-url": "1.0.9",
-        "walk": "2.3.4",
-        "webpack": "4.10.2",
-        "webpack-cli": "2.0.9",
+        "webpack": "4.12.0",
+        "webpack-cli": "2.1.5",
         "webpack-dev-middleware": "3.1.3",
         "wpcom": "5.4.1",
         "wpcom-oauth": "0.3.4",
@@ -12706,10 +12699,185 @@
               "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
               "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
             },
+            "babel-core": {
+              "version": "5.8.38",
+              "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+              "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
+              "requires": {
+                "babel-plugin-constant-folding": "^1.0.1",
+                "babel-plugin-dead-code-elimination": "^1.0.2",
+                "babel-plugin-eval": "^1.0.1",
+                "babel-plugin-inline-environment-variables": "^1.0.1",
+                "babel-plugin-jscript": "^1.0.4",
+                "babel-plugin-member-expression-literals": "^1.0.1",
+                "babel-plugin-property-literals": "^1.0.1",
+                "babel-plugin-proto-to-assign": "^1.0.3",
+                "babel-plugin-react-constant-elements": "^1.0.3",
+                "babel-plugin-react-display-name": "^1.0.3",
+                "babel-plugin-remove-console": "^1.0.1",
+                "babel-plugin-remove-debugger": "^1.0.1",
+                "babel-plugin-runtime": "^1.0.7",
+                "babel-plugin-undeclared-variables-check": "^1.0.2",
+                "babel-plugin-undefined-to-void": "^1.1.6",
+                "babylon": "^5.8.38",
+                "bluebird": "^2.9.33",
+                "chalk": "^1.0.0",
+                "convert-source-map": "^1.1.0",
+                "core-js": "^1.0.0",
+                "debug": "^2.1.1",
+                "detect-indent": "^3.0.0",
+                "esutils": "^2.0.0",
+                "fs-readdir-recursive": "^0.1.0",
+                "globals": "^6.4.0",
+                "home-or-tmp": "^1.0.0",
+                "is-integer": "^1.0.4",
+                "js-tokens": "1.0.1",
+                "json5": "^0.4.0",
+                "lodash": "^3.10.0",
+                "minimatch": "^2.0.3",
+                "output-file-sync": "^1.1.0",
+                "path-exists": "^1.0.0",
+                "path-is-absolute": "^1.0.0",
+                "private": "^0.1.6",
+                "regenerator": "0.8.40",
+                "regexpu": "^1.3.0",
+                "repeating": "^1.1.2",
+                "resolve": "^1.1.6",
+                "shebang-regex": "^1.0.0",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.0",
+                "source-map-support": "^0.2.10",
+                "to-fast-properties": "^1.0.0",
+                "trim-right": "^1.0.0",
+                "try-resolve": "^1.0.0"
+              },
+              "dependencies": {
+                "babylon": {
+                  "version": "5.8.38",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+                  "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0="
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                  "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                }
+              }
+            },
+            "babylon": {
+              "version": "6.18.0",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+              "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+            },
+            "bluebird": {
+              "version": "2.11.0",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+              "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+            },
+            "colors": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+              "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
+            },
+            "core-js": {
+              "version": "1.2.7",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+              "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+            },
+            "detect-indent": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+              "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
+              "requires": {
+                "get-stdin": "^4.0.1",
+                "minimist": "^1.1.0",
+                "repeating": "^1.1.0"
+              }
+            },
             "esprima": {
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
               "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+            },
+            "fs-readdir-recursive": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
+              "integrity": "sha1-MVtPuMHKW4xH3v7zGdBz2tNWgFk="
+            },
+            "globals": {
+              "version": "6.4.1",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+              "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08="
+            },
+            "home-or-tmp": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+              "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
+              "requires": {
+                "os-tmpdir": "^1.0.1",
+                "user-home": "^1.1.1"
+              }
+            },
+            "js-tokens": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
+              "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4="
+            },
+            "jscodeshift": {
+              "version": "0.3.32",
+              "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.3.32.tgz",
+              "integrity": "sha1-3s5etgLxY0DY2VTH+WrJB8UC6rs=",
+              "requires": {
+                "async": "^1.5.0",
+                "babel-core": "^5",
+                "babel-plugin-transform-flow-strip-types": "^6.8.0",
+                "babel-preset-es2015": "^6.9.0",
+                "babel-preset-stage-1": "^6.5.0",
+                "babel-register": "^6.9.0",
+                "babylon": "^6.17.3",
+                "colors": "^1.1.2",
+                "flow-parser": "^0.*",
+                "lodash": "^4.13.1",
+                "micromatch": "^2.3.7",
+                "node-dir": "0.1.8",
+                "nomnom": "^1.8.1",
+                "recast": "^0.12.5",
+                "temp": "^0.8.1",
+                "write-file-atomic": "^1.2.0"
+              }
+            },
+            "json5": {
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+              "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+              "requires": {
+                "brace-expansion": "^1.0.0"
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            },
+            "output-file-sync": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+              "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+              "requires": {
+                "graceful-fs": "^4.1.4",
+                "mkdirp": "^0.5.1",
+                "object-assign": "^4.1.0"
+              }
+            },
+            "path-exists": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+              "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE="
             },
             "recast": {
               "version": "0.12.9",
@@ -12721,12 +12889,55 @@
                 "esprima": "~4.0.0",
                 "private": "~0.1.5",
                 "source-map": "~0.6.1"
+              },
+              "dependencies": {
+                "core-js": {
+                  "version": "2.5.7",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+                  "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+                },
+                "source-map": {
+                  "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                  "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                }
+              }
+            },
+            "repeating": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+              "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+              "requires": {
+                "is-finite": "^1.0.0"
               }
             },
             "source-map": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+            },
+            "source-map-support": {
+              "version": "0.2.10",
+              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+              "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
+              "requires": {
+                "source-map": "0.1.32"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.1.32",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                  "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
+                  "requires": {
+                    "amdefine": ">=0.0.4"
+                  }
+                }
+              }
+            },
+            "to-fast-properties": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+              "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
             }
           }
         },
@@ -12812,11 +13023,6 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            },
-            "semver": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
             },
             "source-map": {
               "version": "0.5.7",
@@ -13587,13 +13793,6 @@
             "browserslist": "^3.0.0",
             "invariant": "^2.2.2",
             "semver": "^5.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-            }
           }
         },
         "@babel/preset-react": {
@@ -13699,6 +13898,19 @@
             "to-fast-properties": "^2.0.0"
           }
         },
+        "@cronvel/get-pixels": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/@cronvel/get-pixels/-/get-pixels-3.3.1.tgz",
+          "integrity": "sha512-jgDb8vGPkpjRDbiYyHTI2Bna4HJysjPNSiERzBnRJjCR/YqC3u0idTae0tmNECsaZLOpAWmlK9wiIwnLGIT9Bg==",
+          "requires": {
+            "jpeg-js": "^0.1.1",
+            "ndarray": "^1.0.13",
+            "ndarray-pack": "^1.1.1",
+            "node-bitmap": "0.0.1",
+            "omggif": "^1.0.5",
+            "pngjs": "^2.0.0"
+          }
+        },
         "@glimmer/interfaces": {
           "version": "0.30.5",
           "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.30.5.tgz",
@@ -13745,6 +13957,19 @@
           "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz",
           "integrity": "sha512-LAQ1d4OPfSJ/BMbI2DuizmYrrkD9JMaTdi2hQTlI53lQ4kRQPyZQRS4CYQ7O66bnBBnP/oYdRxbk++X0xuFU6A=="
         },
+        "@samverschueren/stream-to-observable": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
+          "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
+          "requires": {
+            "any-observable": "^0.3.0"
+          }
+        },
+        "@sindresorhus/is": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+          "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+        },
         "@types/commander": {
           "version": "2.12.2",
           "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.12.2.tgz",
@@ -13754,9 +13979,9 @@
           }
         },
         "@types/node": {
-          "version": "10.3.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.3.tgz",
-          "integrity": "sha512-/gwCgiI2e9RzzZTKbl+am3vgNqOt7a9fJ/uxv4SqYKxenoEDNVU3KZEadlpusWhQI0A0dOrZ0T68JYKVjzmgdQ=="
+          "version": "10.3.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.4.tgz",
+          "integrity": "sha512-YMLlzdeNnAyLrQew39IFRkMacAR5BqKGIEei9ZjdHsIZtv+ZWKYTu1i7QJhetxQ9ReXx8w5f+cixdHZG3zgMQA=="
         },
         "@types/semver": {
           "version": "5.5.0",
@@ -13764,13 +13989,13 @@
           "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
         },
         "@webassemblyjs/ast": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.5.9.tgz",
-          "integrity": "sha512-xL3hC0TOc4ic1UNG8ZZNeaiPf1klozt6rqajcy7hfO/qqfkEhLff1AFt5g2LJkTjhw+QSEYVMt7qOaaApu7JzA==",
+          "version": "1.5.12",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.5.12.tgz",
+          "integrity": "sha512-bmTBEKuuhSU6dC95QIW250xO769cdYGx9rWn3uBLTw2pUpud0Z5kVuMw9m9fqbNzGeuOU2HpyuZa+yUt2CTEDA==",
           "requires": {
-            "@webassemblyjs/helper-module-context": "1.5.9",
-            "@webassemblyjs/helper-wasm-bytecode": "1.5.9",
-            "@webassemblyjs/wast-parser": "1.5.9",
+            "@webassemblyjs/helper-module-context": "1.5.12",
+            "@webassemblyjs/helper-wasm-bytecode": "1.5.12",
+            "@webassemblyjs/wast-parser": "1.5.12",
             "debug": "^3.1.0",
             "mamacro": "^0.0.3"
           },
@@ -13791,19 +14016,19 @@
           }
         },
         "@webassemblyjs/floating-point-hex-parser": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.5.9.tgz",
-          "integrity": "sha512-naMJjuBqDqx4dPSzwpI9pkjdLds4tDTzvsOEzwxPDp655IfgLLP/QEvK/9PQp4p5DExqrR87rk8DWByoqWWlGA=="
+          "version": "1.5.12",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.5.12.tgz",
+          "integrity": "sha512-epTvkdwOIPpTE9edHS+V+shetYzpTbd91XOzUli1zAS0+NSgSe6ZsNggIqUNzhma1s4bN2f/m8c6B1NMdCERAg=="
         },
         "@webassemblyjs/helper-api-error": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.5.9.tgz",
-          "integrity": "sha512-tzGdqBo7Xf3McJcXbwbwzwElRzF/nELJN+G4MGGfm0DGRQB6UTmMe44jFIOQYT1Za89Aiz5DMQJotdnnLheixw=="
+          "version": "1.5.12",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.5.12.tgz",
+          "integrity": "sha512-Goxag86JvLq8ucHLXFNSLYzf9wrR+CJr37DsESTAzSnGoqDTgw5eqiXSQVd/D9Biih7+DIn8UIQCxMs8emRRwg=="
         },
         "@webassemblyjs/helper-buffer": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.5.9.tgz",
-          "integrity": "sha512-WYkys6y33viEY23tHJ+KkSd9yHZBd54Sy6gcSgwLGPP1or9pLqWBrjWWATHuDuIkpvSJSt/+3qjAV6zHd1nS0g==",
+          "version": "1.5.12",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.5.12.tgz",
+          "integrity": "sha512-tJNUjttL5CxiiS/KLxT4/Zk0Nbl/poFhztFxktb46zoQEUWaGHR9ZJ0SnvE7DbFX5PY5JNJDMZ0Li4lm246fWw==",
           "requires": {
             "debug": "^3.1.0"
           },
@@ -13824,37 +14049,56 @@
           }
         },
         "@webassemblyjs/helper-code-frame": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.5.9.tgz",
-          "integrity": "sha512-SYjNAlqcRH+YynslbIhFYOnGvE3WBl82/XlcFXiNkqnWsvHWnNkJbtxAtzrT/dcf69O/2pt8j1Q0+qc/rtacVw==",
+          "version": "1.5.12",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.5.12.tgz",
+          "integrity": "sha512-0FrJgiST+MQDMvPigzs+UIk1vslLIqGadkEWdn53Lr0NsUC2JbheG9QaO3Zf6ycK2JwsHiUpGaMFcHYXStTPMA==",
           "requires": {
-            "@webassemblyjs/wast-printer": "1.5.9"
+            "@webassemblyjs/wast-printer": "1.5.12"
           }
         },
         "@webassemblyjs/helper-fsm": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.5.9.tgz",
-          "integrity": "sha512-8D+VVIJTRbsn31zt3eyidYyUkhH1jk2/58mrIPiMarflRsisItJa5WZVu/gw0l+ubFOJf9PivTJB6Kw/Kgxx3g=="
+          "version": "1.5.12",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.5.12.tgz",
+          "integrity": "sha512-QBHZ45VPUJ7UyYKvUFoaxrSS9H5hbkC9U7tdWgFHmnTMutkXSEgDg2gZg3I/QTsiKOCIwx4qJUJwPd7J4D5CNQ=="
         },
         "@webassemblyjs/helper-module-context": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.5.9.tgz",
-          "integrity": "sha512-DbeLbFOhioEeY7yAff12+n5sf7WP7Fmi0lnhCSzfW4xBsgwXKmRjAx7nVmsUf3z+BDnwHHVKIXBUM+ucccNUsw=="
+          "version": "1.5.12",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.5.12.tgz",
+          "integrity": "sha512-SCXR8hPI4JOG3cdy9HAO8W5/VQ68YXG/Hfs7qDf1cd64zWuMNshyEour5NYnLMVkrrtc0XzfVS/MdeV94woFHA==",
+          "requires": {
+            "debug": "^3.1.0",
+            "mamacro": "^0.0.3"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
         },
         "@webassemblyjs/helper-wasm-bytecode": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.5.9.tgz",
-          "integrity": "sha512-zHQuTMMd2nTyEa3fbmGfzlJW305py1sgf1gHNCO/LVN8nWlKysB/+6J68sP1Cd+9USnT1VS2vyD1z+YJPS6GqQ=="
+          "version": "1.5.12",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.5.12.tgz",
+          "integrity": "sha512-0Gz5lQcyvElNVbOTKwjEmIxGwdWf+zpAW/WGzGo95B7IgMEzyyfZU+PrGHDwiSH9c0knol9G7smQnY0ljrSA6g=="
         },
         "@webassemblyjs/helper-wasm-section": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.5.9.tgz",
-          "integrity": "sha512-+ff+8Ju6sLCMFNygcDdLRNRsmuD0PHwq77d2mbfWj5YzUvFaKN2q2kRppJSEAixOnM2xLADuG5y/blpMo5G90A==",
+          "version": "1.5.12",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.5.12.tgz",
+          "integrity": "sha512-ge/CKVKBGpiJhFN9PIOQ7sPtGYJhxm/mW1Y3SpG1L6XBunfRz0YnLjW3TmhcOEFozIVyODPS1HZ9f7VR3GBGow==",
           "requires": {
-            "@webassemblyjs/ast": "1.5.9",
-            "@webassemblyjs/helper-buffer": "1.5.9",
-            "@webassemblyjs/helper-wasm-bytecode": "1.5.9",
-            "@webassemblyjs/wasm-gen": "1.5.9",
+            "@webassemblyjs/ast": "1.5.12",
+            "@webassemblyjs/helper-buffer": "1.5.12",
+            "@webassemblyjs/helper-wasm-bytecode": "1.5.12",
+            "@webassemblyjs/wasm-gen": "1.5.12",
             "debug": "^3.1.0"
           },
           "dependencies": {
@@ -13874,34 +14118,39 @@
           }
         },
         "@webassemblyjs/ieee754": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.5.9.tgz",
-          "integrity": "sha512-mhetZBDnpV3VYqZb5Aail9X01VyIqDDZrNYdYj8bfx/PsVPG2znX90wRyVNTeqC5ylqHCgGkJ63bPaPEyINfsw==",
+          "version": "1.5.12",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.5.12.tgz",
+          "integrity": "sha512-F+PEv9QBzPi1ThLBouUJbuxhEr+Sy/oua1ftXFKHiaYYS5Z9tKPvK/hgCxlSdq+RY4MSG15jU2JYb/K5pkoybg==",
           "requires": {
             "ieee754": "^1.1.11"
           }
         },
         "@webassemblyjs/leb128": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.5.9.tgz",
-          "integrity": "sha512-oZ3eUB9EViUtiuMwW/xeYamXgfFS2cmXl6aUIYBfpXJQ5v5aOC8ZuPpz2/LqlgNlT8ThpyFd6kfgkYVwKwkGvQ==",
+          "version": "1.5.12",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.5.12.tgz",
+          "integrity": "sha512-cCOx/LVGiWyCwVrVlvGmTdnwHzIP4+zflLjGkZxWpYCpdNax9krVIJh1Pm7O86Ox/c5PrJpbvZU1cZLxndlPEw==",
           "requires": {
             "leb": "^0.3.0"
           }
         },
+        "@webassemblyjs/utf8": {
+          "version": "1.5.12",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.5.12.tgz",
+          "integrity": "sha512-FX8NYQMiTRU0TfK/tJVntsi9IEKsedSsna8qtsndWVE0x3zLndugiApxdNMIOoElBV9o4j0BUqR+iwU58QfPxQ=="
+        },
         "@webassemblyjs/wasm-edit": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.5.9.tgz",
-          "integrity": "sha512-pMWe3HomnWAMZytJ5sSNBS6qTbSoULUHkvDrtcarmLBTclmupZe25INy1jxbWGKsuFxw6w0xQ+eLRPlC8HPjhg==",
+          "version": "1.5.12",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.5.12.tgz",
+          "integrity": "sha512-r/oZAyC4EZl0ToOYJgvj+b0X6gVEKQMLT34pNNbtvWBehQOnaSXvVUA5FIYlH8ubWjFNAFqYaVGgQTjR1yuJdQ==",
           "requires": {
-            "@webassemblyjs/ast": "1.5.9",
-            "@webassemblyjs/helper-buffer": "1.5.9",
-            "@webassemblyjs/helper-wasm-bytecode": "1.5.9",
-            "@webassemblyjs/helper-wasm-section": "1.5.9",
-            "@webassemblyjs/wasm-gen": "1.5.9",
-            "@webassemblyjs/wasm-opt": "1.5.9",
-            "@webassemblyjs/wasm-parser": "1.5.9",
-            "@webassemblyjs/wast-printer": "1.5.9",
+            "@webassemblyjs/ast": "1.5.12",
+            "@webassemblyjs/helper-buffer": "1.5.12",
+            "@webassemblyjs/helper-wasm-bytecode": "1.5.12",
+            "@webassemblyjs/helper-wasm-section": "1.5.12",
+            "@webassemblyjs/wasm-gen": "1.5.12",
+            "@webassemblyjs/wasm-opt": "1.5.12",
+            "@webassemblyjs/wasm-parser": "1.5.12",
+            "@webassemblyjs/wast-printer": "1.5.12",
             "debug": "^3.1.0"
           },
           "dependencies": {
@@ -13921,25 +14170,26 @@
           }
         },
         "@webassemblyjs/wasm-gen": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.5.9.tgz",
-          "integrity": "sha512-UEhymlxupBUJuwnD2N860MqkpE7LHt0tNKqAgT4YAVjbx+88P6MBBk+q+9wr2FJCXxMgsPTxMWifqC4wd2FzVg==",
+          "version": "1.5.12",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.5.12.tgz",
+          "integrity": "sha512-LTu+cr1YRxGGiVIXWhei/35lXXEwTnQU18x4V/gE+qCSJN21QcVTMjJuasTUh8WtmBZtOlqJbOQIeN7fGnHWhg==",
           "requires": {
-            "@webassemblyjs/ast": "1.5.9",
-            "@webassemblyjs/helper-wasm-bytecode": "1.5.9",
-            "@webassemblyjs/ieee754": "1.5.9",
-            "@webassemblyjs/leb128": "1.5.9"
+            "@webassemblyjs/ast": "1.5.12",
+            "@webassemblyjs/helper-wasm-bytecode": "1.5.12",
+            "@webassemblyjs/ieee754": "1.5.12",
+            "@webassemblyjs/leb128": "1.5.12",
+            "@webassemblyjs/utf8": "1.5.12"
           }
         },
         "@webassemblyjs/wasm-opt": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.5.9.tgz",
-          "integrity": "sha512-oQm84US3e36dPq5bOeybVKA2ZyzeWR4fereg9kJa0Y9XLKxHwlsBa2kFyNXwZNrhMP33iyXAW+ym7om1zPZeAg==",
+          "version": "1.5.12",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.5.12.tgz",
+          "integrity": "sha512-LBwG5KPA9u/uigZVyTsDpS3CVxx3AePCnTItVL+OPkRCp5LqmLsOp4a3/c5CQE0Lecm0Ss9hjUTDcbYFZkXlfQ==",
           "requires": {
-            "@webassemblyjs/ast": "1.5.9",
-            "@webassemblyjs/helper-buffer": "1.5.9",
-            "@webassemblyjs/wasm-gen": "1.5.9",
-            "@webassemblyjs/wasm-parser": "1.5.9",
+            "@webassemblyjs/ast": "1.5.12",
+            "@webassemblyjs/helper-buffer": "1.5.12",
+            "@webassemblyjs/wasm-gen": "1.5.12",
+            "@webassemblyjs/wasm-parser": "1.5.12",
             "debug": "^3.1.0"
           },
           "dependencies": {
@@ -13959,39 +14209,39 @@
           }
         },
         "@webassemblyjs/wasm-parser": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.5.9.tgz",
-          "integrity": "sha512-jBKBTKE4M/WYCSqLjRvK+/QD55E/HNcQjswbksof3GEXfkq0iMqYxoPfqR7uLAD9/jVf9HpBNW2FJOyfTTlYfw==",
+          "version": "1.5.12",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.5.12.tgz",
+          "integrity": "sha512-xset3+1AtoFYEfMg30nzCGBnhKmTBzbIKvMyLhqJT06TvYV+kA884AOUpUvhSmP6XPF3G+HVZPm/PbCGxH4/VQ==",
           "requires": {
-            "@webassemblyjs/ast": "1.5.9",
-            "@webassemblyjs/helper-api-error": "1.5.9",
-            "@webassemblyjs/helper-wasm-bytecode": "1.5.9",
-            "@webassemblyjs/ieee754": "1.5.9",
-            "@webassemblyjs/leb128": "1.5.9",
-            "@webassemblyjs/wasm-parser": "1.5.9"
+            "@webassemblyjs/ast": "1.5.12",
+            "@webassemblyjs/helper-api-error": "1.5.12",
+            "@webassemblyjs/helper-wasm-bytecode": "1.5.12",
+            "@webassemblyjs/ieee754": "1.5.12",
+            "@webassemblyjs/leb128": "1.5.12",
+            "@webassemblyjs/utf8": "1.5.12"
           }
         },
         "@webassemblyjs/wast-parser": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.5.9.tgz",
-          "integrity": "sha512-bDuYH/NR5D+MmwVZdGW2rUvu4UcKGpodiHBSueajon3oNPu+PAKG+7br3BVFKxDUtDoVtuHLUQvkqp1lTrqPCA==",
+          "version": "1.5.12",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.5.12.tgz",
+          "integrity": "sha512-QWUtzhvfY7Ue9GlJ3HeOB6w5g9vNYUUnG+Y96TWPkFHJTxZlcvGfNrUoACCw6eDb9gKaHrjt77aPq41a7y8svg==",
           "requires": {
-            "@webassemblyjs/ast": "1.5.9",
-            "@webassemblyjs/floating-point-hex-parser": "1.5.9",
-            "@webassemblyjs/helper-api-error": "1.5.9",
-            "@webassemblyjs/helper-code-frame": "1.5.9",
-            "@webassemblyjs/helper-fsm": "1.5.9",
+            "@webassemblyjs/ast": "1.5.12",
+            "@webassemblyjs/floating-point-hex-parser": "1.5.12",
+            "@webassemblyjs/helper-api-error": "1.5.12",
+            "@webassemblyjs/helper-code-frame": "1.5.12",
+            "@webassemblyjs/helper-fsm": "1.5.12",
             "long": "^3.2.0",
             "mamacro": "^0.0.3"
           }
         },
         "@webassemblyjs/wast-printer": {
-          "version": "1.5.9",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.5.9.tgz",
-          "integrity": "sha512-04iV32TO69kZChP3DN6W8i6GCa5UtEn1Lnzb4sQGe5YNjIFz2k8+KZLxbovWIZgj9pk06k3Egq/wyD98lSKaLw==",
+          "version": "1.5.12",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.5.12.tgz",
+          "integrity": "sha512-XF9RTeckFgDyl196uRKZWHFFfbkzsMK96QTXp+TC0R9gsV9DMiDGMSIllgy/WdrZ3y3dsQp4fTA5r4GoaOBchA==",
           "requires": {
-            "@webassemblyjs/ast": "1.5.9",
-            "@webassemblyjs/wast-parser": "1.5.9",
+            "@webassemblyjs/ast": "1.5.12",
+            "@webassemblyjs/wast-parser": "1.5.12",
             "long": "^3.2.0"
           }
         },
@@ -14137,6 +14387,11 @@
           "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
           "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
         },
+        "any-observable": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+          "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog=="
+        },
         "anymatch": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
@@ -14176,11 +14431,6 @@
           "requires": {
             "sprintf-js": "~1.0.2"
           }
-        },
-        "argv": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
-          "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas="
         },
         "aria-query": {
           "version": "0.7.1",
@@ -14314,6 +14564,11 @@
             "util": "0.10.3"
           },
           "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+            },
             "util": {
               "version": "0.10.3",
               "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
@@ -14360,9 +14615,9 @@
           "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
         },
         "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "async-each": {
           "version": "1.0.1",
@@ -14406,12 +14661,12 @@
           "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
         },
         "autoprefixer": {
-          "version": "8.6.2",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.6.2.tgz",
-          "integrity": "sha512-cv9v1mYYBcAnZq4MHseJ9AIdjQmNahnpCpPO46oTkQJS2GggsBp2azHjNpAuQ95Epvsg+AIsyjYhfI9YwFxGSA==",
+          "version": "8.6.3",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.6.3.tgz",
+          "integrity": "sha512-KkQyCHBxma7R2eoEkjja/RHUBw+Fc1nY46LdV62fzJI5D7i8mLLCtAZ/AVR3UbXhDZ8mUz4C/PF4lZrbiHa1ZQ==",
           "requires": {
             "browserslist": "^3.2.8",
-            "caniuse-lite": "^1.0.30000851",
+            "caniuse-lite": "^1.0.30000856",
             "normalize-range": "^0.1.2",
             "num2fraction": "^1.2.2",
             "postcss": "^6.0.22",
@@ -14419,9 +14674,9 @@
           }
         },
         "autosize": {
-          "version": "3.0.21",
-          "resolved": "https://registry.npmjs.org/autosize/-/autosize-3.0.21.tgz",
-          "integrity": "sha1-8YL0DRd1fZeKE5pMnKQMTA5EhgM="
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.2.tgz",
+          "integrity": "sha512-jnSyH2d+qdfPGpWlcuhGiHmqBJ6g3X+8T+iRwFrHPLVcdoGJE/x6Qicm6aDHfTsbgZKxyV8UU/YB2p4cjKDRRA=="
         },
         "aws-sign2": {
           "version": "0.6.0",
@@ -15558,9 +15813,19 @@
           "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
         },
         "basic-auth": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz",
-          "integrity": "sha1-ERstn/jk5tE2uMhOpeCWy4c1Fjc="
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
+          "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+              "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+            }
+          }
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
@@ -15647,13 +15912,6 @@
             "qs": "6.5.2",
             "raw-body": "2.3.3",
             "type-is": "~1.6.16"
-          },
-          "dependencies": {
-            "qs": {
-              "version": "6.5.2",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-              "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-            }
           }
         },
         "boolbase": {
@@ -15717,9 +15975,9 @@
           "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
         },
         "browser-resolve": {
-          "version": "1.11.2",
-          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-          "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+          "version": "1.11.3",
+          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+          "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
           "requires": {
             "resolve": "1.1.7"
           },
@@ -15854,6 +16112,25 @@
             "isarray": "^1.0.0"
           }
         },
+        "buffer-alloc": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+          "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+          "requires": {
+            "buffer-alloc-unsafe": "^1.1.0",
+            "buffer-fill": "^1.0.0"
+          }
+        },
+        "buffer-alloc-unsafe": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+          "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+        },
+        "buffer-fill": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+          "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+        },
         "buffer-from": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
@@ -15922,6 +16199,27 @@
             }
           }
         },
+        "cacheable-request": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+          "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+          "requires": {
+            "clone-response": "1.0.2",
+            "get-stream": "3.0.0",
+            "http-cache-semantics": "3.8.1",
+            "keyv": "3.0.0",
+            "lowercase-keys": "1.0.0",
+            "normalize-url": "2.0.1",
+            "responselike": "1.0.2"
+          },
+          "dependencies": {
+            "lowercase-keys": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+              "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+            }
+          }
+        },
         "call-me-maybe": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
@@ -15946,18 +16244,18 @@
           "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
         },
         "camel-case": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz",
-          "integrity": "sha1-Gsp8TRlTWaLOmVV5NDPG5VQlEfI=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+          "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
           "requires": {
-            "sentence-case": "^1.1.1",
+            "no-case": "^2.2.0",
             "upper-case": "^1.1.1"
           }
         },
         "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
         },
         "camelcase-keys": {
           "version": "2.1.0",
@@ -15966,13 +16264,6 @@
           "requires": {
             "camelcase": "^2.0.0",
             "map-obj": "^1.0.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-              "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-            }
           }
         },
         "caniuse-db": {
@@ -16017,13 +16308,16 @@
           }
         },
         "chai": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-          "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+          "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
           "requires": {
             "assertion-error": "^1.0.1",
-            "deep-eql": "^0.1.3",
-            "type-detect": "^1.0.0"
+            "check-error": "^1.0.1",
+            "deep-eql": "^3.0.0",
+            "get-func-name": "^2.0.0",
+            "pathval": "^1.0.0",
+            "type-detect": "^4.0.0"
           }
         },
         "chai-enzyme": {
@@ -16063,29 +16357,6 @@
             }
           }
         },
-        "change-case": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz",
-          "integrity": "sha1-LE/ePwY7tB0AzWjg1aCdthy+iU8=",
-          "requires": {
-            "camel-case": "^1.1.1",
-            "constant-case": "^1.1.0",
-            "dot-case": "^1.1.0",
-            "is-lower-case": "^1.1.0",
-            "is-upper-case": "^1.1.0",
-            "lower-case": "^1.1.1",
-            "lower-case-first": "^1.0.0",
-            "param-case": "^1.1.0",
-            "pascal-case": "^1.1.0",
-            "path-case": "^1.1.0",
-            "sentence-case": "^1.1.1",
-            "snake-case": "^1.1.0",
-            "swap-case": "^1.1.0",
-            "title-case": "^1.1.0",
-            "upper-case": "^1.1.1",
-            "upper-case-first": "^1.1.0"
-          }
-        },
         "character-entities": {
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
@@ -16105,6 +16376,16 @@
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
           "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+        },
+        "charenc": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+          "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+        },
+        "check-error": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+          "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
         },
         "check-node-version": {
           "version": "2.1.0",
@@ -16466,9 +16747,12 @@
           "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
         },
         "chrome-trace-event": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-0.1.3.tgz",
-          "integrity": "sha512-sjndyZHrrWiu4RY7AkHgjn80GfAM2ZSzUkZLV/Js59Ldmh6JDThf0SUmOHU53rFu2rVxxfCzJ30Ukcfch3Gb/A=="
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
+          "integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
+          "requires": {
+            "tslib": "^1.9.0"
+          }
         },
         "chrono-node": {
           "version": "1.3.5",
@@ -16534,34 +16818,22 @@
           }
         },
         "classnames": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/classnames/-/classnames-1.2.2.tgz",
-          "integrity": "sha1-6WoqAiLYSSXdj62yBdZuEviI7fk="
+          "version": "2.2.6",
+          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+          "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
         },
         "clean-css": {
-          "version": "3.4.28",
-          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
-          "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
+          "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
           "requires": {
-            "commander": "2.8.x",
-            "source-map": "0.4.x"
+            "source-map": "0.5.x"
           },
           "dependencies": {
-            "commander": {
-              "version": "2.8.1",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-              "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-              "requires": {
-                "graceful-readlink": ">= 1.0.0"
-              }
-            },
             "source-map": {
-              "version": "0.4.4",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
             }
           }
         },
@@ -16644,19 +16916,19 @@
           }
         },
         "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
-            "wordwrap": "0.0.2"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "clone": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
         },
         "clone-buffer": {
           "version": "1.0.0",
@@ -16672,10 +16944,18 @@
             "is-supported-regexp-flag": "^1.0.0"
           }
         },
+        "clone-response": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+          "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+          "requires": {
+            "mimic-response": "^1.0.0"
+          }
+        },
         "clone-stats": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
         },
         "cloneable-readable": {
           "version": "1.1.2",
@@ -16696,118 +16976,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-        },
-        "codecov": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.0.2.tgz",
-          "integrity": "sha512-9ljtIROIjPIUmMRqO+XuDITDoV8xRrZmA0jcEq6p2hg2+wY9wGmLfreAZGIL72IzUfdEDZaU8+Vjidg1fBQ8GQ==",
-          "requires": {
-            "argv": "0.0.2",
-            "request": "^2.81.0",
-            "urlgrey": "0.4.4"
-          },
-          "dependencies": {
-            "ajv": {
-              "version": "5.5.2",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-              "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-              "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
-              }
-            },
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-            },
-            "aws-sign2": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-              "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-            },
-            "fast-deep-equal": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-              "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-            },
-            "form-data": {
-              "version": "2.3.2",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-              "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-              "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "^2.1.12"
-              }
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-              "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-              "requires": {
-                "ajv": "^5.1.0",
-                "har-schema": "^2.0.0"
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-              "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-              "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-              }
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-              "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-            },
-            "request": {
-              "version": "2.87.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-              "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
-              "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.6.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.1",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.1",
-                "har-validator": "~5.0.3",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.17",
-                "oauth-sign": "~0.8.2",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.1",
-                "safe-buffer": "^5.1.1",
-                "tough-cookie": "~2.3.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.1.0"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-              "requires": {
-                "safe-buffer": "^5.0.1"
-              }
-            }
-          }
         },
         "collapse-white-space": {
           "version": "1.0.4",
@@ -16957,11 +17125,6 @@
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
               }
-            },
-            "q": {
-              "version": "1.5.1",
-              "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-              "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
             }
           }
         },
@@ -17051,13 +17214,6 @@
             "inherits": "^2.0.3",
             "readable-stream": "^2.2.2",
             "typedarray": "^0.0.6"
-          },
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-            }
           }
         },
         "console-browserify": {
@@ -17072,15 +17228,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-        },
-        "constant-case": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz",
-          "integrity": "sha1-jsLKW6ND4Aqjjb9OIA/VrJB+/WM=",
-          "requires": {
-            "snake-case": "^1.1.0",
-            "upper-case": "^1.1.1"
-          }
         },
         "constants-browserify": {
           "version": "1.0.0",
@@ -17328,14 +17475,12 @@
             "semver": "^5.5.0",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-            }
           }
+        },
+        "crypt": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+          "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
         },
         "cryptiles": {
           "version": "2.0.5",
@@ -17620,11 +17765,6 @@
           "resolved": "https://registry.npmjs.org/dashify/-/dashify-0.2.2.tgz",
           "integrity": "sha1-agdBWgHJH69KMuONnfunH2HLIP4="
         },
-        "data-uri-to-buffer": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-0.0.3.tgz",
-          "integrity": "sha1-GK6XmmoMqZSwYlhTkW0mYruuCxo="
-        },
         "data-urls": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
@@ -17646,9 +17786,9 @@
           "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
         },
         "dateformat": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+          "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
         },
         "debug": {
           "version": "2.6.9",
@@ -17689,18 +17829,11 @@
           "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
         },
         "deep-eql": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+          "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
           "requires": {
-            "type-detect": "0.1.1"
-          },
-          "dependencies": {
-            "type-detect": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
-            }
+            "type-detect": "^4.0.0"
           }
         },
         "deep-equal": {
@@ -17709,9 +17842,9 @@
           "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
         },
         "deep-extend": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
         },
         "deep-freeze": {
           "version": "0.0.1",
@@ -17816,6 +17949,21 @@
             "yargs": "~3.27.0"
           },
           "dependencies": {
+            "camelcase": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+              "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+            },
+            "cliui": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+              "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+              "requires": {
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
+                "wordwrap": "0.0.2"
+              }
+            },
             "esprima-fb": {
               "version": "15001.1001.0-dev-harmony-fb",
               "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
@@ -18084,6 +18232,30 @@
                 "readable-stream": ">=1.0.33-1 <1.1.0-0",
                 "xtend": ">=4.0.0 <4.1.0-0"
               }
+            },
+            "window-size": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+              "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+            },
+            "y18n": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+            },
+            "yargs": {
+              "version": "3.32.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+              "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+              "requires": {
+                "camelcase": "^2.0.1",
+                "cliui": "^3.0.3",
+                "decamelize": "^1.1.1",
+                "os-locale": "^1.4.0",
+                "string-width": "^1.0.1",
+                "window-size": "^0.1.4",
+                "y18n": "^3.2.0"
+              }
             }
           }
         },
@@ -18122,11 +18294,6 @@
             }
           }
         },
-        "dom-walk": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-          "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
-        },
         "domain-browser": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -18154,9 +18321,9 @@
           }
         },
         "dompurify": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-1.0.2.tgz",
-          "integrity": "sha512-3POD2YKOvoG/qI7e+IMUBAdKyN5CmeMyrFQu7rk92neduPFWl81/ramY6UrYkJInMUTBwzqw0QS5GEr27kmV4A=="
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-1.0.5.tgz",
+          "integrity": "sha512-W7QHgBwTbTh3/Xv0jQyckJOTN2uigyrwOTidFv0qRbT6s6HtuIO3e1LXKbA35FJ34dbptQ5Yznkd/ELAdJ2wOw=="
         },
         "domutils": {
           "version": "1.7.0",
@@ -18167,18 +18334,10 @@
             "domelementtype": "1"
           }
         },
-        "dot-case": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz",
-          "integrity": "sha1-HnOCaQDeKNbeVIC8HeMdCEKwa+w=",
-          "requires": {
-            "sentence-case": "^1.1.2"
-          }
-        },
         "draft-js": {
-          "version": "0.10.4",
-          "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.10.4.tgz",
-          "integrity": "sha1-FHdBZCCXyBINjtwjLpUD6Lf7jTU=",
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.10.5.tgz",
+          "integrity": "sha512-LE6jSCV9nkPhfVX2ggcRLA4FKs6zWq9ceuO/88BpXdNCS7mjRTgs0NsV6piUCJX9YxMsB9An33wnkMmU2sD2Zg==",
           "requires": {
             "fbjs": "^0.8.15",
             "immutable": "~3.7.4",
@@ -18262,13 +18421,6 @@
             "lru-cache": "^4.1.1",
             "semver": "^5.4.1",
             "sigmund": "^1.0.1"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-            }
           }
         },
         "editorconfig-to-prettier": {
@@ -18287,9 +18439,9 @@
           "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
         },
         "electron-to-chromium": {
-          "version": "1.3.48",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",
-          "integrity": "sha1-07DYWTgUBE4JLs4hCPw6ya6kuQA="
+          "version": "1.3.50",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.50.tgz",
+          "integrity": "sha1-dDi3b5K0G5GfP73TUPvQdX2s3fc="
         },
         "elegant-spinner": {
           "version": "1.0.1",
@@ -18451,6 +18603,11 @@
             "through": "~2.3.4"
           }
         },
+        "envinfo": {
+          "version": "5.10.0",
+          "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-5.10.0.tgz",
+          "integrity": "sha512-rXbzXWvnQxy+TcqZlARbWVQwgGVVouVJgFZhLVN5htjLxl1thstrP2ZGi0pXC309AbK7gVOPU+ulz/tmpCI7iw=="
+        },
         "enzyme": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.3.0.tgz",
@@ -18524,9 +18681,9 @@
           }
         },
         "error-ex": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+          "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
           "requires": {
             "is-arrayish": "^0.2.1"
           }
@@ -18551,46 +18708,6 @@
             "is-callable": "^1.1.1",
             "is-date-object": "^1.0.1",
             "is-symbol": "^1.0.1"
-          }
-        },
-        "es3ify": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/es3ify/-/es3ify-0.1.4.tgz",
-          "integrity": "sha1-rZ+l3xrjTz8x4SEbWBiy1RB439E=",
-          "requires": {
-            "esprima-fb": "~3001.0001.0000-dev-harmony-fb",
-            "jstransform": "~3.0.0",
-            "through": "~2.3.4"
-          },
-          "dependencies": {
-            "base62": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
-              "integrity": "sha1-e0F0wvlESXU7EcJlHAg9qEGnsIQ="
-            },
-            "esprima-fb": {
-              "version": "3001.1.0-dev-harmony-fb",
-              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
-              "integrity": "sha1-t303q8046gt3Qmu4vCkizmtCZBE="
-            },
-            "jstransform": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-3.0.0.tgz",
-              "integrity": "sha1-olkats7o2XvzvoMNv6IxO4fNZAs=",
-              "requires": {
-                "base62": "0.1.1",
-                "esprima-fb": "~3001.1.0-dev-harmony-fb",
-                "source-map": "0.1.31"
-              }
-            },
-            "source-map": {
-              "version": "0.1.31",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
-              "integrity": "sha1-n3BNDWnZ4TioG63267T94z0VHGE=",
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
-            }
           }
         },
         "es5-ext": {
@@ -18630,11 +18747,6 @@
             "es6-symbol": "~3.1.1",
             "event-emitter": "~0.3.5"
           }
-        },
-        "es6-promise": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-          "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
         },
         "es6-set": {
           "version": "0.1.5",
@@ -18843,6 +18955,32 @@
               "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
               "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
             },
+            "inquirer": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+              "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+              "requires": {
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^2.0.4",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rx-lite": "^4.0.8",
+                "rx-lite-aggregates": "^4.0.8",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+            },
             "json-schema-traverse": {
               "version": "0.3.1",
               "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
@@ -18866,10 +19004,14 @@
                 "wordwrap": "~1.0.0"
               }
             },
-            "semver": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
             },
             "strip-ansi": {
               "version": "4.0.0",
@@ -19079,11 +19221,6 @@
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
           "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
         },
-        "esmangle-evaluator": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.1.tgz",
-          "integrity": "sha1-Yg2GbvSGGzMR91dm1SqFcrs8YzY="
-        },
         "espree": {
           "version": "3.5.4",
           "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
@@ -19137,9 +19274,9 @@
           "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
         },
         "estree-walker": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
-          "integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4="
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
+          "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao="
         },
         "esutils": {
           "version": "2.0.2",
@@ -19366,10 +19503,10 @@
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
               "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
             },
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+            "qs": {
+              "version": "6.5.1",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+              "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
             },
             "raw-body": {
               "version": "2.3.2",
@@ -19468,29 +19605,6 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
           "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-        },
-        "falafel": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
-          "integrity": "sha1-wY0k71CRF0pJfzGM0ksCaiXN2rQ=",
-          "requires": {
-            "acorn": "^1.0.3",
-            "foreach": "^2.0.5",
-            "isarray": "0.0.1",
-            "object-keys": "^1.0.6"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "1.2.2",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
-              "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ="
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-            }
-          }
         },
         "fancy-log": {
           "version": "1.3.2",
@@ -20039,21 +20153,6 @@
             }
           }
         },
-        "finished": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/finished/-/finished-1.2.2.tgz",
-          "integrity": "sha1-QWCOr639ZWg7RqEiC8Sx7D2u3Ng=",
-          "requires": {
-            "ee-first": "1.0.3"
-          },
-          "dependencies": {
-            "ee-first": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz",
-              "integrity": "sha1-bJjECJq+y1p7hcGsRJqmA9Oz2r4="
-            }
-          }
-        },
         "first-chunk-stream": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
@@ -20084,9 +20183,9 @@
           "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
         },
         "flow-parser": {
-          "version": "0.74.0",
-          "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.74.0.tgz",
-          "integrity": "sha512-iQHi88aFCkPLr8cW1L9FtP9lmiT/9g20YaycW6sSWX6U9EdwN6K6OkWBlLhrfG5rbDJfJ9k0npVSfAkGNR7x2Q=="
+          "version": "0.75.0",
+          "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.75.0.tgz",
+          "integrity": "sha512-QEyV/t9TERBOSI/zSx0zhKH6924135WPI7pMmug2n/n/4puFm4mdAq1QaKPA3IPhXDRtManbySkKhRqws5UUGA=="
         },
         "flush-write-stream": {
           "version": "1.0.3",
@@ -20147,11 +20246,6 @@
           "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
           "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
         },
-        "foreachasync": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
-          "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY="
-        },
         "forever-agent": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -20210,6 +20304,16 @@
           "requires": {
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+          "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "fs-readdir-recursive": {
@@ -20727,9 +20831,9 @@
           "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
         },
         "fuse.js": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-2.6.1.tgz",
-          "integrity": "sha1-0RjgD5qFn3s1TtT3dAIUJJ4ypXo="
+          "version": "2.7.4",
+          "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-2.7.4.tgz",
+          "integrity": "sha1-luQg/efvARrEnCWKYhMU/ldlNvk="
         },
         "gather-stream": {
           "version": "1.0.0",
@@ -20782,23 +20886,10 @@
           "resolved": "https://registry.npmjs.org/get-document/-/get-document-1.0.0.tgz",
           "integrity": "sha1-SCG85m8cJMsDMWAr5strEsTwHEs="
         },
-        "get-pixels": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/get-pixels/-/get-pixels-3.3.0.tgz",
-          "integrity": "sha1-jZeVvq4YhQuED3SVgbrcBdPjbkE=",
-          "requires": {
-            "data-uri-to-buffer": "0.0.3",
-            "jpeg-js": "^0.1.1",
-            "mime-types": "^2.0.1",
-            "ndarray": "^1.0.13",
-            "ndarray-pack": "^1.1.1",
-            "node-bitmap": "0.0.1",
-            "omggif": "^1.0.5",
-            "parse-data-uri": "^0.2.0",
-            "pngjs": "^2.0.0",
-            "request": "^2.44.0",
-            "through": "^2.3.4"
-          }
+        "get-func-name": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+          "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
         },
         "get-src": {
           "version": "1.0.1",
@@ -20850,6 +20941,55 @@
           "requires": {
             "got": "^7.0.0",
             "is-plain-obj": "^1.1.0"
+          },
+          "dependencies": {
+            "got": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+              "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+              "requires": {
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
+              }
+            },
+            "p-cancelable": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+              "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+            },
+            "p-timeout": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+              "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+              "requires": {
+                "p-finally": "^1.0.0"
+              }
+            },
+            "prepend-http": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+              "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+            },
+            "url-parse-lax": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+              "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+              "requires": {
+                "prepend-http": "^1.0.1"
+              }
+            }
           }
         },
         "github-username": {
@@ -20919,22 +21059,6 @@
           "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
           "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
         },
-        "global": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-          "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-          "requires": {
-            "min-document": "^2.19.0",
-            "process": "~0.5.1"
-          },
-          "dependencies": {
-            "process": {
-              "version": "0.5.2",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-              "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
-            }
-          }
-        },
         "global-modules": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
@@ -20958,9 +21082,9 @@
           }
         },
         "globals": {
-          "version": "11.5.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
-          "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ=="
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
         },
         "globby": {
           "version": "6.1.0",
@@ -20987,13 +21111,6 @@
             "glob": "~7.1.1",
             "lodash": "~4.17.10",
             "minimatch": "~3.0.2"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "4.17.10",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-              "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-            }
           }
         },
         "glogg": {
@@ -21013,35 +21130,40 @@
           }
         },
         "got": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-          "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+          "version": "8.3.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-8.3.1.tgz",
+          "integrity": "sha512-tiLX+bnYm5A56T5N/n9Xo89vMaO1mrS9qoDqj3u/anVooqGozvY/HbXzEpDfbNeKsHCBpK40gSbz8wGYSp3i1w==",
           "requires": {
-            "decompress-response": "^3.2.0",
+            "@sindresorhus/is": "^0.7.0",
+            "cacheable-request": "^2.1.1",
+            "decompress-response": "^3.3.0",
             "duplexer3": "^0.1.4",
             "get-stream": "^3.0.0",
-            "is-plain-obj": "^1.1.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
+            "into-stream": "^3.1.0",
+            "is-retry-allowed": "^1.1.0",
             "isurl": "^1.0.0-alpha5",
             "lowercase-keys": "^1.0.0",
-            "p-cancelable": "^0.3.0",
-            "p-timeout": "^1.1.1",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "url-parse-lax": "^1.0.0",
+            "mimic-response": "^1.0.0",
+            "p-cancelable": "^0.4.0",
+            "p-timeout": "^2.0.1",
+            "pify": "^3.0.0",
+            "safe-buffer": "^5.1.1",
+            "timed-out": "^4.0.1",
+            "url-parse-lax": "^3.0.0",
             "url-to-options": "^1.0.1"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+            }
           }
         },
         "graceful-fs": {
           "version": "4.1.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-        },
-        "graceful-readlink": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
         },
         "graphql": {
           "version": "0.13.2",
@@ -21097,15 +21219,10 @@
             "vinyl": "^0.5.0"
           },
           "dependencies": {
-            "clone": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-              "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-            },
-            "clone-stats": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-              "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+            "dateformat": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+              "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
             },
             "minimist": {
               "version": "1.2.0",
@@ -21116,11 +21233,6 @@
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
               "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-            },
-            "replace-ext": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-              "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
             },
             "vinyl": {
               "version": "0.5.3",
@@ -21169,10 +21281,22 @@
             "uglify-js": "^2.6"
           },
           "dependencies": {
-            "async": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+            "camelcase": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+              "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+              "optional": true
+            },
+            "cliui": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+              "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+              "optional": true,
+              "requires": {
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
+                "wordwrap": "0.0.2"
+              }
             },
             "source-map": {
               "version": "0.4.4",
@@ -21180,6 +21304,43 @@
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "requires": {
                 "amdefine": ">=0.0.4"
+              }
+            },
+            "uglify-js": {
+              "version": "2.8.29",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+              "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+              "optional": true,
+              "requires": {
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.5.7",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                  "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                  "optional": true
+                }
+              }
+            },
+            "window-size": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+              "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+              "optional": true
+            },
+            "yargs": {
+              "version": "3.10.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "optional": true,
+              "requires": {
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
+                "window-size": "0.1.0"
               }
             }
           }
@@ -21347,13 +21508,6 @@
           "requires": {
             "inherits": "^2.0.3",
             "minimalistic-assert": "^1.0.0"
-          },
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-            }
           }
         },
         "hawk": {
@@ -21436,96 +21590,35 @@
           "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
         },
         "html-loader": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-0.4.0.tgz",
-          "integrity": "sha1-hB4LT46fD9QgnJTOATNwJh1kEOE=",
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-0.5.5.tgz",
+          "integrity": "sha512-7hIW7YinOYUpo//kSYcPB6dCKoceKLmOwjEMmhIobHuWGDVl0Nwe4l68mdG/Ru0wcUxQjVMEoZpkalZ/SE7zog==",
           "requires": {
-            "es6-templates": "^0.2.2",
-            "fastparse": "^1.0.0",
-            "html-minifier": "^1.0.0",
-            "loader-utils": "~0.2.2",
-            "object-assign": "^4.0.1",
-            "source-map": "^0.5.3"
-          },
-          "dependencies": {
-            "loader-utils": {
-              "version": "0.2.17",
-              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-              "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-              "requires": {
-                "big.js": "^3.1.3",
-                "emojis-list": "^2.0.0",
-                "json5": "^0.5.0",
-                "object-assign": "^4.0.1"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-            }
+            "es6-templates": "^0.2.3",
+            "fastparse": "^1.1.1",
+            "html-minifier": "^3.5.8",
+            "loader-utils": "^1.1.0",
+            "object-assign": "^4.1.1"
           }
         },
         "html-minifier": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-1.5.0.tgz",
-          "integrity": "sha1-vrBf2cw0CUWGXBD0Cu30aa9LFTQ=",
+          "version": "3.5.16",
+          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.16.tgz",
+          "integrity": "sha512-zP5EfLSpiLRp0aAgud4CQXPQZm9kXwWjR/cF0PfdOj+jjWnOaCgeZcll4kYXSvIBPeUMmyaSc7mM4IDtA+kboA==",
           "requires": {
-            "change-case": "2.3.x",
-            "clean-css": "3.4.x",
-            "commander": "2.9.x",
-            "concat-stream": "1.5.x",
-            "he": "1.0.x",
-            "ncname": "1.0.x",
+            "camel-case": "3.0.x",
+            "clean-css": "4.1.x",
+            "commander": "2.15.x",
+            "he": "1.1.x",
+            "param-case": "2.1.x",
             "relateurl": "0.2.x",
-            "uglify-js": "2.6.x"
+            "uglify-js": "3.3.x"
           },
           "dependencies": {
-            "commander": {
-              "version": "2.9.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-              "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-              "requires": {
-                "graceful-readlink": ">= 1.0.0"
-              }
-            },
-            "concat-stream": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
-              "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
-              "requires": {
-                "inherits": "~2.0.1",
-                "readable-stream": "~2.0.0",
-                "typedarray": "~0.0.5"
-              }
-            },
             "he": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/he/-/he-1.0.0.tgz",
-              "integrity": "sha1-baWyZdfyw7XkgHSRaODhWdBXKNo="
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-            },
-            "readable-stream": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-              "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~1.0.6",
-                "string_decoder": "~0.10.x",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+              "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
             }
           }
         },
@@ -21540,14 +21633,14 @@
           "integrity": "sha1-x43mW1Zjqll5id0rerSSANfk25g="
         },
         "html-to-react": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.3.1.tgz",
-          "integrity": "sha1-Db1/OPzklBkPZ0jVow/5YDvKOMs=",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.3.3.tgz",
+          "integrity": "sha512-4Qi5/t8oBr6c1t1kBJKyxEeJu0lb7ctvq29oFZioiUHH0Wz88VWGwoXuH26HDt9v64bDHA4NMPNTH8bVrcaJWA==",
           "requires": {
             "domhandler": "^2.3.0",
             "escape-string-regexp": "^1.0.5",
             "htmlparser2": "^3.8.3",
-            "ramda": "^0.24.1",
+            "ramda": "^0.25.0",
             "underscore.string.fp": "^1.0.4"
           }
         },
@@ -21564,6 +21657,11 @@
             "readable-stream": "^2.0.2"
           }
         },
+        "http-cache-semantics": {
+          "version": "3.8.1",
+          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+          "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
+        },
         "http-errors": {
           "version": "1.6.3",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -21573,13 +21671,6 @@
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
             "statuses": ">= 1.4.0 < 2"
-          },
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-            }
           }
         },
         "http-signature": {
@@ -21620,9 +21711,9 @@
           }
         },
         "i18n-calypso": {
-          "version": "1.8.4",
-          "resolved": "https://registry.npmjs.org/i18n-calypso/-/i18n-calypso-1.8.4.tgz",
-          "integrity": "sha512-vAEAmvbuytZEs/2d0M4WJYCKtzuCt4L2R7jMg57yO50kCmm5uPIj/9EJadum+MBPU7JgyWzDHH5J8PDr7deW4A==",
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/i18n-calypso/-/i18n-calypso-1.9.1.tgz",
+          "integrity": "sha512-5lnGA5+ew4m+jlWjH54rTt+KrsCoYbFPxg/20dGyuZZHIQ4+BizMqzIVkS6L091mmrCNnUHtv8Slf0/u+74cRQ==",
           "requires": {
             "async": "^1.5.2",
             "commander": "^2.9.0",
@@ -21637,14 +21728,10 @@
             "lru": "^3.1.0",
             "moment-timezone": "0.5.11",
             "react": "0.14.8 || ^15.5.0 || ^16.0.0",
-            "xgettext-js": "1.0.0"
+            "sha1": "^1.1.1",
+            "xgettext-js": "^1.0.0"
           },
           "dependencies": {
-            "async": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-            },
             "debug": {
               "version": "2.2.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
@@ -21652,6 +21739,11 @@
               "requires": {
                 "ms": "0.7.1"
               }
+            },
+            "ms": {
+              "version": "0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
             }
           }
         },
@@ -21674,9 +21766,9 @@
           "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
         },
         "ignore": {
-          "version": "3.3.8",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
-          "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg=="
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
         },
         "immediate": {
           "version": "3.0.6",
@@ -21684,9 +21776,9 @@
           "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
         },
         "immutability-helper": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.4.0.tgz",
-          "integrity": "sha512-rW/L/56ZMo9NStMK85kFrUFFGy4NeJbCdhfrDHIZrFfxYtuwuxD+dT3mWMcdmrNO61hllc60AeGglCRhfZ1dZw==",
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.7.1.tgz",
+          "integrity": "sha512-6uhvN9F1TRPtirUV3b7MIeY34h+U2hFR5hyK6jaWOvT36BNXYCx2tGujZhx/41fzUta/VNmK47scDhohTFYRDw==",
           "requires": {
             "invariant": "^2.2.0"
           }
@@ -21706,24 +21798,18 @@
           }
         },
         "imports-loader": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz",
-          "integrity": "sha1-rnRlMDHVnjezwvslRKxhrq41MKY=",
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.8.0.tgz",
+          "integrity": "sha512-kXWL7Scp8KQ4552ZcdVTeaQCZSLW+e6nJfp3cwUMB673T7Hr98Xjx5JK+ql7ADlJUvj1JS5O01RLbKoutN5QDQ==",
           "requires": {
-            "loader-utils": "0.2.x",
-            "source-map": "0.1.x"
+            "loader-utils": "^1.0.2",
+            "source-map": "^0.6.1"
           },
           "dependencies": {
-            "loader-utils": {
-              "version": "0.2.17",
-              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-              "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-              "requires": {
-                "big.js": "^3.1.3",
-                "emojis-list": "^2.0.0",
-                "json5": "^0.5.0",
-                "object-assign": "^4.0.1"
-              }
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
             }
           }
         },
@@ -21765,72 +21851,30 @@
           }
         },
         "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
-        "inline-process-browser": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-1.0.0.tgz",
-          "integrity": "sha1-RqYbFT3TybFiSxoAYm7bT39BTyI=",
-          "requires": {
-            "falafel": "^1.0.1",
-            "through2": "^0.6.5"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-            },
-            "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-            },
-            "through2": {
-              "version": "0.6.5",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-              "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-              "requires": {
-                "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                "xtend": ">=4.0.0 <4.1.0-0"
-              }
-            }
-          }
-        },
         "inquirer": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+          "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
           "requires": {
             "ansi-escapes": "^3.0.0",
             "chalk": "^2.0.0",
             "cli-cursor": "^2.1.0",
             "cli-width": "^2.0.0",
-            "external-editor": "^2.0.4",
+            "external-editor": "^2.1.0",
             "figures": "^2.0.0",
             "lodash": "^4.3.0",
             "mute-stream": "0.0.7",
             "run-async": "^2.2.0",
-            "rx-lite": "^4.0.8",
-            "rx-lite-aggregates": "^4.0.8",
+            "rxjs": "^5.5.2",
             "string-width": "^2.1.0",
             "strip-ansi": "^4.0.0",
             "through": "^2.3.6"
@@ -21889,6 +21933,15 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
           "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+        },
+        "into-stream": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+          "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+          "requires": {
+            "from2": "^2.1.1",
+            "p-is-promise": "^1.1.0"
+          }
         },
         "invariant": {
           "version": "2.2.4",
@@ -22089,14 +22142,6 @@
             "is-finite": "^1.0.0"
           }
         },
-        "is-lower-case": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
-          "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
-          "requires": {
-            "lower-case": "^1.1.0"
-          }
-        },
         "is-my-ip-valid": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
@@ -22131,6 +22176,14 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
           "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+        },
+        "is-observable": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+          "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+          "requires": {
+            "symbol-observable": "^1.1.0"
+          }
         },
         "is-odd": {
           "version": "2.0.0",
@@ -22269,14 +22322,6 @@
           "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
         },
-        "is-upper-case": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
-          "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
-          "requires": {
-            "upper-case": "^1.1.0"
-          }
-        },
         "is-utf8": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -22309,6 +22354,11 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isbinaryfile": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.2.tgz",
+          "integrity": "sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE="
         },
         "isexe": {
           "version": "2.0.0",
@@ -22362,11 +22412,6 @@
               "version": "1.0.9",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
               "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
-            },
-            "async": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
             },
             "escodegen": {
               "version": "1.8.1",
@@ -22483,11 +22528,6 @@
                 "source-map": "^0.5.3"
               }
             },
-            "lodash": {
-              "version": "4.17.10",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-              "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-            },
             "ms": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -22531,11 +22571,6 @@
               "version": "6.18.0",
               "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
               "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-            },
-            "semver": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
             }
           }
         },
@@ -22933,20 +22968,6 @@
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
-              }
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-            },
-            "source-map-support": {
-              "version": "0.5.6",
-              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-              "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
-              "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
               }
             }
           }
@@ -23469,221 +23490,67 @@
           "optional": true
         },
         "jscodeshift": {
-          "version": "0.3.30",
-          "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.3.30.tgz",
-          "integrity": "sha1-c/RZ2Pw7OoCEGZGut9JICc7238U=",
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.5.1.tgz",
+          "integrity": "sha512-sRMollbhbmSDrR79JMAnhEjyZJlQQVozeeY9A6/KNuV26DNcuB3mGSCWXp0hks9dcwRNOELbNOiwraZaXXRk5Q==",
           "requires": {
-            "async": "^1.5.0",
-            "babel-core": "^5",
             "babel-plugin-transform-flow-strip-types": "^6.8.0",
             "babel-preset-es2015": "^6.9.0",
             "babel-preset-stage-1": "^6.5.0",
             "babel-register": "^6.9.0",
-            "babylon": "^6.8.1",
+            "babylon": "^7.0.0-beta.47",
             "colors": "^1.1.2",
-            "es6-promise": "^3.0.0",
             "flow-parser": "^0.*",
             "lodash": "^4.13.1",
             "micromatch": "^2.3.7",
+            "neo-async": "^2.5.0",
             "node-dir": "0.1.8",
             "nomnom": "^1.8.1",
-            "recast": "^0.11.11",
+            "recast": "^0.15.0",
             "temp": "^0.8.1",
             "write-file-atomic": "^1.2.0"
           },
           "dependencies": {
-            "async": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-            },
-            "babel-core": {
-              "version": "5.8.38",
-              "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
-              "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-              "requires": {
-                "babel-plugin-constant-folding": "^1.0.1",
-                "babel-plugin-dead-code-elimination": "^1.0.2",
-                "babel-plugin-eval": "^1.0.1",
-                "babel-plugin-inline-environment-variables": "^1.0.1",
-                "babel-plugin-jscript": "^1.0.4",
-                "babel-plugin-member-expression-literals": "^1.0.1",
-                "babel-plugin-property-literals": "^1.0.1",
-                "babel-plugin-proto-to-assign": "^1.0.3",
-                "babel-plugin-react-constant-elements": "^1.0.3",
-                "babel-plugin-react-display-name": "^1.0.3",
-                "babel-plugin-remove-console": "^1.0.1",
-                "babel-plugin-remove-debugger": "^1.0.1",
-                "babel-plugin-runtime": "^1.0.7",
-                "babel-plugin-undeclared-variables-check": "^1.0.2",
-                "babel-plugin-undefined-to-void": "^1.1.6",
-                "babylon": "^5.8.38",
-                "bluebird": "^2.9.33",
-                "chalk": "^1.0.0",
-                "convert-source-map": "^1.1.0",
-                "core-js": "^1.0.0",
-                "debug": "^2.1.1",
-                "detect-indent": "^3.0.0",
-                "esutils": "^2.0.0",
-                "fs-readdir-recursive": "^0.1.0",
-                "globals": "^6.4.0",
-                "home-or-tmp": "^1.0.0",
-                "is-integer": "^1.0.4",
-                "js-tokens": "1.0.1",
-                "json5": "^0.4.0",
-                "lodash": "^3.10.0",
-                "minimatch": "^2.0.3",
-                "output-file-sync": "^1.1.0",
-                "path-exists": "^1.0.0",
-                "path-is-absolute": "^1.0.0",
-                "private": "^0.1.6",
-                "regenerator": "0.8.40",
-                "regexpu": "^1.3.0",
-                "repeating": "^1.1.2",
-                "resolve": "^1.1.6",
-                "shebang-regex": "^1.0.0",
-                "slash": "^1.0.0",
-                "source-map": "^0.5.0",
-                "source-map-support": "^0.2.10",
-                "to-fast-properties": "^1.0.0",
-                "trim-right": "^1.0.0",
-                "try-resolve": "^1.0.0"
-              },
-              "dependencies": {
-                "babylon": {
-                  "version": "5.8.38",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
-                  "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0="
-                },
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                  "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-                }
-              }
+            "ast-types": {
+              "version": "0.11.5",
+              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.5.tgz",
+              "integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw=="
             },
             "babylon": {
-              "version": "6.18.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-              "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-            },
-            "bluebird": {
-              "version": "2.11.0",
-              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-              "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+              "version": "7.0.0-beta.47",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
+              "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
             },
             "colors": {
               "version": "1.3.0",
               "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
               "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
             },
-            "core-js": {
-              "version": "1.2.7",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-              "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+            "esprima": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+              "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
             },
-            "detect-indent": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-              "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
+            "neo-async": {
+              "version": "2.5.1",
+              "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.1.tgz",
+              "integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA=="
+            },
+            "recast": {
+              "version": "0.15.0",
+              "resolved": "https://registry.npmjs.org/recast/-/recast-0.15.0.tgz",
+              "integrity": "sha512-47C2mIxQYvFICrTNuV4+xGgBa1nAoq42ANN5oDTSBIJ50NX7jcki7gAC6HWYptnQgHmqIRTHJq8OKdi3fwgyNQ==",
               "requires": {
-                "get-stdin": "^4.0.1",
-                "minimist": "^1.1.0",
-                "repeating": "^1.1.0"
-              }
-            },
-            "fs-readdir-recursive": {
-              "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
-              "integrity": "sha1-MVtPuMHKW4xH3v7zGdBz2tNWgFk="
-            },
-            "globals": {
-              "version": "6.4.1",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-              "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08="
-            },
-            "home-or-tmp": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-              "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-              "requires": {
-                "os-tmpdir": "^1.0.1",
-                "user-home": "^1.1.1"
-              }
-            },
-            "js-tokens": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-              "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4="
-            },
-            "json5": {
-              "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-              "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-              "requires": {
-                "brace-expansion": "^1.0.0"
-              }
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-            },
-            "output-file-sync": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-              "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-              "requires": {
-                "graceful-fs": "^4.1.4",
-                "mkdirp": "^0.5.1",
-                "object-assign": "^4.1.0"
-              }
-            },
-            "path-exists": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-              "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE="
-            },
-            "repeating": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-              "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-              "requires": {
-                "is-finite": "^1.0.0"
+                "ast-types": "0.11.5",
+                "esprima": "~4.0.0",
+                "private": "~0.1.5",
+                "source-map": "~0.6.1"
               }
             },
             "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-            },
-            "source-map-support": {
-              "version": "0.2.10",
-              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-              "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
-              "requires": {
-                "source-map": "0.1.32"
-              },
-              "dependencies": {
-                "source-map": {
-                  "version": "0.1.32",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-                  "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-                  "requires": {
-                    "amdefine": ">=0.0.4"
-                  }
-                }
-              }
-            },
-            "to-fast-properties": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-              "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
             }
           }
         },
@@ -23841,10 +23708,10 @@
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
           "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
         },
-        "json-loader": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz",
-          "integrity": "sha1-i6oTZaYy9Yo8RtIBdfxgAsluN94="
+        "json-buffer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+          "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
@@ -23888,6 +23755,14 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
         },
         "jsonfilter": {
           "version": "1.1.2",
@@ -24025,11 +23900,11 @@
           }
         },
         "jsx-to-string": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/jsx-to-string/-/jsx-to-string-1.3.1.tgz",
-          "integrity": "sha512-RLJvtKXEKfn8JGDn3VaNruwSHi4N6C1CYcCD6+JXytCUXhDRMUv7QspHjpIYkuf5tMKIYoY2DzBYJynNAkZsXA==",
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/jsx-to-string/-/jsx-to-string-1.4.0.tgz",
+          "integrity": "sha1-Ztw013PaufQP6ZPP+ZQOXaZVtwU=",
           "requires": {
-            "immutable": "4.0.0-rc.2",
+            "immutable": "^4.0.0-rc.9",
             "json-stringify-pretty-compact": "^1.0.1",
             "react": "^0.14.0"
           },
@@ -24052,9 +23927,9 @@
               }
             },
             "immutable": {
-              "version": "4.0.0-rc.2",
-              "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.2.tgz",
-              "integrity": "sha1-/dCUiq5yj9ojBqAvcrtz4Xc0MtE="
+              "version": "4.0.0-rc.9",
+              "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.9.tgz",
+              "integrity": "sha512-uw4u9Jy3G2Y1qkIFtEGy9NgJxFJT1l3HKgeSFHfrvy91T8W54cJoQ+qK3fTwhil8XkEHuc2S+MI+fbD0vKObDA=="
             },
             "react": {
               "version": "0.14.9",
@@ -24081,6 +23956,14 @@
           "version": "1.6.2",
           "resolved": "https://registry.npmjs.org/keymaster/-/keymaster-1.6.2.tgz",
           "integrity": "sha1-4a5U0OqUiPn2C2a2aPAumhlGxus="
+        },
+        "keyv": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+          "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+          "requires": {
+            "json-buffer": "3.0.0"
+          }
         },
         "kind-of": {
           "version": "3.2.2",
@@ -24169,36 +24052,33 @@
           }
         },
         "lie": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/lie/-/lie-3.0.2.tgz",
-          "integrity": "sha1-/9oh17uibzd8rYZdNkmy/Izjn+o=",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+          "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
           "requires": {
-            "es3ify": "^0.1.3",
-            "immediate": "~3.0.5",
-            "inline-process-browser": "^1.0.0",
-            "unreachable-branch-transform": "^0.3.0"
+            "immediate": "~3.0.5"
           }
         },
         "listr": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/listr/-/listr-0.12.0.tgz",
-          "integrity": "sha1-a84sD1YD+klYDqF81qAMwOX6RRo=",
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.1.tgz",
+          "integrity": "sha512-MSMUUVN1f8aRnPi4034RkOqdiUlpYW+FqwFE3aL0uYNPRavkt2S2SsSpDDofn8BDpqv2RNnsdOcCHWsChcq77A==",
           "requires": {
-            "chalk": "^1.1.3",
+            "@samverschueren/stream-to-observable": "^0.3.0",
             "cli-truncate": "^0.2.1",
             "figures": "^1.7.0",
             "indent-string": "^2.1.0",
+            "is-observable": "^1.1.0",
             "is-promise": "^2.1.0",
             "is-stream": "^1.1.0",
             "listr-silent-renderer": "^1.1.1",
-            "listr-update-renderer": "^0.2.0",
+            "listr-update-renderer": "^0.4.0",
             "listr-verbose-renderer": "^0.4.0",
             "log-symbols": "^1.0.2",
             "log-update": "^1.0.2",
             "ora": "^0.2.3",
             "p-map": "^1.1.1",
-            "rxjs": "^5.0.0-beta.11",
-            "stream-to-observable": "^0.1.0",
+            "rxjs": "^6.1.0",
             "strip-ansi": "^3.0.1"
           },
           "dependencies": {
@@ -24218,6 +24098,14 @@
               "requires": {
                 "chalk": "^1.0.0"
               }
+            },
+            "rxjs": {
+              "version": "6.2.1",
+              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.1.tgz",
+              "integrity": "sha512-OwMxHxmnmHTUpgO+V7dZChf3Tixf4ih95cmXjzzadULziVl/FKhHScGLj4goEw9weePVOH2Q0+GcCBUhKCZc/g==",
+              "requires": {
+                "tslib": "^1.9.0"
+              }
             }
           }
         },
@@ -24227,9 +24115,9 @@
           "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4="
         },
         "listr-update-renderer": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz",
-          "integrity": "sha1-yoDhd5tOcCZoB+ju0a1qvjmFUPk=",
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+          "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
           "requires": {
             "chalk": "^1.1.3",
             "cli-truncate": "^0.2.1",
@@ -24337,11 +24225,11 @@
           }
         },
         "localforage": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.4.3.tgz",
-          "integrity": "sha1-ohJUPDnHx2Qk7dEr9HTEiarKSUw=",
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.2.tgz",
+          "integrity": "sha1-+kRCYC+Abt0rympUq05lbwMfEhw=",
           "requires": {
-            "lie": "3.0.2"
+            "lie": "3.1.1"
           }
         },
         "locate-path": {
@@ -24564,9 +24452,9 @@
           "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
         },
         "log-symbols": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
-          "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
           "requires": {
             "chalk": "^2.0.1"
           },
@@ -24667,14 +24555,6 @@
           "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
           "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
         },
-        "lower-case-first": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
-          "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
-          "requires": {
-            "lower-case": "^1.1.2"
-          }
-        },
         "lowercase-keys": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -24698,9 +24578,9 @@
           }
         },
         "lunr": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/lunr/-/lunr-0.5.7.tgz",
-          "integrity": "sha1-4hp8eDIlqtKwTD4b+iG01IqFLm8="
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/lunr/-/lunr-0.7.2.tgz",
+          "integrity": "sha1-eaMOky4hbLoWNUHuN6NgfBLNcoE="
         },
         "magic-string": {
           "version": "0.22.5",
@@ -24785,19 +24665,12 @@
           "requires": {
             "loader-utils": "^1.1.0",
             "marked": "^0.4.0"
-          },
-          "dependencies": {
-            "marked": {
-              "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
-              "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw=="
-            }
           }
         },
         "marked": {
-          "version": "0.3.9",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.9.tgz",
-          "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw=="
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
+          "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw=="
         },
         "marked-terminal": {
           "version": "2.0.0",
@@ -24817,9 +24690,12 @@
           "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
         },
         "md5-file": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-3.1.0.tgz",
-          "integrity": "sha1-obCC/KOtQjHTaIAGIkJfs1x03VM="
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-3.2.3.tgz",
+          "integrity": "sha512-3Tkp1piAHaworfcCgH0jKbTvj1jWWFgbvh2cXaNCgHwyTCBxxvD1Y04rmfpvdPm1P4oXMOpm6+2H7sr7v9v8Fw==",
+          "requires": {
+            "buffer-alloc": "^1.1.0"
+          }
         },
         "md5.js": {
           "version": "1.3.4",
@@ -24851,50 +24727,73 @@
             "through2": "^2.0.0",
             "vinyl": "^1.1.0",
             "vinyl-file": "^2.0.0"
-          },
-          "dependencies": {
-            "clone": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-              "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-            },
-            "clone-stats": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-              "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
-            },
-            "replace-ext": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-              "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
-            },
-            "vinyl": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-              "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-              "requires": {
-                "clone": "^1.0.0",
-                "clone-stats": "^0.0.1",
-                "replace-ext": "0.0.1"
-              }
-            }
           }
         },
         "mem-fs-editor": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz",
-          "integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-4.0.2.tgz",
+          "integrity": "sha512-QHvdXLLNmwJXxKdf7x27aNUren6IoPxwcM8Sfd+S6/ddQQMcYdEtVKsh6ilpqMrU18VQuKZEaH0aCGt3JDbA0g==",
           "requires": {
             "commondir": "^1.0.1",
-            "deep-extend": "^0.4.0",
-            "ejs": "^2.3.1",
+            "deep-extend": "^0.5.1",
+            "ejs": "^2.5.9",
             "glob": "^7.0.3",
-            "globby": "^6.1.0",
+            "globby": "^8.0.0",
+            "isbinaryfile": "^3.0.2",
             "mkdirp": "^0.5.0",
             "multimatch": "^2.0.0",
             "rimraf": "^2.2.8",
             "through2": "^2.0.0",
             "vinyl": "^2.0.1"
+          },
+          "dependencies": {
+            "clone": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+              "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+            },
+            "clone-stats": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+              "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+            },
+            "globby": {
+              "version": "8.0.1",
+              "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+              "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+              "requires": {
+                "array-union": "^1.0.1",
+                "dir-glob": "^2.0.0",
+                "fast-glob": "^2.0.2",
+                "glob": "^7.1.2",
+                "ignore": "^3.3.5",
+                "pify": "^3.0.0",
+                "slash": "^1.0.0"
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+            },
+            "replace-ext": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+              "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+            },
+            "vinyl": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+              "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+              "requires": {
+                "clone": "^2.1.1",
+                "clone-buffer": "^1.0.0",
+                "clone-stats": "^1.0.0",
+                "cloneable-readable": "^1.0.0",
+                "remove-trailing-separator": "^1.0.1",
+                "replace-ext": "^1.0.0"
+              }
+            }
           }
         },
         "memory-fs": {
@@ -24905,6 +24804,11 @@
             "errno": "^0.1.3",
             "readable-stream": "^2.0.1"
           }
+        },
+        "memorystream": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+          "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI="
         },
         "meow": {
           "version": "3.7.0",
@@ -25015,14 +24919,6 @@
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
           "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
         },
-        "min-document": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-          "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-          "requires": {
-            "dom-walk": "^0.1.0"
-          }
-        },
         "minimalistic-assert": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -25107,9 +25003,9 @@
           }
         },
         "moment": {
-          "version": "2.21.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-          "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
+          "version": "2.22.2",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+          "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
         },
         "moment-timezone": {
           "version": "0.5.11",
@@ -25120,26 +25016,15 @@
           }
         },
         "morgan": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.2.0.tgz",
-          "integrity": "sha1-jcF6V1mVmPgM16fh47VOcsaJkQ0=",
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
+          "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
           "requires": {
-            "basic-auth": "1.0.0",
-            "bytes": "1.0.0",
-            "depd": "0.4.2",
-            "finished": "~1.2.2"
-          },
-          "dependencies": {
-            "bytes": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
-              "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g="
-            },
-            "depd": {
-              "version": "0.4.2",
-              "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.2.tgz",
-              "integrity": "sha1-pLyKDkgBdwpmNj2qbTUTjz47VN0="
-            }
+            "basic-auth": "~2.0.0",
+            "debug": "2.6.9",
+            "depd": "~1.1.1",
+            "on-finished": "~2.3.0",
+            "on-headers": "~1.0.1"
           }
         },
         "move-concurrently": {
@@ -25156,9 +25041,9 @@
           }
         },
         "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+          "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
         },
         "multimatch": {
           "version": "2.1.0",
@@ -25230,14 +25115,6 @@
           "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
           "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
         },
-        "ncname": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
-          "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
-          "requires": {
-            "xml-char-classes": "^1.0.0"
-          }
-        },
         "ndarray": {
           "version": "1.0.18",
           "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.18.tgz",
@@ -25281,11 +25158,6 @@
                 "underscore": "~1.4.4"
               }
             },
-            "semver": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-            },
             "underscore": {
               "version": "1.4.4",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
@@ -25309,28 +25181,73 @@
           "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
         },
         "nextgen-events": {
-          "version": "0.10.2",
-          "resolved": "https://registry.npmjs.org/nextgen-events/-/nextgen-events-0.10.2.tgz",
-          "integrity": "sha512-P6efDoVOOJjVLOhwINq+aqhC2B3a9IxojbWMn9fTv2coDiyRaaGLSgWsm84wQHlQeuqVgqiLEE+xiHXf3EVN6w=="
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/nextgen-events/-/nextgen-events-1.1.0.tgz",
+          "integrity": "sha512-Emz5rh584fygInd3gtwP+xGyJhEnyxQa0/Xbmw8sbpXVGV/luqDnVPq1cQopYR7qg6KUlPfwWVhxrhZri1wDAw=="
         },
         "nice-try": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
           "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
         },
+        "no-case": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+          "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+          "requires": {
+            "lower-case": "^1.1.1"
+          }
+        },
         "nock": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/nock/-/nock-8.0.0.tgz",
-          "integrity": "sha1-+G1nZWjHOjuyFE68gHkdRHuzNNI=",
+          "version": "8.2.2",
+          "resolved": "https://registry.npmjs.org/nock/-/nock-8.2.2.tgz",
+          "integrity": "sha512-f4s5qR4Eg/NgaLuBYTThc/abl5mohCgIvnGdHkoqR5WgRe5amjFQTU2aia085OE8o3OAY7ZerDkRAeXfR720TA==",
           "requires": {
             "chai": ">=1.9.2 <4.0.0",
             "debug": "^2.2.0",
             "deep-equal": "^1.0.0",
             "json-stringify-safe": "^5.0.1",
-            "lodash": "^4.8.2",
+            "lodash": "~4.9.0",
             "mkdirp": "^0.5.0",
             "propagate": "0.4.0",
             "qs": "^6.0.2"
+          },
+          "dependencies": {
+            "chai": {
+              "version": "3.5.0",
+              "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+              "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+              "requires": {
+                "assertion-error": "^1.0.1",
+                "deep-eql": "^0.1.3",
+                "type-detect": "^1.0.0"
+              }
+            },
+            "deep-eql": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+              "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+              "requires": {
+                "type-detect": "0.1.1"
+              },
+              "dependencies": {
+                "type-detect": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+                  "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
+                }
+              }
+            },
+            "lodash": {
+              "version": "4.9.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.9.0.tgz",
+              "integrity": "sha1-TCDXQvA86F3HAODderm8q4Xm/BQ="
+            },
+            "type-detect": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+              "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
+            }
           }
         },
         "node-bitmap": {
@@ -25430,6 +25347,11 @@
               "version": "1.1.1",
               "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
               "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+            },
+            "path-browserify": {
+              "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+              "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
             }
           }
         },
@@ -25442,13 +25364,6 @@
             "semver": "^5.4.1",
             "shellwords": "^0.1.1",
             "which": "^1.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-            }
           }
         },
         "node-sass": {
@@ -25556,62 +25471,411 @@
           "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
           "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM="
         },
+        "normalize-url": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+          "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+          "requires": {
+            "prepend-http": "^2.0.0",
+            "query-string": "^5.0.1",
+            "sort-keys": "^2.0.0"
+          }
+        },
         "notifications-panel": {
           "version": "2.1.10",
           "resolved": "https://registry.npmjs.org/notifications-panel/-/notifications-panel-2.1.10.tgz",
           "integrity": "sha512-lGQocN7VDL5aue1SMwLifFe88UT1zqcLJ6v0x+QtL3Ws5yYfLC3sM+qaHVGrRdqFh3GZsc4PG4gzt+oGZgX+7Q=="
         },
-        "npm-run-all": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.0.2.tgz",
-          "integrity": "sha1-qEZpNI5ttsy+BSIAtM22v+A0pP4=",
+        "npm-merge-driver": {
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/npm-merge-driver/-/npm-merge-driver-2.3.5.tgz",
+          "integrity": "sha512-MUxE26ZdDWAc+wlqwyOEIhRH1EdaIXCWSZbqAQ76dUkz3uSrxrLhfgQ3nb3oZbqC5e4NyLcCdzTSDVwkisoJpg==",
           "requires": {
-            "chalk": "^1.1.3",
-            "cross-spawn": "^5.0.1",
-            "minimatch": "^3.0.2",
-            "ps-tree": "^1.0.1",
-            "read-pkg": "^2.0.0",
-            "shell-quote": "^1.6.1",
-            "string.prototype.padend": "^3.0.0"
+            "mkdirp": "^0.5.1",
+            "yargs": "^10.0.3"
           },
           "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
             "cross-spawn": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+              "bundled": true,
               "requires": {
                 "lru-cache": "^4.0.1",
                 "shebang-command": "^1.2.0",
                 "which": "^1.2.9"
               }
             },
-            "load-json-file": {
+            "decamelize": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "execa": {
+              "version": "0.7.0",
+              "bundled": true,
+              "requires": {
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+              }
+            },
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            },
+            "get-caller-file": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "invert-kv": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "isexe": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-              "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+              "bundled": true
+            },
+            "lcid": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "invert-kv": "^1.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "lru-cache": {
+              "version": "4.1.1",
+              "bundled": true,
+              "requires": {
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
+              }
+            },
+            "mem": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "mimic-fn": "^1.0.0"
+              }
+            },
+            "mimic-fn": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "npm-run-path": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "path-key": "^2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "os-locale": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "execa": "^0.7.0",
+                "lcid": "^1.0.0",
+                "mem": "^1.1.0"
+              }
+            },
+            "p-finally": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "p-limit": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "p-locate": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^1.1.0"
+              }
+            },
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "path-key": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "pseudomap": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "require-directory": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "require-main-filename": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "shebang-command": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "shebang-regex": "^1.0.0"
+              }
+            },
+            "shebang-regex": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-eof": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "which": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            },
+            "which-module": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "wrap-ansi": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+              }
+            },
+            "y18n": {
+              "version": "3.2.1",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "bundled": true
+            },
+            "yargs": {
+              "version": "10.0.3",
+              "bundled": true,
+              "requires": {
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^8.0.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "cliui": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "^1.0.1",
+                    "strip-ansi": "^3.0.1",
+                    "wrap-ansi": "^2.0.0"
+                  },
+                  "dependencies": {
+                    "string-width": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                      }
+                    }
+                  }
+                },
+                "string-width": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-fullwidth-code-point": "^2.0.0",
+                    "strip-ansi": "^4.0.0"
+                  },
+                  "dependencies": {
+                    "is-fullwidth-code-point": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    },
+                    "strip-ansi": {
+                      "version": "4.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-regex": "^3.0.0"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "yargs-parser": {
+              "version": "8.0.0",
+              "bundled": true,
+              "requires": {
+                "camelcase": "^4.1.0"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "npm-run-all": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.3.tgz",
+          "integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.4",
+            "memorystream": "^0.3.1",
+            "minimatch": "^3.0.4",
+            "ps-tree": "^1.1.0",
+            "read-pkg": "^3.0.0",
+            "shell-quote": "^1.6.1",
+            "string.prototype.padend": "^3.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.1",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+              "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "load-json-file": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+              "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
               "requires": {
                 "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
                 "strip-bom": "^3.0.0"
               }
             },
-            "path-type": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-              "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+            "parse-json": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+              "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
               "requires": {
-                "pify": "^2.0.0"
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
               }
             },
-            "read-pkg": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-              "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+            "path-type": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+              "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
               "requires": {
-                "load-json-file": "^2.0.0",
+                "pify": "^3.0.0"
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+            },
+            "read-pkg": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+              "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+              "requires": {
+                "load-json-file": "^4.0.0",
                 "normalize-package-data": "^2.3.2",
-                "path-type": "^2.0.0"
+                "path-type": "^3.0.0"
               }
             },
             "strip-bom": {
@@ -25719,14 +25983,14 @@
           "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
         },
         "object-keys": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-          "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+          "version": "1.0.12",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+          "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
         },
         "object-path-immutable": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/object-path-immutable/-/object-path-immutable-0.5.2.tgz",
-          "integrity": "sha512-6fnJfXjj/SCdqctFRN8wJAxvbnHsFZ9ISnvgEImZ3ophWDx38r6Wu8PZJ9LXrjhihOOhGiLKicN682VtL/9cfg=="
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/object-path-immutable/-/object-path-immutable-0.5.3.tgz",
+          "integrity": "sha512-MKKU8uPX+Xa2PlQw7ibOh6Qh8GUxQVd2g/19Ym8bVa04XXSoPebzXoiV+a4298tnDtjDtSwDfcHLjoYmKHSz8Q=="
         },
         "object-visit": {
           "version": "1.0.1",
@@ -25826,6 +26090,11 @@
           "requires": {
             "ee-first": "1.1.1"
           }
+        },
+        "on-headers": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+          "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
         },
         "once": {
           "version": "1.4.0",
@@ -25935,11 +26204,6 @@
             "lcid": "^1.0.0"
           }
         },
-        "os-shim": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-          "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc="
-        },
         "os-tmpdir": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -25965,9 +26229,9 @@
           }
         },
         "p-cancelable": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
         },
         "p-each-series": {
           "version": "1.0.0",
@@ -25981,6 +26245,11 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
           "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+        },
+        "p-is-promise": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+          "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
         },
         "p-lazy": {
           "version": "1.0.0",
@@ -26014,9 +26283,9 @@
           "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
         },
         "p-timeout": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
-          "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+          "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
           "requires": {
             "p-finally": "^1.0.0"
           }
@@ -26062,21 +26331,14 @@
             "cyclist": "~0.2.2",
             "inherits": "^2.0.3",
             "readable-stream": "^2.1.5"
-          },
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-            }
           }
         },
         "param-case": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz",
-          "integrity": "sha1-3LCRpDwlm5Io8cNB57akTqC/l0M=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+          "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
           "requires": {
-            "sentence-case": "^1.1.2"
+            "no-case": "^2.2.0"
           }
         },
         "parse-asn1": {
@@ -26089,14 +26351,6 @@
             "create-hash": "^1.1.0",
             "evp_bytestokey": "^1.0.0",
             "pbkdf2": "^3.0.3"
-          }
-        },
-        "parse-data-uri": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/parse-data-uri/-/parse-data-uri-0.2.0.tgz",
-          "integrity": "sha1-vwTYUd1ch7CrI45dAazklLYEtMk=",
-          "requires": {
-            "data-uri-to-buffer": "0.0.3"
           }
         },
         "parse-entities": {
@@ -26182,15 +26436,6 @@
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
           "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
         },
-        "pascal-case": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz",
-          "integrity": "sha1-Pl1kogBDgwp8STRMLXS0G+DJyZs=",
-          "requires": {
-            "camel-case": "^1.1.1",
-            "upper-case-first": "^1.1.0"
-          }
-        },
         "pascalcase": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -26206,17 +26451,9 @@
           }
         },
         "path-browserify": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-          "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
-        },
-        "path-case": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz",
-          "integrity": "sha1-UM5roNO+090LXCqcRVNpdDRAlRQ=",
-          "requires": {
-            "sentence-case": "^1.1.2"
-          }
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.0.tgz",
+          "integrity": "sha512-Hkavx/nY4/plImrZPHRk2CL9vpOymZLgEbMNX1U0bjcBL7QN9wODxyx0yaMZURSQaUtSEvDrfAvxa9oPb0at9g=="
         },
         "path-dirname": {
           "version": "1.0.2",
@@ -26262,6 +26499,11 @@
             "pify": "^2.0.0",
             "pinkie-promise": "^2.0.0"
           }
+        },
+        "pathval": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+          "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
         },
         "pause-stream": {
           "version": "0.0.11",
@@ -26386,9 +26628,9 @@
           "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
         },
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "requires": {
             "chalk": "^2.4.1",
             "source-map": "^0.6.1",
@@ -26413,19 +26655,25 @@
           }
         },
         "postcss-cli": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/postcss-cli/-/postcss-cli-2.5.1.tgz",
-          "integrity": "sha1-uwHFRSG6fg1lTtTRg8U7HK6bX30=",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/postcss-cli/-/postcss-cli-2.6.0.tgz",
+          "integrity": "sha1-8N45PKoCb8/BsUeYIpia9QjtUV0=",
           "requires": {
-            "chokidar": "^1.0.3",
-            "globby": "^3.0.1",
+            "chokidar": "^1.5.1",
+            "globby": "^4.1.0",
+            "mkdirp": "^0.5.1",
             "neo-async": "^1.0.0",
             "postcss": "^5.0.0",
             "read-file-stdin": "^0.2.0",
             "resolve": "^1.1.6",
-            "yargs": "^3.8.0"
+            "yargs": "^4.7.1"
           },
           "dependencies": {
+            "camelcase": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+            },
             "chokidar": {
               "version": "1.7.0",
               "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
@@ -26444,9 +26692,9 @@
               }
             },
             "glob": {
-              "version": "5.0.15",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "version": "6.0.4",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+              "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
               "requires": {
                 "inflight": "^1.0.4",
                 "inherits": "2",
@@ -26456,35 +26704,22 @@
               }
             },
             "globby": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/globby/-/globby-3.0.1.tgz",
-              "integrity": "sha1-IJSvhCHhkVIVDViT62QWsxLZoi8=",
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
+              "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
               "requires": {
                 "array-union": "^1.0.1",
                 "arrify": "^1.0.0",
-                "glob": "^5.0.3",
+                "glob": "^6.0.1",
                 "object-assign": "^4.0.1",
                 "pify": "^2.0.0",
-                "pinkie-promise": "^1.0.0"
+                "pinkie-promise": "^2.0.0"
               }
             },
             "has-flag": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
               "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-            },
-            "pinkie": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-              "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q="
-            },
-            "pinkie-promise": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-              "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
-              "requires": {
-                "pinkie": "^1.0.0"
-              }
             },
             "postcss": {
               "version": "5.2.18",
@@ -26509,16 +26744,51 @@
               "requires": {
                 "has-flag": "^1.0.0"
               }
+            },
+            "y18n": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+            },
+            "yargs": {
+              "version": "4.8.1",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+              "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+              "requires": {
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "lodash.assign": "^4.0.3",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.1",
+                "which-module": "^1.0.0",
+                "window-size": "^0.2.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^2.4.1"
+              }
+            },
+            "yargs-parser": {
+              "version": "2.4.1",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+              "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+              "requires": {
+                "camelcase": "^3.0.0",
+                "lodash.assign": "^4.0.6"
+              }
             }
           }
         },
         "postcss-custom-properties": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-6.2.0.tgz",
-          "integrity": "sha512-eNR2h9T9ciKMoQEORrPjH33XeN/nuvVuxArOKmHtsFbGbNss631tgTrKou3/pmjAZbA4QQkhLIkPQkIk3WW+8w==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-6.3.1.tgz",
+          "integrity": "sha512-zoiwn4sCiUFbr4KcgcNZLFkR6gVQom647L+z1p/KBVHZ1OYwT87apnS42atJtx6XlX2yI7N5fjXbFixShQO2QQ==",
           "requires": {
             "balanced-match": "^1.0.0",
-            "postcss": "^6.0.13"
+            "postcss": "^6.0.18"
           }
         },
         "postcss-less": {
@@ -26659,9 +26929,9 @@
           "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
         },
         "prepend-http": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
         },
         "preserve": {
           "version": "0.2.0",
@@ -26669,7 +26939,7 @@
           "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
         },
         "prettier": {
-          "version": "github:Automattic/wp-prettier#a2d1d9a2158bc6cdb9641f90f3bd7ea16eafb668",
+          "version": "github:Automattic/wp-prettier#d1b87d900ae80351a8551b97037b7fb638b9e739",
           "from": "github:Automattic/wp-prettier#wp-prettier-1.13.5",
           "requires": {
             "@babel/code-frame": "7.0.0-beta.49",
@@ -26861,11 +27131,24 @@
           }
         },
         "prismjs": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.6.0.tgz",
-          "integrity": "sha1-EY2V+3pm26InLjQ7NF9SNmWds2U=",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.15.0.tgz",
+          "integrity": "sha512-Lf2JrFYx8FanHrjoV5oL8YHCclLQgbJcVZR+gikGGMqz6ub5QVWDTM6YIwm3BuPxM/LOV+rKns3LssXNLIf+DA==",
           "requires": {
-            "clipboard": "^1.5.5"
+            "clipboard": "^2.0.0"
+          },
+          "dependencies": {
+            "clipboard": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.1.tgz",
+              "integrity": "sha512-7yhQBmtN+uYZmfRjjVjKa0dZdWuabzpSKGtyQZN+9C8xlC788SSJjOHWh7tzurfwTqTD5UDYAhIv5fRJg3sHjQ==",
+              "optional": true,
+              "requires": {
+                "good-listener": "^1.2.2",
+                "select": "^1.1.2",
+                "tiny-emitter": "^2.0.0"
+              }
+            }
           }
         },
         "private": {
@@ -26907,11 +27190,10 @@
           "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
         },
         "prop-types": {
-          "version": "15.6.1",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-          "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
           "requires": {
-            "fbjs": "^0.8.16",
             "loose-envify": "^1.3.1",
             "object-assign": "^4.1.1"
           }
@@ -26977,13 +27259,6 @@
             "duplexify": "^3.6.0",
             "inherits": "^2.0.3",
             "pump": "^2.0.0"
-          },
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-            }
           }
         },
         "punycode": {
@@ -26992,9 +27267,9 @@
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
         "q": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz",
-          "integrity": "sha1-EYcq7t7okmgRCxCnGESP+xARKhQ="
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+          "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
         },
         "qr.js": {
           "version": "0.0.0",
@@ -27002,18 +27277,28 @@
           "integrity": "sha1-ys6GOG9ZoNuAUPqQ2baw6IoeNk8="
         },
         "qrcode.react": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-0.7.2.tgz",
-          "integrity": "sha512-s1x+E3bsp0ojI8cHQ+czr+aG3huLZegH+tqAuRsXh6oXvzNfC+9L2PeFRBBu8eRBiejMRrRzSH7iwi5LDyWfRg==",
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-0.8.0.tgz",
+          "integrity": "sha512-16wKpuFvLwciIq2YAsfmPUCnSR8GrYPsXRK5KVdcIuX0+W/MKZbBkFhl44ttRx4TWZHqRjfztoWOxdPF0Hb9JA==",
           "requires": {
-            "prop-types": "^15.5.8",
+            "prop-types": "^15.6.0",
             "qr.js": "0.0.0"
           }
         },
         "qs": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "query-string": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
         },
         "querystring": {
           "version": "0.2.0",
@@ -27039,9 +27324,9 @@
           "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
         },
         "ramda": {
-          "version": "0.24.1",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
-          "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc="
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
+          "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
         },
         "randexp": {
           "version": "0.4.6",
@@ -27108,9 +27393,9 @@
           }
         },
         "react": {
-          "version": "16.4.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.4.0.tgz",
-          "integrity": "sha512-K0UrkLXSAekf5nJu89obKUM7o2vc6MMN9LYoKnCa+c+8MJRAT120xzPLENcWSRc7GYKIg0LlgJRDorrufdglQQ==",
+          "version": "16.4.1",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
+          "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
           "requires": {
             "fbjs": "^0.8.16",
             "loose-envify": "^1.1.0",
@@ -27182,6 +27467,11 @@
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
               "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+            },
+            "ast-types": {
+              "version": "0.10.1",
+              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
+              "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
             },
             "babel-core": {
               "version": "6.26.3",
@@ -27260,6 +27550,11 @@
               "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
               "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
             },
+            "bluebird": {
+              "version": "2.11.0",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+              "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+            },
             "bser": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
@@ -27286,15 +27581,15 @@
                 "restore-cursor": "^1.0.1"
               }
             },
-            "cliui": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-              "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wrap-ansi": "^2.0.0"
-              }
+            "colors": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+              "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
+            },
+            "core-js": {
+              "version": "1.2.7",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+              "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
             },
             "cssstyle": {
               "version": "0.2.37",
@@ -27302,6 +27597,16 @@
               "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
               "requires": {
                 "cssom": "0.3.x"
+              }
+            },
+            "detect-indent": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+              "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
+              "requires": {
+                "get-stdin": "^4.0.1",
+                "minimist": "^1.1.0",
+                "repeating": "^1.1.0"
               }
             },
             "doctrine": {
@@ -27353,6 +27658,11 @@
                 "user-home": "^2.0.0"
               }
             },
+            "esprima": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+              "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+            },
             "fb-watchman": {
               "version": "1.9.2",
               "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
@@ -27388,10 +27698,31 @@
                 "pinkie-promise": "^2.0.0"
               }
             },
+            "fs-readdir-recursive": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
+              "integrity": "sha1-MVtPuMHKW4xH3v7zGdBz2tNWgFk="
+            },
             "globals": {
               "version": "9.18.0",
               "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
               "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+            },
+            "home-or-tmp": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+              "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
+              "requires": {
+                "os-tmpdir": "^1.0.1",
+                "user-home": "^1.1.1"
+              },
+              "dependencies": {
+                "user-home": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+                  "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+                }
+              }
             },
             "inquirer": {
               "version": "0.12.0",
@@ -27644,6 +27975,124 @@
                 "mkdirp": "^0.5.1"
               }
             },
+            "js-tokens": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
+              "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4="
+            },
+            "jscodeshift": {
+              "version": "0.3.32",
+              "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.3.32.tgz",
+              "integrity": "sha1-3s5etgLxY0DY2VTH+WrJB8UC6rs=",
+              "requires": {
+                "async": "^1.5.0",
+                "babel-core": "^5",
+                "babel-plugin-transform-flow-strip-types": "^6.8.0",
+                "babel-preset-es2015": "^6.9.0",
+                "babel-preset-stage-1": "^6.5.0",
+                "babel-register": "^6.9.0",
+                "babylon": "^6.17.3",
+                "colors": "^1.1.2",
+                "flow-parser": "^0.*",
+                "lodash": "^4.13.1",
+                "micromatch": "^2.3.7",
+                "node-dir": "0.1.8",
+                "nomnom": "^1.8.1",
+                "recast": "^0.12.5",
+                "temp": "^0.8.1",
+                "write-file-atomic": "^1.2.0"
+              },
+              "dependencies": {
+                "babel-core": {
+                  "version": "5.8.38",
+                  "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+                  "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
+                  "requires": {
+                    "babel-plugin-constant-folding": "^1.0.1",
+                    "babel-plugin-dead-code-elimination": "^1.0.2",
+                    "babel-plugin-eval": "^1.0.1",
+                    "babel-plugin-inline-environment-variables": "^1.0.1",
+                    "babel-plugin-jscript": "^1.0.4",
+                    "babel-plugin-member-expression-literals": "^1.0.1",
+                    "babel-plugin-property-literals": "^1.0.1",
+                    "babel-plugin-proto-to-assign": "^1.0.3",
+                    "babel-plugin-react-constant-elements": "^1.0.3",
+                    "babel-plugin-react-display-name": "^1.0.3",
+                    "babel-plugin-remove-console": "^1.0.1",
+                    "babel-plugin-remove-debugger": "^1.0.1",
+                    "babel-plugin-runtime": "^1.0.7",
+                    "babel-plugin-undeclared-variables-check": "^1.0.2",
+                    "babel-plugin-undefined-to-void": "^1.1.6",
+                    "babylon": "^5.8.38",
+                    "bluebird": "^2.9.33",
+                    "chalk": "^1.0.0",
+                    "convert-source-map": "^1.1.0",
+                    "core-js": "^1.0.0",
+                    "debug": "^2.1.1",
+                    "detect-indent": "^3.0.0",
+                    "esutils": "^2.0.0",
+                    "fs-readdir-recursive": "^0.1.0",
+                    "globals": "^6.4.0",
+                    "home-or-tmp": "^1.0.0",
+                    "is-integer": "^1.0.4",
+                    "js-tokens": "1.0.1",
+                    "json5": "^0.4.0",
+                    "lodash": "^3.10.0",
+                    "minimatch": "^2.0.3",
+                    "output-file-sync": "^1.1.0",
+                    "path-exists": "^1.0.0",
+                    "path-is-absolute": "^1.0.0",
+                    "private": "^0.1.6",
+                    "regenerator": "0.8.40",
+                    "regexpu": "^1.3.0",
+                    "repeating": "^1.1.2",
+                    "resolve": "^1.1.6",
+                    "shebang-regex": "^1.0.0",
+                    "slash": "^1.0.0",
+                    "source-map": "^0.5.0",
+                    "source-map-support": "^0.2.10",
+                    "to-fast-properties": "^1.0.0",
+                    "trim-right": "^1.0.0",
+                    "try-resolve": "^1.0.0"
+                  },
+                  "dependencies": {
+                    "babylon": {
+                      "version": "5.8.38",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+                      "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0="
+                    },
+                    "lodash": {
+                      "version": "3.10.1",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                    }
+                  }
+                },
+                "globals": {
+                  "version": "6.4.1",
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+                  "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08="
+                },
+                "json5": {
+                  "version": "0.4.0",
+                  "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+                  "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+                  "requires": {
+                    "brace-expansion": "^1.0.0"
+                  }
+                },
+                "path-exists": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+                  "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE="
+                }
+              }
+            },
             "jsdom": {
               "version": "9.12.0",
               "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
@@ -27703,6 +28152,16 @@
               "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
               "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
             },
+            "output-file-sync": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+              "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+              "requires": {
+                "graceful-fs": "^4.1.4",
+                "mkdirp": "^0.5.1",
+                "object-assign": "^4.1.0"
+              }
+            },
             "parse5": {
               "version": "1.5.1",
               "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
@@ -27730,6 +28189,38 @@
               "version": "1.1.8",
               "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
               "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
+            },
+            "recast": {
+              "version": "0.12.9",
+              "resolved": "https://registry.npmjs.org/recast/-/recast-0.12.9.tgz",
+              "integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
+              "requires": {
+                "ast-types": "0.10.1",
+                "core-js": "^2.4.1",
+                "esprima": "~4.0.0",
+                "private": "~0.1.5",
+                "source-map": "~0.6.1"
+              },
+              "dependencies": {
+                "core-js": {
+                  "version": "2.5.7",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+                  "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+                },
+                "source-map": {
+                  "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                  "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                }
+              }
+            },
+            "repeating": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+              "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+              "requires": {
+                "is-finite": "^1.0.0"
+              }
             },
             "restore-cursor": {
               "version": "1.0.1",
@@ -27775,6 +28266,24 @@
               "version": "0.5.7",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+            },
+            "source-map-support": {
+              "version": "0.2.10",
+              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+              "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
+              "requires": {
+                "source-map": "0.1.32"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.1.32",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                  "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
+                  "requires": {
+                    "amdefine": ">=0.0.4"
+                  }
+                }
+              }
             },
             "strip-json-comments": {
               "version": "1.0.4",
@@ -27834,6 +28343,11 @@
               "version": "3.2.0",
               "resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
               "integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w=="
+            },
+            "to-fast-properties": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+              "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
             },
             "tr46": {
               "version": "0.0.3",
@@ -27919,9 +28433,9 @@
           }
         },
         "react-dom": {
-          "version": "16.4.0",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.0.tgz",
-          "integrity": "sha512-bbLd+HYpBEnYoNyxDe9XpSG2t9wypMohwQPvKw8Hov3nF7SJiJIgK56b46zHpBUpHb06a1iEuw7G3rbrsnNL6w==",
+          "version": "16.4.1",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
+          "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
           "requires": {
             "fbjs": "^0.8.16",
             "loose-envify": "^1.1.0",
@@ -27966,6 +28480,11 @@
             "scrollparent": "^2.0.1"
           }
         },
+        "react-lifecycles-compat": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+          "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+        },
         "react-live": {
           "version": "1.10.1",
           "resolved": "https://registry.npmjs.org/react-live/-/react-live-1.10.1.tgz",
@@ -27980,12 +28499,13 @@
           }
         },
         "react-modal": {
-          "version": "3.1.11",
-          "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.11.tgz",
-          "integrity": "sha512-Pm4QAc+sWYrfRC+WRERV+JGeGZIfodZGdbvWmjPzeSWqP+EW5ATK4N1U/btNHZWFzKL1UOmkmNtozEQlEg7c+A==",
+          "version": "3.4.5",
+          "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.4.5.tgz",
+          "integrity": "sha512-fYaGmsvt4z5voC2Bl/9ngIWES4BSRYgGnTljMwuzTuYZ1BBpaZbnXia8xlvj7mF0kg3aPV+5APjZRiMfRG6vyA==",
           "requires": {
             "exenv": "^1.2.0",
             "prop-types": "^15.5.10",
+            "react-lifecycles-compat": "^3.0.0",
             "warning": "^3.0.0"
           }
         },
@@ -28019,21 +28539,21 @@
           },
           "dependencies": {
             "hoist-non-react-statics": {
-              "version": "2.5.4",
-              "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.4.tgz",
-              "integrity": "sha512-yklXtcYj0Pt5Dz9No8xUh7d+/7fy5XRIm+r7U/BXgwJ/VsD75EfXA8t4p9tIL0jykzo5A/sGzt1xV6oqd/gP0w=="
+              "version": "2.5.5",
+              "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+              "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
             }
           }
         },
         "react-test-renderer": {
-          "version": "16.4.0",
-          "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.4.0.tgz",
-          "integrity": "sha512-Seh1t9xFY6TKiV/hRlPzUkqX1xHOiKIMsctfU0cggo1ajsLjoIJFL520LlrxV+4/VIj+clrCeH6s/aVv/vTStg==",
+          "version": "16.4.1",
+          "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.4.1.tgz",
+          "integrity": "sha512-wyyiPxRZOTpKnNIgUBOB6xPLTpIzwcQMIURhZvzUqZzezvHjaGNsDPBhMac5fIY3Jf5NuKxoGvV64zDSOECPPQ==",
           "requires": {
             "fbjs": "^0.8.16",
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.0",
-            "react-is": "^16.4.0"
+            "react-is": "^16.4.1"
           }
         },
         "react-transition-group": {
@@ -28056,15 +28576,16 @@
           }
         },
         "react-virtualized": {
-          "version": "9.9.0",
-          "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.9.0.tgz",
-          "integrity": "sha512-TDe2haZiFr5apN3myuumGyeJ7iqHcGcQ648tfNf9x+R6tkE1+o8yAmeh4nKC4ldcs9My1dOHN3x/lmEX9LyOLA==",
+          "version": "9.19.1",
+          "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.19.1.tgz",
+          "integrity": "sha512-2l6uFicZKZ3x4rdnS0W+1TfyLmPO/+hfZKsCtoChoSmH5aEezGLpSuHc7oplekNIOaEwChfCk30zjx+Zw6B8YQ==",
           "requires": {
-            "babel-runtime": "^6.11.6",
+            "babel-runtime": "^6.26.0",
             "classnames": "^2.2.3",
             "dom-helpers": "^2.4.0 || ^3.0.0",
             "loose-envify": "^1.3.0",
-            "prop-types": "^15.5.4"
+            "prop-types": "^15.6.0",
+            "react-lifecycles-compat": "^3.0.4"
           },
           "dependencies": {
             "classnames": {
@@ -28148,13 +28669,6 @@
             "safe-buffer": "~5.1.1",
             "string_decoder": "~1.1.1",
             "util-deprecate": "~1.0.1"
-          },
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-            }
           }
         },
         "readdirp": {
@@ -28169,9 +28683,9 @@
           }
         },
         "readline-sync": {
-          "version": "1.4.5",
-          "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.5.tgz",
-          "integrity": "sha1-xw0rFHPsq8Hk1TPLrz6CSft36ZI="
+          "version": "1.4.9",
+          "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.9.tgz",
+          "integrity": "sha1-PtqOZfI80qF+YTAbHwADOWr17No="
         },
         "readline2": {
           "version": "1.0.1",
@@ -28273,16 +28787,16 @@
           },
           "dependencies": {
             "hoist-non-react-statics": {
-              "version": "2.5.4",
-              "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.4.tgz",
-              "integrity": "sha512-yklXtcYj0Pt5Dz9No8xUh7d+/7fy5XRIm+r7U/BXgwJ/VsD75EfXA8t4p9tIL0jykzo5A/sGzt1xV6oqd/gP0w=="
+              "version": "2.5.5",
+              "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+              "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
             }
           }
         },
         "redux-thunk": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-1.0.0.tgz",
-          "integrity": "sha1-41VEoQ/NnJ47qWCDrBbHAjlPQAk="
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-1.0.3.tgz",
+          "integrity": "sha1-d4qgCZ7qBZUDGrazkWX2Zw2NJr0="
         },
         "regenerate": {
           "version": "1.4.0",
@@ -28522,9 +29036,9 @@
           }
         },
         "replace-ext": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
         },
         "request": {
           "version": "2.79.0",
@@ -28649,6 +29163,14 @@
           "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
         },
+        "responselike": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+          "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+          "requires": {
+            "lowercase-keys": "^1.0.0"
+          }
+        },
         "restore-cursor": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -28708,9 +29230,9 @@
           "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
         },
         "rtlcss": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-2.2.1.tgz",
-          "integrity": "sha512-JjQ5DlrmwiItAjlmhoxrJq5ihgZcE0wMFxt7S17bIrt4Lw0WwKKFk+viRhvodB/0falyG/5fiO043ZDh6/aqTw==",
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-2.4.0.tgz",
+          "integrity": "sha512-hdjFhZ5FCI0ABOfyXOMOhBtwPWtANLCG7rOiOcRf+yi5eDdxmDjqBruWouEnwVdzfh/TWF6NNncIEsigOCFZOA==",
           "requires": {
             "chalk": "^2.3.0",
             "findup": "^0.1.5",
@@ -28751,11 +29273,6 @@
           "requires": {
             "aproba": "^1.1.1"
           }
-        },
-        "rx": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-          "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
         },
         "rx-lite": {
           "version": "4.0.8",
@@ -29097,48 +29614,6 @@
             "lodash": "^4.0.0",
             "scss-tokenizer": "^0.2.3",
             "yargs": "^7.0.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-            },
-            "cliui": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-              "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wrap-ansi": "^2.0.0"
-              }
-            },
-            "y18n": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-            },
-            "yargs": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-              "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-              "requires": {
-                "camelcase": "^3.0.0",
-                "cliui": "^3.2.0",
-                "decamelize": "^1.1.1",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^1.4.0",
-                "read-pkg-up": "^1.0.1",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^1.0.2",
-                "which-module": "^1.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^5.0.0"
-              }
-            }
           }
         },
         "sax": {
@@ -29195,9 +29670,9 @@
           "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
         },
         "semver": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU="
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
         },
         "send": {
           "version": "0.16.2",
@@ -29229,14 +29704,6 @@
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
               "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
             }
-          }
-        },
-        "sentence-case": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz",
-          "integrity": "sha1-gDSq/CFFdy06vhUJqkLJ4QQtwTk=",
-          "requires": {
-            "lower-case": "^1.1.1"
           }
         },
         "serialize-javascript": {
@@ -29305,6 +29772,15 @@
             "safe-buffer": "^5.0.1"
           }
         },
+        "sha1": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz",
+          "integrity": "sha1-rdqnqTFo85PxnrKxUJFhjicA+Eg=",
+          "requires": {
+            "charenc": ">= 0.0.1",
+            "crypt": ">= 0.0.1"
+          }
+        },
         "shebang-command": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -29330,9 +29806,9 @@
           }
         },
         "shelljs": {
-          "version": "0.7.8",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-          "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
+          "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
           "requires": {
             "glob": "^7.0.0",
             "interpret": "^1.0.0",
@@ -29399,14 +29875,6 @@
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
           "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
-        },
-        "snake-case": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz",
-          "integrity": "sha1-DC8l4wUVjZoY09l3BmGH/vilpmo=",
-          "requires": {
-            "sentence-case": "^1.1.2"
-          }
         },
         "snapdragon": {
           "version": "0.8.2",
@@ -29622,6 +30090,14 @@
             }
           }
         },
+        "sort-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+          "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+          "requires": {
+            "is-plain-obj": "^1.0.0"
+          }
+        },
         "source-list-map": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
@@ -29648,20 +30124,18 @@
           }
         },
         "source-map-support": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.2.tgz",
-          "integrity": "sha1-c31ckB4LeP21OspxPSTyPMuxC+E=",
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+          "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
           "requires": {
-            "source-map": "0.1.32"
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
           },
           "dependencies": {
             "source-map": {
-              "version": "0.1.32",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
             }
           }
         },
@@ -29674,15 +30148,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
           "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw=="
-        },
-        "spawn-sync": {
-          "version": "1.0.15",
-          "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-          "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-          "requires": {
-            "concat-stream": "^1.4.7",
-            "os-shim": "^0.1.2"
-          }
         },
         "spdx-correct": {
           "version": "3.0.0",
@@ -29930,15 +30395,15 @@
           "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
           "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
         },
-        "stream-to-observable": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.1.0.tgz",
-          "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4="
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
         },
         "string-kit": {
-          "version": "0.6.18",
-          "resolved": "https://registry.npmjs.org/string-kit/-/string-kit-0.6.18.tgz",
-          "integrity": "sha512-G/nR5FBUcVkFagf0ckMPCnV8UIlldTa60LaYPR4bZ6MtAj6o03cQcJK9TqoU13dOy52Sjt/XqY+bO7iJcJ+chw==",
+          "version": "0.7.9",
+          "resolved": "https://registry.npmjs.org/string-kit/-/string-kit-0.7.9.tgz",
+          "integrity": "sha512-0tsaKmWQxdgMnTyskxjEpxPKLtFSD+JURzT6dFhUgIR1PjdJyvlSw2UwYm9Zn9bv+5l8Z4gzQLllUkyFbNVX1w==",
           "requires": {
             "xregexp": "^4.1.1"
           }
@@ -30059,9 +30524,9 @@
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         },
         "striptags": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/striptags/-/striptags-2.1.1.tgz",
-          "integrity": "sha1-53G4sxk7l7vtOS3KWaeCedPIpqY="
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/striptags/-/striptags-2.2.1.tgz",
+          "integrity": "sha1-TEULcI1BuL85zyTEn/I0/Gqr/TI="
         },
         "stylehacks": {
           "version": "2.3.2",
@@ -30398,9 +30863,9 @@
           }
         },
         "superagent": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/superagent/-/superagent-2.1.0.tgz",
-          "integrity": "sha1-cfOYNnx1jyFlysb9kI1JwrmpFxo=",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-2.3.0.tgz",
+          "integrity": "sha1-cDUpoHFOV+EjlZ3e+84ZOy5Q0RU=",
           "requires": {
             "component-emitter": "^1.2.0",
             "cookiejar": "^2.0.6",
@@ -30414,11 +30879,6 @@
             "readable-stream": "^2.0.5"
           },
           "dependencies": {
-            "async": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-            },
             "form-data": {
               "version": "1.0.0-rc4",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
@@ -30432,9 +30892,9 @@
           }
         },
         "supertest": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supertest/-/supertest-2.0.0.tgz",
-          "integrity": "sha1-Bg4Y7a5W49YrlcbpxOKl5OUJef8=",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/supertest/-/supertest-2.0.1.tgz",
+          "integrity": "sha1-oFgIHXiPFRXUcA11Aogea3WeRM0=",
           "requires": {
             "methods": "1.x",
             "superagent": "^2.0.0"
@@ -30452,15 +30912,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
           "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q="
-        },
-        "swap-case": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
-          "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
-          "requires": {
-            "lower-case": "^1.1.1",
-            "upper-case": "^1.1.1"
-          }
         },
         "symbol-observable": {
           "version": "1.2.0",
@@ -30598,16 +31049,16 @@
           }
         },
         "terminal-kit": {
-          "version": "1.13.13",
-          "resolved": "https://registry.npmjs.org/terminal-kit/-/terminal-kit-1.13.13.tgz",
-          "integrity": "sha512-6A8b5OJd9oMLvbfPIaRr4F+FBnuH4/sQQPlVCnhbuQ+EwAyUbFB9Z+KTuivtmbWOUErXIYtlQ8t36+YBz5T2vA==",
+          "version": "1.17.11",
+          "resolved": "https://registry.npmjs.org/terminal-kit/-/terminal-kit-1.17.11.tgz",
+          "integrity": "sha512-5wJ84CktBfwCjYd82D/j62Kt7Og86/Is0wJbThTYE5zjCcDKmOQqI3b7gm9e4QZyBBUObrPPealUYr3+/LO1ig==",
           "requires": {
-            "async-kit": "^2.2.3",
-            "get-pixels": "^3.3.0",
+            "@cronvel/get-pixels": "^3.3.1",
+            "async-kit": "^2.2.4",
             "ndarray": "^1.0.18",
-            "nextgen-events": "^0.10.0",
-            "string-kit": "^0.6.1",
-            "tree-kit": "^0.5.26"
+            "nextgen-events": "^1.0.1",
+            "string-kit": "^0.7.9",
+            "tree-kit": "^0.5.27"
           }
         },
         "test-exclude": {
@@ -30904,11 +31355,6 @@
               "requires": {
                 "lodash": "^4.17.10"
               }
-            },
-            "lodash": {
-              "version": "4.17.10",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-              "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
             }
           }
         },
@@ -30958,15 +31404,6 @@
           "version": "4.6.3",
           "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-4.6.3.tgz",
           "integrity": "sha1-lK0k6tTxOTjAkDr9L/RpwLZVYj4="
-        },
-        "title-case": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz",
-          "integrity": "sha1-+uSmrlRr+iLQg6DuqRCkDRLtT1o=",
-          "requires": {
-            "sentence-case": "^1.1.1",
-            "upper-case": "^1.0.3"
-          }
         },
         "title-case-minors": {
           "version": "0.0.2",
@@ -31109,9 +31546,9 @@
           }
         },
         "tracekit": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tracekit/-/tracekit-0.4.3.tgz",
-          "integrity": "sha1-moxDxIonW9stVaRa1B0KJI8xit8="
+          "version": "0.4.5",
+          "resolved": "https://registry.npmjs.org/tracekit/-/tracekit-0.4.5.tgz",
+          "integrity": "sha512-LAb1udnpvhpgcx6/gmv7s6RO5lBwQGgAT/1VW0egSNSMvH/3xU3xKLoJ3pc+nkJ5AMv9qgTBnCkrUzbrHmCLpg=="
         },
         "tree-kit": {
           "version": "0.5.27",
@@ -31180,6 +31617,11 @@
           "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
           "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys="
         },
+        "tslib": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+        },
         "tty-browserify": {
           "version": "0.0.0",
           "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -31210,9 +31652,9 @@
           }
         },
         "type-detect": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
         },
         "type-is": {
           "version": "1.6.16",
@@ -31240,13 +31682,6 @@
           "requires": {
             "lodash.unescape": "4.0.1",
             "semver": "5.5.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-            }
           }
         },
         "ua-parser-js": {
@@ -31255,32 +31690,31 @@
           "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
         },
         "uglify-js": {
-          "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
-          "integrity": "sha1-ZeovswWck5RpLxX+2HwrNsFrmt8=",
+          "version": "3.3.28",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.28.tgz",
+          "integrity": "sha512-68Rc/aA6cswiaQ5SrE979UJcXX+ADA1z33/ZsPd+fbAiVdjZ16OXdbtGO+rJUUBgK6qdf3SOPhQf3K/ybF5Miw==",
           "requires": {
-            "async": "~0.2.6",
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
+            "commander": "~2.15.0",
+            "source-map": "~0.6.1"
           },
           "dependencies": {
             "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
             }
           }
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
+          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+          "optional": true
         },
         "uglifyjs-webpack-plugin": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.4.tgz",
-          "integrity": "sha512-z0IbjpW8b3O/OVn+TTZN4pI29RN1zktFBXLIzzfZ+++cUtZ1ERSlLWgpE/5OERuEUs1ijVQnpYAkSlpoVmQmSQ==",
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.6.tgz",
+          "integrity": "sha512-NDP94ahjW7ZH+qzdjxjIV04n5YGnrYD2jeHgKgnpUKmdAfcXEO5DbVo21fXAm/KPMyX9k21zWFBMYm9m9R2ptg==",
           "requires": {
             "cacache": "^10.0.4",
             "find-cache-dir": "^1.0.0",
@@ -31480,78 +31914,15 @@
             "unist-util-is": "^2.1.1"
           }
         },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        },
         "unpipe": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-        },
-        "unreachable-branch-transform": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.3.0.tgz",
-          "integrity": "sha1-2ZzExudG0mSSiEW2EdtUsPNHTKo=",
-          "requires": {
-            "esmangle-evaluator": "^1.0.0",
-            "recast": "^0.10.1",
-            "through2": "^0.6.2"
-          },
-          "dependencies": {
-            "ast-types": {
-              "version": "0.8.15",
-              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
-              "integrity": "sha1-ju8IJ/BN/w7IhXupJavj/qYZTlI="
-            },
-            "esprima-fb": {
-              "version": "15001.1001.0-dev-harmony-fb",
-              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-              "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-            },
-            "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
-              }
-            },
-            "recast": {
-              "version": "0.10.43",
-              "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
-              "integrity": "sha1-uV1Q9tYHYaX2JS4V2AZ4FoSRzn8=",
-              "requires": {
-                "ast-types": "0.8.15",
-                "esprima-fb": "~15001.1001.0-dev-harmony-fb",
-                "private": "~0.1.5",
-                "source-map": "~0.5.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-            },
-            "through2": {
-              "version": "0.6.5",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-              "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-              "requires": {
-                "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                "xtend": ">=4.0.0 <4.1.0-0"
-              }
-            }
-          }
         },
         "unset-value": {
           "version": "1.0.0",
@@ -31595,12 +31966,9 @@
           }
         },
         "untildify": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
-          "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
-          "requires": {
-            "os-homedir": "^1.0.0"
-          }
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
+          "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
         },
         "upath": {
           "version": "1.1.0",
@@ -31612,20 +31980,19 @@
           "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
           "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
         },
-        "upper-case-first": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
-          "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
-          "requires": {
-            "upper-case": "^1.1.1"
-          }
-        },
         "uppercamelcase": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/uppercamelcase/-/uppercamelcase-1.1.0.tgz",
           "integrity": "sha1-Mk2YprOvx+iolT4QZBUJsOTiP5c=",
           "requires": {
             "camelcase": "^1.2.1"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+              "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+            }
           }
         },
         "uri-js": {
@@ -31670,22 +32037,17 @@
           "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo="
         },
         "url-parse-lax": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
           "requires": {
-            "prepend-http": "^1.0.1"
+            "prepend-http": "^2.0.0"
           }
         },
         "url-to-options": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
           "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
-        },
-        "urlgrey": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
-          "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8="
         },
         "use": {
           "version": "3.1.0",
@@ -31713,13 +32075,6 @@
           "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
           "requires": {
             "inherits": "2.0.3"
-          },
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-            }
           }
         },
         "util-deprecate": {
@@ -31747,9 +32102,9 @@
           "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
         },
         "v8-compile-cache": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-1.1.2.tgz",
-          "integrity": "sha512-ejdrifsIydN1XDH7EuR2hn8ZrkRKUYF7tUcBjBy/lhrCvs2K+zRlbW9UHc0IQ9RsYFZJFqJrieoIHfkCa0DBRA=="
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.0.tgz",
+          "integrity": "sha512-qNdTUMaCjPs4eEnM3W9H94R3sU70YCuT+/ST7nUf+id1bVOrdjrpUaeZLqPBPRph3hsgn4a4BvwpxhHZx+oSDg=="
         },
         "valid-url": {
           "version": "1.0.9",
@@ -31796,6 +32151,13 @@
             "replace-ext": "1.0.0",
             "unist-util-stringify-position": "^1.0.0",
             "vfile-message": "^1.0.0"
+          },
+          "dependencies": {
+            "replace-ext": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+              "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+            }
           }
         },
         "vfile-location": {
@@ -31812,16 +32174,13 @@
           }
         },
         "vinyl": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
-          "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
+            "replace-ext": "0.0.1"
           }
         },
         "vinyl-file": {
@@ -31835,33 +32194,6 @@
             "strip-bom": "^2.0.0",
             "strip-bom-stream": "^2.0.0",
             "vinyl": "^1.1.0"
-          },
-          "dependencies": {
-            "clone": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-              "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-            },
-            "clone-stats": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-              "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
-            },
-            "replace-ext": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-              "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
-            },
-            "vinyl": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-              "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-              "requires": {
-                "clone": "^1.0.0",
-                "clone-stats": "^0.0.1",
-                "replace-ext": "0.0.1"
-              }
-            }
           }
         },
         "vlq": {
@@ -31883,14 +32215,6 @@
           "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
           "requires": {
             "browser-process-hrtime": "^0.1.2"
-          }
-        },
-        "walk": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.4.tgz",
-          "integrity": "sha1-Bs4VQVNTE+iswo6S60Jem2T0xQA=",
-          "requires": {
-            "foreachasync": "3.x"
           }
         },
         "walker": {
@@ -31948,19 +32272,20 @@
           "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
         },
         "webpack": {
-          "version": "4.10.2",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.10.2.tgz",
-          "integrity": "sha512-S4yIBevM7DFSAOAvWSBgvuH5mtJ3HgjAS6tCGsTxxHtrVdbntdRVaPey2u9sCns6KV859Vwd2DwkvBLTcs6t6g==",
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.12.0.tgz",
+          "integrity": "sha512-EJj2FfhgtjrTbJbJaNulcVpDxi9vsQVvTahHN7xJvIv6W+k4r/E6Hxy4eyOrj+IAFWqYgaUtnpxmSGYP8MSZJw==",
           "requires": {
-            "@webassemblyjs/ast": "1.5.9",
-            "@webassemblyjs/wasm-edit": "1.5.9",
-            "@webassemblyjs/wasm-opt": "1.5.9",
-            "@webassemblyjs/wasm-parser": "1.5.9",
-            "acorn": "^5.0.0",
+            "@webassemblyjs/ast": "1.5.12",
+            "@webassemblyjs/helper-module-context": "1.5.12",
+            "@webassemblyjs/wasm-edit": "1.5.12",
+            "@webassemblyjs/wasm-opt": "1.5.12",
+            "@webassemblyjs/wasm-parser": "1.5.12",
+            "acorn": "^5.6.2",
             "acorn-dynamic-import": "^3.0.0",
             "ajv": "^6.1.0",
             "ajv-keywords": "^3.1.0",
-            "chrome-trace-event": "^0.1.1",
+            "chrome-trace-event": "^1.0.0",
             "enhanced-resolve": "^4.0.0",
             "eslint-scope": "^3.7.1",
             "json-parse-better-errors": "^1.0.2",
@@ -32246,11 +32571,6 @@
               "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
               "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
             },
-            "async": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-            },
             "babylon": {
               "version": "6.18.0",
               "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
@@ -32308,9 +32628,9 @@
           }
         },
         "webpack-bundle-analyzer": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.11.1.tgz",
-          "integrity": "sha512-VKUVkVMc6TWVXmF1OxsBXoiRjYiDRA4XT0KqtbLMDK+891VX7FCuklYwzldND8J2upUcHHnuXYNTP+4mSFi4Kg==",
+          "version": "2.13.1",
+          "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.13.1.tgz",
+          "integrity": "sha512-rwxyfecTAxoarCC9VlHlIpfQCmmJ/qWD5bpbjkof+7HrNhTNZIwZITxN6CdlYL2axGmwNUQ+tFgcSOiNXMf/sQ==",
           "requires": {
             "acorn": "^5.3.0",
             "bfj-node4": "^5.2.0",
@@ -32348,60 +32668,42 @@
           }
         },
         "webpack-cli": {
-          "version": "2.0.9",
-          "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-2.0.9.tgz",
-          "integrity": "sha512-KIkOFHhrq8W7ovg5u8M7Xbduzr1aQ1Ch1aGGY0TvL5neO81T6/aCZ/NeG7R92UaXIF/BK4KCkla35wtoOoxyDQ==",
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-2.1.5.tgz",
+          "integrity": "sha512-CiWQR+1JS77rmyiO6y1q8Kt/O+e8nUUC9YfJ25JtSmzDwbqJV7vIsh3+QKRHVTbTCa0DaVh8iY1LBiagUIDB3g==",
           "requires": {
-            "chalk": "^2.0.1",
-            "codecov": "^3.0.0",
-            "cross-spawn": "^5.1.0",
-            "diff": "^3.3.0",
-            "enhanced-resolve": "^3.4.1",
+            "chalk": "^2.4.1",
+            "cross-spawn": "^6.0.5",
+            "diff": "^3.5.0",
+            "enhanced-resolve": "^4.0.0",
+            "envinfo": "^5.7.0",
             "glob-all": "^3.1.0",
-            "global": "^4.3.2",
             "global-modules": "^1.0.0",
-            "got": "^7.1.0",
-            "inquirer": "^3.2.0",
-            "interpret": "^1.0.4",
-            "jscodeshift": "^0.4.0",
-            "listr": "^0.12.0",
+            "got": "^8.3.1",
+            "import-local": "^1.0.0",
+            "inquirer": "^5.2.0",
+            "interpret": "^1.1.0",
+            "jscodeshift": "^0.5.0",
+            "listr": "^0.14.1",
             "loader-utils": "^1.1.0",
-            "lodash": "^4.17.4",
-            "log-symbols": "2.1.0",
+            "lodash": "^4.17.10",
+            "log-symbols": "^2.2.0",
             "mkdirp": "^0.5.1",
             "p-each-series": "^1.0.0",
             "p-lazy": "^1.0.0",
-            "prettier": "^1.5.3",
-            "recast": "^0.13.0",
-            "resolve-cwd": "^2.0.0",
-            "supports-color": "^4.4.0",
-            "uglifyjs-webpack-plugin": "^1.2.2",
-            "v8-compile-cache": "^1.1.0",
+            "prettier": "^1.12.1",
+            "supports-color": "^5.4.0",
+            "v8-compile-cache": "^2.0.0",
             "webpack-addons": "^1.1.5",
-            "webpack-fork-yeoman-generator": "^1.1.1",
-            "yargs": "9.0.1",
-            "yeoman-environment": "^2.0.0"
+            "yargs": "^11.1.0",
+            "yeoman-environment": "^2.1.1",
+            "yeoman-generator": "^2.0.5"
           },
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-            },
-            "ast-types": {
-              "version": "0.10.1",
-              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
-              "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
-            },
-            "async": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-            },
-            "babylon": {
-              "version": "6.18.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-              "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
             },
             "camelcase": {
               "version": "4.1.0",
@@ -32416,117 +32718,22 @@
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "5.4.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-                  "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-                  "requires": {
-                    "has-flag": "^3.0.0"
-                  }
-                }
               }
             },
             "cliui": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+              "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
               "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
                 "wrap-ansi": "^2.0.0"
-              },
-              "dependencies": {
-                "string-width": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                  "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
-                  }
-                }
               }
             },
-            "colors": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
-              "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
-            },
-            "cross-spawn": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-              "requires": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              }
-            },
-            "enhanced-resolve": {
-              "version": "3.4.1",
-              "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
-              "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "memory-fs": "^0.4.0",
-                "object-assign": "^4.0.1",
-                "tapable": "^0.2.7"
-              }
-            },
-            "esprima": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-              "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
-            },
-            "jscodeshift": {
-              "version": "0.4.1",
-              "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.4.1.tgz",
-              "integrity": "sha512-iOX6If+hsw0q99V3n31t4f5VlD1TQZddH08xbT65ZqA7T4Vkx68emrDZMUOLVvCEAJ6NpAk7DECe3fjC/t52AQ==",
-              "requires": {
-                "async": "^1.5.0",
-                "babel-plugin-transform-flow-strip-types": "^6.8.0",
-                "babel-preset-es2015": "^6.9.0",
-                "babel-preset-stage-1": "^6.5.0",
-                "babel-register": "^6.9.0",
-                "babylon": "^6.17.3",
-                "colors": "^1.1.2",
-                "flow-parser": "^0.*",
-                "lodash": "^4.13.1",
-                "micromatch": "^2.3.7",
-                "node-dir": "0.1.8",
-                "nomnom": "^1.8.1",
-                "recast": "^0.12.5",
-                "temp": "^0.8.1",
-                "write-file-atomic": "^1.2.0"
-              },
-              "dependencies": {
-                "recast": {
-                  "version": "0.12.9",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.12.9.tgz",
-                  "integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
-                  "requires": {
-                    "ast-types": "0.10.1",
-                    "core-js": "^2.4.1",
-                    "esprima": "~4.0.0",
-                    "private": "~0.1.5",
-                    "source-map": "~0.6.1"
-                  }
-                }
-              }
-            },
-            "load-json-file": {
+            "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-              "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
-                "strip-bom": "^3.0.0"
-              }
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
             },
             "os-locale": {
               "version": "2.1.0",
@@ -32538,60 +32745,10 @@
                 "mem": "^1.1.0"
               }
             },
-            "path-type": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-              "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-              "requires": {
-                "pify": "^2.0.0"
-              }
-            },
             "prettier": {
               "version": "1.13.5",
               "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.5.tgz",
               "integrity": "sha512-4M90mfvLz6yRf2Dhzd+xPIE6b4xkI8nHMJhsSm9IlfG17g6wujrrm7+H1X8x52tC4cSNm6HmuhCUSNe6Hd5wfw=="
-            },
-            "read-pkg": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-              "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-              "requires": {
-                "load-json-file": "^2.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^2.0.0"
-              }
-            },
-            "read-pkg-up": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-              "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-              "requires": {
-                "find-up": "^2.0.0",
-                "read-pkg": "^2.0.0"
-              }
-            },
-            "recast": {
-              "version": "0.13.2",
-              "resolved": "https://registry.npmjs.org/recast/-/recast-0.13.2.tgz",
-              "integrity": "sha512-Xqo0mKljGUWGUhnkdbODk7oJGFrMcpgKQ9cCyZ4y+G9VfoTKdum8nHbf/SxIdKx5aBSZ29VpVy20bTyt7jyC8w==",
-              "requires": {
-                "ast-types": "0.10.2",
-                "esprima": "~4.0.0",
-                "private": "~0.1.5",
-                "source-map": "~0.6.1"
-              },
-              "dependencies": {
-                "ast-types": {
-                  "version": "0.10.2",
-                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.2.tgz",
-                  "integrity": "sha512-ufWX953VU1eIuWqxS0nRDMYlGyFH+yxln5CsmIHlpzEt3fdYqUnRtsFt0XAsQot8OaVCwFqxT1RiwvtzYjeYeg=="
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
             },
             "string-width": {
               "version": "2.1.1",
@@ -32600,47 +32757,15 @@
               "requires": {
                 "is-fullwidth-code-point": "^2.0.0",
                 "strip-ansi": "^4.0.0"
-              },
-              "dependencies": {
-                "is-fullwidth-code-point": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                  "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-                },
-                "strip-ansi": {
-                  "version": "4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                  "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                  "requires": {
-                    "ansi-regex": "^3.0.0"
-                  }
-                }
               }
             },
-            "strip-bom": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-            },
-            "supports-color": {
-              "version": "4.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
-                "has-flag": "^2.0.0"
-              },
-              "dependencies": {
-                "has-flag": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-                  "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-                }
+                "ansi-regex": "^3.0.0"
               }
-            },
-            "tapable": {
-              "version": "0.2.8",
-              "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
-              "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
             },
             "which-module": {
               "version": "2.0.0",
@@ -32653,29 +32778,28 @@
               "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
             },
             "yargs": {
-              "version": "9.0.1",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
-              "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+              "version": "11.1.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+              "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
               "requires": {
-                "camelcase": "^4.1.0",
-                "cliui": "^3.2.0",
+                "cliui": "^4.0.0",
                 "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
                 "get-caller-file": "^1.0.1",
                 "os-locale": "^2.0.0",
-                "read-pkg-up": "^2.0.0",
                 "require-directory": "^2.1.1",
                 "require-main-filename": "^1.0.1",
                 "set-blocking": "^2.0.0",
                 "string-width": "^2.0.0",
                 "which-module": "^2.0.0",
                 "y18n": "^3.2.1",
-                "yargs-parser": "^7.0.0"
+                "yargs-parser": "^9.0.2"
               }
             },
             "yargs-parser": {
-              "version": "7.0.0",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-              "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+              "version": "9.0.2",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+              "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
               "requires": {
                 "camelcase": "^4.1.0"
               }
@@ -32700,250 +32824,6 @@
               "version": "2.3.1",
               "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
               "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
-            }
-          }
-        },
-        "webpack-fork-yeoman-generator": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/webpack-fork-yeoman-generator/-/webpack-fork-yeoman-generator-1.1.1.tgz",
-          "integrity": "sha512-TrLT6Bw6gl9rJA7iZw+YJ+4xHhEUzfOQB3tHpyINBFdZDmO0tlDW9MtMSMZ5rsUNjHxcEba5yuGaAW86J84j/w==",
-          "requires": {
-            "async": "^2.0.0",
-            "chalk": "^1.0.0",
-            "cli-table": "^0.3.1",
-            "cross-spawn": "^5.0.1",
-            "dargs": "^5.1.0",
-            "dateformat": "^2.0.0",
-            "debug": "^2.1.0",
-            "detect-conflict": "^1.0.0",
-            "error": "^7.0.2",
-            "find-up": "^2.1.0",
-            "github-username": "^4.0.0",
-            "istextorbinary": "^2.1.0",
-            "lodash": "^4.11.1",
-            "mem-fs-editor": "^3.0.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.0",
-            "pretty-bytes": "^4.0.2",
-            "read-chunk": "^2.0.0",
-            "read-pkg-up": "^2.0.0",
-            "rimraf": "^2.2.0",
-            "run-async": "^2.0.0",
-            "shelljs": "^0.7.0",
-            "text-table": "^0.2.0",
-            "through2": "^2.0.0",
-            "yeoman-environment": "^1.1.0"
-          },
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-              "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
-            },
-            "async": {
-              "version": "2.6.1",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-              "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-              "requires": {
-                "lodash": "^4.17.10"
-              },
-              "dependencies": {
-                "lodash": {
-                  "version": "4.17.10",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-                  "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-                }
-              }
-            },
-            "cli-cursor": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-              "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-              "requires": {
-                "restore-cursor": "^1.0.1"
-              }
-            },
-            "cross-spawn": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-              "requires": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              }
-            },
-            "diff": {
-              "version": "2.2.3",
-              "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
-              "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k="
-            },
-            "external-editor": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
-              "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
-              "requires": {
-                "extend": "^3.0.0",
-                "spawn-sync": "^1.0.15",
-                "tmp": "^0.0.29"
-              }
-            },
-            "figures": {
-              "version": "1.7.0",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-              "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-              "requires": {
-                "escape-string-regexp": "^1.0.5",
-                "object-assign": "^4.1.0"
-              }
-            },
-            "glob": {
-              "version": "6.0.4",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-              "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-              "requires": {
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "2 || 3",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "globby": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
-              "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
-              "requires": {
-                "array-union": "^1.0.1",
-                "arrify": "^1.0.0",
-                "glob": "^6.0.1",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-              }
-            },
-            "inquirer": {
-              "version": "1.2.3",
-              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
-              "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
-              "requires": {
-                "ansi-escapes": "^1.1.0",
-                "chalk": "^1.0.0",
-                "cli-cursor": "^1.0.1",
-                "cli-width": "^2.0.0",
-                "external-editor": "^1.1.0",
-                "figures": "^1.3.5",
-                "lodash": "^4.3.0",
-                "mute-stream": "0.0.6",
-                "pinkie-promise": "^2.0.0",
-                "run-async": "^2.2.0",
-                "rx": "^4.1.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.0",
-                "through": "^2.3.6"
-              }
-            },
-            "load-json-file": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-              "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
-                "strip-bom": "^3.0.0"
-              }
-            },
-            "log-symbols": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-              "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-              "requires": {
-                "chalk": "^1.0.0"
-              }
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-            },
-            "mute-stream": {
-              "version": "0.0.6",
-              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
-              "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s="
-            },
-            "onetime": {
-              "version": "1.1.0",
-              "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-              "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
-            },
-            "path-type": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-              "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-              "requires": {
-                "pify": "^2.0.0"
-              }
-            },
-            "read-pkg": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-              "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-              "requires": {
-                "load-json-file": "^2.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^2.0.0"
-              }
-            },
-            "read-pkg-up": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-              "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-              "requires": {
-                "find-up": "^2.0.0",
-                "read-pkg": "^2.0.0"
-              }
-            },
-            "restore-cursor": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-              "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-              "requires": {
-                "exit-hook": "^1.0.0",
-                "onetime": "^1.0.0"
-              }
-            },
-            "strip-bom": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-            },
-            "tmp": {
-              "version": "0.0.29",
-              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-              "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
-              "requires": {
-                "os-tmpdir": "~1.0.1"
-              }
-            },
-            "yeoman-environment": {
-              "version": "1.6.6",
-              "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.6.tgz",
-              "integrity": "sha1-zYX6Z9FWBg5EDXgH1+988NLR1nE=",
-              "requires": {
-                "chalk": "^1.0.0",
-                "debug": "^2.0.0",
-                "diff": "^2.1.2",
-                "escape-string-regexp": "^1.0.2",
-                "globby": "^4.0.0",
-                "grouped-queue": "^0.3.0",
-                "inquirer": "^1.0.2",
-                "lodash": "^4.11.1",
-                "log-symbols": "^1.0.1",
-                "mem-fs": "^1.1.0",
-                "text-table": "^0.2.0",
-                "untildify": "^2.0.0"
-              }
             }
           }
         },
@@ -33059,9 +32939,9 @@
           }
         },
         "window-size": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
         },
         "wordwrap": {
           "version": "0.0.2",
@@ -33103,6 +32983,11 @@
             "wpcom-xhr-request": "1.0.0"
           },
           "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+            },
             "qs": {
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
@@ -33202,6 +33087,11 @@
               "requires": {
                 "ms": "0.7.1"
               }
+            },
+            "ms": {
+              "version": "0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
             }
           }
         },
@@ -33222,6 +33112,11 @@
               "requires": {
                 "ms": "0.7.1"
               }
+            },
+            "ms": {
+              "version": "0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
             }
           }
         },
@@ -33283,22 +33178,19 @@
           "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
         },
         "xgettext-js": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/xgettext-js/-/xgettext-js-1.0.0.tgz",
-          "integrity": "sha1-zZwElVeUaLH0ODReVEhcOJTqMFc=",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/xgettext-js/-/xgettext-js-1.1.0.tgz",
+          "integrity": "sha1-BSqSm2dVMjmyaqXrHjI1gSvqtm0=",
           "requires": {
-            "babylon": "6.8.4",
-            "estree-walker": "0.2.1",
+            "babylon": "^6.8.4",
+            "estree-walker": "^0.3.0",
             "lodash": "^4.13.1"
           },
           "dependencies": {
             "babylon": {
-              "version": "6.8.4",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.4.tgz",
-              "integrity": "sha1-CXMGuNq66VFZIlzymz6lWRIFMYA=",
-              "requires": {
-                "babel-runtime": "^6.0.0"
-              }
+              "version": "6.18.0",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+              "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
             }
           }
         },
@@ -33306,11 +33198,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
           "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
-        },
-        "xml-char-classes": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
-          "integrity": "sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0="
         },
         "xml-name-validator": {
           "version": "3.0.0",
@@ -33343,14 +33230,35 @@
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         },
         "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
-            "window-size": "0.1.0"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^5.0.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+            },
+            "y18n": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+            }
           }
         },
         "yargs-parser": {
@@ -33432,36 +33340,6 @@
                 "slash": "^1.0.0"
               }
             },
-            "inquirer": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
-              "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
-              "requires": {
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.0",
-                "cli-cursor": "^2.1.0",
-                "cli-width": "^2.0.0",
-                "external-editor": "^2.1.0",
-                "figures": "^2.0.0",
-                "lodash": "^4.3.0",
-                "mute-stream": "0.0.7",
-                "run-async": "^2.2.0",
-                "rxjs": "^5.5.2",
-                "string-width": "^2.1.0",
-                "strip-ansi": "^4.0.0",
-                "through": "^2.3.6"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-            },
-            "lodash": {
-              "version": "4.17.10",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-              "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-            },
             "ms": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -33472,15 +33350,6 @@
               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
             },
-            "string-width": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-              "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-              }
-            },
             "strip-ansi": {
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -33488,11 +33357,133 @@
               "requires": {
                 "ansi-regex": "^3.0.0"
               }
+            }
+          }
+        },
+        "yeoman-generator": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.5.tgz",
+          "integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
+          "requires": {
+            "async": "^2.6.0",
+            "chalk": "^2.3.0",
+            "cli-table": "^0.3.1",
+            "cross-spawn": "^6.0.5",
+            "dargs": "^5.1.0",
+            "dateformat": "^3.0.3",
+            "debug": "^3.1.0",
+            "detect-conflict": "^1.0.0",
+            "error": "^7.0.2",
+            "find-up": "^2.1.0",
+            "github-username": "^4.0.0",
+            "istextorbinary": "^2.2.1",
+            "lodash": "^4.17.10",
+            "make-dir": "^1.1.0",
+            "mem-fs-editor": "^4.0.0",
+            "minimist": "^1.2.0",
+            "pretty-bytes": "^4.0.2",
+            "read-chunk": "^2.1.0",
+            "read-pkg-up": "^3.0.0",
+            "rimraf": "^2.6.2",
+            "run-async": "^2.0.0",
+            "shelljs": "^0.8.0",
+            "text-table": "^0.2.0",
+            "through2": "^2.0.0",
+            "yeoman-environment": "^2.0.5"
+          },
+          "dependencies": {
+            "async": {
+              "version": "2.6.1",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+              "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+              "requires": {
+                "lodash": "^4.17.10"
+              }
             },
-            "untildify": {
-              "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
-              "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
+            "chalk": {
+              "version": "2.4.1",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+              "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "load-json-file": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+              "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            },
+            "parse-json": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+              "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+              "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+              }
+            },
+            "path-type": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+              "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+              "requires": {
+                "pify": "^3.0.0"
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+            },
+            "read-pkg": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+              "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+              "requires": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+              "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+              "requires": {
+                "find-up": "^2.0.0",
+                "read-pkg": "^3.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
             }
           }
         },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -34,9 +34,9 @@
       }
     },
     "@types/node": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.2.tgz",
-      "integrity": "sha512-9NfEUDp3tgRhmoxzTpTo+lq+KIVFxZahuRX0LHF/9IzKHaWuoWsIrrJ61zw5cnnlGINX8lqJzXYfQTOICS5Q+A==",
+      "version": "10.3.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.4.tgz",
+      "integrity": "sha512-YMLlzdeNnAyLrQew39IFRkMacAR5BqKGIEei9ZjdHsIZtv+ZWKYTu1i7QJhetxQ9ReXx8w5f+cixdHZG3zgMQA==",
       "dev": true
     },
     "abab": {
@@ -62,9 +62,9 @@
       }
     },
     "acorn": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.2.tgz",
-      "integrity": "sha512-zUzo1E5dI2Ey8+82egfnttyMlMZ2y0D8xOCO3PNPPlYXpl8NZvF6Qk9L9BEtJs+43FqEmfBViDqc5d1ckRDguw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
       "dev": true
     },
     "acorn-dynamic-import": {
@@ -1972,15 +1972,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000853",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000853.tgz",
-      "integrity": "sha1-MpAafWuTqH1Z8Iqu5H6o/27JD98=",
+      "version": "1.0.30000856",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000856.tgz",
+      "integrity": "sha1-++u5mr4VpWVPx3R+u1MVvf3jNY8=",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000853",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000853.tgz",
-      "integrity": "sha512-vMrE8BED4MJC9IhDJKP8ok6bJUfn5+YHvxwXMYfiPqQOJ3r2B9ihcArlUnXu6yPWf7b3jHqiEBwXZEbrbiFUqg=="
+      "version": "1.0.30000856",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000856.tgz",
+      "integrity": "sha512-x3mYcApHMQemyaHuH/RyqtKCGIYTgEA63fdi+VBvDz8xUSmRiVWTLeyKcoGQCGG6UPR9/+4qG4OKrTa6aSQRKg=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -3366,9 +3366,9 @@
       }
     },
     "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
@@ -5527,9 +5527,9 @@
       "dev": true
     },
     "hoist-non-react-statics": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.4.tgz",
-      "integrity": "sha512-yklXtcYj0Pt5Dz9No8xUh7d+/7fy5XRIm+r7U/BXgwJ/VsD75EfXA8t4p9tIL0jykzo5A/sGzt1xV6oqd/gP0w=="
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -7122,6 +7122,12 @@
         "lodash._isiterateecall": "^3.0.0"
       }
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
     "lodash.findkey": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.findkey/-/lodash.findkey-4.6.0.tgz",
@@ -8365,9 +8371,9 @@
       "dev": true
     },
     "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
       "dev": true
     },
     "object-path-immutable": {
@@ -10164,9 +10170,9 @@
       "integrity": "sha1-t9I/3wC4P6etAnlUb427vXZccEc="
     },
     "resolve": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.5"
@@ -12003,23 +12009,24 @@
           }
         },
         "chokidar": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
-          "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+          "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
           "dev": true,
           "requires": {
             "anymatch": "^2.0.0",
             "async-each": "^1.0.0",
             "braces": "^2.3.0",
-            "fsevents": "^1.1.2",
+            "fsevents": "^1.2.2",
             "glob-parent": "^3.1.0",
             "inherits": "^2.0.1",
             "is-binary-path": "^1.0.0",
             "is-glob": "^4.0.0",
+            "lodash.debounce": "^4.0.8",
             "normalize-path": "^2.1.1",
             "path-is-absolute": "^1.0.0",
             "readdirp": "^2.0.0",
-            "upath": "^1.0.0"
+            "upath": "^1.0.5"
           }
         },
         "glob-parent": {
@@ -12248,23 +12255,24 @@
           "dev": true
         },
         "chokidar": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
-          "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+          "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
           "dev": true,
           "requires": {
             "anymatch": "^2.0.0",
             "async-each": "^1.0.0",
             "braces": "^2.3.0",
-            "fsevents": "^1.1.2",
+            "fsevents": "^1.2.2",
             "glob-parent": "^3.1.0",
             "inherits": "^2.0.1",
             "is-binary-path": "^1.0.0",
             "is-glob": "^4.0.0",
+            "lodash.debounce": "^4.0.8",
             "normalize-path": "^2.1.1",
             "path-is-absolute": "^1.0.0",
             "readdirp": "^2.0.0",
-            "upath": "^1.0.0"
+            "upath": "^1.0.5"
           }
         },
         "cliui": {
@@ -12524,8 +12532,8 @@
       "dev": true
     },
     "wp-calypso": {
-      "version": "github:automattic/wp-calypso#9d78dbb5d3015931691c4d28423b3ce9c10e16c0",
-      "from": "github:automattic/wp-calypso#9d78dbb5d3015931691c4d28423b3ce9c10e16c0",
+      "version": "github:automattic/wp-calypso#2ed3e056afa2be61698fe6ab491668a6652bd51c",
+      "from": "github:automattic/wp-calypso#2ed3e056afa2be61698fe6ab491668a6652bd51c",
       "requires": {
         "@babel/cli": "7.0.0-beta.44",
         "@babel/core": "7.0.0-beta.44",
@@ -12537,68 +12545,66 @@
         "@babel/preset-react": "7.0.0-beta.44",
         "@babel/preset-stage-2": "7.0.0-beta.44",
         "@babel/runtime": "7.0.0-beta.44",
-        "assets-webpack-plugin": "3.5.1",
-        "autoprefixer": "8.6.0",
-        "autosize": "3.0.15",
+        "autoprefixer": "8.6.2",
+        "autosize": "3.0.21",
         "babel-core": "7.0.0-bridge.0",
         "babel-jest": "22.4.1",
-        "babel-loader": "8.0.0-beta.2",
+        "babel-loader": "8.0.0-beta.3",
         "babel-plugin-add-module-exports": "0.2.1",
         "babel-plugin-transform-class-properties": "6.24.1",
         "babel-plugin-transform-export-extensions": "6.22.0",
         "blob": "0.0.4",
         "body-parser": "1.18.3",
         "bounding-client-rect": "1.0.5",
-        "browser-filesaver": "1.1.0",
-        "chalk": "1.0.0",
+        "browser-filesaver": "1.1.1",
+        "chalk": "1.1.3",
         "check-node-version": "2.1.0",
-        "chokidar": "2.0.3",
-        "chrono-node": "1.3.1",
+        "chokidar": "2.0.4",
+        "chrono-node": "1.3.5",
         "circular-dependency-plugin": "5.0.2",
         "classnames": "1.2.2",
         "click-outside": "2.0.2",
-        "clipboard": "1.5.3",
-        "commander": "2.3.0",
+        "clipboard": "1.7.1",
         "component-closest": "0.1.4",
         "component-file-picker": "0.2.1",
-        "cookie": "0.1.2",
+        "cookie": "0.3.1",
         "cookie-parser": "1.4.3",
-        "copy-webpack-plugin": "4.4.3",
+        "copy-webpack-plugin": "4.5.1",
         "cpf_cnpj": "0.2.0",
         "create-react-class": "15.6.3",
         "creditcards": "2.1.2",
-        "cross-env": "5.1.1",
-        "d3-array": "1.2.0",
+        "cross-env": "5.2.0",
+        "d3-array": "1.2.1",
         "d3-axis": "1.0.8",
-        "d3-scale": "1.0.6",
-        "d3-selection": "1.1.0",
+        "d3-scale": "1.0.7",
+        "d3-selection": "1.3.0",
         "d3-shape": "1.2.0",
-        "debug": "2.2.0",
+        "debug": "2.6.9",
         "deep-freeze": "0.0.1",
-        "diff": "3.4.0",
-        "doctrine": "2.0.0",
+        "diff": "3.5.0",
+        "doctrine": "2.1.0",
         "dom-helpers": "2.4.0",
-        "dom-scroll-into-view": "1.0.1",
+        "dom-scroll-into-view": "1.2.1",
         "dompurify": "1.0.2",
         "draft-js": "0.10.4",
         "email-validator": "2.0.4",
         "emoji-text": "0.2.6",
         "escape-regexp": "0.0.1",
-        "escape-string-regexp": "1.0.3",
+        "escape-string-regexp": "1.0.5",
         "events": "3.0.0",
-        "exports-loader": "0.6.2",
+        "exports-loader": "0.7.0",
         "express": "4.16.3",
-        "express-useragent": "1.0.7",
-        "filesize": "3.2.1",
-        "flag-icon-css": "2.3.0",
+        "express-useragent": "1.0.12",
+        "filesize": "3.6.1",
+        "flag-icon-css": "2.9.0",
         "flux": "2.1.1",
         "fsevents": "1.2.4",
         "fuse.js": "2.6.1",
-        "get-video-id": "2.1.4",
+        "get-video-id": "2.1.7",
         "globby": "6.1.0",
         "gridicons": "3.0.1",
         "gzip-size": "4.1.0",
-        "hash.js": "1.1.3",
+        "hash.js": "1.1.4",
         "he": "0.5.0",
         "html-loader": "0.4.0",
         "html-to-react": "1.3.1",
@@ -12616,7 +12622,7 @@
         "keymaster": "1.6.2",
         "loader-utils": "1.1.0",
         "localforage": "1.4.3",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "lru": "3.1.0",
         "lunr": "0.5.7",
         "markdown-loader": "3.0.0",
@@ -12660,7 +12666,7 @@
         "rtlcss": "2.2.1",
         "semver": "5.1.0",
         "social-logos": "2.0.0",
-        "socket.io-client": "1.4.5",
+        "socket.io-client": "2.1.1",
         "source-map": "0.1.39",
         "source-map-support": "0.3.2",
         "store": "1.3.16",
@@ -12681,7 +12687,7 @@
         "webpack-cli": "2.0.9",
         "webpack-dev-middleware": "3.1.3",
         "wpcom": "5.4.1",
-        "wpcom-oauth": "0.3.3",
+        "wpcom-oauth": "0.3.4",
         "wpcom-proxy-request": "5.0.0",
         "wpcom-xhr-request": "1.1.1"
       },
@@ -12755,24 +12761,6 @@
                 "is-glob": "^2.0.0",
                 "path-is-absolute": "^1.0.0",
                 "readdirp": "^2.0.0"
-              }
-            },
-            "commander": {
-              "version": "2.15.1",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-              "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
-            },
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
               }
             },
             "source-map": {
@@ -13061,11 +13049,6 @@
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
               }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
             }
           }
         },
@@ -13771,9 +13754,9 @@
           }
         },
         "@types/node": {
-          "version": "10.3.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.2.tgz",
-          "integrity": "sha512-9NfEUDp3tgRhmoxzTpTo+lq+KIVFxZahuRX0LHF/9IzKHaWuoWsIrrJ61zw5cnnlGINX8lqJzXYfQTOICS5Q+A=="
+          "version": "10.3.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.3.tgz",
+          "integrity": "sha512-/gwCgiI2e9RzzZTKbl+am3vgNqOt7a9fJ/uxv4SqYKxenoEDNVU3KZEadlpusWhQI0A0dOrZ0T68JYKVjzmgdQ=="
         },
         "@types/semver": {
           "version": "5.5.0",
@@ -14041,9 +14024,9 @@
           }
         },
         "acorn": {
-          "version": "5.6.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.2.tgz",
-          "integrity": "sha512-zUzo1E5dI2Ey8+82egfnttyMlMZ2y0D8xOCO3PNPPlYXpl8NZvF6Qk9L9BEtJs+43FqEmfBViDqc5d1ckRDguw=="
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+          "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ=="
         },
         "acorn-dynamic-import": {
           "version": "3.0.0",
@@ -14070,9 +14053,9 @@
           }
         },
         "after": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
-          "integrity": "sha1-q11PuIP1loFtNRX495HAr0ht1ic="
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+          "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
         },
         "ajv": {
           "version": "6.5.1",
@@ -14206,13 +14189,6 @@
           "requires": {
             "ast-types-flow": "0.0.7",
             "commander": "^2.11.0"
-          },
-          "dependencies": {
-            "commander": {
-              "version": "2.15.1",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-              "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
-            }
           }
         },
         "arity-n": {
@@ -14301,9 +14277,9 @@
           "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
         },
         "arraybuffer.slice": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
-          "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+          "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
         },
         "arrify": {
           "version": "1.0.1",
@@ -14357,18 +14333,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
           "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
-        },
-        "assets-webpack-plugin": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/assets-webpack-plugin/-/assets-webpack-plugin-3.5.1.tgz",
-          "integrity": "sha1-kxzg1m1C6I7V5/GNZVIpQ8V6OH0=",
-          "requires": {
-            "camelcase": "^1.2.1",
-            "escape-string-regexp": "^1.0.3",
-            "lodash.assign": "^3.2.0",
-            "lodash.merge": "^3.3.2",
-            "mkdirp": "^0.5.1"
-          }
         },
         "assign-symbols": {
           "version": "1.0.0",
@@ -14442,12 +14406,12 @@
           "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
         },
         "autoprefixer": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.6.0.tgz",
-          "integrity": "sha512-JaYK4gmyklt+es0VDdWVS9R/X96D8eaT0qDLAO6R4niBsoKv6nI4QtfFs8YQskwatIdJ6XZeTBDRpjf4tH+Dlg==",
+          "version": "8.6.2",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.6.2.tgz",
+          "integrity": "sha512-cv9v1mYYBcAnZq4MHseJ9AIdjQmNahnpCpPO46oTkQJS2GggsBp2azHjNpAuQ95Epvsg+AIsyjYhfI9YwFxGSA==",
           "requires": {
             "browserslist": "^3.2.8",
-            "caniuse-lite": "^1.0.30000847",
+            "caniuse-lite": "^1.0.30000851",
             "normalize-range": "^0.1.2",
             "num2fraction": "^1.2.2",
             "postcss": "^6.0.22",
@@ -14455,9 +14419,9 @@
           }
         },
         "autosize": {
-          "version": "3.0.15",
-          "resolved": "https://registry.npmjs.org/autosize/-/autosize-3.0.15.tgz",
-          "integrity": "sha1-in43+vpfQqP0+PEVOn+15jHoyrU="
+          "version": "3.0.21",
+          "resolved": "https://registry.npmjs.org/autosize/-/autosize-3.0.21.tgz",
+          "integrity": "sha1-8YL0DRd1fZeKE5pMnKQMTA5EhgM="
         },
         "aws-sign2": {
           "version": "0.6.0",
@@ -14485,30 +14449,6 @@
             "chalk": "^1.1.3",
             "esutils": "^2.0.2",
             "js-tokens": "^3.0.2"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-            }
           }
         },
         "babel-core": {
@@ -14712,13 +14652,14 @@
           }
         },
         "babel-loader": {
-          "version": "8.0.0-beta.2",
-          "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.0-beta.2.tgz",
-          "integrity": "sha512-P1zch1DvQy3RGmp/1CH78uPg5gTPQQ01S9r6ipCOWVamO0UIC8gnrx7m7LsUsXa470yB6IOZxhtEEwIUclRLNw==",
+          "version": "8.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.0-beta.3.tgz",
+          "integrity": "sha512-yvaAx7cBEjh+R2oGL2vIPmveO6daS5TYP2FSPq4b6CUYjU/ilD4HHyfLIa9KUj6OKBcR9fQcl1NvUOTWNaJ6mw==",
           "requires": {
             "find-cache-dir": "^1.0.0",
             "loader-utils": "^1.0.2",
-            "mkdirp": "^0.5.1"
+            "mkdirp": "^0.5.1",
+            "util.promisify": "^1.0.0"
           }
         },
         "babel-messages": {
@@ -15427,19 +15368,6 @@
               "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
               "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
             },
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            },
             "source-map": {
               "version": "0.5.7",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -15504,23 +15432,10 @@
               "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
               "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
             },
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
             "globals": {
               "version": "9.18.0",
               "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
               "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
@@ -15628,9 +15543,9 @@
           "integrity": "sha512-V6YHUbjLxN1ymqNLb1DPHoU1CpfdL7d2YTIp5W3U4hhoG4hhxNmsFDs66M9EXxBiSEke5Bt5dwdfMwwZF70iLA=="
         },
         "base64-arraybuffer": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
-          "integrity": "sha1-R030qfLaJOBd8xWMOx2zw81GoVQ="
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+          "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
         },
         "base64-js": {
           "version": "1.3.0",
@@ -15638,9 +15553,9 @@
           "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
         },
         "base64id": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
-          "integrity": "sha1-As4P3u4M709ACA4ec+g08LG/zj8="
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+          "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
         },
         "basic-auth": {
           "version": "1.0.0",
@@ -15660,11 +15575,6 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
           "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
-        },
-        "benchmark": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
-          "integrity": "sha1-Lx4vpMNZ8REiqhgwgiGOlX45DHM="
         },
         "better-assert": {
           "version": "1.0.2",
@@ -15739,19 +15649,6 @@
             "type-is": "~1.6.16"
           },
           "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            },
             "qs": {
               "version": "6.5.2",
               "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -15810,9 +15707,9 @@
           "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
         },
         "browser-filesaver": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/browser-filesaver/-/browser-filesaver-1.1.0.tgz",
-          "integrity": "sha1-xmJKvwixzgBmTsRANh775W1LEuY="
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/browser-filesaver/-/browser-filesaver-1.1.1.tgz",
+          "integrity": "sha1-HDUbL1dvWwDx0p1EIcTAQo7uX6E="
         },
         "browser-process-hrtime": {
           "version": "0.1.2",
@@ -15940,11 +15837,6 @@
                 "supports-color": "^5.3.0"
               }
             },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-            },
             "minimist": {
               "version": "1.2.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -16005,21 +15897,6 @@
             "ssri": "^5.2.4",
             "unique-filename": "^1.1.0",
             "y18n": "^4.0.0"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            }
           }
         },
         "cache-base": {
@@ -16099,14 +15976,14 @@
           }
         },
         "caniuse-db": {
-          "version": "1.0.30000852",
-          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000852.tgz",
-          "integrity": "sha1-w3pwYEj42B+HlGp8E/Oe1jaHZlk="
+          "version": "1.0.30000856",
+          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000856.tgz",
+          "integrity": "sha1-++u5mr4VpWVPx3R+u1MVvf3jNY8="
         },
         "caniuse-lite": {
-          "version": "1.0.30000852",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000852.tgz",
-          "integrity": "sha512-NOuitABlrRbIpjtC8HdDnHL9Fi+yH5phDoXlXT7Im++48kll2bUps9dWWdAnBwqT/oEsjobuOLnnJCBjVqadCw=="
+          "version": "1.0.30000856",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000856.tgz",
+          "integrity": "sha512-x3mYcApHMQemyaHuH/RyqtKCGIYTgEA63fdi+VBvDz8xUSmRiVWTLeyKcoGQCGG6UPR9/+4qG4OKrTa6aSQRKg=="
         },
         "capture-exit": {
           "version": "1.2.0",
@@ -16150,9 +16027,9 @@
           }
         },
         "chai-enzyme": {
-          "version": "1.0.0-beta.0",
-          "resolved": "https://registry.npmjs.org/chai-enzyme/-/chai-enzyme-1.0.0-beta.0.tgz",
-          "integrity": "sha512-b2XJjyW1PfnW5a5ZBBcZWZJUhq8CA1kpTyXLf4Nac+EaiTuIyYeYN0Ft0qYoW+clinusKDhvJygiVktjhvvFvg==",
+          "version": "1.0.0-beta.1",
+          "resolved": "https://registry.npmjs.org/chai-enzyme/-/chai-enzyme-1.0.0-beta.1.tgz",
+          "integrity": "sha512-vWT101M7qjq6kM/29G4vHrgLM4Mj1gCnKuvOSF03s8pFVsqol4B6USoGM/aYRKqaaIHs8/AxmHjWGFplQWhIQw==",
           "requires": {
             "html": "^1.0.0"
           }
@@ -16163,48 +16040,26 @@
           "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="
         },
         "chalk": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
-          "integrity": "sha1-s89O0P9Tl8mcdbj2edsvUoMfltw=",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "^2.0.1",
+            "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^1.0.3",
-            "strip-ansi": "^2.0.1",
-            "supports-color": "^1.3.0"
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
-            "ansi-regex": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-              "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0="
-            },
             "ansi-styles": {
               "version": "2.2.1",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
             },
-            "has-ansi": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
-              "integrity": "sha1-wLWxYV2eOCsP9nFp2We0JeSMpTg=",
-              "requires": {
-                "ansi-regex": "^1.1.0",
-                "get-stdin": "^4.0.1"
-              }
-            },
-            "strip-ansi": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-              "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
-              "requires": {
-                "ansi-regex": "^1.0.0"
-              }
-            },
             "supports-color": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
-              "integrity": "sha1-FXWN8J2P87SswwdTn6vicJXhBC0="
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             }
           }
         },
@@ -16295,22 +16150,23 @@
           "integrity": "sha1-AmVfKyazvC7hrh5TFoht4463lzg="
         },
         "chokidar": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
-          "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+          "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
           "requires": {
             "anymatch": "^2.0.0",
             "async-each": "^1.0.0",
             "braces": "^2.3.0",
-            "fsevents": "^1.1.2",
+            "fsevents": "^1.2.2",
             "glob-parent": "^3.1.0",
             "inherits": "^2.0.1",
             "is-binary-path": "^1.0.0",
             "is-glob": "^4.0.0",
+            "lodash.debounce": "^4.0.8",
             "normalize-path": "^2.1.1",
             "path-is-absolute": "^1.0.0",
             "readdirp": "^2.0.0",
-            "upath": "^1.0.0"
+            "upath": "^1.0.5"
           },
           "dependencies": {
             "anymatch": {
@@ -16357,14 +16213,6 @@
                     "is-extendable": "^0.1.0"
                   }
                 }
-              }
-            },
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
               }
             },
             "expand-brackets": {
@@ -16609,11 +16457,6 @@
                 "snapdragon": "^0.8.1",
                 "to-regex": "^3.0.2"
               }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
@@ -16628,9 +16471,9 @@
           "integrity": "sha512-sjndyZHrrWiu4RY7AkHgjn80GfAM2ZSzUkZLV/Js59Ldmh6JDThf0SUmOHU53rFu2rVxxfCzJ30Ukcfch3Gb/A=="
         },
         "chrono-node": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-1.3.1.tgz",
-          "integrity": "sha1-0Nx2Kk2SYFG3UBatY8EAyv+dHYQ=",
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-1.3.5.tgz",
+          "integrity": "sha1-oklSmKMtqCvMAa2b59d++l4kQSI=",
           "requires": {
             "moment": "^2.10.3"
           }
@@ -16791,13 +16634,13 @@
           }
         },
         "clipboard": {
-          "version": "1.5.3",
-          "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.5.3.tgz",
-          "integrity": "sha1-unh0tHK4BJ9eAfJgsIU5emb625Q=",
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
+          "integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
           "requires": {
-            "good-listener": "^1.1.2",
-            "select": "^1.0.4",
-            "tiny-emitter": "^1.0.0"
+            "good-listener": "^1.2.2",
+            "select": "^1.1.2",
+            "tiny-emitter": "^2.0.0"
           }
         },
         "cliui": {
@@ -17020,23 +16863,6 @@
             "yargs": "^1.2.6"
           },
           "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
             "has-flag": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
@@ -17059,16 +16885,6 @@
                 "js-base64": "^2.1.9",
                 "source-map": "^0.5.6",
                 "supports-color": "^3.2.3"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "3.2.3",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                  "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                  "requires": {
-                    "has-flag": "^1.0.0"
-                  }
-                }
               }
             },
             "source-map": {
@@ -17077,9 +16893,12 @@
               "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
             },
             "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
             },
             "yargs": {
               "version": "1.3.3",
@@ -17102,9 +16921,9 @@
           }
         },
         "commander": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-          "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
         },
         "commondir": {
           "version": "1.0.1",
@@ -17127,11 +16946,6 @@
             "recast": "^0.11.17"
           },
           "dependencies": {
-            "commander": {
-              "version": "2.15.1",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-              "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
-            },
             "glob": {
               "version": "5.0.15",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
@@ -17299,9 +17113,9 @@
           "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
         },
         "cookie": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
-          "integrity": "sha1-cv7D0k5Io0Mgc9kMEmQgBQYQBLE="
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
         },
         "cookie-parser": {
           "version": "1.4.3",
@@ -17310,13 +17124,6 @@
           "requires": {
             "cookie": "0.3.1",
             "cookie-signature": "1.0.6"
-          },
-          "dependencies": {
-            "cookie": {
-              "version": "0.3.1",
-              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-              "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-            }
           }
         },
         "cookie-signature": {
@@ -17348,11 +17155,11 @@
           "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
         },
         "copy-webpack-plugin": {
-          "version": "4.4.3",
-          "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.4.3.tgz",
-          "integrity": "sha512-v4THQ24Tks2NkyOvZuFDgZVfDD9YaA9rwYLZTrWg2GHIA8lrH5DboEyeoorh5Skki+PUbgSmnsCwhMWqYrQZrA==",
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.5.1.tgz",
+          "integrity": "sha512-OlTo6DYg0XfTKOF8eLf79wcHm4Ut10xU2cRBRPMW/NA5F9VMjZGTfRHWDIYC3s+1kObGYrBLshXWU1K0hILkNQ==",
           "requires": {
-            "cacache": "^10.0.1",
+            "cacache": "^10.0.4",
             "find-cache-dir": "^1.0.0",
             "globby": "^7.1.1",
             "is-glob": "^4.0.0",
@@ -17362,19 +17169,6 @@
             "serialize-javascript": "^1.4.0"
           },
           "dependencies": {
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
             "globby": {
               "version": "7.1.1",
               "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
@@ -17387,11 +17181,6 @@
                 "pify": "^3.0.0",
                 "slash": "^1.0.0"
               }
-            },
-            "ignore": {
-              "version": "3.3.8",
-              "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
-              "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg=="
             },
             "is-extglob": {
               "version": "2.1.1",
@@ -17521,22 +17310,31 @@
           }
         },
         "cross-env": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.1.tgz",
-          "integrity": "sha512-Wtvr+z0Z06KO1JxjfRRsPC+df7biIOiuV4iZ73cThjFGkH+ULBZq1MkBdywEcJC4cTDbO6c8IjgRjfswx3YTBA==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+          "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
           "requires": {
-            "cross-spawn": "^5.1.0",
+            "cross-spawn": "^6.0.5",
             "is-windows": "^1.0.0"
           }
         },
         "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "requires": {
-            "lru-cache": "^4.0.1",
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+            }
           }
         },
         "cryptiles": {
@@ -17715,9 +17513,9 @@
           }
         },
         "d3-array": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.0.tgz",
-          "integrity": "sha1-FH0mlyDhdMQFen9CvosPPyulMQg="
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.1.tgz",
+          "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
         },
         "d3-axis": {
           "version": "1.0.8",
@@ -17753,9 +17551,9 @@
           "integrity": "sha1-JB6xhJvZ6egCHA0KeZ+KDo5EF2Q="
         },
         "d3-scale": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.6.tgz",
-          "integrity": "sha1-vOGdqA06DPQiyVQ64zIghiILNO0=",
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+          "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
           "requires": {
             "d3-array": "^1.2.0",
             "d3-collection": "1",
@@ -17767,9 +17565,9 @@
           }
         },
         "d3-selection": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.1.0.tgz",
-          "integrity": "sha1-GZhoSJZIj4OcoDchI9o08dMYgJw="
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
+          "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA=="
         },
         "d3-shape": {
           "version": "1.2.0",
@@ -17853,11 +17651,18 @@
           "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
         },
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
-            "ms": "0.7.1"
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
           }
         },
         "decamelize": {
@@ -18132,9 +17937,9 @@
           }
         },
         "diff": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA=="
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
         },
         "diffie-hellman": {
           "version": "5.0.3",
@@ -18176,12 +17981,11 @@
           "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
         },
         "doctrine": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-          "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
+            "esutils": "^2.0.2"
           }
         },
         "doiuse": {
@@ -18203,11 +18007,6 @@
             "yargs": "^3.5.4"
           },
           "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
             "browserslist": {
               "version": "1.7.7",
               "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
@@ -18215,25 +18014,6 @@
               "requires": {
                 "caniuse-db": "^1.0.30000639",
                 "electron-to-chromium": "^1.2.7"
-              }
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-                }
               }
             },
             "has-flag": {
@@ -18322,9 +18102,9 @@
           }
         },
         "dom-scroll-into-view": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-1.0.1.tgz",
-          "integrity": "sha1-Mqu5Lw2P7KYhUWKu9D5LRJq42Zw="
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-1.2.1.tgz",
+          "integrity": "sha1-6PNnMt0ImwIBqI14Fdw/iObWbH4="
         },
         "dom-serializer": {
           "version": "0.1.0",
@@ -18484,11 +18264,6 @@
             "sigmund": "^1.0.1"
           },
           "dependencies": {
-            "commander": {
-              "version": "2.15.1",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-              "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
-            },
             "semver": {
               "version": "5.5.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
@@ -18540,11 +18315,6 @@
           "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
           "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ=="
         },
-        "emitter-component": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.0.0.tgz",
-          "integrity": "sha1-8E3Rj8PcPpp0y8DzELCIZm5MAW8="
-        },
         "emoji-regex": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
@@ -18585,98 +18355,76 @@
           }
         },
         "engine.io": {
-          "version": "1.6.8",
-          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.8.tgz",
-          "integrity": "sha1-3gWga3V+dRdpXgiMewUcR4GfURs=",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
+          "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
           "requires": {
-            "accepts": "1.1.4",
-            "base64id": "0.1.0",
-            "debug": "2.2.0",
-            "engine.io-parser": "1.2.4",
-            "ws": "1.0.1"
+            "accepts": "~1.3.4",
+            "base64id": "1.0.0",
+            "cookie": "0.3.1",
+            "debug": "~3.1.0",
+            "engine.io-parser": "~2.1.0",
+            "ws": "~3.3.1"
           },
           "dependencies": {
-            "accepts": {
-              "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
-              "integrity": "sha1-1xyW99QdD+2iw4zRToonwEFY30o=",
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
               "requires": {
-                "mime-types": "~2.0.4",
-                "negotiator": "0.4.9"
+                "ms": "2.0.0"
               }
             },
-            "mime-db": {
-              "version": "1.12.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-              "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
-            },
-            "mime-types": {
-              "version": "2.0.14",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-              "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
-              "requires": {
-                "mime-db": "~1.12.0"
-              }
-            },
-            "negotiator": {
-              "version": "0.4.9",
-              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
-              "integrity": "sha1-kuRrbbU8fkIe1koryU8IvnYw3z8="
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
         "engine.io-client": {
-          "version": "1.6.8",
-          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.8.tgz",
-          "integrity": "sha1-bi2xFki0XkBcRrFy6j49rDfMDOs=",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+          "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
           "requires": {
-            "component-emitter": "1.1.2",
+            "component-emitter": "1.2.1",
             "component-inherit": "0.0.3",
-            "debug": "2.2.0",
-            "engine.io-parser": "1.2.4",
+            "debug": "~3.1.0",
+            "engine.io-parser": "~2.1.1",
             "has-cors": "1.1.0",
             "indexof": "0.0.1",
-            "parsejson": "0.0.1",
-            "parseqs": "0.0.2",
-            "parseuri": "0.0.4",
-            "ws": "1.0.1",
-            "xmlhttprequest-ssl": "1.5.1",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "ws": "~3.3.1",
+            "xmlhttprequest-ssl": "~1.5.4",
             "yeast": "0.1.2"
           },
           "dependencies": {
-            "component-emitter": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-              "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM="
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
         "engine.io-parser": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
-          "integrity": "sha1-4Il7C/FOeS1M0qWVBVORnFaUjEI=",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
+          "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
           "requires": {
-            "after": "0.8.1",
-            "arraybuffer.slice": "0.0.6",
-            "base64-arraybuffer": "0.1.2",
+            "after": "0.8.2",
+            "arraybuffer.slice": "~0.0.7",
+            "base64-arraybuffer": "0.1.5",
             "blob": "0.0.4",
-            "has-binary": "0.1.6",
-            "utf8": "2.1.0"
-          },
-          "dependencies": {
-            "has-binary": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
-              "integrity": "sha1-JTJvOc+k9hath4eJTjryz7x7bhA=",
-              "requires": {
-                "isarray": "0.0.1"
-              }
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-            }
+            "has-binary2": "~1.0.2"
           }
         },
         "enhanced-resolve": {
@@ -18945,9 +18693,9 @@
           "integrity": "sha1-nGO20LJf8qiMOtvRjFthrMO5+qI="
         },
         "escape-string-regexp": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-          "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "escodegen": {
           "version": "1.10.0",
@@ -19067,6 +18815,16 @@
                 "supports-color": "^5.3.0"
               }
             },
+            "cross-spawn": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
             "debug": {
               "version": "3.1.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -19074,19 +18832,6 @@
               "requires": {
                 "ms": "2.0.0"
               }
-            },
-            "doctrine": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-              "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-              "requires": {
-                "esutils": "^2.0.2"
-              }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
             },
             "fast-deep-equal": {
               "version": "1.1.0",
@@ -19097,19 +18842,6 @@
               "version": "2.0.6",
               "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
               "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-            },
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
             },
             "json-schema-traverse": {
               "version": "0.3.1",
@@ -19186,21 +18918,6 @@
           "requires": {
             "debug": "^2.6.9",
             "resolve": "^1.5.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            }
           }
         },
         "eslint-module-utils": {
@@ -19212,14 +18929,6 @@
             "pkg-dir": "^1.0.0"
           },
           "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
             "find-up": {
               "version": "1.1.2",
               "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -19228,11 +18937,6 @@
                 "path-exists": "^2.0.0",
                 "pinkie-promise": "^2.0.0"
               }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             },
             "path-exists": {
               "version": "2.1.0",
@@ -19253,30 +18957,22 @@
           }
         },
         "eslint-plugin-import": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz",
-          "integrity": "sha1-JgAu+/ylmJtyiKwEdQi9JPIXsWk=",
+          "version": "2.12.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.12.0.tgz",
+          "integrity": "sha1-2tMXgSktZmSyUxf9BJ0uKy8CIF0=",
           "requires": {
-            "builtin-modules": "^1.1.1",
             "contains-path": "^0.1.0",
             "debug": "^2.6.8",
             "doctrine": "1.5.0",
             "eslint-import-resolver-node": "^0.3.1",
-            "eslint-module-utils": "^2.1.1",
+            "eslint-module-utils": "^2.2.0",
             "has": "^1.0.1",
             "lodash": "^4.17.4",
             "minimatch": "^3.0.3",
-            "read-pkg-up": "^2.0.0"
+            "read-pkg-up": "^2.0.0",
+            "resolve": "^1.6.0"
           },
           "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
             "doctrine": {
               "version": "1.5.0",
               "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
@@ -19296,11 +18992,6 @@
                 "pify": "^2.0.0",
                 "strip-bom": "^3.0.0"
               }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             },
             "path-type": {
               "version": "2.0.0",
@@ -19356,24 +19047,14 @@
           }
         },
         "eslint-plugin-react": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
-          "integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
+          "version": "7.9.1",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.9.1.tgz",
+          "integrity": "sha512-uvq+2ZkiqzjwF+pMZ8xqIC3pChV4KviPvvPIyQOvKWnjtvyW3iGfHIRqVumw05L3itby0QGmA4VdBA9m1OdMmg==",
           "requires": {
-            "doctrine": "^2.0.2",
-            "has": "^1.0.1",
+            "doctrine": "^2.1.0",
+            "has": "^1.0.2",
             "jsx-ast-utils": "^2.0.1",
-            "prop-types": "^15.6.0"
-          },
-          "dependencies": {
-            "doctrine": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-              "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-              "requires": {
-                "esutils": "^2.0.2"
-              }
-            }
+            "prop-types": "^15.6.1"
           }
         },
         "eslint-plugin-wpcalypso": {
@@ -19527,6 +19208,18 @@
             "p-finally": "^1.0.0",
             "signal-exit": "^3.0.0",
             "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            }
           }
         },
         "execall": {
@@ -19599,24 +19292,18 @@
           }
         },
         "exports-loader": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/exports-loader/-/exports-loader-0.6.2.tgz",
-          "integrity": "sha1-ChAog42RKukDzJYQcHt4ljFQ2rg=",
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/exports-loader/-/exports-loader-0.7.0.tgz",
+          "integrity": "sha512-RKwCrO4A6IiKm0pG3c9V46JxIHcDplwwGJn6+JJ1RcVnh/WSGJa0xkmk5cRVtgOPzCAtTMGj2F7nluh9L0vpSA==",
           "requires": {
-            "loader-utils": "0.2.x",
-            "source-map": "0.1.x"
+            "loader-utils": "^1.1.0",
+            "source-map": "0.5.0"
           },
           "dependencies": {
-            "loader-utils": {
-              "version": "0.2.17",
-              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-              "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-              "requires": {
-                "big.js": "^3.1.3",
-                "emojis-list": "^2.0.0",
-                "json5": "^0.5.0",
-                "object-assign": "^4.0.1"
-              }
+            "source-map": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.0.tgz",
+              "integrity": "sha1-D+llA6yGpa213mP05BKuSHLNvoY="
             }
           }
         },
@@ -19674,19 +19361,6 @@
                 "type-is": "~1.6.15"
               }
             },
-            "cookie": {
-              "version": "0.3.1",
-              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-              "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-            },
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
             "iconv-lite": {
               "version": "0.4.19",
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -19696,11 +19370,6 @@
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             },
             "raw-body": {
               "version": "2.3.2",
@@ -19749,9 +19418,9 @@
           }
         },
         "express-useragent": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/express-useragent/-/express-useragent-1.0.7.tgz",
-          "integrity": "sha1-FT3mR+Wl0FxOwbQXJ5Ska8DQeZE="
+          "version": "1.0.12",
+          "resolved": "https://registry.npmjs.org/express-useragent/-/express-useragent-1.0.12.tgz",
+          "integrity": "sha1-W64BCakl7Js1QX8xpOitE/GRJTo="
         },
         "extend": {
           "version": "3.0.1",
@@ -19886,14 +19555,6 @@
                     "is-extendable": "^0.1.0"
                   }
                 }
-              }
-            },
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
               }
             },
             "expand-brackets": {
@@ -20138,11 +19799,6 @@
                 "snapdragon": "^0.8.1",
                 "to-regex": "^3.0.2"
               }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
@@ -20263,19 +19919,6 @@
                 "which": "^1.2.9"
               }
             },
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            },
             "source-map": {
               "version": "0.5.7",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -20289,13 +19932,6 @@
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "requires": {
             "escape-string-regexp": "^1.0.5"
-          },
-          "dependencies": {
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-            }
           }
         },
         "file-entry-cache": {
@@ -20322,9 +19958,9 @@
           }
         },
         "filesize": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.2.1.tgz",
-          "integrity": "sha1-oG8cVJftY1gFfEFeU0A/dkwfteY="
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
+          "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
         },
         "fill-range": {
           "version": "2.2.4",
@@ -20352,19 +19988,6 @@
             "unpipe": "~1.0.0"
           },
           "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            },
             "statuses": {
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -20440,9 +20063,9 @@
           }
         },
         "flag-icon-css": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/flag-icon-css/-/flag-icon-css-2.3.0.tgz",
-          "integrity": "sha1-DiCpvfoCB+r1DJ7bigzo/izC5nY="
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/flag-icon-css/-/flag-icon-css-2.9.0.tgz",
+          "integrity": "sha512-SeHvGEB43XFPZiJz6lFFRGHfp+Db+s1qGiClW70cZauQVbPM42wImlNUEuXSXs94kPchz7xvoxP0QK1y6FxLfg=="
         },
         "flat-cache": {
           "version": "1.3.0",
@@ -21198,9 +20821,9 @@
           "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
         },
         "get-video-id": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/get-video-id/-/get-video-id-2.1.4.tgz",
-          "integrity": "sha1-lyKhEi4bxlK2lUOIo8jLngv8XBs=",
+          "version": "2.1.7",
+          "resolved": "https://registry.npmjs.org/get-video-id/-/get-video-id-2.1.7.tgz",
+          "integrity": "sha512-uGZbADzdLQgmxFJmYT0tbn63k2gPHDEFos7k/WToE44Wm5NLq9ucZ7FxKFFAJghkuxxJ1lbtGmEKNEKwaMLQkQ==",
           "requires": {
             "get-src": "^1.0.1"
           }
@@ -21238,13 +20861,14 @@
           }
         },
         "glob": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
-          "integrity": "sha1-CqI1kxpKlqwT1g/6wvuHe9btT1g=",
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
+            "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "2 || 3",
+            "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
@@ -21258,19 +20882,6 @@
             "yargs": "~1.2.6"
           },
           "dependencies": {
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
             "minimist": {
               "version": "0.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
@@ -21361,21 +20972,6 @@
             "object-assign": "^4.0.1",
             "pify": "^2.0.0",
             "pinkie-promise": "^2.0.0"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            }
           }
         },
         "globjoin": {
@@ -21393,19 +20989,6 @@
             "minimatch": "~3.0.2"
           },
           "dependencies": {
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
             "lodash": {
               "version": "4.17.10",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
@@ -21615,35 +21198,6 @@
             "commander": "^2.9.0",
             "is-my-json-valid": "^2.12.4",
             "pinkie-promise": "^2.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
-            "commander": {
-              "version": "2.15.1",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-              "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-            }
           }
         },
         "has": {
@@ -21662,18 +21216,18 @@
             "ansi-regex": "^2.0.0"
           }
         },
-        "has-binary": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
-          "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+        "has-binary2": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+          "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
           "requires": {
-            "isarray": "0.0.1"
+            "isarray": "2.0.1"
           },
           "dependencies": {
             "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+              "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
             }
           }
         },
@@ -21787,9 +21341,9 @@
           }
         },
         "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.4.tgz",
+          "integrity": "sha512-A6RlQvvZEtFS5fLU43IDu0QUmBy+fDO9VMdTXvufKwIkt/rFfvICAViCax5fbDO4zdNzaC3/27ZhKUok5bAJyw==",
           "requires": {
             "inherits": "^2.0.3",
             "minimalistic-assert": "^1.0.0"
@@ -21995,13 +21549,6 @@
             "htmlparser2": "^3.8.3",
             "ramda": "^0.24.1",
             "underscore.string.fp": "^1.0.4"
-          },
-          "dependencies": {
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-            }
           }
         },
         "htmlparser2": {
@@ -22051,42 +21598,24 @@
           "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
         },
         "husky": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/husky/-/husky-0.13.3.tgz",
-          "integrity": "sha1-vCBmCAutyLj+NRbogfW8aKVwUv8=",
+          "version": "0.14.3",
+          "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+          "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
           "requires": {
-            "chalk": "^1.1.3",
-            "find-parent-dir": "^0.3.0",
-            "is-ci": "^1.0.9",
-            "normalize-path": "^1.0.0"
+            "is-ci": "^1.0.10",
+            "normalize-path": "^1.0.0",
+            "strip-indent": "^2.0.0"
           },
           "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
             "normalize-path": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
               "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k="
             },
-            "supports-color": {
+            "strip-indent": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+              "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
             }
           }
         },
@@ -22116,15 +21645,13 @@
               "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
               "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
             },
-            "commander": {
-              "version": "2.15.1",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-              "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
-            },
-            "lodash.assign": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-              "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+            "debug": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+              "requires": {
+                "ms": "0.7.1"
+              }
             }
           }
         },
@@ -22147,9 +21674,9 @@
           "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
         },
         "ignore": {
-          "version": "3.3.5",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
-          "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw=="
+          "version": "3.3.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
+          "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg=="
         },
         "immediate": {
           "version": "3.0.6",
@@ -22323,11 +21850,6 @@
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
               }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
@@ -23151,24 +22673,6 @@
                 "wrap-ansi": "^2.0.0"
               }
             },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-            },
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -23316,24 +22820,6 @@
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
               }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-            },
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
             }
           }
         },
@@ -23357,11 +22843,6 @@
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
               }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
             }
           }
         },
@@ -23454,11 +22935,6 @@
                 "supports-color": "^5.3.0"
               }
             },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-            },
             "source-map": {
               "version": "0.6.1",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -23510,11 +22986,6 @@
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
               }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
             }
           }
         },
@@ -23528,23 +22999,6 @@
             "jest-util": "^17.0.2"
           },
           "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
             "jest-diff": {
               "version": "17.0.3",
               "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-17.0.3.tgz",
@@ -23587,11 +23041,6 @@
               "version": "4.2.3",
               "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-4.2.3.tgz",
               "integrity": "sha1-iJTCrIFBnPgBYp2PZjIKJTgNiwU="
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             }
           }
         },
@@ -23616,11 +23065,6 @@
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
               }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
             }
           }
         },
@@ -23652,11 +23096,6 @@
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
               }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
             }
           }
         },
@@ -23793,28 +23232,10 @@
                 "wrap-ansi": "^2.0.0"
               }
             },
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-            },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             },
             "os-locale": {
               "version": "2.1.0",
@@ -23929,11 +23350,6 @@
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
               }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
             }
           }
         },
@@ -23966,11 +23382,6 @@
                 "supports-color": "^5.3.0"
               }
             },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-            },
             "source-map": {
               "version": "0.6.1",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -23999,11 +23410,6 @@
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
               }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
             },
             "leven": {
               "version": "2.1.0",
@@ -24478,11 +23884,6 @@
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
           "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
         },
-        "json3": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-          "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
-        },
         "json5": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
@@ -24801,23 +24202,6 @@
             "strip-ansi": "^3.0.1"
           },
           "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
             "figures": {
               "version": "1.7.0",
               "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -24825,13 +24209,6 @@
               "requires": {
                 "escape-string-regexp": "^1.0.5",
                 "object-assign": "^4.1.0"
-              },
-              "dependencies": {
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-                }
               }
             },
             "log-symbols": {
@@ -24841,11 +24218,6 @@
               "requires": {
                 "chalk": "^1.0.0"
               }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             }
           }
         },
@@ -24869,23 +24241,6 @@
             "strip-ansi": "^3.0.1"
           },
           "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
             "figures": {
               "version": "1.7.0",
               "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -24893,13 +24248,6 @@
               "requires": {
                 "escape-string-regexp": "^1.0.5",
                 "object-assign": "^4.1.0"
-              },
-              "dependencies": {
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-                }
               }
             },
             "indent-string": {
@@ -24914,11 +24262,6 @@
               "requires": {
                 "chalk": "^1.0.0"
               }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             }
           }
         },
@@ -24933,23 +24276,6 @@
             "figures": "^1.7.0"
           },
           "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
             "cli-cursor": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
@@ -24965,13 +24291,6 @@
               "requires": {
                 "escape-string-regexp": "^1.0.5",
                 "object-assign": "^4.1.0"
-              },
-              "dependencies": {
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-                }
               }
             },
             "onetime": {
@@ -24987,11 +24306,6 @@
                 "exit-hook": "^1.0.0",
                 "onetime": "^1.0.0"
               }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             }
           }
         },
@@ -25040,9 +24354,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "lodash-es": {
           "version": "4.17.10",
@@ -25106,16 +24420,6 @@
           "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
           "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
         },
-        "lodash._createassigner": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-          "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-          "requires": {
-            "lodash._bindcallback": "^3.0.0",
-            "lodash._isiterateecall": "^3.0.0",
-            "lodash.restparam": "^3.0.0"
-          }
-        },
         "lodash._getnative": {
           "version": "3.9.1",
           "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
@@ -25147,19 +24451,19 @@
           "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
         },
         "lodash.assign": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-          "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
-          "requires": {
-            "lodash._baseassign": "^3.0.0",
-            "lodash._createassigner": "^3.0.0",
-            "lodash.keys": "^3.0.0"
-          }
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
           "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+        },
+        "lodash.debounce": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+          "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
         },
         "lodash.escape": {
           "version": "3.2.0",
@@ -25189,21 +24493,6 @@
           "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
           "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
         },
-        "lodash.isplainobject": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
-          "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
-          "requires": {
-            "lodash._basefor": "^3.0.0",
-            "lodash.isarguments": "^3.0.0",
-            "lodash.keysin": "^3.0.0"
-          }
-        },
-        "lodash.istypedarray": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
-          "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I="
-        },
         "lodash.keys": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
@@ -25212,33 +24501,6 @@
             "lodash._getnative": "^3.0.0",
             "lodash.isarguments": "^3.0.0",
             "lodash.isarray": "^3.0.0"
-          }
-        },
-        "lodash.keysin": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
-          "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
-          "requires": {
-            "lodash.isarguments": "^3.0.0",
-            "lodash.isarray": "^3.0.0"
-          }
-        },
-        "lodash.merge": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
-          "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
-          "requires": {
-            "lodash._arraycopy": "^3.0.0",
-            "lodash._arrayeach": "^3.0.0",
-            "lodash._createassigner": "^3.0.0",
-            "lodash._getnative": "^3.0.0",
-            "lodash.isarguments": "^3.0.0",
-            "lodash.isarray": "^3.0.0",
-            "lodash.isplainobject": "^3.0.0",
-            "lodash.istypedarray": "^3.0.0",
-            "lodash.keys": "^3.0.0",
-            "lodash.keysin": "^3.0.0",
-            "lodash.toplainobject": "^3.0.0"
           }
         },
         "lodash.mergewith": {
@@ -25291,15 +24553,6 @@
           "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
           "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
         },
-        "lodash.toplainobject": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
-          "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
-          "requires": {
-            "lodash._basecopy": "^3.0.0",
-            "lodash.keysin": "^3.0.0"
-          }
-        },
         "lodash.unescape": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
@@ -25327,11 +24580,6 @@
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
               }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
             }
           }
         },
@@ -25561,35 +24809,6 @@
             "cli-table": "^0.3.1",
             "lodash.assign": "^4.2.0",
             "node-emoji": "^1.4.1"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
-            "lodash.assign": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-              "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-            }
           }
         },
         "math-random": {
@@ -25676,21 +24895,6 @@
             "rimraf": "^2.2.8",
             "through2": "^2.0.0",
             "vinyl": "^2.0.1"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            }
           }
         },
         "memory-fs": {
@@ -26180,19 +25384,6 @@
             "which": "1"
           },
           "dependencies": {
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
             "semver": {
               "version": "5.3.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -26286,23 +25477,6 @@
             "true-case-path": "^1.0.2"
           },
           "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
             "cross-spawn": {
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
@@ -26311,29 +25485,6 @@
                 "lru-cache": "^4.0.1",
                 "which": "^1.2.9"
               }
-            },
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "lodash.assign": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-              "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             }
           }
         },
@@ -26424,21 +25575,14 @@
             "string.prototype.padend": "^3.0.0"
           },
           "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "cross-spawn": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
               "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
               }
             },
             "load-json-file": {
@@ -26474,11 +25618,6 @@
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
               "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             }
           }
         },
@@ -26525,9 +25664,9 @@
           "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
         },
         "nwsapi": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.3.tgz",
-          "integrity": "sha512-zFJF9lOpg2+uicP0BQKOAfIOqeTp/p8PC669mewxgRkR1hGjne8BMUHk4wpRS9o5Z0icA5Nv04HmGkW31KfMKw=="
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.4.tgz",
+          "integrity": "sha512-Zt6HRR6RcJkuj5/N9zeE7FN6YitRW//hK2wTOwX274IBphbY3Zf5+yn5mZ9v/SzAOTMjQNxZf9KkmPLWn0cV4g=="
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -26743,11 +25882,6 @@
             }
           }
         },
-        "options": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-          "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
-        },
         "ora": {
           "version": "0.2.3",
           "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
@@ -26759,23 +25893,6 @@
             "object-assign": "^4.0.1"
           },
           "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
             "cli-cursor": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
@@ -26797,11 +25914,6 @@
                 "exit-hook": "^1.0.0",
                 "onetime": "^1.0.0"
               }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             }
           }
         },
@@ -27049,26 +26161,18 @@
             "@types/node": "*"
           }
         },
-        "parsejson": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
-          "integrity": "sha1-mxDGwNglq1ieaFFTgm3go7oni8w=",
-          "requires": {
-            "better-assert": "~1.0.0"
-          }
-        },
         "parseqs": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
-          "integrity": "sha1-nf5wss3aw4i95PNbHyQPpYrb5sc=",
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+          "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
           "requires": {
             "better-assert": "~1.0.0"
           }
         },
         "parseuri": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
-          "integrity": "sha1-gGWCo5iH4eoY3V4v4OAZAiaOk1A=",
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+          "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
           "requires": {
             "better-assert": "~1.0.0"
           }
@@ -27301,11 +26405,6 @@
                 "supports-color": "^5.3.0"
               }
             },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-            },
             "source-map": {
               "version": "0.6.1",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -27327,30 +26426,6 @@
             "yargs": "^3.8.0"
           },
           "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-                }
-              }
-            },
             "chokidar": {
               "version": "1.7.0",
               "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
@@ -27454,30 +26529,6 @@
             "postcss": "^5.2.16"
           },
           "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-                }
-              }
-            },
             "has-flag": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
@@ -27525,11 +26576,6 @@
             "postcss": "^5.0.0"
           },
           "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
             "has-flag": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
@@ -27552,27 +26598,6 @@
                 "js-base64": "^2.1.9",
                 "source-map": "^0.5.6",
                 "supports-color": "^3.2.3"
-              },
-              "dependencies": {
-                "chalk": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                  "requires": {
-                    "ansi-styles": "^2.2.1",
-                    "escape-string-regexp": "^1.0.2",
-                    "has-ansi": "^2.0.0",
-                    "strip-ansi": "^3.0.0",
-                    "supports-color": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-                    }
-                  }
-                }
               }
             },
             "source-map": {
@@ -27736,11 +26761,6 @@
               "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
               "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
             },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-            },
             "flow-parser": {
               "version": "0.73.0",
               "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.73.0.tgz",
@@ -27846,25 +26866,6 @@
           "integrity": "sha1-EY2V+3pm26InLjQ7NF9SNmWds2U=",
           "requires": {
             "clipboard": "^1.5.5"
-          },
-          "dependencies": {
-            "clipboard": {
-              "version": "1.7.1",
-              "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
-              "integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
-              "optional": true,
-              "requires": {
-                "good-listener": "^1.2.2",
-                "select": "^1.1.2",
-                "tiny-emitter": "^2.0.0"
-              }
-            },
-            "tiny-emitter": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
-              "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow==",
-              "optional": true
-            }
           }
         },
         "private": {
@@ -28182,11 +27183,6 @@
               "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
               "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
             },
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
             "babel-core": {
               "version": "6.26.3",
               "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
@@ -28282,18 +27278,6 @@
               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
               "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
             },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
             "cli-cursor": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
@@ -28318,14 +27302,6 @@
               "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
               "requires": {
                 "cssom": "0.3.x"
-              }
-            },
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
               }
             },
             "doctrine": {
@@ -28392,13 +27368,6 @@
               "requires": {
                 "escape-string-regexp": "^1.0.5",
                 "object-assign": "^4.1.0"
-              },
-              "dependencies": {
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-                }
               }
             },
             "file-entry-cache": {
@@ -28701,11 +27670,6 @@
                 "xml-name-validator": "^2.0.1"
               }
             },
-            "lodash.assign": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-              "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-            },
             "lodash.clonedeep": {
               "version": "3.0.2",
               "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
@@ -28719,11 +27683,6 @@
               "version": "1.2.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             },
             "node-notifier": {
               "version": "4.6.1",
@@ -28821,11 +27780,6 @@
               "version": "1.0.4",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
               "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             },
             "table": {
               "version": "3.8.3",
@@ -29000,9 +27954,9 @@
           }
         },
         "react-is": {
-          "version": "16.4.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.4.0.tgz",
-          "integrity": "sha512-8ADZg/mBw+t2Fbr5Hm1K64v8q8Q6E+DprV5wQ5A8PSLW6XP0XJFMdUskVEW8efQ5oUgWHn8EYdHEPAMF0Co6hA=="
+          "version": "16.4.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.4.1.tgz",
+          "integrity": "sha512-xpb0PpALlFWNw/q13A+1aHeyJyLYCg0/cCHPUA43zYluZuIPHaHL3k8OBsTgQtxqW0FhyDEMvi8fZ/+7+r4OSQ=="
         },
         "react-lazily-render": {
           "version": "1.0.1",
@@ -29293,11 +28247,6 @@
               "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k="
             }
           }
-        },
-        "reduce-component": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
-          "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo="
         },
         "redux": {
           "version": "4.0.0",
@@ -29666,9 +28615,9 @@
           "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww=="
         },
         "resolve": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-          "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+          "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
           "requires": {
             "path-parse": "^1.0.5"
           }
@@ -29733,21 +28682,6 @@
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "requires": {
             "glob": "^7.0.5"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            }
           }
         },
         "ripemd160": {
@@ -29794,11 +28728,6 @@
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
               }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
             }
           }
         },
@@ -29939,14 +28868,6 @@
                     "is-extendable": "^0.1.0"
                   }
                 }
-              }
-            },
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
               }
             },
             "expand-brackets": {
@@ -30164,11 +29085,6 @@
               "version": "1.2.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
@@ -30196,19 +29112,6 @@
                 "string-width": "^1.0.1",
                 "strip-ansi": "^3.0.1",
                 "wrap-ansi": "^2.0.0"
-              }
-            },
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
               }
             },
             "y18n": {
@@ -30316,14 +29219,6 @@
             "statuses": "~1.4.0"
           },
           "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
             "ms": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -30442,21 +29337,6 @@
             "glob": "^7.0.0",
             "interpret": "^1.0.0",
             "rechoir": "^0.6.2"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            }
           }
         },
         "shellwords": {
@@ -30644,109 +29524,101 @@
           "integrity": "sha1-5x71006P0BSpRaI+VdBu+k4Ctr0="
         },
         "socket.io": {
-          "version": "1.4.5",
-          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.5.tgz",
-          "integrity": "sha1-8gL0nuuc989sCXGtddjZbUUepPc=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
+          "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
           "requires": {
-            "debug": "2.2.0",
-            "engine.io": "1.6.8",
-            "has-binary": "0.1.7",
-            "socket.io-adapter": "0.4.0",
-            "socket.io-client": "1.4.5",
-            "socket.io-parser": "2.2.6"
-          }
-        },
-        "socket.io-adapter": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
-          "integrity": "sha1-+5+CqxqmUpC/csNleVW5MKmRok8=",
-          "requires": {
-            "debug": "2.2.0",
-            "socket.io-parser": "2.2.2"
+            "debug": "~3.1.0",
+            "engine.io": "~3.2.0",
+            "has-binary2": "~1.0.2",
+            "socket.io-adapter": "~1.1.0",
+            "socket.io-client": "2.1.1",
+            "socket.io-parser": "~3.2.0"
           },
           "dependencies": {
-            "component-emitter": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-              "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM="
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-            },
-            "json3": {
-              "version": "3.2.6",
-              "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
-              "integrity": "sha1-9u/JPAagTemuxTBT3yVZuxniA4s="
-            },
-            "socket.io-parser": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
-              "integrity": "sha1-PXr2tkSX6Va32f53X5mXFgJ/lBc=",
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
               "requires": {
-                "benchmark": "1.0.0",
-                "component-emitter": "1.1.2",
-                "debug": "0.7.4",
-                "isarray": "0.0.1",
-                "json3": "3.2.6"
-              },
-              "dependencies": {
-                "debug": {
-                  "version": "0.7.4",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-                  "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
-                }
+                "ms": "2.0.0"
               }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
+        "socket.io-adapter": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
+          "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
+        },
         "socket.io-client": {
-          "version": "1.4.5",
-          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.5.tgz",
-          "integrity": "sha1-QA1jDDHnyVeeRRc/l35PW9jcfS4=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
+          "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
           "requires": {
             "backo2": "1.0.2",
+            "base64-arraybuffer": "0.1.5",
             "component-bind": "1.0.0",
-            "component-emitter": "1.2.0",
-            "debug": "2.2.0",
-            "engine.io-client": "1.6.8",
-            "has-binary": "0.1.7",
+            "component-emitter": "1.2.1",
+            "debug": "~3.1.0",
+            "engine.io-client": "~3.2.0",
+            "has-binary2": "~1.0.2",
+            "has-cors": "1.1.0",
             "indexof": "0.0.1",
             "object-component": "0.0.3",
-            "parseuri": "0.0.4",
-            "socket.io-parser": "2.2.6",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "socket.io-parser": "~3.2.0",
             "to-array": "0.1.4"
           },
           "dependencies": {
-            "component-emitter": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
-              "integrity": "sha1-zNETqGOI0GSC0D3j/H35hSa6jv4="
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
         "socket.io-parser": {
-          "version": "2.2.6",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
-          "integrity": "sha1-ON/WHfUNz4qx2eIJEyK/kCuii5k=",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+          "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
           "requires": {
-            "benchmark": "1.0.0",
-            "component-emitter": "1.1.2",
-            "debug": "2.2.0",
-            "isarray": "0.0.1",
-            "json3": "3.3.2"
+            "component-emitter": "1.2.1",
+            "debug": "~3.1.0",
+            "isarray": "2.0.1"
           },
           "dependencies": {
-            "component-emitter": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-              "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM="
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "requires": {
+                "ms": "2.0.0"
+              }
             },
             "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+              "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
@@ -31209,11 +30081,6 @@
             "write-file-stdout": "0.0.2"
           },
           "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
             "browserslist": {
               "version": "1.7.7",
               "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
@@ -31221,18 +30088,6 @@
               "requires": {
                 "caniuse-db": "^1.0.30000639",
                 "electron-to-chromium": "^1.2.7"
-              }
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
               }
             },
             "has-flag": {
@@ -31262,16 +30117,6 @@
                 "js-base64": "^2.1.9",
                 "source-map": "^0.5.6",
                 "supports-color": "^3.2.3"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "3.2.3",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                  "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                  "requires": {
-                    "has-flag": "^1.0.0"
-                  }
-                }
               }
             },
             "source-map": {
@@ -31280,9 +30125,12 @@
               "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
             },
             "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
             }
           }
         },
@@ -31343,11 +30191,6 @@
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
             },
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
             "autoprefixer": {
               "version": "6.7.7",
               "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
@@ -31373,25 +30216,6 @@
               "requires": {
                 "caniuse-db": "^1.0.30000639",
                 "electron-to-chromium": "^1.2.7"
-              }
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-                }
               }
             },
             "cosmiconfig": {
@@ -31492,6 +30316,14 @@
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
             },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
             "supports-color": {
               "version": "3.2.3",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
@@ -31521,14 +30353,6 @@
                     "is-fullwidth-code-point": "^2.0.0",
                     "strip-ansi": "^4.0.0"
                   }
-                },
-                "strip-ansi": {
-                  "version": "4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                  "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                  "requires": {
-                    "ansi-regex": "^3.0.0"
-                  }
                 }
               }
             }
@@ -31542,30 +30366,6 @@
             "postcss": "^5.2.0"
           },
           "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-                }
-              }
-            },
             "has-flag": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
@@ -31724,11 +30524,6 @@
                 "supports-color": "^5.3.0"
               }
             },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-            },
             "fast-deep-equal": {
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
@@ -31862,14 +30657,6 @@
                     "is-extendable": "^0.1.0"
                   }
                 }
-              }
-            },
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
               }
             },
             "expand-brackets": {
@@ -32082,11 +30869,6 @@
                 "snapdragon": "^0.8.1",
                 "to-regex": "^3.0.2"
               }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
@@ -32168,9 +30950,9 @@
           }
         },
         "tiny-emitter": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-1.2.0.tgz",
-          "integrity": "sha1-bchFBSywjr78GHRyO1jySmSMO28="
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
+          "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow=="
         },
         "tinymce": {
           "version": "4.6.3",
@@ -32537,9 +31319,9 @@
           "integrity": "sha1-XkpdS3gTi09w+J/Tx2/FmqnS8QM="
         },
         "ultron": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-          "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
         },
         "underscore": {
           "version": "1.6.0",
@@ -32925,11 +31707,6 @@
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
           "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
         },
-        "utf8": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz",
-          "integrity": "sha1-DP7FyAUtRKI+OqqQgQToB1+V39U="
-        },
         "util": {
           "version": "0.10.4",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
@@ -33238,14 +32015,6 @@
                 }
               }
             },
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
             "expand-brackets": {
               "version": "2.1.4",
               "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -33457,11 +32226,6 @@
                 "to-regex": "^3.0.2"
               }
             },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            },
             "neo-async": {
               "version": "2.5.1",
               "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.1.tgz",
@@ -33571,21 +32335,6 @@
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
               }
-            },
-            "commander": {
-              "version": "2.15.1",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-              "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-            },
-            "filesize": {
-              "version": "3.6.1",
-              "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-              "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
             },
             "ws": {
               "version": "4.1.0",
@@ -33706,6 +32455,16 @@
               "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
               "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
             },
+            "cross-spawn": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
             "enhanced-resolve": {
               "version": "3.4.1",
               "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
@@ -33716,11 +32475,6 @@
                 "object-assign": "^4.0.1",
                 "tapable": "^0.2.7"
               }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
             },
             "esprima": {
               "version": "4.0.0",
@@ -34009,6 +32763,16 @@
                 "restore-cursor": "^1.0.1"
               }
             },
+            "cross-spawn": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
             "diff": {
               "version": "2.2.3",
               "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
@@ -34031,13 +32795,6 @@
               "requires": {
                 "escape-string-regexp": "^1.0.5",
                 "object-assign": "^4.1.0"
-              },
-              "dependencies": {
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-                }
               }
             },
             "glob": {
@@ -34221,11 +32978,6 @@
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
               }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
             }
           }
         },
@@ -34364,69 +33116,68 @@
                 "debug": "~2.2.0",
                 "superagent": "^2.1.0",
                 "wp-error": "^1.3.0"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.2.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                  "requires": {
+                    "ms": "0.7.1"
+                  }
+                }
               }
             }
           }
         },
         "wpcom-oauth": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/wpcom-oauth/-/wpcom-oauth-0.3.3.tgz",
-          "integrity": "sha1-rQt+uARxF6z/Bc7a1suID8CckjY=",
+          "version": "0.3.4",
+          "resolved": "https://registry.npmjs.org/wpcom-oauth/-/wpcom-oauth-0.3.4.tgz",
+          "integrity": "sha512-EJfIhiIRsgppbaTN2+GuTnGdtCG+0Lie0Fbu9G9vxBnyReLP52uUK8EFqjt42QSm6sx2MjIDTtsMEAgqVgqXnA==",
           "requires": {
             "debug": "*",
-            "superagent": "0.17.0"
+            "superagent": "^3.8.3"
           },
           "dependencies": {
-            "cookiejar": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-1.3.0.tgz",
-              "integrity": "sha1-3QCzVnkCHpnL1OhVua0EGRNHR2U="
+            "form-data": {
+              "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+              "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+              "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "1.0.6",
+                "mime-types": "^2.1.12"
+              }
             },
-            "extend": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
-              "integrity": "sha1-oPX9bPyDpf5J72mNYOyKYk3UV2w="
-            },
-            "formidable": {
-              "version": "1.0.14",
-              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
-              "integrity": "sha1-Kz9MQRy7X91pXESEPiojUUpDIxo="
-            },
-            "methods": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz",
-              "integrity": "sha1-J3yQ+L7zlwlkWoNxxRw7bGSOBow="
-            },
-            "mime": {
-              "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.5.tgz",
-              "integrity": "sha1-nu0HMCKov14WyFZsaGe4gyv7+hM="
-            },
-            "qs": {
-              "version": "0.6.5",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.5.tgz",
-              "integrity": "sha1-KUsmjksNQlD23eGbO4s0k13/FO8="
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             },
             "superagent": {
-              "version": "0.17.0",
-              "resolved": "https://registry.npmjs.org/superagent/-/superagent-0.17.0.tgz",
-              "integrity": "sha1-qtzVD75ak+cZkRGNeb8HFNYlu6g=",
+              "version": "3.8.3",
+              "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+              "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
               "requires": {
-                "cookiejar": "1.3.0",
-                "debug": "~0.7.2",
-                "emitter-component": "1.0.0",
-                "extend": "~1.2.1",
-                "formidable": "1.0.14",
-                "methods": "0.0.1",
-                "mime": "1.2.5",
-                "qs": "0.6.5",
-                "reduce-component": "1.0.1"
+                "component-emitter": "^1.2.0",
+                "cookiejar": "^2.1.0",
+                "debug": "^3.1.0",
+                "extend": "^3.0.0",
+                "form-data": "^2.3.1",
+                "formidable": "^1.2.0",
+                "methods": "^1.1.1",
+                "mime": "^1.4.1",
+                "qs": "^6.5.1",
+                "readable-stream": "^2.3.5"
               },
               "dependencies": {
                 "debug": {
-                  "version": "0.7.4",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-                  "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                  "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
                 }
               }
             }
@@ -34442,6 +33193,16 @@
             "progress-event": "~1.0.0",
             "uid": "0.0.2",
             "wp-error": "^1.3.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+              "requires": {
+                "ms": "0.7.1"
+              }
+            }
           }
         },
         "wpcom-xhr-request": {
@@ -34452,6 +33213,16 @@
             "debug": "~2.2.0",
             "superagent": "^2.1.0",
             "wp-error": "^1.3.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+              "requires": {
+                "ms": "0.7.1"
+              }
+            }
           }
         },
         "wrap-ansi": {
@@ -34492,12 +33263,13 @@
           "integrity": "sha1-wlLXx8WxtAKJdjDjRTx7/mkNnKE="
         },
         "ws": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
-          "integrity": "sha1-fQsqLljN3YGQOcKcneZQReGzEOk=",
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "requires": {
-            "options": ">=0.0.5",
-            "ultron": "1.0.x"
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
           }
         },
         "x-is-function": {
@@ -34546,9 +33318,9 @@
           "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
         },
         "xmlhttprequest-ssl": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz",
-          "integrity": "sha1-O3dB/qSoZnWXbpCNKW1ERZYfqmc="
+          "version": "1.5.5",
+          "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+          "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
         },
         "xregexp": {
           "version": "4.2.0",
@@ -34636,25 +33408,6 @@
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
-              },
-              "dependencies": {
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-                }
-              }
-            },
-            "cross-spawn": {
-              "version": "6.0.5",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-              "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-              "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
               }
             },
             "debug": {
@@ -34663,19 +33416,6 @@
               "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
               "requires": {
                 "ms": "2.0.0"
-              }
-            },
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
               }
             },
             "globby": {
@@ -34691,11 +33431,6 @@
                 "pify": "^3.0.0",
                 "slash": "^1.0.0"
               }
-            },
-            "ignore": {
-              "version": "3.3.8",
-              "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
-              "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg=="
             },
             "inquirer": {
               "version": "5.2.0",
@@ -34736,11 +33471,6 @@
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-            },
-            "semver": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
             },
             "string-width": {
               "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,6 @@
     "redux-thunk": "^2.2.0",
     "reselect": "^2.5.4",
     "whatwg-fetch": "^2.0.2",
-    "wp-calypso": "github:automattic/wp-calypso#2ed3e056afa2be61698fe6ab491668a6652bd51c"
+    "wp-calypso": "github:automattic/wp-calypso#cc49f0a87c039c2267395490a5ec8c5630d4b296"
   }
 }

--- a/package.json
+++ b/package.json
@@ -104,6 +104,6 @@
     "redux-thunk": "^2.2.0",
     "reselect": "^2.5.4",
     "whatwg-fetch": "^2.0.2",
-    "wp-calypso": "github:automattic/wp-calypso#9d78dbb5d3015931691c4d28423b3ce9c10e16c0"
+    "wp-calypso": "github:automattic/wp-calypso#2ed3e056afa2be61698fe6ab491668a6652bd51c"
   }
 }


### PR DESCRIPTION
Updates Calypso dependency to include:
https://github.com/Automattic/wp-calypso/pull/25628
https://github.com/Automattic/wp-calypso/pull/25307
