### PR TITLE
Fix the "Your customer selected Express Mail" notice for WooCommerce 2.6

### DIFF
--- a/client/calypso-stubs/extensions/woocommerce/state/sites/http-request.js
+++ b/client/calypso-stubs/extensions/woocommerce/state/sites/http-request.js
@@ -77,7 +77,7 @@ const _requestWithHeaders = ( method, path, siteId, body, action, namespace ) =>
  * @return {Object} An object with the properties "get", "post", "put" and "del", which are functions to
  * make an HTTP GET, POST, PUT and DELETE request, respectively.
  */
-export default ( siteId, action, namespace = 'wc/v2' ) => ( {
+export default ( siteId, action, namespace = 'wc/v1' ) => ( {
 	/**
 	 * Sends a GET request to the API
 	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json/wc/v#/" prefix


### PR DESCRIPTION
This notice:
![screen shot 2018-07-09 at 21 56 06](https://user-images.githubusercontent.com/1715800/42475654-287e0ec4-83c3-11e8-9abf-8aba24e766ee.png)

Didn't work in WooCommerce `2.6`. The reason is that, for requests that use the Calypso data layer, we were stubbing it to always use the `/wc/v2` namespace (only present in 3.0 and up). For now, the only endpoint being used is the `order` endpoint, and it's just used to display that "Your customer selected..." notice in the Label Purchase flow.

The `order` endpoint is also present in `/wc/v1` and it has all the information the plugin needs, so there's no harm in changing it.

To test:
* Downgrade to WooCommerce 2.6.x
* Go purchase a label
* In the `Rates` step, you should see the notice indicating which rate the customer chose

I know we officially only support `WooCommerce 3.0` and up, but we (@jeffstieler and I) agreed that a sensible approach would be to make a release specifically breaking compatibility. We could even do a `2.0.0` release, for those users who understand semantic versioning :)