### PR TITLE
Release 1.15.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-services",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-services",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "scripts": {
     "start": "cross-env NODE_ENV=development webpack-dev-server --hot --inline --watch --content-base dist --port 8085",
     "dist": "cross-env NODE_ENV=production webpack",

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: automattic, woothemes, allendav, kellychoffman, jkudish, jeffstieler, nabsul, robobot3000, danreylop, mikeyarce, shaunkuschel, orangesareorange, pauldechov, dappermountain
 Tags: canada-post, shipping, stamps, usps, woocommerce, taxes, payment, stripe
 Requires at least: 4.6
-Tested up to: 4.9.5
-Stable tag: 1.15.0
+Tested up to: 4.9.6
+Stable tag: 1.15.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -90,6 +90,10 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 10. Checking and exporting the label purchase reports
 
 == Changelog ==
+
+= 1.15.1 =
+* Fix the "Save changes" button staying disabled after failing to save the shipping method settings
+* Remove emojis from the shipping rates messages, they were causing problems at checkout on sites with a non-default MySQL charset configuration
 
 = 1.15.0 =
 * Several bugfixes and improvements for Automated Taxes

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -7,9 +7,9 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-services
  * Domain Path: /i18n/languages/
- * Version: 1.15.0
+ * Version: 1.15.1
  * WC requires at least: 3.0.0
- * WC tested up to: 3.3.4
+ * WC tested up to: 3.4.3
  *
  * Copyright (c) 2017 Automattic
  *


### PR DESCRIPTION
Changes since the last release:
* https://github.com/Automattic/woocommerce-services/pull/1440
* https://github.com/Automattic/woocommerce-services/pull/1457
* I also updated the "Tested up to" WordPress version and "WC tested up to" to the latest versions, since we were falling behind for no reason (I've been using WooCommerce 3.4 in my local dev site for months).

cc/ @dechov Anything you want to add/change about the changelog or the release?