### PR TITLE
Add Stripe OAuth connect action into settings

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -6,7 +6,6 @@
 // stylesheet order does not matter.
 // ==========================================================================
 
-@import 'components/action-card/style';
 @import 'components/button/style';
 @import 'components/button-group/style';
 @import 'components/card/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -6,6 +6,7 @@
 // stylesheet order does not matter.
 // ==========================================================================
 
+@import 'components/action-card/style';
 @import 'components/button/style';
 @import 'components/button-group/style';
 @import 'components/card/style';

--- a/classes/class-wc-connect-stripe.php
+++ b/classes/class-wc-connect-stripe.php
@@ -187,9 +187,21 @@ if ( ! class_exists( 'WC_Connect_Stripe' ) ) {
 		}
 
 		/**
-		 * Trigger Stripe connection-related admin notice if one is meant to be shown.
+		 * Handle connection and just-in-time messaging around OAuth flow.
 		 */
 		public function maybe_show_notice() {
+			// Handle redirect back from OAuth flow.
+			if ( isset( $_GET[ 'wcs_stripe_code' ] ) && isset( $_GET[ 'wcs_stripe_state' ] ) ) {
+				$response = $this->connect_oauth( $_GET[ 'wcs_stripe_state' ], $_GET[ 'wcs_stripe_code' ] );
+				if ( ! is_wp_error( $response ) ) {
+					WC_Connect_Options::update_option( 'banner_stripe', 'success' );
+				}
+
+				wp_safe_redirect( remove_query_arg( array( 'wcs_stripe_state', 'wcs_stripe_code' ) ) );
+				exit;
+			}
+
+			// Trigger connection-related admin notice if triggered and if on relevant screen.
 			$setting = WC_Connect_Options::get_option( 'banner_stripe', null );
 			if ( is_null( $setting ) ) {
 				return;
@@ -199,16 +211,6 @@ if ( ! class_exists( 'WC_Connect_Stripe' ) ) {
 				add_action( 'admin_notices', array( $this, 'connection_success_notice' ) );
 				WC_Connect_Options::delete_option( 'banner_stripe' );
 				return;
-			}
-
-			if ( isset( $_GET[ 'wcs_stripe_code' ] ) && isset( $_GET[ 'wcs_stripe_state' ] ) ) {
-				$response = $this->connect_oauth( $_GET[ 'wcs_stripe_state' ], $_GET[ 'wcs_stripe_code' ] );
-				if ( ! is_wp_error( $response ) ) {
-					WC_Connect_Options::update_option( 'banner_stripe', 'success' );
-				}
-
-				wp_safe_redirect( remove_query_arg( array( 'wcs_stripe_state', 'wcs_stripe_code' ) ) );
-				exit;
 			}
 
 			$screen = get_current_screen();

--- a/classes/class-wc-rest-connect-stripe-oauth-init-controller.php
+++ b/classes/class-wc-rest-connect-stripe-oauth-init-controller.php
@@ -19,7 +19,7 @@ class WC_REST_Connect_Stripe_Oauth_Init_Controller extends WC_REST_Connect_Base_
 
 	public function post( $request ) {
 		$data = $request->get_json_params();
-		$response = $this->stripe->get_oauth_url( $data['returnUrl'] );
+		$response = $this->stripe->get_oauth_url( isset( $data['returnUrl'] ) ? $data['returnUrl'] : '' );
 
 		if ( is_wp_error( $response ) ) {
 			$this->logger->log( $response, __CLASS__ );

--- a/client/apps/stripe-connect-account/style.scss
+++ b/client/apps/stripe-connect-account/style.scss
@@ -4,7 +4,6 @@
 	}
 
 	.stripe__connect-account-body {
-		max-width: 545px;
 		border: 1px solid #ccc;
 		line-height: 1.5;
 	}
@@ -27,4 +26,8 @@
 		@extend .stripe__connect-account-body;
 		@include placeholder();
 	}
+}
+
+&.wc-connect-stripe-connect-account {
+	max-width: 545px;
 }

--- a/client/apps/stripe-connect-account/view-wrapper.js
+++ b/client/apps/stripe-connect-account/view-wrapper.js
@@ -12,7 +12,6 @@ import { reloadPage } from './state/actions';
 // from calypso
 import StripeConnectAccount from 'woocommerce/app/settings/payments/stripe/payment-method-stripe-connect-account';
 import Notice from 'components/notice';
-import ActionCard from 'components/action-card';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	getIsRequesting,
@@ -74,15 +73,9 @@ class StripeConnectAccountWrapper extends Component {
 		if ( oauthURL ) {
 			return (
 				<div className="stripe-connect-account__connect-action">
-					<ActionCard
-						headerText={ translate( 'Connect your account' ) }
-						mainText={ translate( 'To start accepting payments with Stripe, you\'ll need to connect it to your store.' ) }
-						buttonText={ translate( 'Connect' ) }
-						buttonIcon="external"
-						buttonPrimary={ true }
-						buttonHref={ oauthURL }
-						buttonOnClick={ null }
-					/>
+					{ translate( 'To automatically copy keys from a Stripe account, {{a}}connect{{/a}} it to your store.', {
+						components: { a: <a href={ oauthURL } /> },
+					} ) }
 				</div>
 			);
 		}

--- a/client/apps/stripe-connect-account/view-wrapper.js
+++ b/client/apps/stripe-connect-account/view-wrapper.js
@@ -12,21 +12,32 @@ import { reloadPage } from './state/actions';
 // from calypso
 import StripeConnectAccount from 'woocommerce/app/settings/payments/stripe/payment-method-stripe-connect-account';
 import Notice from 'components/notice';
+import ActionCard from 'components/action-card';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	getIsRequesting,
 	getStripeConnectAccount,
 	getIsDeauthorizing,
+	getIsOAuthInitializing,
+	getOAuthURL,
 } from 'woocommerce/state/sites/settings/stripe-connect-account/selectors';
 import {
 	fetchAccountDetails,
 	deauthorizeAccount,
+	oauthInit,
 } from 'woocommerce/state/sites/settings/stripe-connect-account/actions';
 
 class StripeConnectAccountWrapper extends Component {
 	componentDidMount() {
 		const { siteId } = this.props;
 		this.props.fetchAccountDetails( siteId );
+	}
+
+	componentDidUpdate( prevProps ) {
+		const { siteId, isLoading, connectedUserID, oauthURL } = this.props;
+		if ( ! isLoading && prevProps.isLoading && ! connectedUserID && ! oauthURL ) {
+			this.props.oauthInit( siteId );
+		}
 	}
 
 	onDeauthorize = () => {
@@ -36,14 +47,15 @@ class StripeConnectAccountWrapper extends Component {
 
 	render() {
 		const {
-			isRequesting,
+			isLoading,
 			stripeConnectAccount,
 			isDeauthorizing,
 			isReloading,
+			oauthURL,
 			translate,
 		} = this.props;
 
-		if ( isRequesting ) {
+		if ( isLoading ) {
 			return (
 				<div className="stripe-connect-account__placeholder-container">
 					<div className="stripe-connect-account__placeholder-body" />
@@ -59,8 +71,20 @@ class StripeConnectAccountWrapper extends Component {
 			);
 		}
 
-		if ( ! stripeConnectAccount.connectedUserID ) {
-			return translate( 'No account connected via WooCommerce Services. Stripe account keys may be configured below.' );
+		if ( oauthURL ) {
+			return (
+				<div className="stripe-connect-account__connect-action">
+					<ActionCard
+						headerText={ translate( 'Connect your account' ) }
+						mainText={ translate( 'To start accepting payments with Stripe, you\'ll need to connect it to your store.' ) }
+						buttonText={ translate( 'Connect' ) }
+						buttonIcon="external"
+						buttonPrimary={ true }
+						buttonHref={ oauthURL }
+						buttonOnClick={ null }
+					/>
+				</div>
+			);
 		}
 
 		return (
@@ -76,12 +100,16 @@ class StripeConnectAccountWrapper extends Component {
 export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
+		const stripeConnectAccount = getStripeConnectAccount( state, siteId );
+
 		return {
 			siteId,
-			isRequesting: getIsRequesting( state, siteId ),
-			stripeConnectAccount: getStripeConnectAccount( state, siteId ),
+			isLoading: getIsRequesting( state, siteId ) || getIsOAuthInitializing( state, siteId ),
+			stripeConnectAccount,
+			connectedUserID: stripeConnectAccount.connectedUserID,
 			isDeauthorizing: getIsDeauthorizing( state, siteId ),
 			isReloading: state.isReloading,
+			oauthURL: getOAuthURL( state, siteId ),
 		};
 	},
 	dispatch => ( {
@@ -91,5 +119,6 @@ export default connect(
 				dispatch( reloadPage );
 			} );
 		},
+		oauthInit: ( siteId ) => dispatch( oauthInit( siteId ) ),
 	} ),
 )( localize( StripeConnectAccountWrapper ) );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/1500

_Edit:_ <s>Fixes https://github.com/Automattic/woocommerce-services/issues/1526</s> (already fixed by https://github.com/Automattic/woocommerce-services/pull/1547)

Closes the loop for the "Connected Stripe account" section of the Stripe settings (added by WooCommerce Services) by adding an entry point for the merchant to connect their account into the Stripe settings, when no account is connected – replacing the "No account connected via WooCommerce Services" notice:

<img width="777" alt="screen shot 2018-10-13 at 2 17 39 pm" src="https://user-images.githubusercontent.com/1867547/46961213-46f15080-d06e-11e8-8216-e6097e6d2e28.png">

(The only existing ways to enter the OAuth flow and connect an account are a) via Calypso and b) via the wp-admin NUX banner that shows up after completing the OBW when a Stripe account already exists at the provided email.)

To test:
- With WooCommerce Services enabled, go to WooCommerce » Settings » Payments » Stripe, and see the "Connected Stripe account" section near the top
  - If a Stripe account is already connected, disconnect it
- Verify that a card with a "Connect" action appears
- Click "Connect" and complete the OAuth connection flow
- Verify that the connected account view appears, and that API keys are filled
- Disconnect the account
- Verify that the "Connect your account" action card appears again after auto-refresh

Concerns:
- Do we want a "create account" action here as well, using our deferred account creation mechanism? The OAuth connection provides for creating an account on the spot, but demands much much information from the merchant upfront.
- The copy is taken from the banner. Does it work here, or is it a bit out of step with the description at the top of the settings? Should it depend on whether keys are already filled? Maybe it should at least say "you can" (not "you'll need to") connect your account?