### PR TITLE
Fix: Add priority to 'shipping_phone' checkout field

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1229,6 +1229,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				'clear'        => true,
 				'validate'     => array( 'phone' ),
 				'autocomplete' => 'tel',
+				'priority'     => 80,
 			);
 			return $fields;
 		}


### PR DESCRIPTION
My dev site is showing many notices in the WooCommerce checkout page:
`Notice: Undefined index: priority in [..]/plugins/woocommerce/includes/wc-core-functions.php on line 1535`

By tracing down the issue I found that this plugin didn't specify a priority for the `shipping_phone` field it adds to the shipping form in the `add_shipping_phone_to_checkout`.  This causes PHP notices when WooCommerce tries to compare the fields priority indexes.

This PR add the priority key to the field, killing the warnings.