### PR TITLE
Dismiss the label NUX pointer when the label modal is opened

### DIFF
--- a/client/apps/shipping-label/redux-middleware.js
+++ b/client/apps/shipping-label/redux-middleware.js
@@ -1,9 +1,14 @@
+/*
+ * External dependencies
+ */
+import jQuery from 'jquery';
 /**
  * Internal dependencies
  */
 //from calypso
 import {
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_PURCHASE_RESPONSE,
+	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW,
 } from 'woocommerce/woocommerce-services/state/action-types';
 
 const middlewareActions = {
@@ -12,6 +17,10 @@ const middlewareActions = {
 			return;
 		}
 		window.wc_shipment_tracking_refresh && window.wc_shipment_tracking_refresh();
+	},
+	[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW ]: () => {
+		//dismiss the nux pointer if the user opens the printing flow
+		jQuery( '#woocommerce-order-label' ).pointer( 'close' );
 	},
 };
 


### PR DESCRIPTION
The nux pointer would remain open if the user clicks on the "print label" button without dismissing it. This PR addresses that.

To test:
* If not on a fresh install:
  * modify `is_new_labels_user()` in `class-wc-connect-nux.php` to always return `true` 
  * remove `wc_services_labels_metabox` from the `dismissed_wp_pointers` row in `wp_usermeta` table
  * the pointer should appear
* Without dismissing the label pointer, open the label print modal
* The pointer should be dismissed in the background and shouldn't reappear after a page refresh