### PR TITLE
Remove "(WooCommerce Services)" from shipping method names

### DIFF
--- a/classes/class-wc-connect-service-schemas-validator.php
+++ b/classes/class-wc-connect-service-schemas-validator.php
@@ -72,6 +72,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Validator' ) ) {
 				'id'                 => 'string',
 				'method_description' => 'string',
 				'method_title'       => 'string',
+				'carrier_name'       => 'string',
 				'service_settings'   => 'object',
 				'form_layout'        => 'array'
 			);

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -365,8 +365,8 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				$service_settings = $this->get_service_settings( $method->method_id, $method->instance_id );
 				if ( is_object( $service_settings ) && property_exists( $service_settings, 'title' ) ) {
 					$title = $service_settings->title;
-				} else if ( is_object( $service_schema ) && property_exists( $service_schema, 'method_title' ) ) {
-					$title = $service_schema->method_title;
+				} else if ( is_object( $service_schema ) && property_exists( $service_schema, 'carrier_name' ) ) {
+					$title = $service_schema->carrier_name;
 				} else {
 					$title = _x( 'Unknown', 'A service with an unknown title and unknown method_title', 'woocommerce-services' );
 				}

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -24,7 +24,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		 */
 		protected $api_client;
 
-		public function __construct( $id_or_instance_id = null ) {
+		public function __construct( $id_or_instance_id, $existing_shipping_methods = array() ) {
 			parent::__construct( $id_or_instance_id );
 
 			// If $arg looks like a number, treat it as an instance_id
@@ -60,7 +60,11 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				$this->title = '';
 			} else {
 				$this->id = $this->service_schema->method_id;
-				$this->method_title = $this->service_schema->method_title;
+				// If there is already a shipping method with the "$service_schema->id" ID ("usps", "canada_post", etc),
+				// use the longer "method_title" property for the method title, which has the "XXX (WooCommerce Services)" disambiguation
+				$this->method_title = isset( $existing_shipping_methods[ $this->service_schema->id ] )
+					? $this->service_schema->method_title
+					: $this->service_schema->carrier_name;
 				$this->method_description = $this->service_schema->method_description;
 				$this->supports = array(
 					'shipping-zones',

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -24,7 +24,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		 */
 		protected $api_client;
 
-		public function __construct( $id_or_instance_id, $existing_shipping_methods = array() ) {
+		public function __construct( $id_or_instance_id = null, $existing_shipping_methods = array() ) {
 			parent::__construct( $id_or_instance_id );
 
 			// If $arg looks like a number, treat it as an instance_id

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -68,7 +68,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				);
 
 				// Set title to default value
-				$this->title = $this->service_schema->method_title;
+				$this->title = $this->service_schema->carrier_name;
 
 				// Load form values from options, updating title if present
 				$this->init_form_settings();

--- a/tests/php/test_wc-connect-services-validator.php
+++ b/tests/php/test_wc-connect-services-validator.php
@@ -20,6 +20,7 @@ class WP_Test_WC_Connect_Service_Schemas_Validator extends WC_Unit_Test_Case {
 					'id' => 'usps',
 					'method_description' => 'Obtains rates dynamically from the USPS API during cart/checkout.',
 					'method_title' => 'USPS (WooCommerce Services)',
+					'carrier_name' => 'USPS',
 					'form_layout' => array(),
 					'service_settings' => (object) array(
 						'type' => 'object',

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -645,7 +645,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$schemas = $schemas_store->get_service_schemas();
 
 			if ( $schemas ) {
-				add_filter( 'woocommerce_shipping_methods', array( $this, 'woocommerce_shipping_methods' ) );
+				add_filter( 'woocommerce_shipping_methods', array( $this, 'woocommerce_shipping_methods' ), 9999 );
 				add_filter( 'woocommerce_payment_gateways', array( $this, 'woocommerce_payment_gateways' ) );
 				add_action( 'wc_connect_service_init', array( $this, 'init_service' ), 10, 2 );
 				add_action( 'wc_connect_service_admin_options', array( $this, 'localize_and_enqueue_service_script' ), 10, 2 );
@@ -1052,7 +1052,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$shipping_service_ids = $this->get_service_schemas_store()->get_all_shipping_method_ids();
 
 			foreach ( $shipping_service_ids as $shipping_service_id ) {
-				$shipping_methods[ $shipping_service_id ] = new WC_Connect_Shipping_Method( $shipping_service_id );
+				$shipping_methods[ $shipping_service_id ] = new WC_Connect_Shipping_Method( $shipping_service_id, $shipping_methods );
 			}
 
 			return $shipping_methods;

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1027,9 +1027,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * @param int|string                 $id_or_instance_id
 		 */
 		public function init_service( WC_Connect_Shipping_Method $method, $id_or_instance_id ) {
-
-			// TODO - make more generic - allow things other than WC_Connect_Shipping_Method to work here
-
 			$method->set_api_client( $this->get_api_client() );
 			$method->set_logger( $this->get_shipping_logger() );
 			$method->set_service_settings_store( $this->get_service_settings_store() );


### PR DESCRIPTION
This PR removes the "___ (WooCommerce Services)" string from the "Add shipping method" list. It keeps it only when there is another extension that offers the shipping method for the same carrier, to not confuse the merchant.

## UI:
<img width="683" alt="screen shot 2018-08-07 at 16 44 26" src="https://user-images.githubusercontent.com/1715800/43787317-9cc45224-9a62-11e8-89e6-aa17430146ae.png">

## Questions:
* What happens if there is only one extension that clashes with one of our methods? For example, in the screenshot, "FedEx" comes from the FedEx extension, "FedEx (WooCommerce Services)" comes from WooCommerce Services (duh), and "USPS" comes from WooCommerce Services too. Should we add the "(WooCommerce Services)" string to all of our methods in that case?
* Do we want to keep the existing descriptions? `USPS Shipping Rates, Powered by WooCommerce Services`, or do we want to hide the "WooCommerce Services" brand as much as possible?
* I've abused the current structure we have on the shipping schemas in the server, so `id: "usps", method_id: "wc_services_usps", method_title: "USPS (WooCommerce Services)", carrier_name: "USPS"`. Is that too fragile? Should we have this logic coded in the client side instead, and start relying less on the server-side schemas?

## To test: 
* Install an extension that provides a shipping method that we offer too, like `woocommerce-shipping-fedex`.
* Check that the UI when adding a shipping method to a shipping zone looks like the screenshot.