### PR TITLE
Fix crash when making proxy requests with broken Jetpack token

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -455,7 +455,12 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			$proxy_url = trailingslashit( WOOCOMMERCE_CONNECT_SERVER_URL );
 			$proxy_url .= ltrim( $path, '/' );
 
-			$args['headers']['Authorization'] = $this->authorization_header();
+			$authorization = $this->authorization_header();
+			if ( is_wp_error( $authorization ) ) {
+				return $authorization;
+			}
+			$args['headers']['Authorization'] = $authorization;
+
 
 			$http_timeout = 60; // 1 minute
 


### PR DESCRIPTION
Fixes #1529 

To test:
* The easiest way to simulate Jetpack token problems is to return new `WP_Error` in `class-wc-connect-api-client.php` around line `538`. You can also delete `jetpack_private_options` from `wp_options`, but that might have unintended side effects.
* Enable automated taxes and navigate to the cart page
* The page should load properly