### PR TITLE
Do not log invalid tax to_zip errors and show them to the customer

### DIFF
--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -300,7 +300,10 @@ class WC_Connect_TaxJar_Integration {
 			} else {
 				$message = sprintf( _x( 'Invalid %s entered.', '%s - Postcode/Zip checkout field label', 'woocommerce-services' ), $postcode_field_name );
 			}
-			wc_add_notice( $message, 'error' );
+
+			if ( ! wc_has_notice( $message, 'error' ) ) {
+				wc_add_notice( $message, 'error' );
+			}
 
 			return;
 		}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -286,8 +286,8 @@ class WC_Connect_TaxJar_Integration {
 		$formatted_message = is_scalar( $message ) ? $message : json_encode( $message );
 
 		//ignore error messages caused by customer input
-		$state_zip_mismatch = 1 === preg_match( '/to_zip [^"}]* is not used within to_state/', $formatted_message );
-		$invalid_postcode = 1 === preg_match( '/isn\'t a valid postal code for/', $formatted_message );
+		$state_zip_mismatch = false !== strpos( $formatted_message, 'to_zip' ) && false !== strpos( $formatted_message, 'is not used within to_state' );
+		$invalid_postcode = false !== strpos( $formatted_message, 'isn\'t a valid postal code for' );
 		if ( $state_zip_mismatch || $invalid_postcode ) {
 			$fields = WC()->countries->get_address_fields();
 			$postcode_field_name = __( 'Postcode / ZIP', 'woocommerce-services' );

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -288,7 +288,7 @@ class WC_Connect_TaxJar_Integration {
 		//ignore error messages caused by customer input
 		$state_zip_mismatch = false !== strpos( $formatted_message, 'to_zip' ) && false !== strpos( $formatted_message, 'is not used within to_state' );
 		$invalid_postcode = false !== strpos( $formatted_message, 'isn\'t a valid postal code for' );
-		if ( $state_zip_mismatch || $invalid_postcode ) {
+		if ( ! is_admin() && ( $state_zip_mismatch || $invalid_postcode ) ) {
 			$fields = WC()->countries->get_address_fields();
 			$postcode_field_name = __( 'Postcode / ZIP', 'woocommerce-services' );
 			if ( isset( $fields['billing_postcode'] ) && isset( $fields['billing_postcode']['label'] ) ) {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -296,9 +296,9 @@ class WC_Connect_TaxJar_Integration {
 			}
 
 			if ( $state_zip_mismatch ) {
-				$message = sprintf( __( '%s does not match the selected state.', '%s - Postcode/Zip checkout field label', 'woocommerce-services' ), $postcode_field_name );
+				$message = sprintf( _x( '%s does not match the selected state.', '%s - Postcode/Zip checkout field label', 'woocommerce-services' ), $postcode_field_name );
 			} else {
-				$message = sprintf( __( 'Invalid %s entered.', '%s - Postcode/Zip checkout field label', 'woocommerce-services' ), $postcode_field_name );
+				$message = sprintf( _x( 'Invalid %s entered.', '%s - Postcode/Zip checkout field label', 'woocommerce-services' ), $postcode_field_name );
 			}
 			wc_add_notice( $message, 'error' );
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -285,6 +285,12 @@ class WC_Connect_TaxJar_Integration {
 	public function _error( $message ) {
 		$formatted_message = is_scalar( $message ) ? $message : json_encode( $message );
 
+		//ignore error messages caused by customer input
+		if ( 1 === preg_match( '/to_zip .* is not used within to_state/', $formatted_message ) ) {
+			wc_add_notice( __( 'ZIP does not match the selected state.', 'woocommerce-services' ), 'error' );
+			return;
+		}
+
 		$this->logger->error( $formatted_message, 'WCS Tax' );
 	}
 


### PR DESCRIPTION
Fixes #1427 

To test:
* Enable automated taxes
* Make sure the "An error occurred in WooCommerce Services" notice is closed in wp-admin
* On checkout, enter a mismatching zip/state combination
* A notice should appear on the checkout page (see below) and proceeding with the checkout should not be possible
* No notice should appear in wp-admin and no error should be logged in the tax logs on the status page

<img width="820" alt="screen shot 2018-08-24 at 13 14 15" src="https://user-images.githubusercontent.com/800604/44584096-bd28b380-a79f-11e8-95b9-40e3709d9226.png">
