### PR TITLE
Rename 'PayPal Express Checkout' to 'PayPal Checkout'

### DIFF
--- a/classes/class-wc-connect-paypal-ec.php
+++ b/classes/class-wc-connect-paypal-ec.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 
 	/**
-	 * Integrates with WooCommerce PayPal Express Checkout Payment Gateway,
+	 * Integrates with WooCommerce PayPal Checkout Payment Gateway,
 	 * modifying that plugin's behavior to facilitate authenticating requests
 	 * not by linking an account but via the WCS server through which we proxy.
 	 */
@@ -133,7 +133,7 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 						__( 'Link a PayPal account' ,'woocommerce-services' ),
 						sprintf(
 							wp_kses(
-								__( 'To issue refunds via PayPal Express Checkout, you will need to <a href="%s">link a PayPal account</a> with the email address that received this payment.', 'woocommerce-services' ),
+								__( 'To issue refunds via PayPal Checkout, you will need to <a href="%s">link a PayPal account</a> with the email address that received this payment.', 'woocommerce-services' ),
 								array(  'a' => array( 'href' => array() ) )
 							),
 							wc_gateway_ppec()->ips->get_signup_url( wc_gateway_ppec()->settings->environment )

--- a/readme.txt
+++ b/readme.txt
@@ -28,7 +28,7 @@ Give customers lower rates on their shipping. Create ready-to-print shipping lab
 We've got taxes for you - no need to enter tax rates manually.
 
 = Be ready to accept payments instantly =
-Have a Stripe account created on your behalf or accept PayPal Express Checkout payments without having to setup an account.
+Have a Stripe account created on your behalf or accept PayPal Checkout payments without having to setup an account.
 
 == Installation ==
 
@@ -50,7 +50,7 @@ This section describes how to install the plugin and get it working.
 * USPS label purchase/printing (domestic USA only)
 * Automated tax calculation
 * Stripe account provisioning (through WooCommerce setup wizard)
-* PayPal Express Checkout payment authorization
+* PayPal Checkout payment authorization
 
 = Are Real-Time Rates in Checkout Free? =
 


### PR DESCRIPTION
To align with https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/441, changes all instances of name except those close to the API layer (as the API is unchanged).

Only merchant-facing change is in this text:

<img width="340" alt="screen shot 2018-07-06 at 1 17 54 pm" src="https://user-images.githubusercontent.com/1867547/42391983-36f9d6b4-811f-11e8-9ab3-e3be4b6ae59e.png">
