### PR TITLE
Remove emojis so they don't break the checkout when saving metadata into the database

### DIFF
--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -405,16 +405,14 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 						$package_measurements = '';
 
 						if ( ! property_exists( $rate_package, 'box_id' ) ) {
-							$package_name = __( 'Unknown package 📦', 'woocommerce-services' );
+							$package_name = __( 'Unknown package', 'woocommerce-services' );
 						} else if ( 'individual' === $rate_package->box_id ) {
-							$package_name = __( 'Individual packaging 📦', 'woocommerce-services' );
+							$package_name = __( 'Individual packaging', 'woocommerce-services' );
 						} else if (
 							isset( $packaging_lookup[ $rate_package->box_id ] ) &&
 							isset( $packaging_lookup[ $rate_package->box_id ]['name'] )
 						) {
-							$is_letter = isset( $packaging_lookup[ $rate_package->box_id ]['is_letter'] ) && $packaging_lookup[ $rate_package->box_id ]['is_letter'];
-							$icon = $is_letter ? '✉️' : '📦';
-							$package_name = $packaging_lookup[ $rate_package->box_id ]['name'] . ' ' . $icon;
+							$package_name = $packaging_lookup[ $rate_package->box_id ]['name'];
 							$package_measurements = sprintf(
 								$measurements_format,
 								$rate_package->length,


### PR DESCRIPTION
A few versions ago we added an "envelope" emoji or "package" emoji to each package name in each shipping rate metadata.

These emojis are displayed in the Order page (as part of the "Packaging" metadata string), and in the debug notices.

Since that metadata is serialized into JSON and stored in the database (and in the session), this caused trouble on certain MySQL configurations.

According to [this Reddit thread](https://www.reddit.com/r/PHP/comments/3fvi0u/emojis_are_breaking_our_json_decodes_help/), if the database charset is `utf8`, storing emojis in it would break. It needs to be `utf8mb4` instead. My local WordPress install (and the majority of people's) use `utfmb4`, since it's the default setting for `DB_CHARSET` in the most recent versions of WordPress. But the site that was having problems had it set to `utf8`.

Since the emojis have very little utility (if the package is called "Large Flat Envelope", you can figure out it's an envelope without an icon) and can break the entire checkout in some cases, I've remove them.

Props to @marcinbot for figuring this one out. This has been really weird.

cc/ @madeincosmos Since this has been reported by several users, we'll make a plugin release just with this, as long as someone else gives a look to these 5 lines of code.