### PR TITLE
Update TaxJar to the latest version

### DIFF
--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -471,7 +471,7 @@ class WC_Connect_TaxJar_Integration {
 	 * Get line items at checkout
 	 *
 	 * Unchanged from the TaxJar plugin.
-	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L626
+	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L645
 	 *
 	 * @return array
 	 */
@@ -488,12 +488,12 @@ class WC_Connect_TaxJar_Integration {
 			$tax_class = explode( '-', $product->get_tax_class() );
 			$tax_code = '';
 
-			if ( ! $product->is_taxable() || 'zero-rate' == sanitize_title( $product->get_tax_class() ) ) {
-				$tax_code = '99999';
-			}
-
 			if ( isset( $tax_class ) && is_numeric( end( $tax_class ) ) ) {
 				$tax_code = end( $tax_class );
+			}
+
+			if ( ! $product->is_taxable() || 'zero-rate' == sanitize_title( $product->get_tax_class() ) ) {
+				$tax_code = '99999';
 			}
 
 			// Get WC Subscription sign-up fees for calculations
@@ -524,7 +524,7 @@ class WC_Connect_TaxJar_Integration {
 	 * Get line items for backend orders
 	 *
 	 * Unchanged from the TaxJar plugin.
-	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L676
+	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L695
 	 *
 	 * @return array
 	 */
@@ -553,12 +553,12 @@ class WC_Connect_TaxJar_Integration {
 			$unit_price = $product->get_price();
 			$tax_code = '';
 
-			if ( ! $product->is_taxable() || 'zero-rate' == sanitize_title( $product->get_tax_class() ) ) {
-				$tax_code = '99999';
-			}
-
 			if ( isset( $tax_class[1] ) && is_numeric( $tax_class[1] ) ) {
 				$tax_code = $tax_class[1];
+			}
+
+			if ( ! $product->is_taxable() || 'zero-rate' == sanitize_title( $product->get_tax_class() ) ) {
+				$tax_code = '99999';
 			}
 
 			if ( $unit_price ) {


### PR DESCRIPTION
The TaxJar folks haven't made a release after `1.7.0`, but there are still several bug fixes that we don't have. These are all of them: https://github.com/taxjar/taxjar-woocommerce-plugin/compare/1.7.0...master

- https://github.com/taxjar/taxjar-woocommerce-plugin/commit/b877838317d9a8ee112d6ff570d12c7d265cd70f was already applied
- https://github.com/taxjar/taxjar-woocommerce-plugin/commit/f41f124065806a5273184d28e16aaf37213d5ab3 is for the Nexus, doesn't apply in our integration
- https://github.com/taxjar/taxjar-woocommerce-plugin/commit/7a743ac94d78562ddc29c15dce7a6a2e75ab30b5 and https://github.com/taxjar/taxjar-woocommerce-plugin/commit/96b5d57fb807e2529b50994adc1a5fe251dbdbe3 change the same function, updated in https://github.com/Automattic/woocommerce-services/commit/fc70ed891606a9d51a0a4dfbc6d80f7443c475df
- https://github.com/taxjar/taxjar-woocommerce-plugin/commit/2173d81cde18811608b9a2975c269199112795ef updated in https://github.com/Automattic/woocommerce-services/commit/9011e7c520f2f0da985c142a04c4af03f1c25506
- https://github.com/taxjar/taxjar-woocommerce-plugin/commit/8824639bacf3ef91793dcc45b3eb84ef32d3cc0d updated in https://github.com/Automattic/woocommerce-services/commit/7ef8beaec4bb7715364c1b2c14d23a7aa96b2831

This was straight-forward because all the functions affected by these changes are copied verbatim from the TaxJar plugin.