### PR TITLE
Fix lodash exporting _ as a global variable

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -92,6 +92,9 @@ module.exports = {
 	module: {
 		rules: [
 			{
+				parser: { amd: false },
+			},
+			{
 				test: /\.jsx?$/,
 				enforce: 'pre',
 				use: {


### PR DESCRIPTION
With the recent changes to webpack, lodash started setting `window._` and overwriting the Underscore variable that is expected by JavaScript files from WP core and other plugins. This causes things to break in wp-admin. 

The issue that was reported the most was missing shipping methods UI when both WCS and Stripe extensions are activated.

The fix is to not import the modules as AMD - see [here](https://github.com/lodash/lodash/issues/1798) and [here](https://github.com/webpack/webpack/issues/3017#issuecomment-285954512).

We don't use AMD - Webpack compiles all scripts into one file and nothing is loaded asynchronously.