### PR TITLE
Update taxjar to the latest version

### DIFF
--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -372,6 +372,9 @@ class WC_Connect_TaxJar_Integration {
 			do_action( 'woocommerce_cart_reset', $wc_cart_object, false );
 			do_action( 'woocommerce_before_calculate_totals', $wc_cart_object );
 			new WC_Cart_Totals( $wc_cart_object );
+			remove_action( 'woocommerce_after_calculate_totals', array( $this, 'calculate_totals' ), 20 );
+			do_action( 'woocommerce_after_calculate_totals', $wc_cart_object );
+			add_action( 'woocommerce_after_calculate_totals', array( $this, 'calculate_totals' ), 20 );
 		} else {
 			remove_action( 'woocommerce_calculate_totals', array( $this, 'calculate_totals' ), 20 );
 			$wc_cart_object->calculate_totals();

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -12,9 +12,6 @@ class WC_Connect_TaxJar_Integration {
 	 */
 	public $logger;
 
-	/**
-	 * @var string
-	 */
 	public $wc_connect_base_url;
 
 	private $expected_options = array(
@@ -43,7 +40,7 @@ class WC_Connect_TaxJar_Integration {
 	public function __construct(
 		WC_Connect_API_Client $api_client,
 		WC_Connect_Logger $logger,
-		string $wc_connect_base_url
+		$wc_connect_base_url
 	) {
 		$this->api_client = $api_client;
 		$this->logger = $logger;

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -486,11 +486,12 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		if ( 'base' === $tax_based_on ) {
-			$country  = WC()->countries->get_base_country();
-			$state    = WC()->countries->get_base_state();
-			$postcode = WC()->countries->get_base_postcode();
-			$city     = WC()->countries->get_base_city();
-			$street   = WC()->countries->get_base_address();
+			$store_settings = $this->get_store_settings();
+			$country  = $store_settings['country'];
+			$state    = $store_settings['state'];
+			$postcode = $store_settings['postcode'];
+			$city     = $store_settings['city'];
+			$street   = $store_settings['street'];
 		} elseif ( 'billing' === $tax_based_on ) {
 			$country  = WC()->customer->get_billing_country();
 			$state    = WC()->customer->get_billing_state();

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -346,13 +346,13 @@ class WC_Connect_TaxJar_Integration {
 			do_action( 'woocommerce_cart_reset', $wc_cart_object, false );
 			do_action( 'woocommerce_before_calculate_totals', $wc_cart_object );
 			new WC_Cart_Totals( $wc_cart_object );
-			remove_action( 'woocommerce_after_calculate_totals', array( $this, 'calculate_totals' ), 20 );
+			remove_action( 'woocommerce_after_calculate_totals', array( $this, 'maybe_calculate_totals' ), 20 );
 			do_action( 'woocommerce_after_calculate_totals', $wc_cart_object );
-			add_action( 'woocommerce_after_calculate_totals', array( $this, 'calculate_totals' ), 20 );
+			add_action( 'woocommerce_after_calculate_totals', array( $this, 'maybe_calculate_totals' ), 20 );
 		} else {
-			remove_action( 'woocommerce_calculate_totals', array( $this, 'calculate_totals' ), 20 );
+			remove_action( 'woocommerce_calculate_totals', array( $this, 'maybe_calculate_totals' ), 20 );
 			$wc_cart_object->calculate_totals();
-			add_action( 'woocommerce_calculate_totals', array( $this, 'calculate_totals' ), 20 );
+			add_action( 'woocommerce_calculate_totals', array( $this, 'maybe_calculate_totals' ), 20 );
 		}
 	}
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -342,6 +342,15 @@ class WC_Connect_TaxJar_Integration {
 		$this->response_rate_ids = $taxes['rate_ids'];
 		$this->response_line_items = $taxes['line_items'];
 
+		if ( isset( $this->response_line_items ) ) {
+			foreach ( $this->response_line_items as $response_line_item_key => $response_line_item ) {
+				$line_item = $this->get_line_item( $response_line_item_key, $line_items );
+ 				if ( isset( $line_item ) ) {
+					$this->response_line_items[ $response_line_item_key ]->line_total = ( $line_item['unit_price'] * $line_item['quantity'] ) - $line_item['discount'];
+				}
+			}
+		}
+
 		foreach ( $wc_cart_object->get_cart() as $cart_item_key => $cart_item ) {
 			$product = $cart_item['data'];
 			$line_item_key = $product->get_id() . '-' . $cart_item_key;
@@ -566,6 +575,15 @@ class WC_Connect_TaxJar_Integration {
 		return $line_items;
 	}
 
+	protected function get_line_item( $id, $line_items ) {
+		foreach ( $line_items as $line_item ) {
+			if ( $line_item['id'] === $id ) {
+				return $line_item;
+			}
+		}
+ 		return null;
+	}
+
 	/**
 	 * Override Woo's native tax rates to handle multiple line items with the same tax rate
 	 * within the same tax class with different rates due to exemption thresholds
@@ -596,7 +614,7 @@ class WC_Connect_TaxJar_Integration {
 
 			foreach ( $this->response_line_items as $line_item_key => $line_item ) {
 				// If line item belongs to rate and matches the price, manually set the tax
-				if ( in_array( $line_item_key, $line_items ) && $price == $line_item->taxable_amount ) {
+				if ( in_array( $line_item_key, $line_items ) && $price == $line_item->line_total ) {
 					if ( function_exists( 'wc_add_number_precision' ) ) {
 						$taxes[ $tax_rate_id ] = wc_add_number_precision( $line_item->tax_collectable );
 					} else {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -66,10 +66,6 @@ class WC_Connect_TaxJar_Integration {
 		// Settings values filter to handle the hardcoded settings
 		add_filter( 'woocommerce_admin_settings_sanitize_option', array( $this, 'sanitize_tax_option' ), 10, 2 );
 
-		// Settings Page
-		add_action( 'woocommerce_sections_tax', array( $this, 'output_sections_before' ),  9 );
-		add_action( 'woocommerce_sections_tax', array( $this, 'output_sections_after' ),  11 );
-
 		// Bow out if we're not wanted
 		if ( ! $this->is_enabled() ) {
 			return;
@@ -197,28 +193,6 @@ class WC_Connect_TaxJar_Integration {
 				update_option( $option, $value );
 			}
 		}
-	}
-
-	/**
-	 * Hack to hide the tax sections for additional tax class rate tables.
-	 */
-	public function output_sections_before() {
-		if ( ! $this->is_enabled() ) {
-			return;
-		}
-		?>
-		<div style="display: none">
-		<?php
-	}
-
-	/**
-	 * Hack to hide the tax sections for additional tax class rate tables.
-	 */
-	public function output_sections_after() {
-		if ( ! $this->is_enabled() ) {
-			return;
-		}
-		?></div><?php
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -97,6 +97,7 @@ class WC_Connect_TaxJar_Integration {
 		add_filter( 'woocommerce_customer_taxable_address', array( $this, 'append_base_address_to_customer_taxable_address' ), 10, 1 );
 
 		add_filter( 'woocommerce_calc_tax', array( $this, 'override_woocommerce_tax_rates' ), 10, 3 );
+		add_filter( 'woocommerce_matched_rates', array( $this, 'allow_street_address_for_matched_rates' ), 10, 2 );
 	}
 
 	/**
@@ -445,6 +446,30 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	/**
+	 * Allow street address to be passed when finding rates
+	 *
+	 * @param array $matched_tax_rates
+	 * @param string $tax_class
+	 * @return array
+	 */
+	public function allow_street_address_for_matched_rates( $matched_tax_rates, $tax_class = '' ) {
+		$tax_class         = sanitize_title( $tax_class );
+		$location          = WC_Tax::get_tax_location( $tax_class );
+		$matched_tax_rates = array();
+ 		if ( sizeof( $location ) >= 4 ) {
+			list( $country, $state, $postcode, $city, $street ) = array_pad( $location, 5, '' );
+ 			$matched_tax_rates = WC_Tax::find_rates( array(
+				'country' 	=> $country,
+				'state' 	=> $state,
+				'postcode' 	=> $postcode,
+				'city' 		=> $city,
+				'tax_class' => $tax_class,
+			) );
+		}
+ 		return $matched_tax_rates;
+	}
+
+	/**
 	 * Get taxable address.
 	 * @return array
 	 */
@@ -674,7 +699,6 @@ class WC_Connect_TaxJar_Integration {
 	 * @return array
 	 */
 	public function append_base_address_to_customer_taxable_address( $address ) {
-		$store_settings = $this->get_store_settings();
 		$tax_based_on = '';
 
 		list( $country, $state, $postcode, $city, $street ) = array_pad( $address, 5, '' );
@@ -692,6 +716,7 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		if ( 'base' == $tax_based_on ) {
+			$store_settings = $this->get_store_settings();
 			$postcode = $store_settings['postcode'];
 			$city = strtoupper( $store_settings['city'] );
 			$street = $store_settings['street'];

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -419,7 +419,9 @@ class WC_Connect_TaxJar_Integration {
 		} else { // Recalculate tax for Woo 2.6 to apply new tax rates
 			if ( class_exists( 'WC_AJAX' ) ) {
 				remove_action( 'woocommerce_before_save_order_items', array( $this, 'calculate_backend_totals' ), 20 );
-				WC_AJAX::calc_line_taxes();
+				if ( check_ajax_referer( 'calc-totals', 'security', false ) ) {
+					WC_AJAX::calc_line_taxes();
+				}
 				add_action( 'woocommerce_before_save_order_items', array( $this, 'calculate_backend_totals' ), 20 );
 			}
 		}

--- a/client/new-order-taxjar.js
+++ b/client/new-order-taxjar.js
@@ -1,0 +1,29 @@
+/*global woocommerce_admin_meta_boxes */
+/**
+ * External dependencies
+ */
+import jQuery from 'jquery';
+
+jQuery( document ).ready( function() {
+	/*
+	* JavaScript for WooCommerce new order page
+	*/
+	const TaxJarOrder = function( $ ){ // eslint-disable-line no-unused-vars
+		$( document ).ajaxSend( function( event, request, settings ) {
+			if ( settings.data ) {
+				const data = JSON.parse( '{"' + decodeURIComponent( settings.data.replace( /&/g, '","' ).replace( /=/g, '":"' ) ) + '"}' );
+ 				if ( 'woocommerce_calc_line_taxes' === data.action ) {
+					let street = '';
+ 					if ( 'shipping' === woocommerce_admin_meta_boxes.tax_based_on ) {
+						street = $( '#_shipping_address_1' ).val();
+					}
+ 					if ( 'billing' === woocommerce_admin_meta_boxes.tax_based_on ) {
+						street = $( '#_billing_address_1' ).val();
+					}
+ 					data.street = street;
+					settings.data = $.param( data );
+				}
+			}
+		} );
+	}( jQuery );
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,7 @@ const config = {
 		'woocommerce-services': [ './client/main.js' ],
 		'woocommerce-services-banner': [ './client/banner.js' ],
 		'woocommerce-services-admin-pointers': [ './client/admin-pointers.js' ],
+		'woocommerce-services-new-order-taxjar': [ './client/new-order-taxjar.js' ],
 	},
 	output: {
 		path: path.join( __dirname, 'dist' ),

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -597,7 +597,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$tracks                = new WC_Connect_Tracks( $logger, __FILE__ );
 			$shipping_label        = new WC_Connect_Shipping_Label( $api_client, $settings_store, $schemas_store );
 			$nux                   = new WC_Connect_Nux( $tracks, $shipping_label );
-			$taxjar                = new WC_Connect_TaxJar_Integration( $api_client, $taxes_logger );
+			$taxjar                = new WC_Connect_TaxJar_Integration( $api_client, $taxes_logger, $this->wc_connect_base_url );
 			$options               = new WC_Connect_Options();
 			$stripe                = new WC_Connect_Stripe( $api_client, $options, $payments_logger );
 			$paypal_ec             = new WC_Connect_PayPal_EC( $api_client, $nux );


### PR DESCRIPTION
* 3fc5821 contains taxjar/taxjar-woocommerce-plugin@a06281a - need to verify the diff to test, the change was simple to port
* 8786ec9 contains taxjar/taxjar-woocommerce-plugin@a92e8a7 - another simple change where diff compare should be enough
* 63b28e6 contains taxjar/taxjar-woocommerce-plugin@aee517d - fixes #1471 - note that this contains a bug that was fixed in the next commit (see below)
* 84b7f4a contains taxjar/taxjar-woocommerce-plugin@5e22378 - should expose the native rate tables, mostly deletes code. Using native rate tables the users will be able to handle the cases like Australia import tax law. Fixes #1456
* 8e15894 fixes an error where an infinite loop would occur because a wrong hook was being removed. This error might have already been affecting the WC2.6 users
*  c869e61 contains taxjar/taxjar-woocommerce-plugin@a9a3d1e - street level accuracy