### PR TITLE
Removing the background of borderless buttons in hover state

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -41,6 +41,10 @@
 			background-image: linear-gradient( -45deg, $blue-medium 28%, darken( $blue-medium, 5% ) 28%, darken( $blue-medium, 5% ) 72%, $blue-medium 72%) !important;
 			border-color: #0081a9 !important;
 		}
+
+		&.is-borderless {
+			background: none;
+		}
 	}
 
 	input[type=checkbox]:checked:before {


### PR DESCRIPTION
Adding an additional selector in order to restore the default Calypso behavior.

__Broken state:__
![broken](https://user-images.githubusercontent.com/5311119/48782531-b0542700-ecde-11e8-915c-1e7032ae70b8.png)

__Proper state:__
![proper](https://user-images.githubusercontent.com/5311119/48782578-cb269b80-ecde-11e8-8cbc-b6f33cc2a255.png)
