### PR TITLE
Use the wc/v3/data/continents endpoint

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -300,27 +300,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return in_array( $currency_code, $this->supported_currencies );
 		}
 
-		protected function get_states_map() {
-			$result = array();
-			$all_countries = WC()->countries->get_countries();
-
-			foreach ( $all_countries as $country_code => $country_name ) {
-				$country_data = array( 'name' => html_entity_decode( $country_name ) );
-				$states = WC()->countries->get_states( $country_code );
-
-				if ( $states ) {
-					$country_data['states'] = array();
-					foreach ( $states as $state_code => $name ) {
-						$country_data['states'][ $state_code ] = html_entity_decode( $name );
-					}
-				}
-
-				$result[ $country_code ] = $country_data;
-			}
-
-			return $result;
-		}
-
 		public function should_show_meta_box() {
 			if ( null === $this->show_metabox ) {
 				$this->show_metabox = $this->calculate_should_show_meta_box();
@@ -374,22 +353,16 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				return false;
 			}
 
-			$account_settings = $this->settings_store->get_account_settings();
-
 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
 			$payload = array(
 				'orderId'            => $order_id,
 				'paperSize'          => $this->settings_store->get_preferred_paper_size(),
 				'formData'           => $this->get_form_data( $order ),
 				'labelsData'         => $this->settings_store->get_label_order_meta_data( $order_id ),
+				'storeOptions'       => $this->settings_store->get_store_options(),
 				//for backwards compatibility, still disable the country dropdown for calypso users with older plugin versions
 				'canChangeCountries' => true,
 			);
-
-			$store_options = $this->settings_store->get_store_options();
-			// TODO: Get this country info from the /v3/continents endpoint instead, at least in Calypso
-			$store_options['countriesData'] = $this->get_states_map();
-			$payload['storeOptions'] = $store_options;
 
 			return $payload;
 		}

