### PR TITLE
Show shipping label meta box for all origin and destination countries

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -396,23 +396,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				return true;
 			}
 
-			// Restrict showing the metabox to supported store currencies.
-			$base_currency = get_woocommerce_currency();
-			if ( ! $this->is_supported_currency( $base_currency ) ) {
-				return false;
-			}
-
-			// Restrict showing the meta-box to supported origin and destinations: US domestic, for now
-			$base_location = wc_get_base_location();
-			if ( ! $this->is_supported_country( $base_location['country'] ) ) {
-				return false;
-			}
-
-			$dest_address = $order->get_address( 'shipping' );
-			if ( ! $this->is_supported_address( $dest_address ) ) {
-				return false;
-			}
-
 			// If the order was created using WCS checkout rates, show the meta-box regardless of the products' state
 			if ( $this->get_packaging_metadata( $order ) ) {
 				return true;


### PR DESCRIPTION
We'd like to show the shipping label meta box for all orders, regardless if the label can be purchased or not, and display messages to users based on their settings to help them get set up.

The meta box will be displayed even if:
- the base currency is not supported (e.g. USD)
- the base location is not supported (e.g. USA)
- the destination location is not supported (e.g. outside of USA)

The meta box will still not be displayed if there are no shippable products in the order.

For this PR to be merged, we need the international shipping feature (the way it's written right now) - otherwise we'll need to display a warning in the case of international shipping destinations.

The meta box will:
- display a warning for non-US origin addresses
- not show the payment info if there's a warning showing up

TODO:
- [ ] use `ACCEPTED_USPS_ORIGIN_COUNTRIES` from https://github.com/Automattic/wp-calypso/blob/bce7fd909d90a938704f69e706fd914f78c90b91/client/extensions/woocommerce/woocommerce-services/state/shipping-label/constants.js#L2 instead of creating a new one inline
- [ ] which service would we like to recommend in the warning?