### PR TITLE
Prevent Stripe from attempting to connect if the site is not using ssl

### DIFF
--- a/classes/class-wc-connect-stripe.php
+++ b/classes/class-wc-connect-stripe.php
@@ -237,7 +237,10 @@ if ( ! class_exists( 'WC_Connect_Stripe' ) ) {
 			$result = $this->get_oauth_url();
 
 			if ( is_wp_error( $result ) ) {
-				$this->logger->log( $result, __CLASS__ );
+				//do not log the invalid url protocol error when attempting to render the banner
+				if ( 'invalid_url_protocol' !== $result->get_error_code() ) {
+					$this->logger->log( $result, __CLASS__ );
+				}
 				return;
 			}
 

--- a/classes/class-wc-connect-stripe.php
+++ b/classes/class-wc-connect-stripe.php
@@ -46,6 +46,11 @@ if ( ! class_exists( 'WC_Connect_Stripe' ) ) {
 			if ( empty( $return_url ) ) {
 				$return_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe' );
 			}
+
+			if ( substr( $return_url, 0, 8 ) !== 'https://' ) {
+				return new WP_Error( 'invalid_url_protocol', __( 'Your site requires SSL in order to connect your Stripe account via WooCommerce Services', 'woocommerce-services' ) );
+			}
+
 			$result = $this->api->get_stripe_oauth_init( $return_url );
 
 			if ( is_wp_error( $result ) ) {

--- a/classes/class-wc-connect-stripe.php
+++ b/classes/class-wc-connect-stripe.php
@@ -48,7 +48,7 @@ if ( ! class_exists( 'WC_Connect_Stripe' ) ) {
 			}
 
 			if ( substr( $return_url, 0, 8 ) !== 'https://' ) {
-				return new WP_Error( 'invalid_url_protocol', __( 'Your site requires SSL in order to connect your Stripe account via WooCommerce Services', 'woocommerce-services' ) );
+				return new WP_Error( 'invalid_url_protocol', __( 'Your site must be served over HTTPS in order to connect your Stripe account via WooCommerce Services', 'woocommerce-services' ) );
 			}
 
 			$result = $this->api->get_stripe_oauth_init( $return_url );


### PR DESCRIPTION
See server PR 1165 for extra detail

Currently, if the site is not using SSL in the admin url the plugin will try to connect to the server to generate the OAuth url and fail every time.

This prevents the site from attempting to connect in the first place, reducing the traffic and increasing performance.