### PR TITLE
Store the submitted product declared value and weight in the product metadata

### DIFF
--- a/classes/class-wc-connect-compatibility-wc26.php
+++ b/classes/class-wc-connect-compatibility-wc26.php
@@ -117,6 +117,22 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC26' ) ) {
 		}
 
 		/**
+		 * For a given product ID, it tries to find its price inside an order's line items.
+		 *
+		 * @param int $product_id Product ID or variation ID
+		 * @param WC_Order $order
+		 * @return float The product (or variation) price, or NULL if it wasn't found
+		 */
+		public function get_product_price_from_order( $product_id, $order ) {
+			foreach ( $order->get_items() as $line_item ) {
+				if ( (int) $line_item[ 'product_id' ] === $product_id || (int) $line_item[ 'variation_id' ] === $product_id ) {
+					return round( floatval( $line_item[ 'total' ] ) / $line_item[ 'qty' ], 2 );
+				}
+			}
+			return null;
+		}
+
+		/**
 		 * For a given product, return it's name. In supported versions, variable
 		 * products will include their attributes.
 		 *

--- a/classes/class-wc-connect-compatibility-wc30.php
+++ b/classes/class-wc-connect-compatibility-wc30.php
@@ -131,6 +131,33 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC30' ) ) {
 		}
 
 		/**
+		 * For a given product ID, it tries to find its price inside an order's line items.
+		 *
+		 * @param int $product_id Product ID or variation ID
+		 * @param WC_Order $order
+		 * @return float The product (or variation) price, or NULL if it wasn't found
+		 */
+		public function get_product_price_from_order( $product_id, $order ) {
+			foreach ( $order->get_items() as $line_item ) {
+				$line_product_id = $line_item->get_product_id();
+				$line_variation_id = $line_item->get_variation_id();
+
+				if ( ! $line_product_id ) {
+					$line_product_id = (int) get_metadata( 'order_item', $line_item->get_id(), '_product_id', true );
+				}
+
+				if ( ! $line_variation_id ) {
+					$line_variation_id = (int) get_metadata( 'order_item', $line_item->get_id(), '_variation_id', true );
+				}
+
+				if ( $line_product_id === $product_id || $line_variation_id === $product_id ) {
+					return round( floatval( $line_item->get_total() ) / $line_item->get_quantity(), 2 );
+				}
+			}
+			return null;
+		}
+
+		/**
 		 * For a given product, return it's name. In supported versions, variable
 		 * products will include their attributes.
 		 *

--- a/classes/class-wc-connect-compatibility.php
+++ b/classes/class-wc-connect-compatibility.php
@@ -130,6 +130,15 @@ if ( ! class_exists( 'WC_Connect_Compatibility' ) ) {
 		abstract public function get_product_name_from_order( $product_id, $order );
 
 		/**
+		 * For a given product ID, it tries to find its price inside an order's line items.
+		 *
+		 * @param int $product_id Product ID or variation ID
+		 * @param WC_Order $order
+		 * @return float The product (or variation) price, or NULL if it wasn't found
+		 */
+		abstract public function get_product_price_from_order( $product_id, $order );
+
+		/**
 		 * For a given product, return it's name. In supported versions, variable
 		 * products will include their attributes.
 		 *

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -175,7 +175,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 							$formatted = WC_Connect_Compatibility::instance()->get_formatted_variation( $product, true );
 							$product_data['attributes'] = $formatted;
 						}
-						$customs_info = get_post_meta( $product_data['product_id'], 'customs_info', true );
+						$customs_info = get_post_meta( $product_data['product_id'], 'wc_connect_customs_info', true );
 						if ( $customs_info ) {
 							$product_data = array_merge( $product_data, $customs_info );
 						}

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -300,27 +300,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return in_array( $currency_code, $this->supported_currencies );
 		}
 
-		protected function get_states_map() {
-			$result = array();
-			$all_countries = WC()->countries->get_countries();
-
-			foreach ( $all_countries as $country_code => $country_name ) {
-				$country_data = array( 'name' => html_entity_decode( $country_name ) );
-				$states = WC()->countries->get_states( $country_code );
-
-				if ( $states ) {
-					$country_data['states'] = array();
-					foreach ( $states as $state_code => $name ) {
-						$country_data['states'][ $state_code ] = html_entity_decode( $name );
-					}
-				}
-
-				$result[ $country_code ] = $country_data;
-			}
-
-			return $result;
-		}
-
 		public function should_show_meta_box() {
 			if ( null === $this->show_metabox ) {
 				$this->show_metabox = $this->calculate_should_show_meta_box();
@@ -374,22 +353,16 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				return false;
 			}
 
-			$account_settings = $this->settings_store->get_account_settings();
-
 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
 			$payload = array(
 				'orderId'            => $order_id,
 				'paperSize'          => $this->settings_store->get_preferred_paper_size(),
 				'formData'           => $this->get_form_data( $order ),
 				'labelsData'         => $this->settings_store->get_label_order_meta_data( $order_id ),
+				'storeOptions'       => $this->settings_store->get_store_options(),
 				//for backwards compatibility, still disable the country dropdown for calypso users with older plugin versions
 				'canChangeCountries' => true,
 			);
-
-			$store_options = $this->settings_store->get_store_options();
-			// TODO: Get this country info from the /v3/continents endpoint instead, at least in Calypso
-			$store_options['countriesData'] = $this->get_states_map();
-			$payload['storeOptions'] = $store_options;
 
 			return $payload;
 		}

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -186,7 +186,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 					if ( ! $product_data['value'] ) {
 						$product_data['value'] = 0;
 					}
-					$product_data['parent_product_id'] = ( $product && $product->is_type( 'variation' ) ) ? $product->get_parent_id() : $product_data['product_id'];
 
 					$formatted_packages[ $package_id ]['items'][ $item_index ] = $product_data;
 				}

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -144,7 +144,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				$items = $this->get_all_items( $order );
 				$weight = array_sum( wp_list_pluck( $items, 'weight' ) );
 
-				return array(
+				$packages = array(
 					'default_box' => array(
 						'id'     => 'default_box',
 						'box_id' => 'not_selected',

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -182,9 +182,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 					} else {
 						$product_data['name'] = WC_Connect_Compatibility::instance()->get_product_name_from_order( $product_data['product_id'], $order );
 					}
-					$product_data['value'] = WC_Connect_Compatibility::instance()->get_product_price_from_order( $product_data['product_id'], $order );
 					if ( ! isset( $product_data['value'] ) ) {
-						$product_data['value'] = 0;
+						$product_data['value'] = WC_Connect_Compatibility::instance()->get_product_price_from_order( $product_data['product_id'], $order );
 					}
 
 					$formatted_packages[ $package_id ]['items'][ $item_index ] = $product_data;

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -183,7 +183,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 						$product_data['name'] = WC_Connect_Compatibility::instance()->get_product_name_from_order( $product_data['product_id'], $order );
 					}
 					$product_data['value'] = WC_Connect_Compatibility::instance()->get_product_price_from_order( $product_data['product_id'], $order );
-					if ( ! $product_data['value'] ) {
+					if ( ! isset( $product_data['value'] ) ) {
 						$product_data['value'] = 0;
 					}
 

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -64,7 +64,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 			$product_data = array(
 				'height'     => (float) $height,
-				'product_id' => $item['product_id'],
+				'product_id' => $product->get_id(),
 				'length'     => (float) $length,
 				'quantity'   => 1,
 				'weight'     => (float) $weight,

--- a/classes/class-wc-rest-connect-shipping-rates-controller.php
+++ b/classes/class-wc-rest-connect-shipping-rates-controller.php
@@ -28,11 +28,11 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WC_REST_Connect_Base_Con
 
 		// Update the customs information on all this order's products
 		$updated_product_ids = array();
-		foreach ( $payload[ 'packages' ] as $package ) {
+		foreach ( $payload[ 'packages' ] as $package_id => $package ) {
 			if ( ! isset( $package[ 'contents_type' ] ) ) {
 				break; // No customs information in this order, bail
 			}
-			foreach ( $package[ 'items' ] as $item ) {
+			foreach ( $package[ 'items' ] as $index => $item ) {
 				if ( ! isset( $updated_product_ids[ $item[ 'product_id' ] ] ) ) {
 					$updated_product_ids[ $item[ 'product_id' ] ] = true;
 					update_post_meta( $item[ 'product_id' ], 'wc_connect_customs_info', array(
@@ -41,11 +41,7 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WC_REST_Connect_Base_Con
 						'origin_country' => $item[ 'origin_country' ],
 					) );
 				}
-			}
-		}
-		foreach ( $payload[ 'packages' ] as $package_id => $package ) {
-			foreach ( $package[ 'items' ] as $index => $item ) {
-				// The server doesn't require the "product_id property
+				// The server doesn't require the "product_id" property
 				unset( $payload[ 'packages' ][ $package_id ][ 'items' ][ $index ][ 'product_id' ] );
 			}
 		}

--- a/classes/class-wc-rest-connect-shipping-rates-controller.php
+++ b/classes/class-wc-rest-connect-shipping-rates-controller.php
@@ -45,6 +45,11 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WC_REST_Connect_Base_Con
 						'origin_country' => $item[ 'origin_country' ],
 						'value' => $item[ 'value' ],
 					) );
+					$product = wc_get_product( $item[ 'product_id' ] );
+					if ( $product && $product->get_weight() !== wc_format_decimal( $item[ 'weight' ] ) ) {
+						$product->set_weight( $item[ 'weight' ] );
+						$product->save();
+					}
 				}
 			}
 		}

--- a/classes/class-wc-rest-connect-shipping-rates-controller.php
+++ b/classes/class-wc-rest-connect-shipping-rates-controller.php
@@ -41,8 +41,6 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WC_REST_Connect_Base_Con
 						'origin_country' => $item[ 'origin_country' ],
 					) );
 				}
-				// The server doesn't require the "product_id" property
-				unset( $payload[ 'packages' ][ $package_id ][ 'items' ][ $index ][ 'product_id' ] );
 			}
 		}
 

--- a/classes/class-wc-rest-connect-shipping-rates-controller.php
+++ b/classes/class-wc-rest-connect-shipping-rates-controller.php
@@ -11,6 +11,10 @@ if ( class_exists( 'WC_REST_Connect_Shipping_Rates_Controller' ) ) {
 class WC_REST_Connect_Shipping_Rates_Controller extends WC_REST_Connect_Base_Controller {
 	protected $rest_base = 'connect/label/(?P<order_id>\d+)/rates';
 
+	private function has_customs_data( $package ) {
+		return isset( $package['contents_type'] );
+	}
+
 	/**
 	 *
 	 * @param WP_REST_Request $request - See WC_Connect_API_Client::get_label_rates()
@@ -29,8 +33,8 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WC_REST_Connect_Base_Con
 		// Update the customs information on all this order's products
 		$updated_product_ids = array();
 		foreach ( $payload[ 'packages' ] as $package_id => $package ) {
-			if ( ! isset( $package[ 'contents_type' ] ) ) {
-				break; // No customs information in this order, bail
+			if ( ! $this->has_customs_data( $package ) ) {
+				break;
 			}
 			foreach ( $package[ 'items' ] as $index => $item ) {
 				if ( ! isset( $updated_product_ids[ $item[ 'product_id' ] ] ) ) {

--- a/classes/class-wc-rest-connect-shipping-rates-controller.php
+++ b/classes/class-wc-rest-connect-shipping-rates-controller.php
@@ -43,6 +43,7 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WC_REST_Connect_Base_Con
 						'description' => $item[ 'description' ],
 						'hs_tariff_number' => $item[ 'hs_tariff_number' ],
 						'origin_country' => $item[ 'origin_country' ],
+						'value' => $item[ 'value' ],
 					) );
 				}
 			}

--- a/classes/class-wc-rest-connect-shipping-rates-controller.php
+++ b/classes/class-wc-rest-connect-shipping-rates-controller.php
@@ -37,7 +37,7 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WC_REST_Connect_Base_Con
 					$updated_product_ids[ $item[ 'product_id' ] ] = true;
 					update_post_meta( $item[ 'product_id' ], 'wc_connect_customs_info', array(
 						'description' => $item[ 'description' ],
-						'hs_tariff_code' => $item[ 'hs_tariff_code' ],
+						'hs_tariff_number' => $item[ 'hs_tariff_number' ],
 						'origin_country' => $item[ 'origin_country' ],
 					) );
 				}

--- a/classes/class-wc-rest-connect-shipping-rates-controller.php
+++ b/classes/class-wc-rest-connect-shipping-rates-controller.php
@@ -35,7 +35,7 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WC_REST_Connect_Base_Con
 			foreach ( $package[ 'items' ] as $item ) {
 				if ( ! isset( $updated_product_ids[ $item[ 'product_id' ] ] ) ) {
 					$updated_product_ids[ $item[ 'product_id' ] ] = true;
-					update_post_meta( $item[ 'product_id' ], 'customs_info', array(
+					update_post_meta( $item[ 'product_id' ], 'wc_connect_customs_info', array(
 						'description' => $item[ 'description' ],
 						'hs_tariff_code' => $item[ 'hs_tariff_code' ],
 						'origin_country' => $item[ 'origin_country' ],

--- a/classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php
+++ b/classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php
@@ -1,0 +1,357 @@
+<?php
+/**
+ * REST API Data controller.
+ *
+ * Handles requests to the /data/continents endpoint.
+ *
+ * Directly copied from the wc-api-dev plugin. Delete this when the "v3" REST API is included in all the WC versions we support.
+ *
+ * @author   Automattic
+ * @category API
+ * @package  WooCommerce/API
+ * @since    3.1.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API Data controller class.
+ *
+ * @package WooCommerce/API
+ * @extends WC_REST_Controller
+ */
+class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'data/continents';
+
+	/**
+	 * Register routes.
+	 *
+	 * @since 3.1.0
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<location>[\w-]+)', array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_item' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				'args' => array(
+					'continent' => array(
+						'description' => __( '2 character continent code.', 'woocommerce' ),
+						'type'        => 'string',
+					),
+				),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+	}
+
+	/**
+	 * Return the list of countries and states for a given continent.
+	 *
+	 * @since  3.1.0
+	 * @param  string          $continent_code
+	 * @param  WP_REST_Request $request
+	 * @return array|mixed Response data, ready for insertion into collection data.
+	 */
+	public function get_continent( $continent_code = false, $request ) {
+		$continents  = WC()->countries->get_continents();
+		$countries   = WC()->countries->get_countries();
+		$states      = WC()->countries->get_states();
+		$locale_info = include WC()->plugin_path() . '/i18n/locale-info.php';
+		$data        = array();
+
+		if ( ! array_key_exists( $continent_code, $continents ) ) {
+			return false;
+		}
+
+		$continent_list = $continents[ $continent_code ];
+
+		$continent = array(
+			'code' => $continent_code,
+			'name' => $continent_list['name'],
+		);
+
+		$local_countries = array();
+		foreach ( $continent_list['countries'] as $country_code ) {
+			if ( isset( $countries[ $country_code ] ) ) {
+				$country = array(
+					'code' => $country_code,
+					'name' => $countries[ $country_code ],
+				);
+
+				// If we have detailed locale information include that in the response
+				if ( array_key_exists( $country_code, $locale_info ) ) {
+					// Defensive programming against unexpected changes in locale-info.php
+					$country_data = wp_parse_args( $locale_info[ $country_code ], array(
+						'currency_code'  => 'USD',
+						'currency_pos'   => 'left',
+						'decimal_sep'    => '.',
+						'dimension_unit' => 'in',
+						'num_decimals'   => 2,
+						'thousand_sep'   => ',',
+						'weight_unit'    => 'lbs',
+					) );
+
+					$country = array_merge( $country, $country_data );
+				}
+
+				$local_states = array();
+				if ( isset( $states[ $country_code ] ) ) {
+					foreach ( $states[ $country_code ] as $state_code => $state_name ) {
+						$local_states[] = array(
+							'code' => $state_code,
+							'name' => $state_name,
+						);
+					}
+				}
+				$country['states'] = $local_states;
+
+				// Allow only desired keys (e.g. filter out tax rates)
+				$allowed = array(
+					'code',
+					'currency_code',
+					'currency_pos',
+					'decimal_sep',
+					'dimension_unit',
+					'name',
+					'num_decimals',
+					'states',
+					'thousand_sep',
+					'weight_unit',
+				);
+				$country = array_intersect_key( $country, array_flip( $allowed ) );
+
+				$local_countries[] = $country;
+			}
+		}
+
+		$continent['countries'] = $local_countries;
+		return $continent;
+	}
+
+	/**
+	 * Return the list of states for all continents.
+	 *
+	 * @since  3.1.0
+	 * @param  WP_REST_Request $request
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$continents = WC()->countries->get_continents();
+		$data       = array();
+
+		foreach ( array_keys( $continents ) as $continent_code ) {
+			$continent = $this->get_continent( $continent_code, $request );
+			$response  = $this->prepare_item_for_response( $continent, $request );
+			$data[]    = $this->prepare_response_for_collection( $response );
+		}
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Return the list of locations for a given continent.
+	 *
+	 * @since  3.1.0
+	 * @param  WP_REST_Request $request
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		$data = $this->get_continent( strtoupper( $request['location'] ), $request );
+		if ( empty( $data ) ) {
+			return new WP_Error( 'woocommerce_rest_data_invalid_location', __( 'There are no locations matching these parameters.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+		return $this->prepare_item_for_response( $data, $request );
+	}
+
+	/**
+	 * Prepare the data object for response.
+	 *
+	 * @since  3.1.0
+	 * @param object $item Data object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$data     = $this->add_additional_fields_to_object( $item, $request );
+		$data     = $this->filter_response_by_context( $data, 'view' );
+		$response = rest_ensure_response( $data );
+
+		$response->add_links( $this->prepare_links( $item ) );
+
+		/**
+		 * Filter the location list returned from the API.
+		 *
+		 * Allows modification of the loction data right before it is returned.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param array            $item     The original list of continent(s), countries, and states.
+		 * @param WP_REST_Request  $request  Request used to generate the response.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_data_continent', $response, $item, $request );
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param object $item Data object.
+	 * @return array Links for the given continent.
+	 */
+	protected function prepare_links( $item ) {
+		$continent_code = strtolower( $item['code'] );
+		$links = array(
+			'self' => array(
+				'href' => rest_url( sprintf( '/%s/%s/%s', $this->namespace, $this->rest_base, $continent_code ) ),
+			),
+			'collection' => array(
+				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ),
+			),
+		);
+		return $links;
+	}
+
+	/**
+	 * Get the location schema, conforming to JSON Schema.
+	 *
+	 * @since  3.1.0
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema' => 'http://json-schema.org/draft-04/schema#',
+			'title'   => 'data_continents',
+			'type'       => 'object',
+			'properties' => array(
+				'code' => array(
+					'type'        => 'string',
+					'description' => __( '2 character continent code.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'name' => array(
+					'type'        => 'string',
+					'description' => __( 'Full name of continent.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'countries' => array(
+					'type'        => 'array',
+					'description' => __( 'List of countries on this continent.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+					'items'       => array(
+						'type'       => 'object',
+						'context'    => array( 'view' ),
+						'readonly'   => true,
+						'properties' => array(
+							'code' => array(
+								'type'        => 'string',
+								'description' => __( 'ISO3166 alpha-2 country code.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'currency_code' => array(
+								'type'        => 'string',
+								'description' => __( 'Default ISO4127 alpha-3 currency code for the country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'currency_pos' => array(
+								'type'        => 'string',
+								'description' => __( 'Currency symbol position for this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'decimal_sep' => array(
+								'type'        => 'string',
+								'description' => __( 'Decimal separator for displayed prices for this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'dimension_unit' => array(
+								'type'        => 'string',
+								'description' => __( 'The unit lengths are defined in for this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'name' => array(
+								'type'        => 'string',
+								'description' => __( 'Full name of country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'num_decimals' => array(
+								'type'        => 'integer',
+								'description' => __( 'Number of decimal points shown in displayed prices for this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'states' => array(
+								'type'        => 'array',
+								'description' => __( 'List of states in this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+								'items'       => array(
+									'type'       => 'object',
+									'context'    => array( 'view' ),
+									'readonly'   => true,
+									'properties' => array(
+										'code' => array(
+											'type'        => 'string',
+											'description' => __( 'State code.', 'woocommerce' ),
+											'context'     => array( 'view' ),
+											'readonly'    => true,
+										),
+										'name' => array(
+											'type'        => 'string',
+											'description' => __( 'Full name of state.', 'woocommerce' ),
+											'context'     => array( 'view' ),
+											'readonly'    => true,
+										),
+									),
+								),
+							),
+							'thousand_sep' => array(
+								'type'        => 'string',
+								'description' => __( 'Thousands separator for displayed prices in this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'weight_unit' => array(
+								'type'        => 'string',
+								'description' => __( 'The unit weights are defined in for this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+						),
+					),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/classes/wc-api-dev/class-wc-rest-dev-data-controller.php
+++ b/classes/wc-api-dev/class-wc-rest-dev-data-controller.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * REST API Data controller.
+ *
+ * Handles requests to the /data endpoint.
+ *
+ * Directly copied from the wc-api-dev plugin. Delete this when the "v3" REST API is included in all the WC versions we support.
+ *
+ * @author   Automattic
+ * @category API
+ * @package  WooCommerce/API
+ * @since    3.1.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API Data controller class.
+ *
+ * @package WooCommerce/API
+ * @extends WC_REST_Controller
+ */
+class WC_REST_Dev_Data_Controller extends WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'data';
+
+	/**
+	 * Register routes.
+	 *
+	 * @since 3.1.0
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+	}
+
+	/**
+	 * Check whether a given request has permission to read site data.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check whether a given request has permission to read site settings.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_item_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Return the list of data resources.
+	 *
+	 * @since  3.1.0
+	 * @param  WP_REST_Request $request
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$data = array();
+		$resources = array(
+			array(
+				'slug'        => 'continents',
+				'description' => __( 'List of supported continents, countries, and states.', 'woocommerce' ),
+			),
+			array(
+				'slug'        => 'countries',
+				'description' => __( 'List of supported states in a given country.', 'woocommerce' ),
+			),
+			array(
+				'slug'        => 'currencies',
+				'description' => __( 'List of supported currencies.', 'woocommerce' ),
+			),
+		);
+
+		foreach ( $resources as $resource ) {
+			$item   = $this->prepare_item_for_response( (object) $resource, $request );
+			$data[] = $this->prepare_response_for_collection( $item );
+		}
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Prepare a data resource object for serialization.
+	 *
+	 * @param stdClass $report Report data.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $resource, $request ) {
+		$data = array(
+			'slug'        => $resource->slug,
+			'description' => $resource->description,
+		);
+
+		$data = $this->add_additional_fields_to_object( $data, $request );
+		$data = $this->filter_response_by_context( $data, 'view' );
+
+		// Wrap the data in a response object.
+		$response = rest_ensure_response( $data );
+		$response->add_links( $this->prepare_links( $resource ) );
+
+		return $response;
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param object $item Data object.
+	 * @return array Links for the given country.
+	 */
+	protected function prepare_links( $item ) {
+		$links = array(
+			'self' => array(
+				'href' => rest_url( sprintf( '/%s/%s/%s', $this->namespace, $this->rest_base, $item->slug ) ),
+			),
+			'collection' => array(
+				'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
+			),
+		);
+
+		return $links;
+	}
+
+	/**
+	 * Get the data index schema, conforming to JSON Schema.
+	 *
+	 * @since  3.1.0
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'data_index',
+			'type'       => 'object',
+			'properties' => array(
+				'slug' => array(
+					'description' => __( 'Data resource ID.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'description' => array(
+					'description' => __( 'Data resource description.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/client/apps/shipping-label/index.js
+++ b/client/apps/shipping-label/index.js
@@ -17,6 +17,9 @@ import ordersReducer from 'woocommerce/state/sites/orders/reducer';
 import { combineReducers } from 'state/utils';
 import orders from 'woocommerce/state/data-layer/orders';
 import { middleware as rawWpcomApiMiddleware } from 'state/data-layer/wpcom-api-middleware';
+import locations from 'woocommerce/state/data-layer/data/locations';
+import locationsReducer from 'woocommerce/state/sites/data/locations/reducer';
+import { mergeHandlers } from 'state/action-watchers/utils';
 
 export default ( { orderId } ) => {
 	return {
@@ -34,6 +37,9 @@ export default ( { orderId } ) => {
 						sites: combineReducers( {
 							1: combineReducers( {
 								orders: ordersReducer,
+								data: combineReducers( {
+									locations: locationsReducer,
+								} )
 							} ),
 						} ),
 					} ),
@@ -74,7 +80,7 @@ export default ( { orderId } ) => {
 		},
 
 		getMiddlewares() {
-			return [ reduxMiddleware, rawWpcomApiMiddleware( orders ) ];
+			return [ reduxMiddleware, rawWpcomApiMiddleware( mergeHandlers( orders, locations ) ) ];
 		},
 
 		View: () => (

--- a/client/calypso-stubs/extensions/woocommerce/state/sites/http-request.js
+++ b/client/calypso-stubs/extensions/woocommerce/state/sites/http-request.js
@@ -32,6 +32,11 @@ const _request = ( method, path, siteId, body, action, namespace ) => {
 	if ( namespace && ! namespace.endsWith( '/' ) ) {
 		namespace += '/';
 	}
+	if ( namespace && namespace.startsWith( '/' ) ) {
+		// baseURL ends in a "/", so if namespace starts with another it must be removed
+		namespace = namespace.substr( 1 );
+	}
+
 	if ( -1 !== baseURL.indexOf( '?' ) ) {
 		path = path.replace( '?', '&' );
 	}

--- a/tests/php/test_class-wc-connect-shipping-label.php
+++ b/tests/php/test_class-wc-connect-shipping-label.php
@@ -526,44 +526,4 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		$actual = $shipping_label->get_selected_packages( $mock_order );
 		$this->assertEquals( $actual, $this->expected_selected_packages_multiple );
 	}
-
-	public function test_get_items_as_individual_packages_multiple_products() {
-		$products = array(
-			WC_Helper_Product::create_simple_product(),
-			WC_Helper_Product::create_simple_product(),
-		);
-
-		$order = wc_create_order( array(
-			'status'        => 'processing',
-			'customer_id'   => 1,
-			'customer_note' => '',
-			'total'         => '',
-		) );
-
-		// Add order products
-		if ( version_compare( WOOCOMMERCE_VERSION, '3.0.0', '<' ) ) {
-			foreach ( $products as $product ) {
-				$order->add_product( $product );
-			}
-		} else {
-			foreach ( $products as $product ) {
-				$item = new WC_Order_Item_Product();
-
-				$item->set_props( array(
-					'product'  => $product,
-					'quantity' => 1,
-				) );
-
-				$item->save();
-				$order->add_item( $item );
-			}
-
-			$order->save();
-		}
-
-		$shipping_label      = $this->get_shipping_label();
-		$individual_packages = $shipping_label->get_items_as_individual_packages( $order );
-
-		$this->assertEquals( count( $products ), count( $individual_packages ) );
-	}
 }

--- a/tests/php/test_class-wc-connect-shipping-label.php
+++ b/tests/php/test_class-wc-connect-shipping-label.php
@@ -83,7 +83,6 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 			'weight' => 0.25625,
 			'items' => array ( array(
 				'product_id' => 128,
-				'parent_product_id' => 128,
 				'value' => 0,
 				'length' => 3,
 				'width' => 3,
@@ -106,7 +105,6 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 			'weight' => 0.25625,
 			'items' => array ( array(
 				'product_id' => 128,
-				'parent_product_id' => 128,
 				'value' => 0,
 				'length' => 3,
 				'width' => 3,
@@ -127,7 +125,6 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 			'items' => array (
 				array(
 					'product_id' => 128,
-					'parent_product_id' => 128,
 					'value' => 0,
 					'length' => 3,
 					'width' => 3,
@@ -138,7 +135,6 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 				),
 				array (
 					'product_id' => 129,
-					'parent_product_id' => 129,
 					'value' => 0,
 					'length' => 3,
 					'width' => 3,

--- a/tests/php/test_class-wc-connect-shipping-label.php
+++ b/tests/php/test_class-wc-connect-shipping-label.php
@@ -83,6 +83,8 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 			'weight' => 0.25625,
 			'items' => array ( array(
 				'product_id' => 128,
+				'parent_product_id' => 128,
+				'value' => 0,
 				'length' => 3,
 				'width' => 3,
 				'height' => 2.5,
@@ -104,6 +106,8 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 			'weight' => 0.25625,
 			'items' => array ( array(
 				'product_id' => 128,
+				'parent_product_id' => 128,
+				'value' => 0,
 				'length' => 3,
 				'width' => 3,
 				'height' => 2.5,
@@ -123,6 +127,8 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 			'items' => array (
 				array(
 					'product_id' => 128,
+					'parent_product_id' => 128,
+					'value' => 0,
 					'length' => 3,
 					'width' => 3,
 					'height' => 2.5,
@@ -132,6 +138,8 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 				),
 				array (
 					'product_id' => 129,
+					'parent_product_id' => 129,
+					'value' => 0,
 					'length' => 3,
 					'width' => 3,
 					'height' => 2.5,

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -674,6 +674,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'update_option_woocommerce_dimension_unit', array( $this, 'queue_service_schema_refresh' ) );
 
 			add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
+			add_action( 'rest_api_init', array( $this, 'wc_api_dev_init' ), 9999 );
 			add_action( 'wc_connect_fetch_service_schemas', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
 			add_filter( 'woocommerce_hidden_order_itemmeta', array( $this, 'hide_wc_connect_package_meta_data' ) );
 			add_filter( 'is_protected_meta', array( $this, 'hide_wc_connect_order_meta_data' ), 10, 3 );
@@ -812,6 +813,21 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 
 			add_filter( 'rest_request_before_callbacks', array( $this, 'log_rest_api_errors' ), 10, 3 );
+		}
+
+		/**
+		 * If the required v3 REST API endpoints haven't been loaded at this point, load the local copies of said endpoints.
+		 * Delete this when the "v3" REST API is included in all the WC versions we support.
+		 */
+		public function wc_api_dev_init() {
+			$rest_server = rest_get_server();
+			$existing_routes = $rest_server->get_routes();
+			if ( ! isset( $existing_routes['/wc/v3/data/continents'] ) ) {
+				require_once( plugin_basename( 'classes/wc-api-dev/class-wc-rest-dev-data-controller.php' ) );
+				require_once( plugin_basename( 'classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php' ) );
+				$continents = new WC_REST_Dev_Data_Continents_Controller();
+				$continents->register_routes();
+			}
 		}
 
 		/**


### PR DESCRIPTION
Since we're changing the Calypso UI for the Customs form so the `weight` and `declared value` are editable by the merchant, this PR implements logic to persist those properties when the merchant gets label rates (same as with the current `tariffNumber`, `originCountry` and `description` props).

The `declared value` is stored in the product's customs meta-data, since the declared value may not match the product price, sale price, or any other price.

The `weight` property, on the other hand, updates the product's `weight`. I figured that a product's weight is the same in the store and for a Customs inspector, I don't see a use case where we wouldn't want to keep the product weight and the product "customs weight" in sync. I'm willing to be convinced otherwise.

There are testing instructions in https://github.com/Automattic/wp-calypso/pull/26423