### PR TITLE
Reset pointer target's z-index on dismissal to fix the ellipsis menu

### DIFF
--- a/client/admin-pointers.js
+++ b/client/admin-pointers.js
@@ -30,7 +30,9 @@ jQuery( document ).ready( function( $ ) {
 				} );
 
 				if ( pointer.dim ) {
-					$( '#wcs-pointer-page-dimmer' ).fadeOut( 500 );
+					$( '#wcs-pointer-page-dimmer' ).fadeOut( 500, () => $( pointer.target ).css( 'z-index', '' ) );
+				} else {
+					$( pointer.target ).css( 'z-index', '' );
 				}
 
 				show_pointer( pointers, i + 1 );


### PR DESCRIPTION
Fixes #1089 

To test:
* If not on a fresh install:
  * modify `is_new_labels_user()` in `class-wc-connect-nux.php` to always return `true` 
  * remove `wc_services_labels_metabox` from the `dismissed_wp_pointers` row in `wp_usermeta` table
  * the pointer should appear
* Dismiss the pointer and purchase a label
* Without refreshing the page click on the new label's ellipsis menu
* The menu should appear and shouldn't be obscured by the label metabox