### PR TITLE
Fix jQuery pointer errors when opening the label modal

### DIFF
--- a/client/apps/shipping-label/redux-middleware.js
+++ b/client/apps/shipping-label/redux-middleware.js
@@ -20,7 +20,10 @@ const middlewareActions = {
 	},
 	[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW ]: () => {
 		//dismiss the nux pointer if the user opens the printing flow
-		jQuery( '#woocommerce-order-label' ).pointer( 'close' );
+		const labelMetabox = jQuery( '#woocommerce-order-label' );
+		if ( labelMetabox.pointer ) {
+			labelMetabox.pointer().pointer( 'close' );
+		}
 	},
 };
 


### PR DESCRIPTION
Fixes a console error appearing in the console when opening the label modal after the pointers have been dismissed and the page has been refreshed.

There are two kinds of errors:
`Uncaught TypeError: (0 , _jquery2.default)(...).pointer is not a function`
`Uncaught Error: cannot call methods on pointer prior to initialization; attempted to call method 'close'`

To test:
* open a label modal
* verify that there are no errors being logged in the JS console