### PR TITLE
Pass Stripe account details for prefilling activation form

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -299,8 +299,24 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		public function get_stripe_oauth_init( $return_url ) {
+			$address = $this->wc_connect_loader->get_service_settings_store()->get_origin_address();
+			$current_user = wp_get_current_user();
+
 			$request = array(
 				'returnUrl' => $return_url,
+				'businessData' => array(
+					'url' => get_site_url(),
+					'country' => $address['country'],
+					'phone' => $address['phone'],
+					'business_name' => $address['company'],
+					'first_name' => $current_user->user_firstname,
+					'last_name' => $current_user->user_lastname,
+					'street_address' => $address['address'],
+					'city' => $address['city'],
+					'state' => $address['state'],
+					'zip' => $address['postcode'],
+					'currency' => get_woocommerce_currency(),
+				),
 			);
 			return $this->request( 'POST', '/stripe/oauth-init', $request );
 		}


### PR DESCRIPTION
Requires server support (in staging, not yet in production).

If the Stripe account being connected via OAuth is not yet activated with complete account details, Stripe presents a form as part of the flow [[screenshot](https://cloudup.com/cKL_B_-m3eM)].

This change passes info to include in the OAuth URL for prefilling the Stripe activation form.