### PR TITLE
Automatically select credit card if just one is available

### DIFF
--- a/classes/class-wc-connect-payment-methods-store.php
+++ b/classes/class-wc-connect-payment-methods-store.php
@@ -72,12 +72,9 @@ if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 				return;
 			}
 
-			// Has the stored method ID been removed? Select the first available one
+			// Is there no stored method that's in the list? Select the first available one
 			$selected_payment_method_id = $this->service_settings_store->get_selected_payment_method_id();
-			if (
-				$selected_payment_method_id &&
-				! in_array( $selected_payment_method_id, $payment_method_ids )
-			) {
+			if ( ! in_array( $selected_payment_method_id, $payment_method_ids ) ) {
 				$this->service_settings_store->set_selected_payment_method_id( $payment_method_ids[ 0 ] );
 			}
 		}

--- a/classes/class-wc-connect-payment-methods-store.php
+++ b/classes/class-wc-connect-payment-methods-store.php
@@ -72,9 +72,12 @@ if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 				return;
 			}
 
-			// Is there no stored method that's in the list? Select the first available one
+			// Has the stored method ID been removed, or is there only one available? Select the first available one
 			$selected_payment_method_id = $this->service_settings_store->get_selected_payment_method_id();
-			if ( ! in_array( $selected_payment_method_id, $payment_method_ids ) ) {
+			if (
+				( $selected_payment_method_id || 1 === count( $payment_method_ids ) ) &&
+				! in_array( $selected_payment_method_id, $payment_method_ids )
+			) {
 				$this->service_settings_store->set_selected_payment_method_id( $payment_method_ids[ 0 ] );
 			}
 		}


### PR DESCRIPTION
Context: the first available credit card was automatically selected...
- ...if there wasn't a selected card that was still available, as of https://github.com/Automattic/woocommerce-services/pull/488
- ...only if a previously selected card is no longer available, as of https://github.com/Automattic/woocommerce-services/pull/1076

This PR reverts the primary change in https://github.com/Automattic/woocommerce-services/pull/1076 – again automatically selecting a card so there are never available cards with none selected – as it is unnecessary for fixing the main issue in https://github.com/Automattic/woocommerce-services/issues/1073. _Edit:_ **now only does so there's just one card available.**

(I see now that @v18 was mentioned in that issue as the source for "we need the user to confirm that they want to use the credit card on file", so CC in case there's a reason not to do this that's being overlooked.)

<s>Addresses https://github.com/Automattic/woocommerce-services/issues/1315 (at its root)</s> _edit:_ there's more to do there.
Addresses https://github.com/Automattic/wp-calypso/pull/22504#issuecomment-369946283