--- a/classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php
+++ b/classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php
@@ -1,0 +1,357 @@
+<?php
+/**
+ * REST API Data controller.
+ *
+ * Handles requests to the /data/continents endpoint.
+ *
+ * Directly copied from the wc-api-dev plugin. Delete this when the "v3" REST API is included in all the WC versions we support.
+ *
+ * @author   Automattic
+ * @category API
+ * @package  WooCommerce/API
+ * @since    3.1.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API Data controller class.
+ *
+ * @package WooCommerce/API
+ * @extends WC_REST_Controller
+ */
+class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'data/continents';
+
+	/**
+	 * Register routes.
+	 *
+	 * @since 3.1.0
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<location>[\w-]+)', array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_item' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				'args' => array(
+					'continent' => array(
+						'description' => __( '2 character continent code.', 'woocommerce' ),
+						'type'        => 'string',
+					),
+				),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+	}
+
+	/**
+	 * Return the list of countries and states for a given continent.
+	 *
+	 * @since  3.1.0
+	 * @param  string          $continent_code
+	 * @param  WP_REST_Request $request
+	 * @return array|mixed Response data, ready for insertion into collection data.
+	 */
+	public function get_continent( $continent_code = false, $request ) {
+		$continents  = WC()->countries->get_continents();
+		$countries   = WC()->countries->get_countries();
+		$states      = WC()->countries->get_states();
+		$locale_info = include WC()->plugin_path() . '/i18n/locale-info.php';
+		$data        = array();
+
+		if ( ! array_key_exists( $continent_code, $continents ) ) {
+			return false;
+		}
+
+		$continent_list = $continents[ $continent_code ];
+
+		$continent = array(
+			'code' => $continent_code,
+			'name' => $continent_list['name'],
+		);
+
+		$local_countries = array();
+		foreach ( $continent_list['countries'] as $country_code ) {
+			if ( isset( $countries[ $country_code ] ) ) {
+				$country = array(
+					'code' => $country_code,
+					'name' => $countries[ $country_code ],
+				);
+
+				// If we have detailed locale information include that in the response
+				if ( array_key_exists( $country_code, $locale_info ) ) {
+					// Defensive programming against unexpected changes in locale-info.php
+					$country_data = wp_parse_args( $locale_info[ $country_code ], array(
+						'currency_code'  => 'USD',
+						'currency_pos'   => 'left',
+						'decimal_sep'    => '.',
+						'dimension_unit' => 'in',
+						'num_decimals'   => 2,
+						'thousand_sep'   => ',',
+						'weight_unit'    => 'lbs',
+					) );
+
+					$country = array_merge( $country, $country_data );
+				}
+
+				$local_states = array();
+				if ( isset( $states[ $country_code ] ) ) {
+					foreach ( $states[ $country_code ] as $state_code => $state_name ) {
+						$local_states[] = array(
+							'code' => $state_code,
+							'name' => $state_name,
+						);
+					}
+				}
+				$country['states'] = $local_states;
+
+				// Allow only desired keys (e.g. filter out tax rates)
+				$allowed = array(
+					'code',
+					'currency_code',
+					'currency_pos',
+					'decimal_sep',
+					'dimension_unit',
+					'name',
+					'num_decimals',
+					'states',
+					'thousand_sep',
+					'weight_unit',
+				);
+				$country = array_intersect_key( $country, array_flip( $allowed ) );
+
+				$local_countries[] = $country;
+			}
+		}
+
+		$continent['countries'] = $local_countries;
+		return $continent;
+	}
+
+	/**
+	 * Return the list of states for all continents.
+	 *
+	 * @since  3.1.0
+	 * @param  WP_REST_Request $request
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$continents = WC()->countries->get_continents();
+		$data       = array();
+
+		foreach ( array_keys( $continents ) as $continent_code ) {
+			$continent = $this->get_continent( $continent_code, $request );
+			$response  = $this->prepare_item_for_response( $continent, $request );
+			$data[]    = $this->prepare_response_for_collection( $response );
+		}
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Return the list of locations for a given continent.
+	 *
+	 * @since  3.1.0
+	 * @param  WP_REST_Request $request
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		$data = $this->get_continent( strtoupper( $request['location'] ), $request );
+		if ( empty( $data ) ) {
+			return new WP_Error( 'woocommerce_rest_data_invalid_location', __( 'There are no locations matching these parameters.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+		return $this->prepare_item_for_response( $data, $request );
+	}
+
+	/**
+	 * Prepare the data object for response.
+	 *
+	 * @since  3.1.0
+	 * @param object $item Data object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$data     = $this->add_additional_fields_to_object( $item, $request );
+		$data     = $this->filter_response_by_context( $data, 'view' );
+		$response = rest_ensure_response( $data );
+
+		$response->add_links( $this->prepare_links( $item ) );
+
+		/**
+		 * Filter the location list returned from the API.
+		 *
+		 * Allows modification of the loction data right before it is returned.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param array            $item     The original list of continent(s), countries, and states.
+		 * @param WP_REST_Request  $request  Request used to generate the response.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_data_continent', $response, $item, $request );
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param object $item Data object.
+	 * @return array Links for the given continent.
+	 */
+	protected function prepare_links( $item ) {
+		$continent_code = strtolower( $item['code'] );
+		$links = array(
+			'self' => array(
+				'href' => rest_url( sprintf( '/%s/%s/%s', $this->namespace, $this->rest_base, $continent_code ) ),
+			),
+			'collection' => array(
+				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ),
+			),
+		);
+		return $links;
+	}
+
+	/**
+	 * Get the location schema, conforming to JSON Schema.
+	 *
+	 * @since  3.1.0
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema' => 'http://json-schema.org/draft-04/schema#',
+			'title'   => 'data_continents',
+			'type'       => 'object',
+			'properties' => array(
+				'code' => array(
+					'type'        => 'string',
+					'description' => __( '2 character continent code.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'name' => array(
+					'type'        => 'string',
+					'description' => __( 'Full name of continent.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'countries' => array(
+					'type'        => 'array',
+					'description' => __( 'List of countries on this continent.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+					'items'       => array(
+						'type'       => 'object',
+						'context'    => array( 'view' ),
+						'readonly'   => true,
+						'properties' => array(
+							'code' => array(
+								'type'        => 'string',
+								'description' => __( 'ISO3166 alpha-2 country code.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'currency_code' => array(
+								'type'        => 'string',
+								'description' => __( 'Default ISO4127 alpha-3 currency code for the country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'currency_pos' => array(
+								'type'        => 'string',
+								'description' => __( 'Currency symbol position for this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'decimal_sep' => array(
+								'type'        => 'string',
+								'description' => __( 'Decimal separator for displayed prices for this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'dimension_unit' => array(
+								'type'        => 'string',
+								'description' => __( 'The unit lengths are defined in for this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'name' => array(
+								'type'        => 'string',
+								'description' => __( 'Full name of country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'num_decimals' => array(
+								'type'        => 'integer',
+								'description' => __( 'Number of decimal points shown in displayed prices for this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'states' => array(
+								'type'        => 'array',
+								'description' => __( 'List of states in this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+								'items'       => array(
+									'type'       => 'object',
+									'context'    => array( 'view' ),
+									'readonly'   => true,
+									'properties' => array(
+										'code' => array(
+											'type'        => 'string',
+											'description' => __( 'State code.', 'woocommerce' ),
+											'context'     => array( 'view' ),
+											'readonly'    => true,
+										),
+										'name' => array(
+											'type'        => 'string',
+											'description' => __( 'Full name of state.', 'woocommerce' ),
+											'context'     => array( 'view' ),
+											'readonly'    => true,
+										),
+									),
+								),
+							),
+							'thousand_sep' => array(
+								'type'        => 'string',
+								'description' => __( 'Thousands separator for displayed prices in this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'weight_unit' => array(
+								'type'        => 'string',
+								'description' => __( 'The unit weights are defined in for this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+						),
+					),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/classes/wc-api-dev/class-wc-rest-dev-data-controller.php
+++ b/classes/wc-api-dev/class-wc-rest-dev-data-controller.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * REST API Data controller.
+ *
+ * Handles requests to the /data endpoint.
+ *
+ * Directly copied from the wc-api-dev plugin. Delete this when the "v3" REST API is included in all the WC versions we support.
+ *
+ * @author   Automattic
+ * @category API
+ * @package  WooCommerce/API
+ * @since    3.1.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API Data controller class.
+ *
+ * @package WooCommerce/API
+ * @extends WC_REST_Controller
+ */
+class WC_REST_Dev_Data_Controller extends WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'data';
+
+	/**
+	 * Register routes.
+	 *
+	 * @since 3.1.0
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+	}
+
+	/**
+	 * Check whether a given request has permission to read site data.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check whether a given request has permission to read site settings.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_item_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Return the list of data resources.
+	 *
+	 * @since  3.1.0
+	 * @param  WP_REST_Request $request
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$data = array();
+		$resources = array(
+			array(
+				'slug'        => 'continents',
+				'description' => __( 'List of supported continents, countries, and states.', 'woocommerce' ),
+			),
+			array(
+				'slug'        => 'countries',
+				'description' => __( 'List of supported states in a given country.', 'woocommerce' ),
+			),
+			array(
+				'slug'        => 'currencies',
+				'description' => __( 'List of supported currencies.', 'woocommerce' ),
+			),
+		);
+
+		foreach ( $resources as $resource ) {
+			$item   = $this->prepare_item_for_response( (object) $resource, $request );
+			$data[] = $this->prepare_response_for_collection( $item );
+		}
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Prepare a data resource object for serialization.
+	 *
+	 * @param stdClass $report Report data.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $resource, $request ) {
+		$data = array(
+			'slug'        => $resource->slug,
+			'description' => $resource->description,
+		);
+
+		$data = $this->add_additional_fields_to_object( $data, $request );
+		$data = $this->filter_response_by_context( $data, 'view' );
+
+		// Wrap the data in a response object.
+		$response = rest_ensure_response( $data );
+		$response->add_links( $this->prepare_links( $resource ) );
+
+		return $response;
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param object $item Data object.
+	 * @return array Links for the given country.
+	 */
+	protected function prepare_links( $item ) {
+		$links = array(
+			'self' => array(
+				'href' => rest_url( sprintf( '/%s/%s/%s', $this->namespace, $this->rest_base, $item->slug ) ),
+			),
+			'collection' => array(
+				'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
+			),
+		);
+
+		return $links;
+	}
+
+	/**
+	 * Get the data index schema, conforming to JSON Schema.
+	 *
+	 * @since  3.1.0
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'data_index',
+			'type'       => 'object',
+			'properties' => array(
+				'slug' => array(
+					'description' => __( 'Data resource ID.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'description' => array(
+					'description' => __( 'Data resource description.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/client/apps/shipping-label/index.js
+++ b/client/apps/shipping-label/index.js
@@ -17,6 +17,9 @@ import ordersReducer from 'woocommerce/state/sites/orders/reducer';
 import { combineReducers } from 'state/utils';
 import orders from 'woocommerce/state/data-layer/orders';
 import { middleware as rawWpcomApiMiddleware } from 'state/data-layer/wpcom-api-middleware';
+import locations from 'woocommerce/state/data-layer/data/locations';
+import locationsReducer from 'woocommerce/state/sites/data/locations/reducer';
+import { mergeHandlers } from 'state/action-watchers/utils';
 
 export default ( { orderId } ) => {
 	return {
@@ -34,6 +37,9 @@ export default ( { orderId } ) => {
 						sites: combineReducers( {
 							1: combineReducers( {
 								orders: ordersReducer,
+								data: combineReducers( {
+									locations: locationsReducer,
+								} )
 							} ),
 						} ),
 					} ),
@@ -74,7 +80,7 @@ export default ( { orderId } ) => {
 		},
 
 		getMiddlewares() {
-			return [ reduxMiddleware, rawWpcomApiMiddleware( orders ) ];
+			return [ reduxMiddleware, rawWpcomApiMiddleware( mergeHandlers( orders, locations ) ) ];
 		},
 
 		View: () => (

--- a/client/calypso-stubs/extensions/woocommerce/state/sites/http-request.js
+++ b/client/calypso-stubs/extensions/woocommerce/state/sites/http-request.js
@@ -32,6 +32,11 @@ const _request = ( method, path, siteId, body, action, namespace ) => {
 	if ( namespace && ! namespace.endsWith( '/' ) ) {
 		namespace += '/';
 	}
+	if ( namespace && namespace.startsWith( '/' ) ) {
+		// baseURL ends in a "/", so if namespace starts with another it must be removed
+		namespace = namespace.substr( 1 );
+	}
+
 	if ( -1 !== baseURL.indexOf( '?' ) ) {
 		path = path.replace( '?', '&' );
 	}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -820,8 +820,12 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * Delete this when the "v3" REST API is included in all the WC versions we support.
 		 */
 		public function wc_api_dev_init() {
-			if ( ! class_exists( 'WC_REST_Dev_Data_Continents_Controller' ) ) {
-				require_once( plugin_basename( 'classes/wc-api-dev/class-wc-rest-dev-data-controller.php' ) );
+			$rest_server = rest_get_server();
+			$existing_routes = $rest_server->get_routes();
+			if ( ! isset( $existing_routes['/wc/v3/data/continents'] ) ) {
+				if ( ! class_exists( 'WC_REST_Dev_Data_Continents_Controller' ) ) {
+					require_once( plugin_basename( 'classes/wc-api-dev/class-wc-rest-dev-data-controller.php' ) );
+				}
 				require_once( plugin_basename( 'classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php' ) );
 				$continents = new WC_REST_Dev_Data_Continents_Controller();
 				$continents->register_routes();

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -674,6 +674,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'update_option_woocommerce_dimension_unit', array( $this, 'queue_service_schema_refresh' ) );
 
 			add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
+			add_action( 'rest_api_init', array( $this, 'wc_api_dev_init' ), 9999 );
 			add_action( 'wc_connect_fetch_service_schemas', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
 			add_filter( 'woocommerce_hidden_order_itemmeta', array( $this, 'hide_wc_connect_package_meta_data' ) );
 			add_filter( 'is_protected_meta', array( $this, 'hide_wc_connect_order_meta_data' ), 10, 3 );
@@ -812,6 +813,18 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 
 			add_filter( 'rest_request_before_callbacks', array( $this, 'log_rest_api_errors' ), 10, 3 );
+		}
+
+		/**
+		 * If the required v3 REST API endpoints haven't been loaded at this point, load the local copies of said endpoints.
+		 * Delete this when the "v3" REST API is included in all the WC versions we support.
+		 */
+		public function wc_api_dev_init() {
+			if ( ! class_exists( 'WC_REST_Dev_Data_Continents_Controller' ) ) {
+				require_once( plugin_basename( 'classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php' ) );
+				$continents = new WC_REST_Dev_Data_Continents_Controller();
+				$continents->register_routes();
+			}
 		}
 
 		/**

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -821,6 +821,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 */
 		public function wc_api_dev_init() {
 			if ( ! class_exists( 'WC_REST_Dev_Data_Continents_Controller' ) ) {
+				require_once( plugin_basename( 'classes/wc-api-dev/class-wc-rest-dev-data-controller.php' ) );
 				require_once( plugin_basename( 'classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php' ) );
 				$continents = new WC_REST_Dev_Data_Continents_Controller();
 				$continents->register_routes();

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -823,9 +823,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$rest_server = rest_get_server();
 			$existing_routes = $rest_server->get_routes();
 			if ( ! isset( $existing_routes['/wc/v3/data/continents'] ) ) {
-				if ( ! class_exists( 'WC_REST_Dev_Data_Continents_Controller' ) ) {
-					require_once( plugin_basename( 'classes/wc-api-dev/class-wc-rest-dev-data-controller.php' ) );
-				}
+				require_once( plugin_basename( 'classes/wc-api-dev/class-wc-rest-dev-data-controller.php' ) );
 				require_once( plugin_basename( 'classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php' ) );
 				$continents = new WC_REST_Dev_Data_Continents_Controller();
 				$continents->register_routes();


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/pull/25723 for the Calypso part of this PR.

This PR removes the `countriesData` property that was returned in the `labels` payload. Instead, now the countries/states data is fetched from the `wc/v3/data/continents` REST endpoint. Since a site using `woocommerce-services` from WP-Admin may not have the `wc/v3/*` endpoints (right now they're only available through the `wc-api-dev` plugin), the entire endpoint is copied in the plugin, unchanged.

To test:
* Disable or uninstall the `wc-api-dev` plugin.
* Update your `wp-calypso` dependency to the branch `update/store-labels-use-continents-endpoint`. `npm link ../wp-calypso` should work now that we're using `npm 6`.
* Go to an order.
* Open the `Purchase Label` modal.
* See that all the "USPS" countries and territories appear in the `Origin address` `Country` dropdown.
* Select `United States`, see that the military states appear in the `State` dropdown.