### PR TITLE
Remove shipping service status for non-grandfathered sites

### DIFF
--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -161,6 +161,11 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 		}
 
 		protected function get_services_items() {
+			$available_service_method_ids = $this->service_schemas_store->get_all_shipping_method_ids();
+			if ( empty( $available_service_method_ids ) ) {
+				return false;
+			}
+
 			$service_items = array();
 
 			$enabled_services = $this->service_settings_store->get_enabled_services();

--- a/client/apps/plugin-status/services.js
+++ b/client/apps/plugin-status/services.js
@@ -13,6 +13,10 @@ import Indicator from './indicator';
 import SettingsGroupCard from 'woocommerce/woocommerce-services/components/settings-group-card';
 
 const ServicesStatusView = ( { translate, moment, services } ) => {
+	if ( false === services ) {
+		return null;
+	}
+
 	const renderDescription = ( { timestamp, url } ) => {
 		if ( timestamp > 0 ) {
 			return (


### PR DESCRIPTION
When live rates are disabled for the site, the status page will still show the Services section with a link to the shipping settings:
![screen shot 2018-10-31 at 14 27 45](https://user-images.githubusercontent.com/800604/47849548-f5fd8e00-ddc9-11e8-9fa1-441c538c4708.png)

This PR removes the section unless the site is grandfathered.

Test steps:
* Confirm that the status page renders the section when the site is not grandfathered
* In the server database mark your site as not grandfathered
* Confirm that the section is not rendered