### PR TITLE
Update calypso dependency to catch the update to `npm-run-all`.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-services",
-  "version": "1.16.1",
+  "version": "1.17.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -66,11 +66,11 @@
       }
     },
     "@babel/generator": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.3.tgz",
-      "integrity": "sha512-ZoCZGcfIJFJuZBqxcY9OjC1KW2lWK64qrX1o4UYL3yshVhwKFYgzpWZ0vvtGMNJdTlvkw0W+HR1VnYN8q3QPFQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.6.tgz",
+      "integrity": "sha512-brwPBtVvdYdGxtenbQgfCdDPmtkmUBZPjUoK5SXJEBuHaA5BCubh9ly65fzXz7R6o5rA76Rs22ES8Z+HCc0YIQ==",
       "requires": {
-        "@babel/types": "^7.1.3",
+        "@babel/types": "^7.1.6",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.10",
         "source-map": "^0.5.0",
@@ -260,13 +260,13 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.2.tgz",
-      "integrity": "sha512-Myc3pUE8eswD73aWcartxB16K6CGmHDv9KxOmD2CeOs/FaEAQodr3VYGmlvOmog60vNQ2w8QbatuahepZwrHiA==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.5.tgz",
+      "integrity": "sha512-2jkcdL02ywNBry1YNFAH/fViq4fXG0vdckHqeJk+75fpQ2OH+Az6076tX/M0835zA45E0Cqa6pV5Kiv9YOqjEg==",
       "requires": {
         "@babel/template": "^7.1.2",
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.1.2"
+        "@babel/traverse": "^7.1.5",
+        "@babel/types": "^7.1.5"
       }
     },
     "@babel/highlight": {
@@ -280,9 +280,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.3.tgz",
-      "integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w=="
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.6.tgz",
+      "integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.1.0",
@@ -461,9 +461,9 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0.tgz",
-      "integrity": "sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.1.5.tgz",
+      "integrity": "sha512-jlYcDrz+5ayWC7mxgpn1Wj8zj0mmjCT2w0mPIMSwO926eXBRxpEgoN/uQVRBfjtr8ayjcmS+xk2G1jaP8JjMJQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "lodash": "^4.17.10"
@@ -625,9 +625,9 @@
       }
     },
     "@babel/plugin-transform-react-jsx": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0.tgz",
-      "integrity": "sha512-0TMP21hXsSUjIQJmu/r7RiVxeFrXRcMUigbKu0BLegJK9PkYodHstaszcig7zxXfaBji2LYUdtqIkHs+hgYkJQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.1.6.tgz",
+      "integrity": "sha512-iU/IUlPEYDRwuqLwqVobzPAZkBOQoZ9xRTBmj6ANuk5g/Egn/zdNGnXlSoKeNmKoYVeIRxx5GZhWmMhLik8dag==",
       "requires": {
         "@babel/helper-builder-react-jsx": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -818,25 +818,25 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.4.tgz",
-      "integrity": "sha512-my9mdrAIGdDiSVBuMjpn/oXYpva0/EZwWL3sm3Wcy/AVWO2eXnsoZruOT9jOGNRXU8KbCIu5zsKnXcAJ6PcV6Q==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.6.tgz",
+      "integrity": "sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.1.3",
+        "@babel/generator": "^7.1.6",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/parser": "^7.1.3",
-        "@babel/types": "^7.1.3",
-        "debug": "^3.1.0",
+        "@babel/parser": "^7.1.6",
+        "@babel/types": "^7.1.6",
+        "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.10"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -849,9 +849,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.3.tgz",
-      "integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.6.tgz",
+      "integrity": "sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==",
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.10",
@@ -1042,9 +1042,9 @@
       }
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
+      "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg=="
     },
     "acorn-dynamic-import": {
       "version": "3.0.0",
@@ -1052,20 +1052,24 @@
       "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
       "requires": {
         "acorn": "^5.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+        }
       }
     },
     "acorn-jsx": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
-      "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
-      "requires": {
-        "acorn": "^5.0.3"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg=="
     },
     "ajv": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
-      "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
+      "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1095,7 +1099,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
     },
     "ansi-html": {
@@ -1132,7 +1136,7 @@
     },
     "archiver": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
       "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
       "dev": true,
       "requires": {
@@ -1250,11 +1254,6 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-    },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -1293,7 +1292,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "requires": {
             "inherits": "2.0.1"
@@ -1687,9 +1686,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
     },
     "bn.js": {
       "version": "4.11.8",
@@ -1848,13 +1847,13 @@
       }
     },
     "browserslist": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.2.tgz",
-      "integrity": "sha512-wgZJWlYcDvsjRtf8socmAHf1nXq88KrQLB/gMYHGPUc2bzPWsgltSXwPWYHx4Sw0G9E/XGNW5wJDaWlpHRMpjA==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
+      "integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
       "requires": {
-        "caniuse-lite": "^1.0.30000898",
-        "electron-to-chromium": "^1.3.80",
-        "node-releases": "^1.0.0-alpha.14"
+        "caniuse-lite": "^1.0.30000899",
+        "electron-to-chromium": "^1.3.82",
+        "node-releases": "^1.0.1"
       }
     },
     "buffer": {
@@ -1926,9 +1925,9 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "cacache": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.2.0.tgz",
-      "integrity": "sha512-IFWl6lfK6wSeYCHUXh+N1lY72UDrpyrYQJNIVQf48paDuWbv5RbAtJYf/4gUQFObTCHZwdZ5sI8Iw7nqwP6nlQ==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.1.tgz",
+      "integrity": "sha512-2PEw4cRRDu+iQvBTTuttQifacYjLPhET+SYO/gEFMy8uhi+jlJREDAjSF5FWSdV/Aw5h18caHA7vMTw2c+wDzA==",
       "requires": {
         "bluebird": "^3.5.1",
         "chownr": "^1.0.1",
@@ -1979,7 +1978,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
     },
     "camel-case": {
@@ -2006,14 +2005,14 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000898",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000898.tgz",
-      "integrity": "sha512-i8WfgaYakyxHs5kmITs/XHjrdm7QsuuFmI5cE43I0pJ0NIJpe52t2Rz6mliG8yyu1NMXjNceC7udWdiQuA5hUA=="
+      "version": "1.0.30000912",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000912.tgz",
+      "integrity": "sha512-uiepPdHcJ06Na9t15L5l+pp3NWQU4IETbmleghD6tqCqbIYqhHSu7nVfbK2gqPjfy+9jl/wHF1UQlyTszh9tJQ=="
     },
     "caniuse-lite": {
-      "version": "1.0.30000898",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000898.tgz",
-      "integrity": "sha512-ytlTZqO4hYe4rNAJhMynUAIUI33jsP2Bb1two/9OVC39wZjPZ8exIO0eCLw5mqAtegOGiGF0kkTWTn3B02L+mw=="
+      "version": "1.0.30000912",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000912.tgz",
+      "integrity": "sha512-M3zAtV36U+xw5mMROlTXpAHClmPAor6GPKAMD5Yi7glCB5sbMPFtnQ3rGpk4XqPdUrrTIaVYSJZxREZWNy8QJg=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -2181,11 +2180,6 @@
         "kind-of": "^6.0.0",
         "shallow-clone": "^1.0.0"
       }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -2568,9 +2562,9 @@
       }
     },
     "css-selector-tokenizer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
-      "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
+      "integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
       "requires": {
         "cssesc": "^0.1.0",
         "fastparse": "^1.1.1",
@@ -2579,7 +2573,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         },
         "regexpu-core": {
@@ -2594,12 +2588,12 @@
         },
         "regjsgen": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
           "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
         },
         "regjsparser": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+          "resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
           "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
           "requires": {
             "jsesc": "~0.5.0"
@@ -2731,37 +2725,16 @@
       }
     },
     "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+      "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "requires": {
-        "globby": "^5.0.0",
+        "globby": "^6.1.0",
         "is-path-cwd": "^1.0.0",
         "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
+        "p-map": "^1.1.1",
+        "pify": "^3.0.0",
         "rimraf": "^2.2.8"
-      },
-      "dependencies": {
-        "globby": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-          "requires": {
-            "array-union": "^1.0.1",
-            "arrify": "^1.0.0",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        }
       }
     },
     "delayed-stream": {
@@ -2874,9 +2847,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.81",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.81.tgz",
-      "integrity": "sha512-+rym2xtzwPWmoi8AYRrCdW65QOT0vfUHjZb5mjgh0VLyj31pGM3CpP3znKhQNBzQaWujR/KEl/mfC2lnKYgADA=="
+      "version": "1.3.85",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.85.tgz",
+      "integrity": "sha512-kWSDVVF9t3mft2OHVZy4K85X2beP6c6mFm3teFS/mLSDJpQwuFIWHrULCX+w6H1E55ZYmFRlT+ATAFRwhrYzsw=="
     },
     "elliptic": {
       "version": "6.4.1",
@@ -3173,7 +3146,7 @@
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "requires": {
             "esutils": "^2.0.2",
@@ -3253,12 +3226,13 @@
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
     },
     "espree": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-4.0.0.tgz",
-      "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
+      "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
       "requires": {
-        "acorn": "^5.6.0",
-        "acorn-jsx": "^4.1.1"
+        "acorn": "^6.0.2",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
       }
     },
     "esprima": {
@@ -3400,7 +3374,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.0.tgz",
           "integrity": "sha1-D+llA6yGpa213mP05BKuSHLNvoY="
         }
       }
@@ -3568,9 +3542,9 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fastparse": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
-      "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ=="
     },
     "faye-websocket": {
       "version": "0.10.0",
@@ -3596,7 +3570,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         }
       }
@@ -3677,13 +3651,13 @@
       }
     },
     "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "requires": {
         "circular-json": "^0.3.1",
-        "del": "^2.0.2",
         "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
         "write": "^0.2.1"
       }
     },
@@ -3697,9 +3671,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
-      "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
         "debug": "=3.1.0"
       },
@@ -4368,7 +4342,7 @@
     },
     "gettext-parser": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/gettext-parser/-/gettext-parser-1.1.0.tgz",
       "integrity": "sha1-LFpmONiTk0ubVQN9CtgstwBLJnk=",
       "dev": true,
       "requires": {
@@ -4413,13 +4387,13 @@
       "integrity": "sha512-HchvMJNYh9dGSCy8pOQ2O8u/hoXaL+0XhnrwH0RyLiSXMMTl9W3N6KUU73+JFOg5PGjtzl6VZzUQsnrpm7Szag=="
     },
     "globals": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-      "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA=="
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
+      "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg=="
     },
     "globby": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "requires": {
         "array-union": "^1.0.1",
@@ -4447,9 +4421,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "gridicons": {
       "version": "2.1.3",
@@ -4461,7 +4435,7 @@
     },
     "handle-thing": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+      "resolved": "http://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
       "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
     },
     "har-schema": {
@@ -4470,35 +4444,12 @@
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
-        "ajv": "^5.3.0",
+        "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-        }
       }
     },
     "has": {
@@ -4586,9 +4537,9 @@
       }
     },
     "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -4601,9 +4552,12 @@
       }
     },
     "hoist-non-react-statics": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.2.0.tgz",
+      "integrity": "sha512-3IascCRfaEkbmHjJnUxWSspIUE1okLPjGTMVXW8zraUo1t3yg1BadKAxAGILHwgoBzmMnzrgeeaDGBvpuPz6dA==",
+      "requires": {
+        "react-is": "^16.3.2"
+      }
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -4639,14 +4593,14 @@
       }
     },
     "html-minifier": {
-      "version": "3.5.20",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.20.tgz",
-      "integrity": "sha512-ZmgNLaTp54+HFKkONyLFEfs5dd/ZOtlquKaTnqIWFmx3Av5zG6ZPcV2d0o9XM2fXOTxxIf6eDcwzFFotke/5zA==",
+      "version": "3.5.21",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
+      "integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
       "requires": {
         "camel-case": "3.0.x",
         "clean-css": "4.2.x",
         "commander": "2.17.x",
-        "he": "1.1.x",
+        "he": "1.2.x",
         "param-case": "2.1.x",
         "relateurl": "0.2.x",
         "uglify-js": "3.4.x"
@@ -5340,9 +5294,9 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsesc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -5613,12 +5567,12 @@
       }
     },
     "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.4.tgz",
+      "integrity": "sha512-EPstzZ23znHUVLKj+lcXO1KvZkrlw+ZirdwvOmnAnA/1PB4ggyXJ77LRkCqkff+ShQ+cqoxCxLQOh4cKITO5iA==",
       "requires": {
         "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "yallist": "^3.0.2"
       }
     },
     "make-dir": {
@@ -5635,9 +5589,9 @@
       "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA=="
     },
     "map-age-cleaner": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.2.tgz",
-      "integrity": "sha512-UN1dNocxQq44IhJyMI4TU8phc2m9BddacHRPRjKGLYaF0jqd3xLz0jS0skpAU9WgYyoR4gHtUpzytNBS385FWQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "requires": {
         "p-defer": "^1.0.0"
       }
@@ -5829,9 +5783,9 @@
       }
     },
     "mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
     },
     "mime-db": {
       "version": "1.37.0",
@@ -6123,9 +6077,9 @@
       }
     },
     "node-releases": {
-      "version": "1.0.0-alpha.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.14.tgz",
-      "integrity": "sha512-G8nnF9cP9QPP/jUmYWw/uUUhumHmkm+X/EarCugYFjYm2uXRMFeOD6CVT3RLdoyCvDUNy51nirGfUItKWs/S1g==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.4.tgz",
+      "integrity": "sha512-GqRV9GcHw8JCRDaP/JoeNMNzEGzHAknMvIHqMb2VeTOmg1Cf9+ej8bkV12tHfzWHQMCkQ5zUFgwFUkfraynNCw==",
       "requires": {
         "semver": "^5.3.0"
       }
@@ -6329,9 +6283,9 @@
       }
     },
     "object-hash": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.0.tgz",
-      "integrity": "sha512-05KzQ70lSeGSrZJQXE5wNDiTkBJDlUT/myi6RX9dVIvz7a7Qh4oH93BQdiPMn27nldYvVQCKMUaM83AfizZlsQ=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
+      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
     },
     "object-keys": {
       "version": "1.0.12",
@@ -6369,9 +6323,9 @@
       }
     },
     "objectpath": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/objectpath/-/objectpath-1.2.1.tgz",
-      "integrity": "sha1-yHQzvdNSrqAU5PnAtS1wpCZSBS4="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/objectpath/-/objectpath-1.2.2.tgz",
+      "integrity": "sha512-ie+GY5tJsKt7daHH6qGROf3JqxfD2XhfBPLY+HQrVuRY8MQE1ySKVSqQ/TQz/Dx7jDwuy3etQALDE1cRJAC0cg=="
     },
     "obuf": {
       "version": "1.1.2",
@@ -6443,7 +6397,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
@@ -6456,7 +6410,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
@@ -6589,7 +6543,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -6771,9 +6725,9 @@
       },
       "dependencies": {
         "postcss": {
-          "version": "7.0.5",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-          "integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.6.tgz",
+          "integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
           "requires": {
             "chalk": "^2.4.1",
             "source-map": "^0.6.1",
@@ -6788,9 +6742,9 @@
       }
     },
     "postcss-modules-extract-imports": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
-      "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
+      "integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
       "requires": {
         "postcss": "^6.0.1"
       },
@@ -6902,15 +6856,10 @@
         "xxhashjs": "^0.2.1"
       },
       "dependencies": {
-        "mime": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
-        },
         "postcss": {
-          "version": "7.0.5",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-          "integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.6.tgz",
+          "integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
           "requires": {
             "chalk": "^2.4.1",
             "source-map": "^0.6.1",
@@ -7112,14 +7061,14 @@
       }
     },
     "react": {
-      "version": "16.5.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.5.2.tgz",
-      "integrity": "sha512-FDCSVd3DjVTmbEAjUNX6FgfAmQ+ypJfHUsqUJOYNCBUp1h8lqmtC+0mXJ+JjsWx4KAVTkk1vKd1hLQPvEviSuw==",
+      "version": "16.6.3",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
+      "integrity": "sha512-zCvmH2vbEolgKxtqXL2wmGCUxUyNheYn/C+PD1YAjfxHC54+MhdruyhO7QieQrYsYeTxrn93PM2y0jRH1zEExw==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "schedule": "^0.5.0"
+        "scheduler": "^0.11.2"
       },
       "dependencies": {
         "prop-types": {
@@ -7144,14 +7093,14 @@
       }
     },
     "react-dom": {
-      "version": "16.5.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.5.2.tgz",
-      "integrity": "sha512-RC8LDw8feuZOHVgzEf7f+cxBr/DnKdqp56VU0lAs1f4UfKc4cU8wU4fTq/mgnvynLQo8OtlPC19NUFh/zjZPuA==",
+      "version": "16.6.3",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz",
+      "integrity": "sha512-8ugJWRCWLGXy+7PmNh8WJz3g1TaTUt1XyoIcFN+x0Zbkoz+KKdUyx1AQLYJdbFXjuF41Nmjn5+j//rxvhFjgSQ==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "schedule": "^0.5.0"
+        "scheduler": "^0.11.2"
       },
       "dependencies": {
         "prop-types": {
@@ -7165,17 +7114,28 @@
         }
       }
     },
+    "react-is": {
+      "version": "16.6.3",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.3.tgz",
+      "integrity": "sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA=="
+    },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
     "react-redux": {
-      "version": "5.0.7",
-      "resolved": "http://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
-      "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.1.tgz",
+      "integrity": "sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==",
       "requires": {
-        "hoist-non-react-statics": "^2.5.0",
-        "invariant": "^2.0.0",
-        "lodash": "^4.17.5",
-        "lodash-es": "^4.17.5",
+        "@babel/runtime": "^7.1.2",
+        "hoist-non-react-statics": "^3.1.0",
+        "invariant": "^2.2.4",
         "loose-envify": "^1.1.0",
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.6.1",
+        "react-is": "^16.6.0",
+        "react-lifecycles-compat": "^3.0.0"
       },
       "dependencies": {
         "prop-types": {
@@ -7352,7 +7312,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
@@ -7436,7 +7396,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "requires": {
         "caller-path": "^0.1.0",
@@ -7553,7 +7513,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -7587,11 +7547,12 @@
         "pify": "^3.0.0"
       }
     },
-    "schedule": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/schedule/-/schedule-0.5.0.tgz",
-      "integrity": "sha512-HUcJicG5Ou8xfR//c2rPT0lPIRR09vVvN81T9fqfVgBmhERUbDEQoYKjpBxbueJnCPpSu2ujXzOnRQt6x9o/jw==",
+    "scheduler": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.2.tgz",
+      "integrity": "sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==",
       "requires": {
+        "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
       }
     },
@@ -7616,7 +7577,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
             "amdefine": ">=0.0.4"
@@ -7660,6 +7621,13 @@
         "on-finished": "~2.3.0",
         "range-parser": "~1.2.0",
         "statuses": "~1.4.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+        }
       }
     },
     "serialize-javascript": {
@@ -8001,9 +7969,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
-      "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
+      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg=="
     },
     "spdy": {
       "version": "3.4.7",
@@ -8019,9 +7987,9 @@
       }
     },
     "spdy-transport": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
-      "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.1.tgz",
+      "integrity": "sha512-q7D8c148escoB3Z7ySCASadkegMmUZW8Wb/Q1u0/XBgDKMO880rLQDj8Twiew/tYi7ghemKUi/whSYOwE17f5Q==",
       "requires": {
         "debug": "^2.6.8",
         "detect-node": "^2.0.3",
@@ -8046,9 +8014,9 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.1.tgz",
-      "integrity": "sha512-mSdgNUaidk+dRU5MhYtN9zebdzF2iG0cNPWy8HG+W8y+fT1JnSkh0fzzpjOa0L7P8i1Rscz38t0h4gPcKz43xA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
+      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -8103,7 +8071,7 @@
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "requires": {
         "inherits": "~2.0.1",
@@ -8162,7 +8130,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -8183,7 +8151,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-indent": {
@@ -8240,13 +8208,13 @@
       }
     },
     "tapable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.0.tgz",
-      "integrity": "sha512-IlqtmLVaZA2qab8epUXbVWRn3aB1imbDMJtjB3nu4X0NqPkcY/JH9ZtCBWKHWPxs8Svi9tyo8w2dBoi07qZbBA=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.1.tgz",
+      "integrity": "sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA=="
     },
     "tar": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "requires": {
         "block-stream": "*",
@@ -8270,9 +8238,9 @@
       }
     },
     "terser": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-3.10.2.tgz",
-      "integrity": "sha512-+QrFoqBImmsQGB4c/HvaqgZynmbNvNBwoBxuu7fYXtq5EEtlLUzph+WimDj+xMkuqawXPMl2lgCIz81CdXvt+w==",
+      "version": "3.10.12",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-3.10.12.tgz",
+      "integrity": "sha512-3ODPC1eVt25EVNb04s/PkHxOmzKBQUF6bwwuR6h2DbEF8/j265Y1UkwNtOk9am/pRxfJ5HPapOlUlO6c16mKQQ==",
       "requires": {
         "commander": "~2.17.1",
         "source-map": "~0.6.1",
@@ -8400,11 +8368,11 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "requires": {
-        "readable-stream": "^2.1.5",
+        "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
       }
     },
@@ -8563,9 +8531,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "ua-parser-js": {
-      "version": "0.7.18",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
-      "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+      "version": "0.7.19",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
+      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
     },
     "uglify-js": {
       "version": "3.4.9",
@@ -8605,7 +8573,7 @@
       "dependencies": {
         "cacache": {
           "version": "10.0.4",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
           "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
           "requires": {
             "bluebird": "^3.5.1",
@@ -8851,9 +8819,9 @@
       }
     },
     "url-parse": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
-      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+      "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
       "requires": {
         "querystringify": "^2.0.0",
         "requires-port": "^1.0.0"
@@ -8988,6 +8956,11 @@
         "webpack-sources": "^1.2.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+        },
         "eslint-scope": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
@@ -9031,9 +9004,9 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
         },
         "cliui": {
           "version": "4.1.0",
@@ -9055,14 +9028,6 @@
             "semver": "^5.5.0",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
-          }
-        },
-        "decamelize": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
-          "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
-          "requires": {
-            "xregexp": "4.0.0"
           }
         },
         "find-up": {
@@ -9140,12 +9105,12 @@
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
         },
         "yargs": {
-          "version": "12.0.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
-          "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
           "requires": {
             "cliui": "^4.0.0",
-            "decamelize": "^2.0.0",
+            "decamelize": "^1.2.0",
             "find-up": "^3.0.0",
             "get-caller-file": "^1.0.1",
             "os-locale": "^3.0.0",
@@ -9155,15 +9120,16 @@
             "string-width": "^2.0.0",
             "which-module": "^2.0.0",
             "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^10.1.0"
+            "yargs-parser": "^11.1.1"
           }
         },
         "yargs-parser": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -9177,13 +9143,6 @@
         "mime": "^2.3.1",
         "range-parser": "^1.0.3",
         "webpack-log": "^2.0.0"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
-        }
       }
     },
     "webpack-dev-server": {
@@ -9265,19 +9224,6 @@
           "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
           "requires": {
             "xregexp": "4.0.0"
-          }
-        },
-        "del": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
-          "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
-          "requires": {
-            "globby": "^6.1.0",
-            "is-path-cwd": "^1.0.0",
-            "is-path-in-cwd": "^1.0.0",
-            "p-map": "^1.1.1",
-            "pify": "^3.0.0",
-            "rimraf": "^2.2.8"
           }
         },
         "find-up": {
@@ -9459,12 +9405,12 @@
       }
     },
     "wp-calypso": {
-      "version": "github:automattic/wp-calypso#5c892f28b886c821c8047f51eec1e2f0000e2971",
-      "from": "github:automattic/wp-calypso#5c892f28b886c821c8047f51eec1e2f0000e2971",
+      "version": "github:automattic/wp-calypso#ef6cd7465e7c5dce08ce5bacb65677e19c7ca309",
+      "from": "github:automattic/wp-calypso#ef6cd7465e7c5dce08ce5bacb65677e19c7ca309",
       "requires": {
         "@automattic/muriel-base-components": "file:node_modules/wp-calypso/packages/muriel-base-components",
-        "@babel/cli": "7.1.2",
-        "@babel/core": "7.1.2",
+        "@babel/cli": "7.1.5",
+        "@babel/core": "7.1.6",
         "@babel/plugin-proposal-class-properties": "7.1.0",
         "@babel/plugin-proposal-export-default-from": "7.0.0",
         "@babel/plugin-proposal-export-namespace-from": "7.0.0",
@@ -9472,43 +9418,39 @@
         "@babel/plugin-syntax-jsx": "7.0.0",
         "@babel/plugin-transform-runtime": "7.1.0",
         "@babel/polyfill": "7.0.0",
-        "@babel/preset-env": "7.1.0",
+        "@babel/preset-env": "7.1.6",
         "@babel/preset-react": "7.0.0",
-        "@babel/runtime": "7.1.2",
+        "@babel/runtime": "7.1.5",
         "@wordpress/a11y": "2.0.2",
-        "@wordpress/api-fetch": "2.0.2",
+        "@wordpress/api-fetch": "2.2.5",
         "@wordpress/babel-plugin-import-jsx-pragma": "1.1.2",
-        "@wordpress/block-library": "2.1.0",
-        "@wordpress/block-serialization-spec-parser": "1.0.3",
-        "@wordpress/blocks": "4.0.1",
-        "@wordpress/components": "4.1.0",
-        "@wordpress/compose": "2.0.2",
-        "@wordpress/core-data": "2.0.2",
-        "@wordpress/data": "2.1.1",
-        "@wordpress/date": "2.0.2",
-        "@wordpress/deprecated": "2.0.2",
-        "@wordpress/edit-post": "1.0.4",
-        "@wordpress/editor": "4.0.1",
-        "@wordpress/element": "2.1.1",
-        "@wordpress/hooks": "2.0.2",
-        "@wordpress/i18n": "3.0.1",
-        "@wordpress/keycodes": "2.0.2",
-        "@wordpress/nux": "2.0.2",
-        "@wordpress/plugins": "2.0.2",
-        "@wordpress/rich-text": "1.0.0-beta.1",
-        "@wordpress/url": "2.0.2",
-        "@wordpress/viewport": "2.0.2",
+        "@wordpress/block-library": "2.2.6",
+        "@wordpress/blocks": "6.0.2",
+        "@wordpress/components": "7.0.1",
+        "@wordpress/compose": "3.0.0",
+        "@wordpress/core-data": "2.0.14",
+        "@wordpress/data": "4.0.1",
+        "@wordpress/date": "3.0.0",
+        "@wordpress/deprecated": "2.0.3",
+        "@wordpress/edit-post": "3.1.1",
+        "@wordpress/editor": "9.0.1",
+        "@wordpress/element": "2.1.8",
+        "@wordpress/format-library": "1.2.4",
+        "@wordpress/hooks": "2.0.3",
+        "@wordpress/i18n": "3.1.0",
+        "@wordpress/keycodes": "2.0.5",
+        "@wordpress/plugins": "2.0.9",
+        "@wordpress/url": "2.3.1",
+        "@wordpress/viewport": "2.0.12",
         "autoprefixer": "9.2.1",
         "autosize": "4.0.2",
         "babel-loader": "8.0.4",
         "babel-plugin-add-module-exports": "1.0.0",
         "babel-plugin-transform-class-properties": "6.24.1",
         "babel-plugin-transform-export-extensions": "6.22.0",
-        "blob": "0.0.4",
         "body-parser": "1.18.3",
         "bounding-client-rect": "1.0.5",
         "browser-filesaver": "1.1.1",
-        "buble": "0.19.4",
         "chalk": "2.4.1",
         "chokidar": "2.0.4",
         "chrono-node": "1.3.5",
@@ -9516,6 +9458,7 @@
         "classnames": "2.2.6",
         "click-outside": "2.0.2",
         "clipboard": "2.0.1",
+        "color-studio": "github:automattic/color-studio#302bab1a6279ce539cd47cf369bf307a0d300d71",
         "component-closest": "1.0.1",
         "component-file-picker": "0.2.1",
         "cookie": "0.3.1",
@@ -9525,7 +9468,7 @@
         "create-react-class": "15.6.3",
         "creditcards": "3.0.1",
         "cross-env": "5.2.0",
-        "css-loader": "1.0.0",
+        "css-loader": "1.0.1",
         "d3-array": "1.2.4",
         "d3-axis": "1.0.12",
         "d3-scale": "2.1.2",
@@ -9534,8 +9477,8 @@
         "debug": "3.2.6",
         "deep-freeze": "0.0.1",
         "diff": "3.5.0",
-        "doctrine": "2.1.0",
-        "dom-helpers": "3.3.1",
+        "doctrine": "3.0.0",
+        "dom-helpers": "3.4.0",
         "dom-scroll-into-view": "1.2.1",
         "dompurify": "1.0.8",
         "draft-js": "0.10.5",
@@ -9550,10 +9493,10 @@
         "express-useragent": "1.0.12",
         "file-loader": "2.0.0",
         "filesize": "3.6.1",
-        "flag-icon-css": "3.2.0",
+        "flag-icon-css": "3.2.1",
         "flux": "3.1.3",
         "fsevents": "1.2.4",
-        "fuse.js": "3.2.1",
+        "fuse.js": "3.3.0",
         "get-video-id": "3.1.0",
         "gfm-code-blocks": "1.0.0",
         "globby": "8.0.1",
@@ -9567,7 +9510,7 @@
         "i18n-calypso": "3.0.0",
         "ignore-loader": "0.1.2",
         "immutability-helper": "2.8.1",
-        "immutable": "3.7.6",
+        "immutable": "3.8.2",
         "imports-loader": "0.8.0",
         "inherits": "2.0.3",
         "is-my-json-valid": "2.19.0",
@@ -9577,42 +9520,43 @@
         "key-mirror": "1.0.1",
         "keymaster": "1.6.2",
         "loader-utils": "1.1.0",
-        "localforage": "1.7.2",
+        "localforage": "1.7.3",
         "lodash": "4.17.11",
         "lru": "3.1.0",
-        "lunr": "2.3.4",
+        "lunr": "2.3.5",
+        "mapbox-gl": "0.51.0",
         "markdown-it": "8.4.2",
         "marked": "0.5.1",
         "mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300db7027af8caa9a3015f54a34aec545cc54",
         "mkdirp": "0.5.1",
         "moment": "2.22.2",
         "morgan": "1.9.1",
-        "node-sass": "4.9.4",
-        "npm-run-all": "4.1.3",
-        "objectpath": "1.2.1",
-        "page": "1.9.0",
+        "node-sass": "4.10.0",
+        "npm-run-all": "4.1.5",
+        "objectpath": "1.2.2",
+        "page": "1.11.1",
         "path-browserify": "1.0.0",
         "percentage-regex": "3.0.0",
         "phone": "git+https://github.com/Automattic/node-phone.git#6be6549b03137f2cca01e202250bf2590750119e",
         "photon": "2.0.1",
         "postcss-cli": "6.0.1",
-        "postcss-custom-properties": "8.0.8",
+        "postcss-custom-properties": "8.0.9",
         "postcss-loader": "3.0.0",
         "prismjs": "1.15.0",
         "prop-types": "15.6.2",
         "qrcode.react": "0.8.0",
         "qs": "6.5.2",
-        "react": "16.5.2",
+        "react": "16.6.3",
         "react-click-outside": "3.0.1",
         "react-day-picker": "7.2.4",
-        "react-dom": "16.5.2",
+        "react-dom": "16.6.3",
         "react-lazily-render": "1.1.0",
         "react-live": "1.12.0",
         "react-modal": "3.6.1",
         "react-pure-render": "1.0.2",
-        "react-redux": "5.0.7",
+        "react-redux": "5.1.0",
         "react-transition-group": "2.5.0",
-        "react-virtualized": "9.20.1",
+        "react-virtualized": "9.21.0",
         "redux": "4.0.1",
         "redux-form": "7.4.2",
         "redux-thunk": "2.3.0",
@@ -9630,21 +9574,21 @@
         "terser-webpack-plugin": "1.1.0",
         "textarea-caret": "3.1.0",
         "thread-loader": "1.2.0",
-        "tinymce": "4.8.3",
+        "tinymce": "4.8.5",
         "to-title-case": "1.0.0",
         "tracekit": "0.4.5",
-        "twemoji": "11.0.1",
+        "twemoji": "11.2.0",
         "url": "0.11.0",
         "uuid": "3.3.2",
         "valid-url": "1.0.9",
-        "webpack": "4.20.2",
+        "webpack": "4.25.1",
         "webpack-bundle-analyzer": "3.0.3",
         "webpack-cli": "3.1.2",
         "webpack-dev-middleware": "3.4.0",
         "webpack-rtl-plugin": "1.7.0",
         "wpcom": "5.4.2",
         "wpcom-oauth": "0.3.4",
-        "wpcom-proxy-request": "5.0.0",
+        "wpcom-proxy-request": "5.0.2",
         "wpcom-xhr-request": "1.1.2",
         "yargs": "12.0.2"
       },
@@ -9656,9 +9600,9 @@
           }
         },
         "@babel/cli": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.1.2.tgz",
-          "integrity": "sha512-K3WDlpBPGpoW11SLKFEBhMsITomPovsrZ/wnM3y+WStbytukDXC0OBic3yQp+j058QUw0+R/jfx2obwp1fOzcA==",
+          "version": "7.1.5",
+          "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.1.5.tgz",
+          "integrity": "sha512-zbO/DtTnaDappBflIU3zYEgATLToRDmW5uN/EGH1GXaes7ydfjqmAoK++xmJIA+8HfDw7UyPZNdM8fhGhfmMhw==",
           "requires": {
             "chokidar": "^2.0.3",
             "commander": "^2.8.1",
@@ -9688,26 +9632,95 @@
           }
         },
         "@babel/core": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.2.tgz",
-          "integrity": "sha512-IFeSSnjXdhDaoysIlev//UzHZbdEmm7D0EIH2qtse9xK7mXEZQpYjs2P00XlP1qYsYvid79p+Zgg6tz1mp6iVw==",
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.6.tgz",
+          "integrity": "sha512-Hz6PJT6e44iUNpAn8AoyAs6B3bl60g7MJQaI0rZEar6ECzh6+srYO1xlIdssio34mPaUtAb1y+XlkkSJzok3yw==",
           "requires": {
             "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.1.2",
-            "@babel/helpers": "^7.1.2",
-            "@babel/parser": "^7.1.2",
+            "@babel/generator": "^7.1.6",
+            "@babel/helpers": "^7.1.5",
+            "@babel/parser": "^7.1.6",
             "@babel/template": "^7.1.2",
-            "@babel/traverse": "^7.1.0",
-            "@babel/types": "^7.1.2",
+            "@babel/traverse": "^7.1.6",
+            "@babel/types": "^7.1.6",
             "convert-source-map": "^1.1.0",
-            "debug": "^3.1.0",
-            "json5": "^0.5.0",
+            "debug": "^4.1.0",
+            "json5": "^2.1.0",
             "lodash": "^4.17.10",
             "resolve": "^1.3.2",
             "semver": "^5.4.1",
             "source-map": "^0.5.0"
           },
           "dependencies": {
+            "@babel/generator": {
+              "version": "7.1.6",
+              "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.6.tgz",
+              "integrity": "sha512-brwPBtVvdYdGxtenbQgfCdDPmtkmUBZPjUoK5SXJEBuHaA5BCubh9ly65fzXz7R6o5rA76Rs22ES8Z+HCc0YIQ==",
+              "requires": {
+                "@babel/types": "^7.1.6",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.10",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+              }
+            },
+            "@babel/parser": {
+              "version": "7.1.6",
+              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.6.tgz",
+              "integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ=="
+            },
+            "@babel/traverse": {
+              "version": "7.1.6",
+              "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.6.tgz",
+              "integrity": "sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==",
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.1.6",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "@babel/parser": "^7.1.6",
+                "@babel/types": "^7.1.6",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.10"
+              }
+            },
+            "@babel/types": {
+              "version": "7.1.6",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.6.tgz",
+              "integrity": "sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==",
+              "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.10",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "debug": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+              "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "json5": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+              "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+              "requires": {
+                "minimist": "^1.2.0"
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            },
+            "ms": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+            },
             "source-map": {
               "version": "0.5.7",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -9917,13 +9930,76 @@
           }
         },
         "@babel/helpers": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.2.tgz",
-          "integrity": "sha512-Myc3pUE8eswD73aWcartxB16K6CGmHDv9KxOmD2CeOs/FaEAQodr3VYGmlvOmog60vNQ2w8QbatuahepZwrHiA==",
+          "version": "7.1.5",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.5.tgz",
+          "integrity": "sha512-2jkcdL02ywNBry1YNFAH/fViq4fXG0vdckHqeJk+75fpQ2OH+Az6076tX/M0835zA45E0Cqa6pV5Kiv9YOqjEg==",
           "requires": {
             "@babel/template": "^7.1.2",
-            "@babel/traverse": "^7.1.0",
-            "@babel/types": "^7.1.2"
+            "@babel/traverse": "^7.1.5",
+            "@babel/types": "^7.1.5"
+          },
+          "dependencies": {
+            "@babel/generator": {
+              "version": "7.1.6",
+              "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.6.tgz",
+              "integrity": "sha512-brwPBtVvdYdGxtenbQgfCdDPmtkmUBZPjUoK5SXJEBuHaA5BCubh9ly65fzXz7R6o5rA76Rs22ES8Z+HCc0YIQ==",
+              "requires": {
+                "@babel/types": "^7.1.6",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.10",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+              }
+            },
+            "@babel/parser": {
+              "version": "7.1.6",
+              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.6.tgz",
+              "integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ=="
+            },
+            "@babel/traverse": {
+              "version": "7.1.6",
+              "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.6.tgz",
+              "integrity": "sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==",
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.1.6",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "@babel/parser": "^7.1.6",
+                "@babel/types": "^7.1.6",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.10"
+              }
+            },
+            "@babel/types": {
+              "version": "7.1.6",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.6.tgz",
+              "integrity": "sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==",
+              "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.10",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "debug": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+              "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+            }
           }
         },
         "@babel/highlight": {
@@ -10118,9 +10194,9 @@
           }
         },
         "@babel/plugin-transform-block-scoping": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0.tgz",
-          "integrity": "sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==",
+          "version": "7.1.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.1.5.tgz",
+          "integrity": "sha512-jlYcDrz+5ayWC7mxgpn1Wj8zj0mmjCT2w0mPIMSwO926eXBRxpEgoN/uQVRBfjtr8ayjcmS+xk2G1jaP8JjMJQ==",
           "requires": {
             "@babel/helper-plugin-utils": "^7.0.0",
             "lodash": "^4.17.10"
@@ -10282,9 +10358,9 @@
           }
         },
         "@babel/plugin-transform-react-jsx": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0.tgz",
-          "integrity": "sha512-0TMP21hXsSUjIQJmu/r7RiVxeFrXRcMUigbKu0BLegJK9PkYodHstaszcig7zxXfaBji2LYUdtqIkHs+hgYkJQ==",
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.1.6.tgz",
+          "integrity": "sha512-iU/IUlPEYDRwuqLwqVobzPAZkBOQoZ9xRTBmj6ANuk5g/Egn/zdNGnXlSoKeNmKoYVeIRxx5GZhWmMhLik8dag==",
           "requires": {
             "@babel/helper-builder-react-jsx": "^7.0.0",
             "@babel/helper-plugin-utils": "^7.0.0",
@@ -10390,9 +10466,9 @@
           }
         },
         "@babel/preset-env": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.0.tgz",
-          "integrity": "sha512-ZLVSynfAoDHB/34A17/JCZbyrzbQj59QC1Anyueb4Bwjh373nVPq5/HMph0z+tCmcDjXDe+DlKQq9ywQuvWrQg==",
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.6.tgz",
+          "integrity": "sha512-YIBfpJNQMBkb6MCkjz/A9J76SNCSuGVamOVBgoUkLzpJD/z8ghHi9I42LQ4pulVX68N/MmImz6ZTixt7Azgexw==",
           "requires": {
             "@babel/helper-module-imports": "^7.0.0",
             "@babel/helper-plugin-utils": "^7.0.0",
@@ -10407,7 +10483,7 @@
             "@babel/plugin-transform-arrow-functions": "^7.0.0",
             "@babel/plugin-transform-async-to-generator": "^7.1.0",
             "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
-            "@babel/plugin-transform-block-scoping": "^7.0.0",
+            "@babel/plugin-transform-block-scoping": "^7.1.5",
             "@babel/plugin-transform-classes": "^7.1.0",
             "@babel/plugin-transform-computed-properties": "^7.0.0",
             "@babel/plugin-transform-destructuring": "^7.0.0",
@@ -10450,9 +10526,9 @@
           }
         },
         "@babel/runtime": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.2.tgz",
-          "integrity": "sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg==",
+          "version": "7.1.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
+          "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
           "requires": {
             "regenerator-runtime": "^0.12.0"
           },
@@ -10498,19 +10574,6 @@
             "esutils": "^2.0.2",
             "lodash": "^4.17.10",
             "to-fast-properties": "^2.0.0"
-          }
-        },
-        "@cronvel/get-pixels": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/@cronvel/get-pixels/-/get-pixels-3.3.1.tgz",
-          "integrity": "sha512-jgDb8vGPkpjRDbiYyHTI2Bna4HJysjPNSiERzBnRJjCR/YqC3u0idTae0tmNECsaZLOpAWmlK9wiIwnLGIT9Bg==",
-          "requires": {
-            "jpeg-js": "^0.1.1",
-            "ndarray": "^1.0.13",
-            "ndarray-pack": "^1.1.1",
-            "node-bitmap": "0.0.1",
-            "omggif": "^1.0.5",
-            "pngjs": "^2.0.0"
           }
         },
         "@glimmer/interfaces": {
@@ -11350,6 +11413,57 @@
             "write-file-atomic": "^2.3.0"
           }
         },
+        "@mapbox/geojson-area": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",
+          "integrity": "sha1-GNeBSqNr8j+7zDefjiaiKSfevxA=",
+          "requires": {
+            "wgs84": "0.0.0"
+          }
+        },
+        "@mapbox/geojson-types": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
+          "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
+        },
+        "@mapbox/jsonlint-lines-primitives": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+          "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
+        },
+        "@mapbox/mapbox-gl-supported": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.4.0.tgz",
+          "integrity": "sha512-ZD0Io4XK+/vU/4zpANjOtdWfVszAgnaMPsGR6LKsWh4kLIEv9qoobTVmJPPuwuM+ZI2b3BlZ6DYw1XHVmv6YTA=="
+        },
+        "@mapbox/point-geometry": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+          "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
+        },
+        "@mapbox/tiny-sdf": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.1.0.tgz",
+          "integrity": "sha512-dnhyk8X2BkDRWImgHILYAGgo+kuciNYX30CUKj/Qd5eNjh54OWM/mdOS/PWsPeN+3abtN+QDGYM4G220ynVJKA=="
+        },
+        "@mapbox/unitbezier": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+          "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4="
+        },
+        "@mapbox/vector-tile": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+          "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+          "requires": {
+            "@mapbox/point-geometry": "~0.1.0"
+          }
+        },
+        "@mapbox/whoots-js": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+          "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
+        },
         "@mrmlnc/readdir-enhanced": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -11360,9 +11474,9 @@
           }
         },
         "@nodelib/fs.stat": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.2.tgz",
-          "integrity": "sha512-yprFYuno9FtNsSHVlSWd+nRlmGoAbqbeCwOryP6sC/zoCjhpArcRMYp19EvpSUSizJAlsXEwJv+wcWS9XaXdMw=="
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+          "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
         },
         "@romainberger/css-diff": {
           "version": "1.0.3",
@@ -11425,7 +11539,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -11442,9 +11556,9 @@
           }
         },
         "@sinonjs/commons": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
-          "integrity": "sha512-WR3dlgqJP4QNrLC4iXN/5/2WaLQQ0VijOOkmflqFGVJ6wLEpbSjo7c0ZeGIdtY8Crk7xBBp87sM6+Mkerz7alw==",
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+          "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
           "requires": {
             "type-detect": "4.0.8"
           }
@@ -11472,6 +11586,33 @@
           "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.2.tgz",
           "integrity": "sha512-ZwTHAlC9akprWDinwEPD4kOuwaYZlyMwVJIANsKNC3QVp0AHB04m7RnB4eqeWfgmxw8MGTzS9uMaw93Z3QcZbw=="
         },
+        "@tannin/compile": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.0.1.tgz",
+          "integrity": "sha512-ymd9icvnkQin8UG4eRU3+xBc7gqTn/Kv5+EMY3ALWVwIl6j/7McWbCkxB8MgU40UaHJk8kLCk06wiKszXLdXWQ==",
+          "requires": {
+            "@tannin/evaluate": "^1.0.0",
+            "@tannin/postfix": "^1.0.0"
+          }
+        },
+        "@tannin/evaluate": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.0.0.tgz",
+          "integrity": "sha512-gO7YbJsD8sj5/nqUbFZv71Meu2++D9n4DZov/cWwp3YJbBwKShPlWwwlXr/0vz4vuxm/gys+3NiGbZkmhlXf0Q=="
+        },
+        "@tannin/plural-forms": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.0.1.tgz",
+          "integrity": "sha512-SXutT+XLbMOECvmWDBSqIOHhS5hzWG9875HCFGKYgp8ghGPrJ4HZ325Xc0hsRThdjgrWMEQixlbpWl4SXOQTig==",
+          "requires": {
+            "@tannin/compile": "^1.0.0"
+          }
+        },
+        "@tannin/postfix": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.0.0.tgz",
+          "integrity": "sha512-59/mWwU7sXHfoU2kI3RcWRki2Jjbz5nEVJNBN4MUyIhPjXTebAcZqgsQACvlk+sjKVOTMEMHcrFrKQbaxz/1Dw=="
+        },
         "@types/commander": {
           "version": "2.12.2",
           "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.12.2.tgz",
@@ -11481,9 +11622,9 @@
           }
         },
         "@types/node": {
-          "version": "10.12.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
-          "integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ=="
+          "version": "10.12.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.2.tgz",
+          "integrity": "sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ=="
         },
         "@types/semver": {
           "version": "5.5.0",
@@ -11491,156 +11632,156 @@
           "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
         },
         "@webassemblyjs/ast": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.8.tgz",
-          "integrity": "sha512-dOrtdtEyB8sInpl75yLPNksY4sRl0j/+t6aHyB/YA+ab9hV3Fo7FmG12FHzP+2MvWVAJtDb+6eXR5EZbZJ+uVg==",
+          "version": "1.7.11",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",
+          "integrity": "sha512-ZEzy4vjvTzScC+SH8RBssQUawpaInUdMTYwYYLh54/s8TuT0gBLuyUnppKsVyZEi876VmmStKsUs28UxPgdvrA==",
           "requires": {
-            "@webassemblyjs/helper-module-context": "1.7.8",
-            "@webassemblyjs/helper-wasm-bytecode": "1.7.8",
-            "@webassemblyjs/wast-parser": "1.7.8"
+            "@webassemblyjs/helper-module-context": "1.7.11",
+            "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+            "@webassemblyjs/wast-parser": "1.7.11"
           }
         },
         "@webassemblyjs/floating-point-hex-parser": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.8.tgz",
-          "integrity": "sha512-kn2zNKGsbql5i56VAgRYkpG+VazqHhQQZQycT2uXAazrAEDs23gy+Odkh5VblybjnwX2/BITkDtNmSO76hdIvQ=="
+          "version": "1.7.11",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.11.tgz",
+          "integrity": "sha512-zY8dSNyYcgzNRNT666/zOoAyImshm3ycKdoLsyDw/Bwo6+/uktb7p4xyApuef1dwEBo/U/SYQzbGBvV+nru2Xg=="
         },
         "@webassemblyjs/helper-api-error": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.8.tgz",
-          "integrity": "sha512-xUwxDXsd1dUKArJEP5wWM5zxgCSwZApSOJyP1XO7M8rNUChUDblcLQ4FpzTpWG2YeylMwMl1MlP5Ztryiz1x4g=="
+          "version": "1.7.11",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.11.tgz",
+          "integrity": "sha512-7r1qXLmiglC+wPNkGuXCvkmalyEstKVwcueZRP2GNC2PAvxbLYwLLPr14rcdJaE4UtHxQKfFkuDFuv91ipqvXg=="
         },
         "@webassemblyjs/helper-buffer": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.8.tgz",
-          "integrity": "sha512-WXiIMnuvuwlhWvVOm8xEXU9DnHaa3AgAU0ZPfvY8vO1cSsmYb2WbGbHnMLgs43vXnA7XAob9b56zuZaMkxpCBg=="
+          "version": "1.7.11",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.11.tgz",
+          "integrity": "sha512-MynuervdylPPh3ix+mKZloTcL06P8tenNH3sx6s0qE8SLR6DdwnfgA7Hc9NSYeob2jrW5Vql6GVlsQzKQCa13w=="
         },
         "@webassemblyjs/helper-code-frame": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.8.tgz",
-          "integrity": "sha512-TLQxyD9qGOIdX5LPQOPo0Ernd88U5rHkFb8WAjeMIeA0sPjCHeVPaGqUGGIXjUcblUkjuDAc07bruCcNHUrHDA==",
+          "version": "1.7.11",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.11.tgz",
+          "integrity": "sha512-T8ESC9KMXFTXA5urJcyor5cn6qWeZ4/zLPyWeEXZ03hj/x9weSokGNkVCdnhSabKGYWxElSdgJ+sFa9G/RdHNw==",
           "requires": {
-            "@webassemblyjs/wast-printer": "1.7.8"
+            "@webassemblyjs/wast-printer": "1.7.11"
           }
         },
         "@webassemblyjs/helper-fsm": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.8.tgz",
-          "integrity": "sha512-TjK0CnD8hAPkV5mbSp5aWl6SO1+H3WFcjWtixWoy8EMA99YnNzYhpc/WSYWhf7yrhpzkq5tZB0tvLK3Svr3IXA=="
+          "version": "1.7.11",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.11.tgz",
+          "integrity": "sha512-nsAQWNP1+8Z6tkzdYlXT0kxfa2Z1tRTARd8wYnc/e3Zv3VydVVnaeePgqUzFrpkGUyhUUxOl5ML7f1NuT+gC0A=="
         },
         "@webassemblyjs/helper-module-context": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.8.tgz",
-          "integrity": "sha512-uCutAKR7Nm0VsFixcvnB4HhAyHouNbj0Dx1p7eRjFjXGGZ+N7ftTaG1ZbWCasAEbtwGj54LP8+lkBZdTCPmLGg=="
+          "version": "1.7.11",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.11.tgz",
+          "integrity": "sha512-JxfD5DX8Ygq4PvXDucq0M+sbUFA7BJAv/GGl9ITovqE+idGX+J3QSzJYz+LwQmL7fC3Rs+utvWoJxDb6pmC0qg=="
         },
         "@webassemblyjs/helper-wasm-bytecode": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.8.tgz",
-          "integrity": "sha512-AdCCE3BMW6V34WYaKUmPgVHa88t2Z14P4/0LjLwuGkI0X6pf7nzp0CehzVVk51cKm2ymVXjl9dCG+gR1yhITIQ=="
+          "version": "1.7.11",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.11.tgz",
+          "integrity": "sha512-cMXeVS9rhoXsI9LLL4tJxBgVD/KMOKXuFqYb5oCJ/opScWpkCMEz9EJtkonaNcnLv2R3K5jIeS4TRj/drde1JQ=="
         },
         "@webassemblyjs/helper-wasm-section": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.8.tgz",
-          "integrity": "sha512-BkBhYQuzyl4hgTGOKo87Vdw6f9nj8HhI7WYpI0MCC5qFa5ahrAPOGgyETVdnRbv+Rjukl9MxxfDmVcVC435lDg==",
+          "version": "1.7.11",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.11.tgz",
+          "integrity": "sha512-8ZRY5iZbZdtNFE5UFunB8mmBEAbSI3guwbrsCl4fWdfRiAcvqQpeqd5KHhSWLL5wuxo53zcaGZDBU64qgn4I4Q==",
           "requires": {
-            "@webassemblyjs/ast": "1.7.8",
-            "@webassemblyjs/helper-buffer": "1.7.8",
-            "@webassemblyjs/helper-wasm-bytecode": "1.7.8",
-            "@webassemblyjs/wasm-gen": "1.7.8"
+            "@webassemblyjs/ast": "1.7.11",
+            "@webassemblyjs/helper-buffer": "1.7.11",
+            "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+            "@webassemblyjs/wasm-gen": "1.7.11"
           }
         },
         "@webassemblyjs/ieee754": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.8.tgz",
-          "integrity": "sha512-tOarWChdG1a3y1yqCX0JMDKzrat5tQe4pV6K/TX19BcXsBLYxFQOL1DEDa5KG9syeyvCrvZ+i1+Mv1ExngvktQ==",
+          "version": "1.7.11",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.11.tgz",
+          "integrity": "sha512-Mmqx/cS68K1tSrvRLtaV/Lp3NZWzXtOHUW2IvDvl2sihAwJh4ACE0eL6A8FvMyDG9abes3saB6dMimLOs+HMoQ==",
           "requires": {
             "@xtuc/ieee754": "^1.2.0"
           }
         },
         "@webassemblyjs/leb128": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.8.tgz",
-          "integrity": "sha512-GCYeGPgUFWJiZuP4NICbcyUQNxNLJIf476Ei+K+jVuuebtLpfvwkvYT6iTUE7oZYehhkor4Zz2g7SJ/iZaPudQ==",
+          "version": "1.7.11",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.11.tgz",
+          "integrity": "sha512-vuGmgZjjp3zjcerQg+JA+tGOncOnJLWVkt8Aze5eWQLwTQGNgVLcyOTqgSCxWTR4J42ijHbBxnuRaL1Rv7XMdw==",
           "requires": {
             "@xtuc/long": "4.2.1"
           }
         },
         "@webassemblyjs/utf8": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.8.tgz",
-          "integrity": "sha512-9X+f0VV+xNXW2ujfIRSXBJENGE6Qh7bNVKqu3yDjTFB3ar3nsThsGBBKdTG58aXOm2iUH6v28VIf88ymPXODHA=="
+          "version": "1.7.11",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.11.tgz",
+          "integrity": "sha512-C6GFkc7aErQIAH+BMrIdVSmW+6HSe20wg57HEC1uqJP8E/xpMjXqQUxkQw07MhNDSDcGpxI9G5JSNOQCqJk4sA=="
         },
         "@webassemblyjs/wasm-edit": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.8.tgz",
-          "integrity": "sha512-6D3Hm2gFixrfyx9XjSON4ml1FZTugqpkIz5Awvrou8fnpyprVzcm4X8pyGRtA2Piixjl3DqmX/HB1xdWyE097A==",
+          "version": "1.7.11",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.11.tgz",
+          "integrity": "sha512-FUd97guNGsCZQgeTPKdgxJhBXkUbMTY6hFPf2Y4OedXd48H97J+sOY2Ltaq6WGVpIH8o/TGOVNiVz/SbpEMJGg==",
           "requires": {
-            "@webassemblyjs/ast": "1.7.8",
-            "@webassemblyjs/helper-buffer": "1.7.8",
-            "@webassemblyjs/helper-wasm-bytecode": "1.7.8",
-            "@webassemblyjs/helper-wasm-section": "1.7.8",
-            "@webassemblyjs/wasm-gen": "1.7.8",
-            "@webassemblyjs/wasm-opt": "1.7.8",
-            "@webassemblyjs/wasm-parser": "1.7.8",
-            "@webassemblyjs/wast-printer": "1.7.8"
+            "@webassemblyjs/ast": "1.7.11",
+            "@webassemblyjs/helper-buffer": "1.7.11",
+            "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+            "@webassemblyjs/helper-wasm-section": "1.7.11",
+            "@webassemblyjs/wasm-gen": "1.7.11",
+            "@webassemblyjs/wasm-opt": "1.7.11",
+            "@webassemblyjs/wasm-parser": "1.7.11",
+            "@webassemblyjs/wast-printer": "1.7.11"
           }
         },
         "@webassemblyjs/wasm-gen": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.8.tgz",
-          "integrity": "sha512-a7O/wE6eBeVKKUYgpMK7NOHmMADD85rSXLe3CqrWRDwWff5y3cSVbzpN6Qv3z6C4hdkpq9qyij1Ga1kemOZGvQ==",
+          "version": "1.7.11",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.11.tgz",
+          "integrity": "sha512-U/KDYp7fgAZX5KPfq4NOupK/BmhDc5Kjy2GIqstMhvvdJRcER/kUsMThpWeRP8BMn4LXaKhSTggIJPOeYHwISA==",
           "requires": {
-            "@webassemblyjs/ast": "1.7.8",
-            "@webassemblyjs/helper-wasm-bytecode": "1.7.8",
-            "@webassemblyjs/ieee754": "1.7.8",
-            "@webassemblyjs/leb128": "1.7.8",
-            "@webassemblyjs/utf8": "1.7.8"
+            "@webassemblyjs/ast": "1.7.11",
+            "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+            "@webassemblyjs/ieee754": "1.7.11",
+            "@webassemblyjs/leb128": "1.7.11",
+            "@webassemblyjs/utf8": "1.7.11"
           }
         },
         "@webassemblyjs/wasm-opt": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.8.tgz",
-          "integrity": "sha512-3lbQ0PT81NHCdi1sR/7+SNpZadM4qYcTSr62nFFAA7e5lFwJr14M1Gi+A/Y3PgcDWOHYjsaNGPpPU0H03N6Blg==",
+          "version": "1.7.11",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.11.tgz",
+          "integrity": "sha512-XynkOwQyiRidh0GLua7SkeHvAPXQV/RxsUeERILmAInZegApOUAIJfRuPYe2F7RcjOC9tW3Cb9juPvAC/sCqvg==",
           "requires": {
-            "@webassemblyjs/ast": "1.7.8",
-            "@webassemblyjs/helper-buffer": "1.7.8",
-            "@webassemblyjs/wasm-gen": "1.7.8",
-            "@webassemblyjs/wasm-parser": "1.7.8"
+            "@webassemblyjs/ast": "1.7.11",
+            "@webassemblyjs/helper-buffer": "1.7.11",
+            "@webassemblyjs/wasm-gen": "1.7.11",
+            "@webassemblyjs/wasm-parser": "1.7.11"
           }
         },
         "@webassemblyjs/wasm-parser": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.8.tgz",
-          "integrity": "sha512-rZ/zlhp9DHR/05zh1MbAjT2t624sjrPP/OkJCjXqzm7ynH+nIdNcn9Ixc+qzPMFXhIrk0rBoQ3to6sEIvHh9jQ==",
+          "version": "1.7.11",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.11.tgz",
+          "integrity": "sha512-6lmXRTrrZjYD8Ng8xRyvyXQJYUQKYSXhJqXOBLw24rdiXsHAOlvw5PhesjdcaMadU/pyPQOJ5dHreMjBxwnQKg==",
           "requires": {
-            "@webassemblyjs/ast": "1.7.8",
-            "@webassemblyjs/helper-api-error": "1.7.8",
-            "@webassemblyjs/helper-wasm-bytecode": "1.7.8",
-            "@webassemblyjs/ieee754": "1.7.8",
-            "@webassemblyjs/leb128": "1.7.8",
-            "@webassemblyjs/utf8": "1.7.8"
+            "@webassemblyjs/ast": "1.7.11",
+            "@webassemblyjs/helper-api-error": "1.7.11",
+            "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+            "@webassemblyjs/ieee754": "1.7.11",
+            "@webassemblyjs/leb128": "1.7.11",
+            "@webassemblyjs/utf8": "1.7.11"
           }
         },
         "@webassemblyjs/wast-parser": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.8.tgz",
-          "integrity": "sha512-Q/zrvtUvzWuSiJMcSp90fi6gp2nraiHXjTV2VgAluVdVapM4gy1MQn7akja2p6eSBDQpKJPJ6P4TxRkghRS5dg==",
+          "version": "1.7.11",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.11.tgz",
+          "integrity": "sha512-lEyVCg2np15tS+dm7+JJTNhNWq9yTZvi3qEhAIIOaofcYlUp0UR5/tVqOwa/gXYr3gjwSZqw+/lS9dscyLelbQ==",
           "requires": {
-            "@webassemblyjs/ast": "1.7.8",
-            "@webassemblyjs/floating-point-hex-parser": "1.7.8",
-            "@webassemblyjs/helper-api-error": "1.7.8",
-            "@webassemblyjs/helper-code-frame": "1.7.8",
-            "@webassemblyjs/helper-fsm": "1.7.8",
+            "@webassemblyjs/ast": "1.7.11",
+            "@webassemblyjs/floating-point-hex-parser": "1.7.11",
+            "@webassemblyjs/helper-api-error": "1.7.11",
+            "@webassemblyjs/helper-code-frame": "1.7.11",
+            "@webassemblyjs/helper-fsm": "1.7.11",
             "@xtuc/long": "4.2.1"
           }
         },
         "@webassemblyjs/wast-printer": {
-          "version": "1.7.8",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.8.tgz",
-          "integrity": "sha512-GllIthRtwTxRDAURRNXscu7Napzmdf1jt1gpiZiK/QN4fH0lSGs3OTmvdfsMNP7tqI4B3ZtfaaWRlNIQug6Xyg==",
+          "version": "1.7.11",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.11.tgz",
+          "integrity": "sha512-m5vkAsuJ32QpkdkDOUPGSltrg8Cuk3KBx4YrmAGQwCZPRdUHXxG4phIOuuycLemHFr74sWL9Wthqss4fzdzSwg==",
           "requires": {
-            "@webassemblyjs/ast": "1.7.8",
-            "@webassemblyjs/wast-parser": "1.7.8",
+            "@webassemblyjs/ast": "1.7.11",
+            "@webassemblyjs/wast-parser": "1.7.11",
             "@xtuc/long": "4.2.1"
           }
         },
@@ -11654,13 +11795,14 @@
           }
         },
         "@wordpress/api-fetch": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-2.0.2.tgz",
-          "integrity": "sha512-i+vDdoCxNAI9PpSLlLBg10JZq4cAJ3K/aVNxHUyK+Ps8cDUjEBITOV3A0+pnmumLCZgzs+LXIKq/kgNz+POqlA==",
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-2.2.5.tgz",
+          "integrity": "sha512-/59udJQAG5ynrA7j/E6mBhl0gv1MXpBDiuMhY7TBOdgNYIdltrcBbI2PF0r42EGPRtm+rOzBKrEM7WDkWTCkvA==",
           "requires": {
             "@babel/runtime": "^7.0.0",
-            "@wordpress/hooks": "^2.0.2",
-            "@wordpress/i18n": "^3.0.1"
+            "@wordpress/hooks": "^2.0.3",
+            "@wordpress/i18n": "^3.1.0",
+            "@wordpress/url": "^2.3.1"
           }
         },
         "@wordpress/autop": {
@@ -11680,33 +11822,33 @@
           }
         },
         "@wordpress/blob": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-2.0.2.tgz",
-          "integrity": "sha512-zy4INlg/QYsqN5bRE1P2P/rPccR/3KXs4816RQYVCunAd8QrS1d9rvYcaFrXIKoXIZ6rz999EZN/E4wTfja0dg==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-2.1.0.tgz",
+          "integrity": "sha512-2PBjKivnxVSFLn+askRHyYK61zTarNrpi3S8slC12xeFPXTecT+HBdYJVtk32GBFrQmyH7ZdpDrROhCmjXyiOw==",
           "requires": {
             "@babel/runtime": "^7.0.0"
           }
         },
         "@wordpress/block-library": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-2.1.0.tgz",
-          "integrity": "sha512-I3p+P2PA1s7zji6axN/BzKcxBl8bY6K9De0wAWV+426jDLIs4SW+80fUowbTqksI0NYE0AAqkjMduxCNvAwBwA==",
+          "version": "2.2.6",
+          "resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-2.2.6.tgz",
+          "integrity": "sha512-HCRqGzGqeU36tUp26ml+2o8SXCB/gkvzJyeIKX4IGHKjONjxZim/0ht7KoyCEjup/cxNNP8NZ6BQaI3oi6P6JA==",
           "requires": {
             "@babel/runtime": "^7.0.0",
             "@wordpress/autop": "^2.0.2",
-            "@wordpress/blob": "^2.0.2",
-            "@wordpress/blocks": "^4.0.1",
-            "@wordpress/components": "^4.1.0",
-            "@wordpress/compose": "^2.0.2",
-            "@wordpress/core-data": "^2.0.2",
-            "@wordpress/data": "^2.1.1",
-            "@wordpress/deprecated": "^2.0.2",
-            "@wordpress/editor": "^4.0.1",
-            "@wordpress/element": "^2.1.1",
-            "@wordpress/html-entities": "^2.0.2",
-            "@wordpress/i18n": "^3.0.1",
-            "@wordpress/keycodes": "^2.0.2",
-            "@wordpress/viewport": "^2.0.2",
+            "@wordpress/blob": "^2.1.0",
+            "@wordpress/blocks": "^6.0.2",
+            "@wordpress/components": "^7.0.1",
+            "@wordpress/compose": "^3.0.0",
+            "@wordpress/core-data": "^2.0.14",
+            "@wordpress/data": "^4.0.1",
+            "@wordpress/deprecated": "^2.0.3",
+            "@wordpress/editor": "^9.0.1",
+            "@wordpress/element": "^2.1.8",
+            "@wordpress/html-entities": "^2.0.3",
+            "@wordpress/i18n": "^3.1.0",
+            "@wordpress/keycodes": "^2.0.5",
+            "@wordpress/viewport": "^2.0.12",
             "classnames": "^2.2.5",
             "lodash": "^4.17.10",
             "memize": "^1.0.5",
@@ -11717,64 +11859,64 @@
           }
         },
         "@wordpress/block-serialization-default-parser": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-1.0.1.tgz",
-          "integrity": "sha512-r3pi1GVDnxR4MEb8BcS2UX8BQcNHU/7PyueUihSWGbVJaCksSf+wyRKVTuZiOQKagO95fWy7Egc0JcWK6clmiQ==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-2.0.0.tgz",
+          "integrity": "sha512-WPQuQ2IsUOG9wMTst8CYW8c5NMM3iatTW2FinfZrHtH9R1g9qdQPt5Wv56U7eMeDACVOj35jG2oJtZCRaDyL7A==",
           "requires": {
             "@babel/runtime": "^7.0.0"
           }
         },
         "@wordpress/block-serialization-spec-parser": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-spec-parser/-/block-serialization-spec-parser-1.0.3.tgz",
-          "integrity": "sha512-qteB0HjG6Kc2FHMPx3Q76iuUYLaj8R+FZD+WT5eXRHgm0o1iGAYjth2qyAjj0hQ/ij5pWYc3pdEjiwQOcSqnLQ=="
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-spec-parser/-/block-serialization-spec-parser-2.0.0.tgz",
+          "integrity": "sha512-l5N0o2Tkc4IcDhhMfX2W3KuEV/4F7TeitJEDtBpLYf7eRMIn3Uh6l5rPDmmuTDv7UFlMWTiA8z/oCpl13ZyBOw=="
         },
         "@wordpress/blocks": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-4.0.1.tgz",
-          "integrity": "sha512-sLEDS5GnGGsQkOTUt9y7DvJAkryoAI4aIXN9YdovZxYqIgARqyAHxKZ/Ri7zNvNqZD31cX0DQyXkr8KNc/V4LA==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.0.2.tgz",
+          "integrity": "sha512-Y9cIbxXnATT6NPBbT969awm/5iLL/fRYoQ2a0xoqqHdcI8kxPbMv2TdAE8RaM8eeYL17t6CmWdfP+jkAIVGMGg==",
           "requires": {
             "@babel/runtime": "^7.0.0",
             "@wordpress/autop": "^2.0.2",
-            "@wordpress/blob": "^2.0.2",
-            "@wordpress/block-serialization-default-parser": "^1.0.1",
-            "@wordpress/block-serialization-spec-parser": "^1.0.3",
-            "@wordpress/data": "^2.1.1",
-            "@wordpress/deprecated": "^2.0.2",
-            "@wordpress/dom": "^2.0.2",
-            "@wordpress/element": "^2.1.1",
-            "@wordpress/hooks": "^2.0.2",
-            "@wordpress/i18n": "^3.0.1",
+            "@wordpress/blob": "^2.1.0",
+            "@wordpress/block-serialization-default-parser": "^2.0.0",
+            "@wordpress/block-serialization-spec-parser": "^2.0.0",
+            "@wordpress/data": "^4.0.1",
+            "@wordpress/dom": "^2.0.7",
+            "@wordpress/element": "^2.1.8",
+            "@wordpress/hooks": "^2.0.3",
+            "@wordpress/html-entities": "^2.0.3",
+            "@wordpress/i18n": "^3.1.0",
             "@wordpress/is-shallow-equal": "^1.1.4",
             "@wordpress/shortcode": "^2.0.2",
-            "hpq": "^1.2.0",
+            "hpq": "^1.3.0",
             "lodash": "^4.17.10",
             "rememo": "^3.0.0",
             "showdown": "^1.8.6",
             "simple-html-tokenizer": "^0.4.1",
             "tinycolor2": "^1.4.1",
-            "uuid": "^3.1.0"
+            "uuid": "^3.3.2"
           }
         },
         "@wordpress/components": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-4.1.0.tgz",
-          "integrity": "sha512-MWWrdg1HOojJZEY9hgGTZrgbHzuk2F32/f4qBE0L6Q2wfP48tFjvO8952IJ2vxmtGrXK8PfDuvOGJy2K944LBA==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.0.1.tgz",
+          "integrity": "sha512-6Efciw+CwFa0b51bLZUNWv0C2p5j8VIVb6vAHB/ghwD0BkNHZ0N4JBafOIB+6toAtmLzC+SONfHNmFNJHibZ+Q==",
           "requires": {
             "@babel/runtime": "^7.0.0",
             "@wordpress/a11y": "^2.0.2",
-            "@wordpress/api-fetch": "^2.0.2",
-            "@wordpress/compose": "^2.0.2",
-            "@wordpress/deprecated": "^2.0.2",
-            "@wordpress/dom": "^2.0.2",
-            "@wordpress/element": "^2.1.1",
-            "@wordpress/hooks": "^2.0.2",
-            "@wordpress/i18n": "^3.0.1",
+            "@wordpress/api-fetch": "^2.2.5",
+            "@wordpress/compose": "^3.0.0",
+            "@wordpress/dom": "^2.0.7",
+            "@wordpress/element": "^2.1.8",
+            "@wordpress/hooks": "^2.0.3",
+            "@wordpress/i18n": "^3.1.0",
             "@wordpress/is-shallow-equal": "^1.1.4",
-            "@wordpress/keycodes": "^2.0.2",
-            "@wordpress/url": "^2.0.2",
+            "@wordpress/keycodes": "^2.0.5",
+            "@wordpress/rich-text": "^3.0.2",
+            "@wordpress/url": "^2.3.1",
             "classnames": "^2.2.5",
-            "clipboard": "^1.7.1",
+            "clipboard": "^2.0.1",
             "diff": "^3.5.0",
             "dom-scroll-into-view": "^1.2.1",
             "lodash": "^4.17.10",
@@ -11782,79 +11924,59 @@
             "moment": "^2.22.1",
             "mousetrap": "^1.6.2",
             "re-resizable": "^4.7.1",
-            "react-click-outside": "^2.3.1",
-            "react-color": "^2.13.4",
-            "react-datepicker": "^1.4.1",
+            "react-click-outside": "^3.0.0",
+            "react-dates": "^17.1.1",
             "rememo": "^3.0.0",
-            "uuid": "^3.1.0"
-          },
-          "dependencies": {
-            "clipboard": {
-              "version": "1.7.1",
-              "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
-              "integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
-              "requires": {
-                "good-listener": "^1.2.2",
-                "select": "^1.1.2",
-                "tiny-emitter": "^2.0.0"
-              }
-            },
-            "react-click-outside": {
-              "version": "2.3.1",
-              "resolved": "https://registry.npmjs.org/react-click-outside/-/react-click-outside-2.3.1.tgz",
-              "integrity": "sha1-MYc3698IGko7zUaCVmNnTL6YNus=",
-              "requires": {
-                "hoist-non-react-statics": "^1.2.0"
-              }
-            }
+            "tinycolor2": "^1.4.1",
+            "uuid": "^3.3.2"
           }
         },
         "@wordpress/compose": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-2.0.2.tgz",
-          "integrity": "sha512-BBii0uIRHJ63Gu3zpPFjy6Qda+w/Ie4cHx5tN3hmFNWPENhSlosix1eXbxvE3lSEerW509A1Bt8Tn1XlePTElg==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.0.0.tgz",
+          "integrity": "sha512-jghgcLLKYQiIxjKp1q9FGcLlbeTKmYUIbYcru2AX7VF1uqp85oeRcuWsowrQUvomWHADcf09psBfDo2Gz/OH8A==",
           "requires": {
             "@babel/runtime": "^7.0.0",
-            "@wordpress/element": "^2.1.1",
+            "@wordpress/element": "^2.1.8",
             "@wordpress/is-shallow-equal": "^1.1.4",
             "lodash": "^4.17.10"
           }
         },
         "@wordpress/core-data": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-2.0.2.tgz",
-          "integrity": "sha512-ErZgGsKpImg6k2jQ4bWCwFBR6/LDqyLnR05/nDgT14HLvwc0vA9jnw5aPdA2UgqyczY5VuBIEocRQ7JMGxqYXQ==",
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-2.0.14.tgz",
+          "integrity": "sha512-Hbd9tOfxv41jO1VwN9KzKCVgWuUzvZwIhXj848SFi0CzV0E57fiIVAkB/7bQj1EUOGT1qzIRLHhsBAEpxrVaeA==",
           "requires": {
             "@babel/runtime": "^7.0.0",
-            "@wordpress/api-fetch": "^2.0.2",
-            "@wordpress/data": "^2.1.1",
-            "@wordpress/url": "^2.0.2",
-            "equivalent-key-map": "^0.2.1",
+            "@wordpress/api-fetch": "^2.2.5",
+            "@wordpress/data": "^4.0.1",
+            "@wordpress/url": "^2.3.1",
+            "equivalent-key-map": "^0.2.2",
             "lodash": "^4.17.10",
             "rememo": "^3.0.0"
           }
         },
         "@wordpress/data": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-2.1.1.tgz",
-          "integrity": "sha512-7GcID3ZRxIFq+7mFKRkbKZqpscUN3udYhhqiQeJQLd1HW/BmWWgQrug5LrUYeI85lQgtWmyxBEXkEZAFm6h8gA==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.0.1.tgz",
+          "integrity": "sha512-UfuSPjyA4xssOVcgg1wRlngBNGVbMmZGtwoGpAWej/XRpGI26P6Xi+8skPQfLTP2yl+/nMoFd9PTwpE0MwDQ7Q==",
           "requires": {
             "@babel/runtime": "^7.0.0",
-            "@wordpress/compose": "^2.0.2",
-            "@wordpress/deprecated": "^2.0.2",
-            "@wordpress/element": "^2.1.1",
+            "@wordpress/compose": "^3.0.0",
+            "@wordpress/element": "^2.1.8",
             "@wordpress/is-shallow-equal": "^1.1.4",
-            "@wordpress/redux-routine": "^3.0.1",
-            "equivalent-key-map": "^0.2.0",
+            "@wordpress/redux-routine": "^3.0.3",
+            "equivalent-key-map": "^0.2.2",
             "is-promise": "^2.1.0",
             "lodash": "^4.17.10",
-            "redux": "^4.0.0"
+            "redux": "^4.0.0",
+            "turbo-combine-reducers": "^1.0.2"
           }
         },
         "@wordpress/date": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-2.0.2.tgz",
-          "integrity": "sha512-SnEgDZVxVim7Oyokl1KLXAexT4YPoFJtqlomTNxtz208pzWU9MdVGAnF6wUr2D2ALeRccnrw8eImpkuKbs7MDA==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.0.0.tgz",
+          "integrity": "sha512-9Acg/5ABEW55iIbPo4jew1rvV7UEIBwWf0YsQdiYKHHcA5AdcDMxvuFBJXMvO3TByCUa8wTAnF3yP6EwAcgbZw==",
           "requires": {
             "@babel/runtime": "^7.0.0",
             "moment": "^2.22.1",
@@ -11862,18 +11984,18 @@
           }
         },
         "@wordpress/deprecated": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.0.2.tgz",
-          "integrity": "sha512-5qNehHD7/duvouuGjMdGREQORs9LFMVkyFysfWvafZ919zAl0DAKEXsBoxcMSvvqBqCf5MKJBnQBVY4DeS6AEg==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.0.3.tgz",
+          "integrity": "sha512-5v8h6BJ9xQFTho7ucitshpIahD+rVnAhgc/4juYmPLb9/GJzwY1J91Ve5mcjcjgWhdtjBKO0TCq/S4PCfS812w==",
           "requires": {
             "@babel/runtime": "^7.0.0",
-            "@wordpress/hooks": "^2.0.2"
+            "@wordpress/hooks": "^2.0.3"
           }
         },
         "@wordpress/dom": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.0.2.tgz",
-          "integrity": "sha512-lLpxqgGd/oo7J5pw+420DpLovTLZIljKlwWX9EXWvNeBEuWlHkfvVHDBSweUUJtnoD3vVxDE+QfCqfHcMqJT9g==",
+          "version": "2.0.7",
+          "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.0.7.tgz",
+          "integrity": "sha512-vjOdGSpW3WdHH5oOoamfzdoyF4BbUJOWNNT7bBb2y15GII8rN1cGyGxqVDiiajMDe51p3lyWWCpUeY4ppxj/UA==",
           "requires": {
             "@babel/runtime": "^7.0.0",
             "lodash": "^4.17.10"
@@ -11888,369 +12010,63 @@
           }
         },
         "@wordpress/edit-post": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-1.0.4.tgz",
-          "integrity": "sha512-m+VR3S7rsRwQLze+gzmhWC2yWrVGo7bjb0eshsnZ+JiLSjj1/KeW7k0uvH5w8/Unv9/BHZAdbsiT9IEs42tLMQ==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-3.1.1.tgz",
+          "integrity": "sha512-sjGNSTBh6xKZUtpskkc1Hx0y+iqcfOyX+i09I+zrRyoelHvw/0nZ9iHvN34lTszAgPOx9vjy8nHc8obH0gr8AA==",
           "requires": {
             "@babel/runtime": "^7.0.0",
             "@wordpress/a11y": "^2.0.2",
-            "@wordpress/api-fetch": "^2.1.0",
-            "@wordpress/block-library": "^2.1.4",
-            "@wordpress/blocks": "^4.0.4",
-            "@wordpress/components": "^4.2.1",
-            "@wordpress/compose": "^2.0.5",
-            "@wordpress/core-data": "^2.0.6",
-            "@wordpress/data": "^2.1.4",
-            "@wordpress/deprecated": "^2.0.2",
-            "@wordpress/editor": "^5.0.1",
-            "@wordpress/element": "^2.1.4",
-            "@wordpress/hooks": "^2.0.2",
-            "@wordpress/i18n": "^3.0.1",
-            "@wordpress/keycodes": "^2.0.2",
-            "@wordpress/nux": "^2.0.6",
-            "@wordpress/plugins": "^2.0.5",
-            "@wordpress/url": "^2.1.0",
-            "@wordpress/viewport": "^2.0.5",
+            "@wordpress/api-fetch": "^2.2.5",
+            "@wordpress/block-library": "^2.2.6",
+            "@wordpress/blocks": "^6.0.2",
+            "@wordpress/components": "^7.0.1",
+            "@wordpress/compose": "^3.0.0",
+            "@wordpress/core-data": "^2.0.14",
+            "@wordpress/data": "^4.0.1",
+            "@wordpress/editor": "^9.0.1",
+            "@wordpress/element": "^2.1.8",
+            "@wordpress/format-library": "^1.2.4",
+            "@wordpress/hooks": "^2.0.3",
+            "@wordpress/i18n": "^3.1.0",
+            "@wordpress/keycodes": "^2.0.5",
+            "@wordpress/nux": "^3.0.2",
+            "@wordpress/plugins": "^2.0.9",
+            "@wordpress/url": "^2.3.1",
+            "@wordpress/viewport": "^2.0.12",
             "classnames": "^2.2.5",
             "lodash": "^4.17.10",
             "refx": "^3.0.0"
-          },
-          "dependencies": {
-            "@wordpress/api-fetch": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-2.1.0.tgz",
-              "integrity": "sha512-Aa76Soaet8RGLDRuOBzbFyTVIBRDgytAO1EtEppvx444j3LHrgArQD5ViMmZTJB6NOY4wcLA6qmyCG3u+/Xxtg==",
-              "requires": {
-                "@babel/runtime": "^7.0.0",
-                "@wordpress/hooks": "^2.0.2",
-                "@wordpress/i18n": "^3.0.1",
-                "@wordpress/url": "^2.1.0"
-              }
-            },
-            "@wordpress/blob": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-2.1.0.tgz",
-              "integrity": "sha512-2PBjKivnxVSFLn+askRHyYK61zTarNrpi3S8slC12xeFPXTecT+HBdYJVtk32GBFrQmyH7ZdpDrROhCmjXyiOw==",
-              "requires": {
-                "@babel/runtime": "^7.0.0"
-              }
-            },
-            "@wordpress/block-library": {
-              "version": "2.1.4",
-              "resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-2.1.4.tgz",
-              "integrity": "sha512-gRCLt6bkAb9uBZHd+xczxj0bwHtnKfKMkSswyLkp4Nv/XQiA81aajKbaQ1el+xvIESOyCF5ThUc8RWW4dG4MxQ==",
-              "requires": {
-                "@babel/runtime": "^7.0.0",
-                "@wordpress/autop": "^2.0.2",
-                "@wordpress/blob": "^2.1.0",
-                "@wordpress/blocks": "^4.0.4",
-                "@wordpress/components": "^4.2.1",
-                "@wordpress/compose": "^2.0.5",
-                "@wordpress/core-data": "^2.0.6",
-                "@wordpress/data": "^2.1.4",
-                "@wordpress/deprecated": "^2.0.2",
-                "@wordpress/editor": "^5.0.1",
-                "@wordpress/element": "^2.1.4",
-                "@wordpress/html-entities": "^2.0.2",
-                "@wordpress/i18n": "^3.0.1",
-                "@wordpress/keycodes": "^2.0.2",
-                "@wordpress/viewport": "^2.0.5",
-                "classnames": "^2.2.5",
-                "lodash": "^4.17.10",
-                "memize": "^1.0.5",
-                "moment": "^2.22.1",
-                "querystring": "^0.2.0",
-                "querystringify": "^1.0.0",
-                "url": "^0.11.0"
-              }
-            },
-            "@wordpress/blocks": {
-              "version": "4.0.4",
-              "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-4.0.4.tgz",
-              "integrity": "sha512-sJRb4k+duD/tfBY6GBT6sw3NOaJ7jErhavR9hDOkJonBusoc6KFKUFQdt+NBWkwQB+/7QJcshFuChg3FRK6bKw==",
-              "requires": {
-                "@babel/runtime": "^7.0.0",
-                "@wordpress/autop": "^2.0.2",
-                "@wordpress/blob": "^2.1.0",
-                "@wordpress/block-serialization-default-parser": "^1.0.1",
-                "@wordpress/block-serialization-spec-parser": "^1.0.3",
-                "@wordpress/data": "^2.1.4",
-                "@wordpress/deprecated": "^2.0.2",
-                "@wordpress/dom": "^2.0.4",
-                "@wordpress/element": "^2.1.4",
-                "@wordpress/hooks": "^2.0.2",
-                "@wordpress/i18n": "^3.0.1",
-                "@wordpress/is-shallow-equal": "^1.1.4",
-                "@wordpress/shortcode": "^2.0.2",
-                "hpq": "^1.2.0",
-                "lodash": "^4.17.10",
-                "rememo": "^3.0.0",
-                "showdown": "^1.8.6",
-                "simple-html-tokenizer": "^0.4.1",
-                "tinycolor2": "^1.4.1",
-                "uuid": "^3.1.0"
-              }
-            },
-            "@wordpress/components": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-4.2.1.tgz",
-              "integrity": "sha512-RFH54uX2lci5uHpDCLGeTOHWJjM2dzb1ekhUpCDiDaAJatMLDtibXWbFH97SXqB5UVZxXu540SMwqNoxVikATw==",
-              "requires": {
-                "@babel/runtime": "^7.0.0",
-                "@wordpress/a11y": "^2.0.2",
-                "@wordpress/api-fetch": "^2.1.0",
-                "@wordpress/compose": "^2.0.5",
-                "@wordpress/deprecated": "^2.0.2",
-                "@wordpress/dom": "^2.0.4",
-                "@wordpress/element": "^2.1.4",
-                "@wordpress/hooks": "^2.0.2",
-                "@wordpress/i18n": "^3.0.1",
-                "@wordpress/is-shallow-equal": "^1.1.4",
-                "@wordpress/keycodes": "^2.0.2",
-                "@wordpress/url": "^2.1.0",
-                "classnames": "^2.2.5",
-                "clipboard": "^2.0.1",
-                "diff": "^3.5.0",
-                "dom-scroll-into-view": "^1.2.1",
-                "lodash": "^4.17.10",
-                "memize": "^1.0.5",
-                "moment": "^2.22.1",
-                "mousetrap": "^1.6.2",
-                "re-resizable": "^4.7.1",
-                "react-click-outside": "^2.3.1",
-                "react-dates": "^17.1.1",
-                "rememo": "^3.0.0",
-                "tinycolor2": "^1.4.1",
-                "uuid": "^3.1.0"
-              }
-            },
-            "@wordpress/compose": {
-              "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-2.0.5.tgz",
-              "integrity": "sha512-bbf+4nph+/rFBou7PTUyx8rwHVR08ymBgxnmShGTTjuiVxcrz0Gu7Wu2wxulsZobOYaiqvQkCEHKceNsBxJwiA==",
-              "requires": {
-                "@babel/runtime": "^7.0.0",
-                "@wordpress/element": "^2.1.4",
-                "@wordpress/is-shallow-equal": "^1.1.4",
-                "lodash": "^4.17.10"
-              }
-            },
-            "@wordpress/core-data": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-2.0.6.tgz",
-              "integrity": "sha512-7JzU9f+bCAg1oT0IYu7QPO+C5tP8rGN3BodZmbqJOut8DGiMSzDYdfVwwltKzKJmTBeuitYuSK48sXBLSoJb7Q==",
-              "requires": {
-                "@babel/runtime": "^7.0.0",
-                "@wordpress/api-fetch": "^2.1.0",
-                "@wordpress/data": "^2.1.4",
-                "@wordpress/url": "^2.1.0",
-                "equivalent-key-map": "^0.2.1",
-                "lodash": "^4.17.10",
-                "rememo": "^3.0.0"
-              }
-            },
-            "@wordpress/data": {
-              "version": "2.1.4",
-              "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-2.1.4.tgz",
-              "integrity": "sha512-Emfhszi7huasdDhngwk9HvRLUiotCNo9mDDk2Q9VGpGb9SfpQp+84PvenhreiZtezUR+7nUnSQuAJ2d8rUP37Q==",
-              "requires": {
-                "@babel/runtime": "^7.0.0",
-                "@wordpress/compose": "^2.0.5",
-                "@wordpress/deprecated": "^2.0.2",
-                "@wordpress/element": "^2.1.4",
-                "@wordpress/is-shallow-equal": "^1.1.4",
-                "@wordpress/redux-routine": "^3.0.3",
-                "equivalent-key-map": "^0.2.0",
-                "is-promise": "^2.1.0",
-                "lodash": "^4.17.10",
-                "redux": "^4.0.0"
-              }
-            },
-            "@wordpress/date": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-2.0.3.tgz",
-              "integrity": "sha512-ZnIEZT3sp+H2dr4apdoZnM9MhN6FpnMZ2zB+h8KuKExJufu9EUyW4grhEvgCTloJbzXNKCN5eolqeYq9I0pWog==",
-              "requires": {
-                "@babel/runtime": "^7.0.0",
-                "moment": "^2.22.1",
-                "moment-timezone": "^0.5.16"
-              }
-            },
-            "@wordpress/dom": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.0.4.tgz",
-              "integrity": "sha512-uW/yeWayoSu6uUA+xrM+yCbNJc3oQfga1Y1PUgXvowv0ydn5Qhgh2Dj07ANgg1AncZqFZsObPerBFNloaJhsvQ==",
-              "requires": {
-                "@babel/runtime": "^7.0.0",
-                "lodash": "^4.17.10"
-              }
-            },
-            "@wordpress/editor": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-5.0.1.tgz",
-              "integrity": "sha512-+654GVNUT5Rx0o5yBLwbpXD93B/YdBfH1oAS7mwKn1VCPtAZGGJuza28PFpEaJrHYtAXXbcETsH9GOV0ugOEXQ==",
-              "requires": {
-                "@babel/runtime": "^7.0.0",
-                "@wordpress/a11y": "^2.0.2",
-                "@wordpress/api-fetch": "^2.1.0",
-                "@wordpress/blob": "^2.1.0",
-                "@wordpress/blocks": "^4.0.4",
-                "@wordpress/components": "^4.2.1",
-                "@wordpress/compose": "^2.0.5",
-                "@wordpress/core-data": "^2.0.6",
-                "@wordpress/data": "^2.1.4",
-                "@wordpress/date": "^2.0.3",
-                "@wordpress/deprecated": "^2.0.2",
-                "@wordpress/dom": "^2.0.4",
-                "@wordpress/element": "^2.1.4",
-                "@wordpress/hooks": "^2.0.2",
-                "@wordpress/html-entities": "^2.0.2",
-                "@wordpress/i18n": "^3.0.1",
-                "@wordpress/is-shallow-equal": "^1.1.4",
-                "@wordpress/keycodes": "^2.0.2",
-                "@wordpress/nux": "^2.0.6",
-                "@wordpress/token-list": "^1.0.2",
-                "@wordpress/url": "^2.1.0",
-                "@wordpress/viewport": "^2.0.5",
-                "@wordpress/wordcount": "^2.0.2",
-                "classnames": "^2.2.5",
-                "dom-scroll-into-view": "^1.2.1",
-                "inherits": "^2.0.3",
-                "jquery": "^3.3.1",
-                "lodash": "^4.17.10",
-                "memize": "^1.0.5",
-                "react-autosize-textarea": "^3.0.2",
-                "redux-multi": "^0.1.12",
-                "redux-optimist": "^1.0.0",
-                "refx": "^3.0.0",
-                "rememo": "^3.0.0",
-                "tinycolor2": "^1.4.1",
-                "tinymce": "^4.7.2",
-                "traverse": "^0.6.6",
-                "uuid": "^3.1.0"
-              }
-            },
-            "@wordpress/element": {
-              "version": "2.1.4",
-              "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.1.4.tgz",
-              "integrity": "sha512-y/RpvYNd2VeLWXemxEXdMOnUa+HUC0sde2o7gEHKud0LB14xFU1ASif/pz/LP+vSvExcvhj8cu4Sq8tKDzRRPw==",
-              "requires": {
-                "@babel/runtime": "^7.0.0",
-                "@wordpress/escape-html": "^1.0.1",
-                "lodash": "^4.17.10",
-                "react": "^16.4.1",
-                "react-dom": "^16.4.1"
-              }
-            },
-            "@wordpress/escape-html": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.0.1.tgz",
-              "integrity": "sha512-ywRXV6WHbUWlqEDXQcWLmyG+/oBw8myTp+KTbkRRF2EJvx/cqL9XF55I2+aeZ5Q0VYRXXGHp6Tp1iRfJjr/rNQ==",
-              "requires": {
-                "@babel/runtime": "^7.0.0"
-              }
-            },
-            "@wordpress/nux": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/@wordpress/nux/-/nux-2.0.6.tgz",
-              "integrity": "sha512-22nYvccK0NPGZBegR55BTxbClXO8nSfHut+SSA1/CTPqX3yd//KPeAmGfgNCYH/lMz7RSRcj83oFEGpwrWWISQ==",
-              "requires": {
-                "@babel/runtime": "^7.0.0",
-                "@wordpress/components": "^4.2.1",
-                "@wordpress/compose": "^2.0.5",
-                "@wordpress/data": "^2.1.4",
-                "@wordpress/element": "^2.1.4",
-                "@wordpress/i18n": "^3.0.1",
-                "lodash": "^4.17.10",
-                "rememo": "^3.0.0"
-              }
-            },
-            "@wordpress/plugins": {
-              "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-2.0.5.tgz",
-              "integrity": "sha512-fER2dJS9NbZPcEL0TEH30UsH2EXx/WSf3JDzJIK86eu33A34cDXv7CvplwLrsiaysOEiCyMvG9DDrCGdM4PVvA==",
-              "requires": {
-                "@babel/runtime": "^7.0.0",
-                "@wordpress/compose": "^2.0.5",
-                "@wordpress/element": "^2.1.4",
-                "@wordpress/hooks": "^2.0.2",
-                "lodash": "^4.17.10"
-              }
-            },
-            "@wordpress/redux-routine": {
-              "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.0.3.tgz",
-              "integrity": "sha512-wT8GoG0qtwxq8J5g0uYxZYoNcnhQloFvMTkDQsaWWAvaO1wsTaamYbusHc6q7PS+EsS2TioQkZsxTtei6YwBBg==",
-              "requires": {
-                "@babel/runtime": "^7.0.0",
-                "is-promise": "^2.1.0",
-                "rungen": "^0.3.2"
-              }
-            },
-            "@wordpress/url": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.1.0.tgz",
-              "integrity": "sha512-MPWFszPleQ+ofDE8ZMpVLOwK/yAjf6L9f7F9wxE82rQjRzUSkrs+Z7Q9ShYiD5HT7o4J96PY9S0XnoHW/XKnDg==",
-              "requires": {
-                "@babel/runtime": "^7.0.0",
-                "qs": "^6.5.2"
-              }
-            },
-            "@wordpress/viewport": {
-              "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.0.5.tgz",
-              "integrity": "sha512-im0/L6+rwM8gtUuSRkzsPOH1pAwKWHLGfJXdnSuYSV1/K/e3szBLIlkHOK1q4YXkVzHxSSNDcnaHEuxbA/6rNA==",
-              "requires": {
-                "@babel/runtime": "^7.0.0",
-                "@wordpress/compose": "^2.0.5",
-                "@wordpress/data": "^2.1.4",
-                "@wordpress/element": "^2.1.4",
-                "lodash": "^4.17.10"
-              }
-            },
-            "jquery": {
-              "version": "3.3.1",
-              "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-              "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
-            },
-            "react-click-outside": {
-              "version": "2.3.1",
-              "resolved": "https://registry.npmjs.org/react-click-outside/-/react-click-outside-2.3.1.tgz",
-              "integrity": "sha1-MYc3698IGko7zUaCVmNnTL6YNus=",
-              "requires": {
-                "hoist-non-react-statics": "^1.2.0"
-              }
-            }
           }
         },
         "@wordpress/editor": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-4.0.1.tgz",
-          "integrity": "sha512-2bqB8TFiVGcGl71Fi9ZHcPg96aPgIzj0/VM4Pw7zcMLwrL+TAkCBX4rRc8xv7g1TL1dwXZhHbG4CAe3UCb7msw==",
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-9.0.1.tgz",
+          "integrity": "sha512-ZhihGx9huZkJfKRM5dlzesmjoC0Tcl7LwdMC4UXjQSey7blriRGrEMUdhLikbqdLuK1/tVNA2HHIlHUaRBAMMA==",
           "requires": {
             "@babel/runtime": "^7.0.0",
             "@wordpress/a11y": "^2.0.2",
-            "@wordpress/api-fetch": "^2.0.2",
-            "@wordpress/blob": "^2.0.2",
-            "@wordpress/blocks": "^4.0.1",
-            "@wordpress/components": "^4.1.0",
-            "@wordpress/compose": "^2.0.2",
-            "@wordpress/core-data": "^2.0.2",
-            "@wordpress/data": "^2.1.1",
-            "@wordpress/date": "^2.0.2",
-            "@wordpress/deprecated": "^2.0.2",
-            "@wordpress/dom": "^2.0.2",
-            "@wordpress/element": "^2.1.1",
-            "@wordpress/hooks": "^2.0.2",
-            "@wordpress/html-entities": "^2.0.2",
-            "@wordpress/i18n": "^3.0.1",
+            "@wordpress/api-fetch": "^2.2.5",
+            "@wordpress/blob": "^2.1.0",
+            "@wordpress/blocks": "^6.0.2",
+            "@wordpress/components": "^7.0.1",
+            "@wordpress/compose": "^3.0.0",
+            "@wordpress/core-data": "^2.0.14",
+            "@wordpress/data": "^4.0.1",
+            "@wordpress/date": "^3.0.0",
+            "@wordpress/deprecated": "^2.0.3",
+            "@wordpress/dom": "^2.0.7",
+            "@wordpress/element": "^2.1.8",
+            "@wordpress/hooks": "^2.0.3",
+            "@wordpress/html-entities": "^2.0.3",
+            "@wordpress/i18n": "^3.1.0",
             "@wordpress/is-shallow-equal": "^1.1.4",
-            "@wordpress/keycodes": "^2.0.2",
-            "@wordpress/nux": "^2.0.2",
-            "@wordpress/token-list": "^1.0.2",
-            "@wordpress/url": "^2.0.2",
-            "@wordpress/viewport": "^2.0.2",
-            "@wordpress/wordcount": "^2.0.2",
+            "@wordpress/keycodes": "^2.0.5",
+            "@wordpress/notices": "^1.1.0",
+            "@wordpress/nux": "^3.0.2",
+            "@wordpress/token-list": "^1.1.0",
+            "@wordpress/url": "^2.3.1",
+            "@wordpress/viewport": "^2.0.12",
+            "@wordpress/wordcount": "^2.0.3",
             "classnames": "^2.2.5",
             "dom-scroll-into-view": "^1.2.1",
             "inherits": "^2.0.3",
@@ -12264,8 +12080,7 @@
             "rememo": "^3.0.0",
             "tinycolor2": "^1.4.1",
             "tinymce": "^4.7.2",
-            "traverse": "^0.6.6",
-            "uuid": "^3.1.0"
+            "traverse": "^0.6.6"
           },
           "dependencies": {
             "jquery": {
@@ -12276,51 +12091,75 @@
           }
         },
         "@wordpress/element": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.1.1.tgz",
-          "integrity": "sha512-npZP5oAhtG9qqsDNCulSn9jggw8g76Kfp5zmNy1uNfvY+gAhDSDqrO4MC7MCquWygiSxfFWob2ECSCbG4RMFSg==",
+          "version": "2.1.8",
+          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.1.8.tgz",
+          "integrity": "sha512-hPbNWcxGQCpTeXoTdwr0Bu3kNJMSSKAnIb5B8P/2lTQ9mJ6w8l1Vc/0L11Yy8+uElaLwGq4Lja9ljgTlWbXUkA==",
           "requires": {
             "@babel/runtime": "^7.0.0",
-            "@wordpress/escape-html": "^1.0.0-beta.1",
+            "@wordpress/escape-html": "^1.0.1",
             "lodash": "^4.17.10",
-            "react": "^16.4.1",
-            "react-dom": "^16.4.1"
+            "react": "^16.6.3",
+            "react-dom": "^16.6.3"
           }
         },
         "@wordpress/escape-html": {
-          "version": "1.0.0-beta.2",
-          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.0.0-beta.2.tgz",
-          "integrity": "sha512-fLJu2QHNHadYJ5z5SOVwu6PQfnJG+jp/nfYl4iy/z1B98++/Qmhb1kiS1cz+P5fI2sXqjQzTkdIrcEO+nvuhEg==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.0.1.tgz",
+          "integrity": "sha512-ywRXV6WHbUWlqEDXQcWLmyG+/oBw8myTp+KTbkRRF2EJvx/cqL9XF55I2+aeZ5Q0VYRXXGHp6Tp1iRfJjr/rNQ==",
           "requires": {
             "@babel/runtime": "^7.0.0"
           }
         },
+        "@wordpress/format-library": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/@wordpress/format-library/-/format-library-1.2.4.tgz",
+          "integrity": "sha512-zHkYSu01Qpzc0UNAYTe/X39tzCv3ANPeQpdEGKyPOjhNoUi7qYh26Yheas4gWrx2pOs4tG3DfGDbFMIvgPiwZw==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "@wordpress/components": "^7.0.1",
+            "@wordpress/dom": "^2.0.7",
+            "@wordpress/editor": "^9.0.1",
+            "@wordpress/element": "^2.1.8",
+            "@wordpress/i18n": "^3.1.0",
+            "@wordpress/keycodes": "^2.0.5",
+            "@wordpress/rich-text": "^3.0.2",
+            "@wordpress/url": "^2.3.1"
+          }
+        },
         "@wordpress/hooks": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.0.2.tgz",
-          "integrity": "sha512-yWdkjw6YP2kDF+cjjRfkI2cjTRiETaRFMwJpoqnQWxfay1oBtgvaGuRrYrm0rCxxOqCD/4/di2co5VHQxP9Rhw==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.0.3.tgz",
+          "integrity": "sha512-dMXM8VX1MfMN+vrstOdpCXioo4evtvjTESVnSc+AjKVOAWOCbuT/ci3aDLy8DreyDrWYgUR35Gfh7Y8JJix7vA==",
           "requires": {
             "@babel/runtime": "^7.0.0"
           }
         },
         "@wordpress/html-entities": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.0.2.tgz",
-          "integrity": "sha512-cxG7YjH9EMfZyeLJAd/Vc1nFJxitMSzybv71iMPP3Dqqgz3jixX6oSe4ukTqfoOKBaF7pY7LzS6eTKu7KAmyZw==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.0.3.tgz",
+          "integrity": "sha512-qkZL538U0TyC+sp0u5U9t/SulQjOO3pmmGDmJikSn5IHU/EZwYiyFxF2EDPDHR5PHILgAmdJV8Qefmrb3ml3vg==",
           "requires": {
             "@babel/runtime": "^7.0.0"
           }
         },
         "@wordpress/i18n": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.0.1.tgz",
-          "integrity": "sha512-Ut6ihDjcZ7zpU44/WurZrFxrLcMl3Gq+hW8Hb6MTF6+X6Y2fd7QFu3lMvopYNwF8gxWtjvH5n3NIQ6B9DLt7Ng==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.1.0.tgz",
+          "integrity": "sha512-zHqLRuKrDV3FYh8PYDs4ABO/csiEAy1EfTffMtMS/8GAz4BcWrcqDjyH42GJF8iwWdG5+DdsllP5oerAQMHnng==",
           "requires": {
             "@babel/runtime": "^7.0.0",
             "gettext-parser": "^1.3.1",
-            "jed": "^1.1.1",
             "lodash": "^4.17.10",
-            "memize": "^1.0.5"
+            "memize": "^1.0.5",
+            "sprintf-js": "^1.1.1",
+            "tannin": "^1.0.1"
+          },
+          "dependencies": {
+            "sprintf-js": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+              "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+            }
           }
         },
         "@wordpress/is-shallow-equal": {
@@ -12332,45 +12171,57 @@
           }
         },
         "@wordpress/keycodes": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.0.2.tgz",
-          "integrity": "sha512-miMB6uvKZzZmgTb7qSr0NBOadWJ9Eb5Tak/+DRsVrgt9RP4zeCh9Le2T7hOWvNPU/54x2v1eHRrU0L+JDm2JAA==",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.0.5.tgz",
+          "integrity": "sha512-uEnLRbEe+6FkXKTdQordwR9fBExIngnsa6FmAJ2ODzEI872g271jM5W61m33WzsBHfbFHQKqUi+ZaFAzu7XUcg==",
           "requires": {
             "@babel/runtime": "^7.0.0",
+            "@wordpress/i18n": "^3.1.0",
+            "lodash": "^4.17.10"
+          }
+        },
+        "@wordpress/notices": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-1.1.0.tgz",
+          "integrity": "sha512-dVbHKUq1xo4ecGy1j/cxbnRY1L/by+O4Xu+QBdrX5MPCOEU0TLak8k9PUS+nm13zFAJg4kzZip301Udb/OgoZg==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "@wordpress/a11y": "^2.0.2",
+            "@wordpress/data": "^4.0.1",
             "lodash": "^4.17.10"
           }
         },
         "@wordpress/nux": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@wordpress/nux/-/nux-2.0.2.tgz",
-          "integrity": "sha512-N8kUsNvULU/j7D0gIRmPxdC7TJiYwcRLUygI25qAZ/FHYDMiFrzR9ZWkm6rDyDG3i2H8++99Cnyq8L9kX6kDCg==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@wordpress/nux/-/nux-3.0.2.tgz",
+          "integrity": "sha512-La82tFww/UzWjywaFODvZ8YODvDK4GeX8ckkaP1zFk0UelkS8gRZdaWDfkEsBzbKHyhZj3JJGT1WrM1/JJYKFw==",
           "requires": {
             "@babel/runtime": "^7.0.0",
-            "@wordpress/components": "^4.1.0",
-            "@wordpress/compose": "^2.0.2",
-            "@wordpress/data": "^2.1.1",
-            "@wordpress/element": "^2.1.1",
-            "@wordpress/i18n": "^3.0.1",
+            "@wordpress/components": "^7.0.1",
+            "@wordpress/compose": "^3.0.0",
+            "@wordpress/data": "^4.0.1",
+            "@wordpress/element": "^2.1.8",
+            "@wordpress/i18n": "^3.1.0",
             "lodash": "^4.17.10",
             "rememo": "^3.0.0"
           }
         },
         "@wordpress/plugins": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-2.0.2.tgz",
-          "integrity": "sha512-j/2DjkxarAgbjFPUz+cniji16MQmYX/WietVTmjsQ4l+65wjZtvwMmgcJFw8P9t4P22MECeWuvxRmHI7RS/SLQ==",
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-2.0.9.tgz",
+          "integrity": "sha512-9P+XWDaGlvdckvIPbQHPRUC0O3AqDrPngA0CxjhsYuKOd77uQfGlzMdeXNebDmky/u6aV6z7R/Phf6HQEs0aDA==",
           "requires": {
             "@babel/runtime": "^7.0.0",
-            "@wordpress/compose": "^2.0.2",
-            "@wordpress/element": "^2.1.1",
-            "@wordpress/hooks": "^2.0.2",
+            "@wordpress/compose": "^3.0.0",
+            "@wordpress/element": "^2.1.8",
+            "@wordpress/hooks": "^2.0.3",
             "lodash": "^4.17.10"
           }
         },
         "@wordpress/redux-routine": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.0.1.tgz",
-          "integrity": "sha512-BSg/0nrGy9u1ZFNNrsESo6KQYsIUBrlsTVi5gExta+o9uamHTXKAXhasq+wnjm4GqnPkdYck6zNQ/xbeqxNvgA==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.0.3.tgz",
+          "integrity": "sha512-wT8GoG0qtwxq8J5g0uYxZYoNcnhQloFvMTkDQsaWWAvaO1wsTaamYbusHc6q7PS+EsS2TioQkZsxTtei6YwBBg==",
           "requires": {
             "@babel/runtime": "^7.0.0",
             "is-promise": "^2.1.0",
@@ -12378,13 +12229,16 @@
           }
         },
         "@wordpress/rich-text": {
-          "version": "1.0.0-beta.1",
-          "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-1.0.0-beta.1.tgz",
-          "integrity": "sha512-6JbtB/773cjufd6JVyazr1lH54ThbmQCC/+11Pyza4Pq8NHe00InymLMGNpCAdGVr0fKCsBRz+AFcuwuEYHNAw==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.0.2.tgz",
+          "integrity": "sha512-qLhQz142vpEr/j69SLir3Sz8CYMoosyP8xjGAyH22S/gH8jTydnWtDx//xdkzvikXRbV1niXuPMDyLV2QOlong==",
           "requires": {
             "@babel/runtime": "^7.0.0",
-            "@wordpress/escape-html": "^1.0.0-beta.1",
-            "lodash": "^4.17.10"
+            "@wordpress/compose": "^3.0.0",
+            "@wordpress/data": "^4.0.1",
+            "@wordpress/escape-html": "^1.0.1",
+            "lodash": "^4.17.10",
+            "rememo": "^3.0.0"
           }
         },
         "@wordpress/shortcode": {
@@ -12398,39 +12252,39 @@
           }
         },
         "@wordpress/token-list": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-1.0.2.tgz",
-          "integrity": "sha512-hyk3xsLB1OlS52kFlR9PcSzvD6fkB2uOG4Uchs1pd304M/G3WTdD6iPiRVZeMmpWbwMq9KFtu9f8hwUzQTrTow==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-1.1.0.tgz",
+          "integrity": "sha512-1InK0ic0syqUEyY3XkiDiZW9rJB/C/KZEzaOZjyzl/mwDR0npMiAouY3fTQ6qZSsMHjszhSl90yXz1I9M/DapA==",
           "requires": {
             "@babel/runtime": "^7.0.0",
             "lodash": "^4.17.10"
           }
         },
         "@wordpress/url": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.0.2.tgz",
-          "integrity": "sha512-bGmhswKeTTmYIwjH4ekjSDkOTq/kzN4dXi41rXAcjPnO3utV5mEc9GBORGicZNOXv0CksOSP4Cez0vnAgfqRaQ==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.3.1.tgz",
+          "integrity": "sha512-Z4tCYMsW3DHOLnBXM7MK2kcuX26Pszpxjst8x5hzWmYa6zJRn8MA8Bd5RF++R1NwpWJZGk4m47rj6Q36zkr86g==",
           "requires": {
             "@babel/runtime": "^7.0.0",
             "qs": "^6.5.2"
           }
         },
         "@wordpress/viewport": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.0.2.tgz",
-          "integrity": "sha512-2NzlLfGiWdUCc3tAGEORZQqDmnaKqwtZVXaKRmF+6HpX8UlgkKDPqKQVcpq7DqxlcBNcL0GPwFYUaYQPChfUiw==",
+          "version": "2.0.12",
+          "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.0.12.tgz",
+          "integrity": "sha512-W2M+RIbAlfIn7B8nQtR10SD5lLpLNu2bMXk18h5ToS8BhBwEK9dagjSh1i4nJplzNzZUB/JsaVXDRRCFymuT3A==",
           "requires": {
             "@babel/runtime": "^7.0.0",
-            "@wordpress/compose": "^2.0.2",
-            "@wordpress/data": "^2.1.1",
-            "@wordpress/element": "^2.1.1",
+            "@wordpress/compose": "^3.0.0",
+            "@wordpress/data": "^4.0.1",
+            "@wordpress/element": "^2.1.8",
             "lodash": "^4.17.10"
           }
         },
         "@wordpress/wordcount": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-2.0.2.tgz",
-          "integrity": "sha512-FQ9mU/NsEB+IczD8roBGes9fJlZdTtdNhftdoCw32/lpUgP/bjA736NIPtNRedry+VBFykHqUf0CygJ0TgaOKA==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-2.0.3.tgz",
+          "integrity": "sha512-+5W1g1UkQ0zMCbAvHQw7OxJPvacMGift+Rhy1dRJZkJ3h7xkbvI+dO3+cwuEgNqdZboO1c5m35NsRrMUsrwNgA==",
           "requires": {
             "@babel/runtime": "^7.0.0",
             "lodash": "^4.17.10"
@@ -12497,19 +12351,16 @@
           },
           "dependencies": {
             "acorn": {
-              "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.2.tgz",
-              "integrity": "sha512-GXmKIvbrN3TV7aVqAzVFaMW8F8wzVX7voEBRO3bDA64+EX37YSayggRJP5Xig6HYHBkWKpFg9W5gg6orklubhg=="
+              "version": "6.0.4",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
+              "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg=="
             }
           }
         },
         "acorn-jsx": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
-          "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
-          "requires": {
-            "acorn": "^5.0.3"
-          }
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.0.tgz",
+          "integrity": "sha512-XkB50fn0MURDyww9+UYL3c1yLbOBz0ZFvrdYlGB8l+Ije1oSC75qAqrzSPjYQbdnQUzhlUGNKuesryAv0gxZOg=="
         },
         "acorn-walk": {
           "version": "6.1.0",
@@ -12530,9 +12381,9 @@
           }
         },
         "agentkeepalive": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.1.tgz",
-          "integrity": "sha512-Cte/sTY9/XcygXjJ0q58v//SnEQ7ViWExKyJpLJlLqomDbQyMLh6Is4KuWJ/wmxzhiwkGRple7Gqv1zf6Syz5w==",
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
+          "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
           "requires": {
             "humanize-ms": "^1.2.1"
           }
@@ -12554,9 +12405,9 @@
           }
         },
         "ajv": {
-          "version": "6.5.4",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
-          "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
+          "version": "6.5.5",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
+          "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -12585,9 +12436,9 @@
           "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
         },
         "ansi-colors": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.1.0.tgz",
-          "integrity": "sha512-hTv1qPdi+sVEk3jYsdjox5nQI0C9HTbjKShbCdYLKb1LOfNbb7wsF4d7OEKIZoxIHx02tSp3m94jcPW2EfMjmA=="
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.1.tgz",
+          "integrity": "sha512-Xt+zb6nqgvV9SWAVp0EG3lRsHcbq5DDgqjPPz6pwgtj6RKz65zGXMNa82oJfOSBA/to6GmRP7Dr+6o+kbApTzQ=="
         },
         "ansi-escapes": {
           "version": "3.1.0",
@@ -12611,6 +12462,11 @@
           "requires": {
             "color-convert": "^1.9.0"
           }
+        },
+        "ansicolors": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+          "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
         },
         "anymatch": {
           "version": "2.0.0",
@@ -12970,7 +12826,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -13103,6 +12959,14 @@
           "integrity": "sha512-m0sMxPL4FaN2K69GQgaRJa4Ny15qKSdoknIcpN+gz+NaJlAW9pge/povs13tPYsKDboflrEQC+/3kfIsONBTaw==",
           "requires": {
             "chokidar": "^2.0.4"
+          }
+        },
+        "babel-plugin-dynamic-import-node": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.2.0.tgz",
+          "integrity": "sha512-fP899ELUnTaBcIzmrW7nniyqqdYWrWuJUyPWHxFa/c7r7hS6KC8FscNfLlBNIoPSc55kYMGEEKjPjJGCLbE1qA==",
+          "requires": {
+            "object.assign": "^4.1.0"
           }
         },
         "babel-plugin-istanbul": {
@@ -13439,9 +13303,9 @@
           "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg=="
         },
         "blob": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-          "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+          "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
         },
         "block-stream": {
           "version": "0.0.9",
@@ -13646,13 +13510,13 @@
           }
         },
         "browserslist": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.2.1.tgz",
-          "integrity": "sha512-1oO0c7Zhejwd+LXihS89WqtKionSbz298rJZKJgfrHIZhrV8AC15gw553VcB0lcEugja7IhWD7iAlrsamfYVPA==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
+          "integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
           "requires": {
-            "caniuse-lite": "^1.0.30000890",
-            "electron-to-chromium": "^1.3.79",
-            "node-releases": "^1.0.0-alpha.14"
+            "caniuse-lite": "^1.0.30000899",
+            "electron-to-chromium": "^1.3.82",
+            "node-releases": "^1.0.1"
           }
         },
         "bser": {
@@ -13664,18 +13528,15 @@
           }
         },
         "buble": {
-          "version": "0.19.4",
-          "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.4.tgz",
-          "integrity": "sha512-xaTfnWdx80TiajGDZoSYB17nEDqjGnVxeug5W7tvXIAMn61yMa5AfTuWu3F4nLL2Fv/hK8T6GktZvQ6yvPZMpA==",
+          "version": "0.19.6",
+          "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.6.tgz",
+          "integrity": "sha512-9kViM6nJA1Q548Jrd06x0geh+BG2ru2+RMDkIHHgJY/8AcyCs34lTHwra9BX7YdPrZXd5aarkpr/SY8bmPgPdg==",
           "requires": {
-            "acorn": "^5.4.1",
-            "acorn-dynamic-import": "^3.0.0",
-            "acorn-jsx": "^4.1.1",
-            "chalk": "^2.3.1",
-            "magic-string": "^0.22.4",
+            "chalk": "^2.4.1",
+            "magic-string": "^0.25.1",
             "minimist": "^1.2.0",
             "os-homedir": "^1.0.1",
-            "regexpu-core": "^4.1.3",
+            "regexpu-core": "^4.2.0",
             "vlq": "^1.0.0"
           },
           "dependencies": {
@@ -13727,9 +13588,9 @@
           "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
         },
         "byte-size": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-4.0.3.tgz",
-          "integrity": "sha512-JGC3EV2bCzJH/ENSh3afyJrH4vwxbHTuO5ljLoI5+2iJOcEpMgP8T782jH9b5qGxf2mSUIp1lfGnfKNrRHpvVg=="
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-4.0.4.tgz",
+          "integrity": "sha512-82RPeneC6nqCdSwCX2hZUz3JPOvN5at/nTEw/CMf05Smu3Hrpo9Psb7LjN+k+XndNArG1EY8L4+BM3aTM4BCvw=="
         },
         "bytes": {
           "version": "3.0.0",
@@ -13737,9 +13598,9 @@
           "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
         },
         "cacache": {
-          "version": "11.2.0",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.2.0.tgz",
-          "integrity": "sha512-IFWl6lfK6wSeYCHUXh+N1lY72UDrpyrYQJNIVQf48paDuWbv5RbAtJYf/4gUQFObTCHZwdZ5sI8Iw7nqwP6nlQ==",
+          "version": "11.3.1",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.1.tgz",
+          "integrity": "sha512-2PEw4cRRDu+iQvBTTuttQifacYjLPhET+SYO/gEFMy8uhi+jlJREDAjSF5FWSdV/Aw5h18caHA7vMTw2c+wDzA==",
           "requires": {
             "bluebird": "^3.5.1",
             "chownr": "^1.0.1",
@@ -13784,6 +13645,21 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
           "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+        },
+        "caller-callsite": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+          "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+          "requires": {
+            "callsites": "^2.0.0"
+          },
+          "dependencies": {
+            "callsites": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+              "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+            }
+          }
         },
         "caller-path": {
           "version": "0.1.0",
@@ -13856,14 +13732,14 @@
           }
         },
         "caniuse-db": {
-          "version": "1.0.30000892",
-          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000892.tgz",
-          "integrity": "sha512-as/DXjiFJg051+GSJLmkY0hckkVsmTB4nuDUPLwK1sMHk94XsYuocNJuU0wdOpobwI/3sqNeW5ETebvdPGvwBQ=="
+          "version": "1.0.30000906",
+          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000906.tgz",
+          "integrity": "sha512-PrxbTWezapS26wYU+lgGKLW7QTr5QrUWDunjlHOQ1qBoHDJruHGb9pdDKFOI1nUnkudSDPhNoan2FW0vMlwFvA=="
         },
         "caniuse-lite": {
-          "version": "1.0.30000892",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000892.tgz",
-          "integrity": "sha512-X9rxMaWZNbJB5qjkDqPtNv/yfViTeUL6ILk0QJNxLV3OhKC5Acn5vxsuUvllR6B48mog8lmS+whwHq/QIYSL9w=="
+          "version": "1.0.30000906",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000906.tgz",
+          "integrity": "sha512-ME7JFX6h0402om/nC/8Lw+q23QvPe2ust9U0ntLmkX9F2zaGwq47fZkjlyHKirFBuq1EM+T/LXBcDdW4bvkCTA=="
         },
         "capture-exit": {
           "version": "1.2.0",
@@ -13871,6 +13747,15 @@
           "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
           "requires": {
             "rsvp": "^3.3.3"
+          }
+        },
+        "cardinal": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
+          "integrity": "sha1-ylu2iltRG5D+k7ms6km97lwyv+I=",
+          "requires": {
+            "ansicolors": "~0.2.1",
+            "redeyed": "~0.4.0"
           }
         },
         "caseless": {
@@ -14090,7 +13975,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -14255,7 +14140,7 @@
         },
         "color": {
           "version": "0.11.4",
-          "resolved": "http://registry.npmjs.org/color/-/color-0.11.4.tgz",
+          "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
           "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
           "requires": {
             "clone": "^1.0.2",
@@ -14283,6 +14168,10 @@
           "requires": {
             "color-name": "^1.0.0"
           }
+        },
+        "color-studio": {
+          "version": "github:automattic/color-studio#302bab1a6279ce539cd47cf369bf307a0d300d71",
+          "from": "github:automattic/color-studio"
         },
         "colormin": {
           "version": "1.1.2",
@@ -14315,7 +14204,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -14526,46 +14415,92 @@
           "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
         },
         "conventional-changelog-angular": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.1.tgz",
-          "integrity": "sha512-q4ylJ68fWZDdrFC9z4zKcf97HW6hp7Mo2YlqD4owfXhecFKy/PJCU/1oVFF4TqochchChqmZ0Vb0e0g8/MKNlA==",
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.2.tgz",
+          "integrity": "sha512-yx7m7lVrXmt4nKWQgWZqxSALEiAKZhOAcbxdUaU9575mB0CzXVbgrgpfSnSP7OqWDUTYGD0YVJ0MSRdyOPgAwA==",
           "requires": {
             "compare-func": "^1.3.1",
             "q": "^1.5.1"
           }
         },
         "conventional-changelog-core": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.1.0.tgz",
-          "integrity": "sha512-bcZkcFXkqVgG2W8m/1wjlp2wn/BKDcrPgw3/mvSEQtzs8Pax8JbAPFpEQReHY92+EKNNXC67wLA8y2xcNx0rDA==",
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.1.5.tgz",
+          "integrity": "sha512-iwqAotS4zk0wA4S84YY1JCUG7X3LxaRjJxuUo6GI4dZuIy243j5nOg/Ora35ExT4DOiw5dQbMMQvw2SUjh6moQ==",
           "requires": {
-            "conventional-changelog-writer": "^4.0.0",
-            "conventional-commits-parser": "^3.0.0",
+            "conventional-changelog-writer": "^4.0.2",
+            "conventional-commits-parser": "^3.0.1",
             "dateformat": "^3.0.0",
             "get-pkg-repo": "^1.0.0",
-            "git-raw-commits": "^2.0.0",
+            "git-raw-commits": "2.0.0",
             "git-remote-origin-url": "^2.0.0",
-            "git-semver-tags": "^2.0.0",
+            "git-semver-tags": "^2.0.2",
             "lodash": "^4.2.1",
             "normalize-package-data": "^2.3.5",
             "q": "^1.5.1",
-            "read-pkg": "^1.1.0",
-            "read-pkg-up": "^1.0.1",
+            "read-pkg": "^3.0.0",
+            "read-pkg-up": "^3.0.0",
             "through2": "^2.0.0"
+          },
+          "dependencies": {
+            "load-json-file": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+              "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "parse-json": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+              "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+              "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+              }
+            },
+            "read-pkg": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+              "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+              "requires": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+              "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+              "requires": {
+                "find-up": "^2.0.0",
+                "read-pkg": "^3.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+            }
           }
         },
         "conventional-changelog-preset-loader": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.0.1.tgz",
-          "integrity": "sha512-HiSfhXNzAzG9klIqJaA97MMiNBR4js+53g4Px0k7tgKeCNVXmrDrm+CY+nIqcmG5NVngEPf8rAr7iji1TWW7zg=="
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.0.2.tgz",
+          "integrity": "sha512-pBY+qnUoJPXAXXqVGwQaVmcye05xi6z231QM98wHWamGAmu/ghkBprQAwmF5bdmyobdVxiLhPY3PrCfSeUNzRQ=="
         },
         "conventional-changelog-writer": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.0.tgz",
-          "integrity": "sha512-hMZPe0AQ6Bi05epeK/7hz80xxk59nPA5z/b63TOHq2wigM0/akreOc8N4Jam5b9nFgKWX1e9PdPv2ewgW6bcfg==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.2.tgz",
+          "integrity": "sha512-d8/FQY/fix2xXEBUhOo8u3DCbyEw3UOQgYHxLsPDw+wHUDma/GQGAGsGtoH876WyNs32fViHmTOUrgRKVLvBug==",
           "requires": {
             "compare-func": "^1.3.1",
-            "conventional-commits-filter": "^2.0.0",
+            "conventional-commits-filter": "^2.0.1",
             "dateformat": "^3.0.0",
             "handlebars": "^4.0.2",
             "json-stringify-safe": "^5.0.1",
@@ -14683,18 +14618,18 @@
           }
         },
         "conventional-commits-filter": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.0.tgz",
-          "integrity": "sha512-Cfl0j1/NquB/TMVx7Wrmyq7uRM+/rPQbtVVGwzfkhZ6/yH6fcMmP0Q/9044TBZPTNdGzm46vXFXL14wbET0/Mg==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.1.tgz",
+          "integrity": "sha512-92OU8pz/977udhBjgPEbg3sbYzIxMDFTlQT97w7KdhR9igNqdJvy8smmedAAgn4tPiqseFloKkrVfbXCVd+E7A==",
           "requires": {
             "is-subset": "^0.1.1",
             "modify-values": "^1.0.0"
           }
         },
         "conventional-commits-parser": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.0.tgz",
-          "integrity": "sha512-GWh71U26BLWgMykCp+VghZ4s64wVbtseECcKQ/PvcPZR2cUnz+FUc2J9KjxNl7/ZbCxST8R03c9fc+Vi0umS9Q==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.1.tgz",
+          "integrity": "sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==",
           "requires": {
             "JSONStream": "^1.0.4",
             "is-text-path": "^1.0.0",
@@ -14812,16 +14747,16 @@
           }
         },
         "conventional-recommended-bump": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-4.0.1.tgz",
-          "integrity": "sha512-9waJvW01TUs4HQJ3khwGSSlTlKsY+5u7OrxHL+oWEoGNvaNO/0qL6qqnhS3J0Fq9fNKA9bmlf5cOXjCQoW+I4Q==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-4.0.4.tgz",
+          "integrity": "sha512-9mY5Yoblq+ZMqJpBzgS+RpSq+SUfP2miOR3H/NR9drGf08WCrY9B6HAGJZEm6+ThsVP917VHAahSOjM6k1vhPg==",
           "requires": {
             "concat-stream": "^1.6.0",
-            "conventional-changelog-preset-loader": "^2.0.1",
-            "conventional-commits-filter": "^2.0.0",
-            "conventional-commits-parser": "^3.0.0",
-            "git-raw-commits": "^2.0.0",
-            "git-semver-tags": "^2.0.0",
+            "conventional-changelog-preset-loader": "^2.0.2",
+            "conventional-commits-filter": "^2.0.1",
+            "conventional-commits-parser": "^3.0.1",
+            "git-raw-commits": "2.0.0",
+            "git-semver-tags": "^2.0.2",
             "meow": "^4.0.0",
             "q": "^1.5.1"
           },
@@ -15151,19 +15086,19 @@
         },
         "css-color-names": {
           "version": "0.0.4",
-          "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
           "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
         },
         "css-loader": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.0.tgz",
-          "integrity": "sha512-tMXlTYf3mIMt3b0dDCOQFJiVvxbocJ5Ho577WiGPYPZcqVEO218L2iU22pDXzkTZCLDE+9AmGSUkWxeh/nZReA==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.1.tgz",
+          "integrity": "sha512-+ZHAZm/yqvJ2kDtPne3uX0C+Vr3Zn5jFn2N4HywtS5ujwvsVkyg0VArEXpl3BgczDA8anieki1FIzhchX4yrDw==",
           "requires": {
             "babel-code-frame": "^6.26.0",
             "css-selector-tokenizer": "^0.7.0",
             "icss-utils": "^2.1.0",
             "loader-utils": "^1.0.2",
-            "lodash.camelcase": "^4.3.0",
+            "lodash": "^4.17.11",
             "postcss": "^6.0.23",
             "postcss-modules-extract-imports": "^1.2.0",
             "postcss-modules-local-by-default": "^1.2.0",
@@ -15213,9 +15148,9 @@
           }
         },
         "css-selector-tokenizer": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
-          "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
+          "integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
           "requires": {
             "cssesc": "^0.1.0",
             "fastparse": "^1.1.1",
@@ -15253,9 +15188,14 @@
           }
         },
         "css-what": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-          "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.2.tgz",
+          "integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ=="
+        },
+        "csscolorparser": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+          "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
         },
         "cssesc": {
           "version": "0.1.0",
@@ -15264,7 +15204,7 @@
         },
         "cssnano": {
           "version": "3.10.0",
-          "resolved": "http://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
           "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
           "requires": {
             "autoprefixer": "^6.3.1",
@@ -15375,7 +15315,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -15426,14 +15366,6 @@
           "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
           "requires": {
             "array-find-index": "^1.0.1"
-          }
-        },
-        "cwise-compiler": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
-          "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
-          "requires": {
-            "uniq": "^1.0.0"
           }
         },
         "cyclist": {
@@ -15545,12 +15477,12 @@
           "integrity": "sha1-agdBWgHJH69KMuONnfunH2HLIP4="
         },
         "data-urls": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.1.tgz",
-          "integrity": "sha512-0HdcMZzK6ubMUnsMmQmG0AcLQPvbvb47R0+7CCZQCYgcd8OUWG91CG7sM6GoXgjz+WLl4ArFzHtBMy/QqSF4eg==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+          "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
           "requires": {
             "abab": "^2.0.0",
-            "whatwg-mimetype": "^2.1.0",
+            "whatwg-mimetype": "^2.2.0",
             "whatwg-url": "^7.0.0"
           },
           "dependencies": {
@@ -15853,9 +15785,9 @@
           "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
         },
         "doctrine": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+          "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
           "requires": {
             "esutils": "^2.0.2"
           }
@@ -15869,9 +15801,12 @@
           }
         },
         "dom-helpers": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
-          "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+          "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+          "requires": {
+            "@babel/runtime": "^7.1.2"
+          }
         },
         "dom-iterator": {
           "version": "1.0.0",
@@ -15909,9 +15844,9 @@
           "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
         },
         "domelementtype": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-          "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.2.1.tgz",
+          "integrity": "sha512-SQVCLFS2E7G5CRCMdn6K9bIhRj1bS6QBWZfF0TUPh4V/BbqrQ619IdSS3/izn0FZ+9l+uODzaZjb08fjOfablA=="
         },
         "domexception": {
           "version": "1.0.1",
@@ -15959,6 +15894,13 @@
             "fbjs": "^0.8.15",
             "immutable": "~3.7.4",
             "object-assign": "^4.1.0"
+          },
+          "dependencies": {
+            "immutable": {
+              "version": "3.7.6",
+              "resolved": "http://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+              "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
+            }
           }
         },
         "duplexer": {
@@ -15987,6 +15929,11 @@
             "lodash": "^4.17.4",
             "semver": "^5.4.1"
           }
+        },
+        "earcut": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.1.3.tgz",
+          "integrity": "sha512-AxdCdWUk1zzK/NuZ7e1ljj6IGC+VAdC3Qb7QQDsXpfNrc5IM8tL9nNXUmEGE6jRHTfZ10zhzRhtDmWVsR5pd3A=="
         },
         "ecc-jsbn": {
           "version": "0.1.2",
@@ -16026,9 +15973,9 @@
           "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
         },
         "electron-to-chromium": {
-          "version": "1.3.79",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.79.tgz",
-          "integrity": "sha512-LQdY3j4PxuUl6xfxiFruTSlCniTrTrzAd8/HfsLEMi0PUpaQ0Iy+Pr4N4VllDYjs0Hyu2lkTbvzqlG+PX9NsNw=="
+          "version": "1.3.83",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.83.tgz",
+          "integrity": "sha512-DqJoDarxq50dcHsOOlMLNoy+qQitlMNbYb6wwbE0oUw2veHdRkpNrhmngiUYKMErdJ8SJ48rpJsZTQgy5SoEAA=="
         },
         "elliptic": {
           "version": "6.4.1",
@@ -16089,9 +16036,9 @@
           }
         },
         "engine.io": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
-          "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.1.tgz",
+          "integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
           "requires": {
             "accepts": "~1.3.4",
             "base64id": "1.0.0",
@@ -16140,14 +16087,14 @@
           }
         },
         "engine.io-parser": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
-          "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+          "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
           "requires": {
             "after": "0.8.2",
             "arraybuffer.slice": "~0.0.7",
             "base64-arraybuffer": "0.1.5",
-            "blob": "0.0.4",
+            "blob": "0.0.5",
             "has-binary2": "~1.0.2"
           }
         },
@@ -16162,9 +16109,9 @@
           }
         },
         "entities": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
         },
         "envify": {
           "version": "3.4.1",
@@ -16202,27 +16149,35 @@
           }
         },
         "enzyme-adapter-react-16": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.6.0.tgz",
-          "integrity": "sha512-ay9eGFpChyUDnjTFMMJHzrb681LF3hPWJLEA7RoLFG9jSWAdAm2V50pGmFV9dYGJgh5HfdiqM+MNvle41Yf/PA==",
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.7.0.tgz",
+          "integrity": "sha512-rDr0xlnnFPffAPYrvG97QYJaRl9unVDslKee33wTStsBEwZTkESX1H7VHGT5eUc6ifNzPgOJGvSh2zpHT4gXjA==",
           "requires": {
-            "enzyme-adapter-utils": "^1.8.0",
+            "enzyme-adapter-utils": "^1.9.0",
             "function.prototype.name": "^1.1.0",
             "object.assign": "^4.1.0",
             "object.values": "^1.0.4",
             "prop-types": "^15.6.2",
-            "react-is": "^16.5.2",
+            "react-is": "^16.6.1",
             "react-test-renderer": "^16.0.0-0"
+          },
+          "dependencies": {
+            "react-is": {
+              "version": "16.6.1",
+              "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.1.tgz",
+              "integrity": "sha512-wOKsGtvTMYs7WAscmwwdM8sfRRvE17Ym30zFj3n37Qx5tHRfhenPKEPILHaHob6WoLFADmQm1ZNrE5xMCM6sCw=="
+            }
           }
         },
         "enzyme-adapter-utils": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.8.1.tgz",
-          "integrity": "sha512-s3QB3xQAowaDS2sHhmEqrT13GJC4+n5bG015ZkLv60n9k5vhxxHTQRIneZmQ4hmdCZEBrvUJ89PG6fRI5OEeuQ==",
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.9.0.tgz",
+          "integrity": "sha512-uMe4xw4l/Iloh2Fz+EO23XUYMEQXj5k/5ioLUXCNOUCI8Dml5XQMO9+QwUq962hBsY5qftfHHns+d990byWHvg==",
           "requires": {
             "function.prototype.name": "^1.1.0",
             "object.assign": "^4.1.0",
-            "prop-types": "^15.6.2"
+            "prop-types": "^15.6.2",
+            "semver": "^5.6.0"
           }
         },
         "enzyme-to-json": {
@@ -16349,9 +16304,9 @@
           }
         },
         "eslint": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.7.0.tgz",
-          "integrity": "sha512-zYCeFQahsxffGl87U2aJ7DPyH8CbWgxBC213Y8+TCanhUTf2gEvfq3EKpHmEcozTLyPmGe9LZdMAwC/CpJBM5A==",
+          "version": "5.9.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.9.0.tgz",
+          "integrity": "sha512-g4KWpPdqN0nth+goDNICNXGfJF7nNnepthp46CAlJoJtC5K/cLu3NgCM3AHu1CkJ5Hzt9V0Y0PBAO6Ay/gGb+w==",
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "ajv": "^6.5.3",
@@ -16411,6 +16366,14 @@
               "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
               "requires": {
                 "ms": "^2.1.1"
+              }
+            },
+            "doctrine": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+              "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+              "requires": {
+                "esutils": "^2.0.2"
               }
             },
             "ignore": {
@@ -16593,9 +16556,9 @@
           }
         },
         "eslint-plugin-jest": {
-          "version": "21.25.1",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-21.25.1.tgz",
-          "integrity": "sha512-mmphmAD/WihjFGq1IUHLSZWQPcd8U9w/SeFCHf3p0V3Q3MBxmj1ZKnh41hID44guIACLuwos/LhVWIr4phN4yg=="
+          "version": "22.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.0.0.tgz",
+          "integrity": "sha512-YOj8cYI5ZXEZUrX2kUBLachR1ffjQiicIMBoivN7bXXHnxi8RcwNvmVzwlu3nTmjlvk5AP3kIpC5i8HcinmhPA=="
         },
         "eslint-plugin-jsx-a11y": {
           "version": "6.1.2",
@@ -16622,6 +16585,16 @@
             "has": "^1.0.3",
             "jsx-ast-utils": "^2.0.1",
             "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "doctrine": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+              "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+              "requires": {
+                "esutils": "^2.0.2"
+              }
+            }
           }
         },
         "eslint-plugin-wpcalypso": {
@@ -16651,22 +16624,25 @@
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
           "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
         },
+        "esm": {
+          "version": "3.0.84",
+          "resolved": "https://registry.npmjs.org/esm/-/esm-3.0.84.tgz",
+          "integrity": "sha512-SzSGoZc17S7P+12R9cg21Bdb7eybX25RnIeRZ80xZs+VZ3kdQKzqTp2k4hZJjR7p9l0186TTXSgrxzlMDBktlw=="
+        },
         "espree": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-4.0.0.tgz",
-          "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
+          "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
           "requires": {
-            "acorn": "^5.6.0",
-            "acorn-jsx": "^4.1.1"
+            "acorn": "^6.0.2",
+            "acorn-jsx": "^5.0.0",
+            "eslint-visitor-keys": "^1.0.0"
           },
           "dependencies": {
-            "acorn-jsx": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
-              "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
-              "requires": {
-                "acorn": "^5.0.3"
-              }
+            "acorn": {
+              "version": "6.0.4",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
+              "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg=="
             }
           }
         },
@@ -16710,21 +16686,6 @@
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-        },
-        "event-stream": {
-          "version": "3.3.6",
-          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-          "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
-          "requires": {
-            "duplexer": "^0.1.1",
-            "flatmap-stream": "^0.1.0",
-            "from": "^0.1.7",
-            "map-stream": "0.0.7",
-            "pause-stream": "^0.0.11",
-            "split": "^1.0.1",
-            "stream-combiner": "^0.2.2",
-            "through": "^2.3.8"
-          }
         },
         "events": {
           "version": "3.0.0",
@@ -16866,6 +16827,14 @@
             }
           }
         },
+        "expand-tilde": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+          "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+          "requires": {
+            "homedir-polyfill": "^1.0.1"
+          }
+        },
         "expand-year": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/expand-year/-/expand-year-1.0.0.tgz",
@@ -16887,6 +16856,11 @@
             "jest-message-util": "^23.4.0",
             "jest-regex-util": "^23.3.0"
           }
+        },
+        "expect.js": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.2.0.tgz",
+          "integrity": "sha1-EChTPSwcNj90pnlv9X7AUg3tK+E="
         },
         "exports-loader": {
           "version": "0.7.0",
@@ -17093,9 +17067,9 @@
           "integrity": "sha1-dZyjqYPdoGdC06PPpvZAcFNqQi8="
         },
         "fastparse": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
-          "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+          "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ=="
         },
         "fb-watchman": {
           "version": "2.0.0",
@@ -17207,7 +17181,7 @@
         },
         "finalhandler": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
           "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
           "requires": {
             "debug": "2.6.9",
@@ -17284,9 +17258,9 @@
           }
         },
         "flag-icon-css": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/flag-icon-css/-/flag-icon-css-3.2.0.tgz",
-          "integrity": "sha512-XwbQgswfJ19jVrYL92+MKK3HJfIG+6lC8oifaG6mOtahWaXHbDFXQ7UVbw1+I+zidM1azOD8aFC0DO+xZzK0Xg=="
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/flag-icon-css/-/flag-icon-css-3.2.1.tgz",
+          "integrity": "sha512-0t7zPm2crM2cBIm3epZQ+EmiHuzgFNTTSMUMkWlrztDDGL+y31D+eY8zaB9zYCzJGAsn4KEMAKY+jCU1mt9jwg=="
         },
         "flat-cache": {
           "version": "1.3.0",
@@ -17298,11 +17272,6 @@
             "graceful-fs": "^4.1.2",
             "write": "^0.2.1"
           }
-        },
-        "flatmap-stream": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.1.tgz",
-          "integrity": "sha512-lAq4tLbm3sidmdCN8G3ExaxH7cUCtP5mgDvrYowsx84dcYkJJ4I28N7gkxA6+YlSXzaGLJYIDEi9WGfXzMiXdw=="
         },
         "flatten": {
           "version": "1.0.2",
@@ -17383,11 +17352,6 @@
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
         },
-        "from": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-          "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
-        },
         "from2": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -17448,25 +17412,21 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+              "bundled": true,
               "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+              "bundled": true,
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-              "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "delegates": "^1.0.0",
@@ -17475,13 +17435,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+              "bundled": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -17489,35 +17447,29 @@
             },
             "chownr": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-              "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+              "bundled": true,
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+              "bundled": true,
               "optional": true
             },
             "debug": {
               "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "ms": "2.0.0"
@@ -17525,26 +17477,22 @@
             },
             "deep-extend": {
               "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-              "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+              "bundled": true,
               "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+              "bundled": true,
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-              "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+              "bundled": true,
               "optional": true
             },
             "fs-minipass": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-              "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "minipass": "^2.2.1"
@@ -17552,14 +17500,12 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+              "bundled": true,
               "optional": true
             },
             "gauge": {
               "version": "2.7.4",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "aproba": "^1.0.3",
@@ -17574,8 +17520,7 @@
             },
             "glob": {
               "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
@@ -17588,14 +17533,12 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+              "bundled": true,
               "optional": true
             },
             "iconv-lite": {
               "version": "0.4.21",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-              "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "safer-buffer": "^2.1.0"
@@ -17603,8 +17546,7 @@
             },
             "ignore-walk": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-              "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "minimatch": "^3.0.4"
@@ -17612,8 +17554,7 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "once": "^1.3.0",
@@ -17622,46 +17563,39 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-              "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+              "bundled": true,
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "bundled": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "bundled": true,
               "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "bundled": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+              "bundled": true
             },
             "minipass": {
               "version": "2.2.4",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
-              "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+              "bundled": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -17669,8 +17603,7 @@
             },
             "minizlib": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-              "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "minipass": "^2.2.1"
@@ -17678,22 +17611,19 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "bundled": true,
               "requires": {
                 "minimist": "0.0.8"
               }
             },
             "ms": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "bundled": true,
               "optional": true
             },
             "needle": {
               "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
-              "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "debug": "^2.1.2",
@@ -17703,8 +17633,7 @@
             },
             "node-pre-gyp": {
               "version": "0.10.0",
-              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
-              "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "detect-libc": "^1.0.2",
@@ -17721,8 +17650,7 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "abbrev": "1",
@@ -17731,14 +17659,12 @@
             },
             "npm-bundled": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
-              "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
+              "bundled": true,
               "optional": true
             },
             "npm-packlist": {
               "version": "1.1.10",
-              "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
-              "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "ignore-walk": "^3.0.1",
@@ -17747,8 +17673,7 @@
             },
             "npmlog": {
               "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "are-we-there-yet": "~1.1.2",
@@ -17759,39 +17684,33 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+              "bundled": true,
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "bundled": true,
               "requires": {
                 "wrappy": "1"
               }
             },
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+              "bundled": true,
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+              "bundled": true,
               "optional": true
             },
             "osenv": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-              "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "os-homedir": "^1.0.0",
@@ -17800,20 +17719,17 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+              "bundled": true,
               "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-              "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+              "bundled": true,
               "optional": true
             },
             "rc": {
               "version": "1.2.7",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-              "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "deep-extend": "^0.5.1",
@@ -17824,16 +17740,14 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                  "bundled": true,
                   "optional": true
                 }
               }
             },
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -17847,8 +17761,7 @@
             },
             "rimraf": {
               "version": "2.6.2",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-              "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "glob": "^7.0.5"
@@ -17856,43 +17769,36 @@
             },
             "safe-buffer": {
               "version": "5.1.1",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-              "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-              "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+              "bundled": true,
               "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-              "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+              "bundled": true,
               "optional": true
             },
             "semver": {
               "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+              "bundled": true,
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+              "bundled": true,
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+              "bundled": true,
               "optional": true
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "bundled": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -17901,8 +17807,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -17910,22 +17815,19 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "bundled": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+              "bundled": true,
               "optional": true
             },
             "tar": {
               "version": "4.4.1",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
-              "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "chownr": "^1.0.1",
@@ -17939,14 +17841,12 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+              "bundled": true,
               "optional": true
             },
             "wide-align": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-              "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+              "bundled": true,
               "optional": true,
               "requires": {
                 "string-width": "^1.0.2"
@@ -17954,13 +17854,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-              "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+              "bundled": true
             }
           }
         },
@@ -17996,9 +17894,9 @@
           "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
         },
         "fuse.js": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.2.1.tgz",
-          "integrity": "sha1-YyDLlM5W7JdVyJred1vNuwNY1CU="
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.3.0.tgz",
+          "integrity": "sha512-ESBRkGLWMuVkapqYCcNO1uqMg5qbCKkgb+VS6wsy17Rix0/cMS9kSOZoYkjH8Ko//pgJ/EEGu0GTjk2mjX2LGQ=="
         },
         "gauge": {
           "version": "2.7.4",
@@ -18040,7 +17938,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -18064,6 +17962,11 @@
             "is-property": "^1.0.2"
           }
         },
+        "generate-json-file-webpack-plugin": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/generate-json-file-webpack-plugin/-/generate-json-file-webpack-plugin-0.0.3.tgz",
+          "integrity": "sha512-/BGIsuujFjgwhWpQTXFAR6toFvtkKyL2L8sOXx3mCh1daWFA48zd+uunh9nFMmtmNlgKgKq8kTuIgL3vo7hYMw=="
+        },
         "generate-object-property": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
@@ -18073,9 +17976,32 @@
           }
         },
         "genfun": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/genfun/-/genfun-4.0.1.tgz",
-          "integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E="
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
+          "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA=="
+        },
+        "geojson-rewind": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/geojson-rewind/-/geojson-rewind-0.3.1.tgz",
+          "integrity": "sha1-IiQHl8hHzC8MHTE+SqDJFa+n8p0=",
+          "requires": {
+            "@mapbox/geojson-area": "0.2.2",
+            "concat-stream": "~1.6.0",
+            "minimist": "1.2.0",
+            "sharkdown": "^0.1.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            }
+          }
+        },
+        "geojson-vt": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
+          "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
         },
         "get-caller-file": {
           "version": "1.0.3",
@@ -18121,7 +18047,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         },
         "get-value": {
@@ -18147,7 +18073,7 @@
         },
         "gettext-parser": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
           "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
           "requires": {
             "encoding": "^0.1.12",
@@ -18302,9 +18228,9 @@
           }
         },
         "git-semver-tags": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-2.0.0.tgz",
-          "integrity": "sha512-lSgFc3zQTul31nFje2Q8XdNcTOI6B4I3mJRPCgFzHQQLfxfqdWTYzdtCaynkK5Xmb2wQlSJoKolhXJ1VhKROnQ==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-2.0.2.tgz",
+          "integrity": "sha512-34lMF7Yo1xEmsK2EkbArdoU79umpvm0MfzaDkSNYSJqtM5QLAVTPWgpiXSVI5o/O9EvZPSrP4Zvnec/CqhSd5w==",
           "requires": {
             "meow": "^4.0.0",
             "semver": "^5.5.0"
@@ -18424,6 +18350,11 @@
             "ini": "^1.3.2"
           }
         },
+        "gl-matrix": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-2.8.1.tgz",
+          "integrity": "sha512-0YCjVpE3pS5XWlN3J4X7AiAx65+nqAI54LndtVFnQZB6G/FVLkZH8y8V6R3cIoOQR4pUdfwQGd1iwyoXHJ4Qfw=="
+        },
         "glob": {
           "version": "7.1.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -18502,10 +18433,32 @@
             "is-symbol": "^1.0.1"
           }
         },
+        "global-modules": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+          "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+          "requires": {
+            "global-prefix": "^1.0.1",
+            "is-windows": "^1.0.1",
+            "resolve-dir": "^1.0.0"
+          }
+        },
         "global-modules-path": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/global-modules-path/-/global-modules-path-2.3.0.tgz",
           "integrity": "sha512-HchvMJNYh9dGSCy8pOQ2O8u/hoXaL+0XhnrwH0RyLiSXMMTl9W3N6KUU73+JFOg5PGjtzl6VZzUQsnrpm7Szag=="
+        },
+        "global-prefix": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+          "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+          "requires": {
+            "expand-tilde": "^2.0.2",
+            "homedir-polyfill": "^1.0.1",
+            "ini": "^1.3.4",
+            "is-windows": "^1.0.1",
+            "which": "^1.2.14"
+          }
         },
         "globals": {
           "version": "11.8.0",
@@ -18572,9 +18525,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+          "version": "4.1.15",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
         },
         "graphql": {
           "version": "0.13.2",
@@ -18583,6 +18536,11 @@
           "requires": {
             "iterall": "^1.2.1"
           }
+        },
+        "grid-index": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.0.0.tgz",
+          "integrity": "sha1-rSxdVM5bNUN/r/HXCprrPR0mERA="
         },
         "gridicons": {
           "version": "3.1.1",
@@ -18787,9 +18745,9 @@
           }
         },
         "hoist-non-react-statics": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-          "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
         },
         "home-or-tmp": {
           "version": "2.0.0",
@@ -18798,6 +18756,14 @@
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.1"
+          }
+        },
+        "homedir-polyfill": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+          "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+          "requires": {
+            "parse-passwd": "^1.0.0"
           }
         },
         "hoopy": {
@@ -18811,9 +18777,9 @@
           "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
         },
         "hpq": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/hpq/-/hpq-1.2.0.tgz",
-          "integrity": "sha1-nGGLI5YqLXPW6Cugh0l4vLNov6I="
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/hpq/-/hpq-1.3.0.tgz",
+          "integrity": "sha512-fvYTvdCFOWQupGxqkahrkA+ERBuMdzkxwtUdKrxR6rmMd4Pfl+iZ1QiQYoaZ0B/v0y59MOMnz3XFUWbT50/NWA=="
         },
         "html": {
           "version": "1.0.0",
@@ -18854,14 +18820,14 @@
           }
         },
         "html-minifier": {
-          "version": "3.5.20",
-          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.20.tgz",
-          "integrity": "sha512-ZmgNLaTp54+HFKkONyLFEfs5dd/ZOtlquKaTnqIWFmx3Av5zG6ZPcV2d0o9XM2fXOTxxIf6eDcwzFFotke/5zA==",
+          "version": "3.5.21",
+          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
+          "integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
           "requires": {
             "camel-case": "3.0.x",
             "clean-css": "4.2.x",
             "commander": "2.17.x",
-            "he": "1.1.x",
+            "he": "1.2.x",
             "param-case": "2.1.x",
             "relateurl": "0.2.x",
             "uglify-js": "3.4.x"
@@ -18871,11 +18837,6 @@
               "version": "2.17.1",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
               "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
-            },
-            "he": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-              "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
             }
           }
         },
@@ -18929,16 +18890,33 @@
           }
         },
         "htmlparser2": {
-          "version": "3.9.2",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-          "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
+          "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
           "requires": {
             "domelementtype": "^1.3.0",
             "domhandler": "^2.3.0",
             "domutils": "^1.5.1",
             "entities": "^1.1.1",
             "inherits": "^2.0.1",
-            "readable-stream": "^2.0.2"
+            "readable-stream": "^3.0.6"
+          },
+          "dependencies": {
+            "domelementtype": {
+              "version": "1.3.0",
+              "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+              "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+            },
+            "readable-stream": {
+              "version": "3.0.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
+              "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            }
           }
         },
         "http-cache-semantics": {
@@ -19009,9 +18987,9 @@
           }
         },
         "husky": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/husky/-/husky-1.1.2.tgz",
-          "integrity": "sha512-9TdkUpBeEOjz0AnFdUN4i3w8kEbOsVs9/WSeJqWLq2OO6bcKQhVW64Zi+pVd/AMRLpN3QTINb6ZXiELczvdmqQ==",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/husky/-/husky-1.1.3.tgz",
+          "integrity": "sha512-6uc48B/A2Mqi65yeg37d/TPcTb0bZ1GTkMYOM0nXLOPuPaTRhXCeee80/noOrbavWd12x72Tusja7GJ5rzvV6g==",
           "requires": {
             "cosmiconfig": "^5.0.6",
             "execa": "^0.9.0",
@@ -19241,9 +19219,9 @@
           }
         },
         "immutable": {
-          "version": "3.7.6",
-          "resolved": "http://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
-          "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
+          "version": "3.8.2",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+          "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
         },
         "import-cwd": {
           "version": "2.1.0",
@@ -19251,6 +19229,25 @@
           "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
           "requires": {
             "import-from": "^2.1.0"
+          }
+        },
+        "import-fresh": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+          "requires": {
+            "caller-path": "^2.0.0",
+            "resolve-from": "^3.0.0"
+          },
+          "dependencies": {
+            "caller-path": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+              "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+              "requires": {
+                "caller-callsite": "^2.0.0"
+              }
+            }
           }
         },
         "import-from": {
@@ -19448,11 +19445,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
           "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-        },
-        "iota-array": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
-          "integrity": "sha1-ge9X/l0FgUzVjCSDYyqZwwoOgIc="
         },
         "ip": {
           "version": "1.1.5",
@@ -20943,11 +20935,6 @@
             "merge-stream": "^1.0.1"
           }
         },
-        "jpeg-js": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.1.2.tgz",
-          "integrity": "sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4="
-        },
         "jquery": {
           "version": "1.12.3",
           "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.12.3.tgz",
@@ -21082,7 +21069,7 @@
         },
         "json5": {
           "version": "0.5.1",
-          "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
         },
         "jsonfile": {
@@ -21192,9 +21179,9 @@
               }
             },
             "immutable": {
-              "version": "4.0.0-rc.10",
-              "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.10.tgz",
-              "integrity": "sha512-tIdM/FgCQKvsOW29sorYe0VCW+MMyV7Yw/5Mx87GELY5vUiAeZSvl0HKZEBbhX0QnoGiFl8YMO8ZVHN3FXoDnA=="
+              "version": "4.0.0-rc.12",
+              "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.12.tgz",
+              "integrity": "sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A=="
             },
             "react": {
               "version": "0.14.9",
@@ -21217,6 +21204,11 @@
           "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
           "integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ=="
         },
+        "kdbush": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-2.0.1.tgz",
+          "integrity": "sha512-9KqSdmWCkBIisFIGclT0FRagKhI7IVbMyUjsxCFG0Ly1Dg6whlxJ7b9lrq8ifk3X/fGeJzok1R75LQfZTfA5zQ=="
+        },
         "key-mirror": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/key-mirror/-/key-mirror-1.0.1.tgz",
@@ -21238,14 +21230,9 @@
           "integrity": "sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ=="
         },
         "known-css-properties": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.8.0.tgz",
-          "integrity": "sha512-pku5zscbIr9YsA6lFU1nhFGSAXsdJtEQ2WilCL40d0YCoDofBlNohMUq32wyt7tpiiaZ09GKyLZFrB1ijx6+WA=="
-        },
-        "lazyness": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/lazyness/-/lazyness-1.0.1.tgz",
-          "integrity": "sha512-8NFbHnT+GkzqsZzOUxoxkW5ItkhySf2yIyzZcryg5AbfhH9NB2fXdtfpREFK1iYa/K224dmxEcZOYhVQ1KqXDw=="
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.9.0.tgz",
+          "integrity": "sha512-2G/A/8XPhH6MmuVgl079wYsgdqfXE3cfm62txk/ajS4wvRWo6tEHcgQCJCHOOy12Fse1Sxlbf7/IJBpR9hnVew=="
         },
         "lcid": {
           "version": "1.0.0",
@@ -21261,25 +21248,25 @@
           "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
         },
         "lerna": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.4.0.tgz",
-          "integrity": "sha512-RCLm0gMi8PESEF8PzMxo35foA2NGGC/NKnKiUmJyRrhLybOIUfVPdPStSAWCjW1c+DYCgLZCbxu57/KWt4ZWZA==",
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.4.3.tgz",
+          "integrity": "sha512-tWq1LvpHqkyB+FaJCmkEweivr88yShDMmauofPVdh0M5gU1cVucszYnIgWafulKYu2LMQ3IfUMUU5Pp3+MvADQ==",
           "requires": {
-            "@lerna/add": "^3.3.2",
-            "@lerna/bootstrap": "^3.3.2",
-            "@lerna/changed": "^3.3.2",
+            "@lerna/add": "^3.4.1",
+            "@lerna/bootstrap": "^3.4.1",
+            "@lerna/changed": "^3.4.1",
             "@lerna/clean": "^3.3.2",
             "@lerna/cli": "^3.2.0",
-            "@lerna/create": "^3.3.1",
+            "@lerna/create": "^3.4.1",
             "@lerna/diff": "^3.3.0",
             "@lerna/exec": "^3.3.2",
             "@lerna/import": "^3.3.1",
             "@lerna/init": "^3.3.0",
             "@lerna/link": "^3.3.0",
             "@lerna/list": "^3.3.2",
-            "@lerna/publish": "^3.4.0",
+            "@lerna/publish": "^3.4.3",
             "@lerna/run": "^3.3.2",
-            "@lerna/version": "^3.3.2",
+            "@lerna/version": "^3.4.1",
             "import-local": "^1.0.0",
             "npmlog": "^4.1.2"
           },
@@ -21404,9 +21391,9 @@
           }
         },
         "localforage": {
-          "version": "1.7.2",
-          "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.2.tgz",
-          "integrity": "sha1-+kRCYC+Abt0rympUq05lbwMfEhw=",
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.3.tgz",
+          "integrity": "sha512-1TulyYfc4udS7ECSBT2vwJksWbkwwTX8BzeUIiq8Y07Riy7bDAAnxDaPU/tWyOVmQAcWJIEIFP9lPfBGqVoPgQ==",
           "requires": {
             "lie": "3.1.1"
           }
@@ -21439,11 +21426,6 @@
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
           "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-        },
-        "lodash.camelcase": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-          "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
@@ -21595,23 +21577,16 @@
           }
         },
         "lunr": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.4.tgz",
-          "integrity": "sha512-o0D846XyAlPkBMVK3ZgVYrLHho3yhJHgpm0BxZT3dGdFa+tpQwdQdI4EUihsmWz8Fr3aaux4eahO9Ih7Z3e1eQ=="
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.5.tgz",
+          "integrity": "sha512-EtnfmHsHJTr3u24sito9JctSxej5Ds0SgUD2Lm+qRHyLgM7BGesFlW14eNh1mil0fV5Muh8gf3dBBXzADlUlzQ=="
         },
         "magic-string": {
-          "version": "0.22.5",
-          "resolved": "http://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
-          "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+          "version": "0.25.1",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
+          "integrity": "sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==",
           "requires": {
-            "vlq": "^0.2.2"
-          },
-          "dependencies": {
-            "vlq": {
-              "version": "0.2.3",
-              "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-              "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
-            }
+            "sourcemap-codec": "^1.4.1"
           }
         },
         "make-dir": {
@@ -21666,11 +21641,6 @@
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
         },
-        "map-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-          "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
-        },
         "map-values": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/map-values/-/map-values-1.0.1.tgz",
@@ -21682,6 +21652,37 @@
           "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
           "requires": {
             "object-visit": "^1.0.0"
+          }
+        },
+        "mapbox-gl": {
+          "version": "0.51.0",
+          "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-0.51.0.tgz",
+          "integrity": "sha512-ToV6WJIgdLIKSwLO13pRf5EMeVx4gjdO10akFFxGVwYO/G1nCIZOurKFPIEXbAg0zmZXJD+55HbOIg+AbJICpQ==",
+          "requires": {
+            "@mapbox/geojson-types": "^1.0.2",
+            "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+            "@mapbox/mapbox-gl-supported": "^1.4.0",
+            "@mapbox/point-geometry": "^0.1.0",
+            "@mapbox/tiny-sdf": "^1.1.0",
+            "@mapbox/unitbezier": "^0.0.0",
+            "@mapbox/vector-tile": "^1.3.1",
+            "@mapbox/whoots-js": "^3.1.0",
+            "csscolorparser": "~1.0.2",
+            "earcut": "^2.1.3",
+            "esm": "^3.0.84",
+            "geojson-rewind": "^0.3.0",
+            "geojson-vt": "^3.2.1",
+            "gl-matrix": "^2.6.1",
+            "grid-index": "^1.0.0",
+            "minimist": "0.0.8",
+            "murmurhash-js": "^1.0.0",
+            "pbf": "^3.0.5",
+            "potpack": "^1.0.1",
+            "quickselect": "^1.0.0",
+            "rw": "^1.3.3",
+            "supercluster": "^4.1.1",
+            "tinyqueue": "^1.1.0",
+            "vt-pbf": "^3.0.1"
           }
         },
         "markdown-escapes": {
@@ -21710,11 +21711,6 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/marked/-/marked-0.5.1.tgz",
           "integrity": "sha512-iUkBZegCZou4AdwbKTwSW/lNDcz5OuRSl3qdcl31Ia0B2QPG0Jn+tKblh/9/eP9/6+4h27vpoh8wel/vQOV0vw=="
-        },
-        "material-colors": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-          "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
         },
         "math-expression-evaluator": {
           "version": "1.2.17",
@@ -21816,9 +21812,9 @@
           }
         },
         "merge": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-          "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+          "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
         },
         "merge-descriptors": {
           "version": "1.0.1",
@@ -21878,16 +21874,16 @@
           "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
         },
         "mime-db": {
-          "version": "1.36.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-          "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
+          "version": "1.37.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+          "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
         },
         "mime-types": {
-          "version": "2.1.20",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-          "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+          "version": "2.1.21",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+          "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
           "requires": {
-            "mime-db": "~1.36.0"
+            "mime-db": "~1.37.0"
           }
         },
         "mimic-fn": {
@@ -21937,9 +21933,9 @@
           }
         },
         "minipass": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
-          "integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -22064,9 +22060,9 @@
           "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
         },
         "moment-timezone": {
-          "version": "0.5.21",
-          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.21.tgz",
-          "integrity": "sha512-j96bAh4otsgj3lKydm3K7kdtA3iKf2m6MY2iSYCzCm5a1zmHo1g+aK3068dDEeocLZQIS9kU8bsdQHLqEvgW0A==",
+          "version": "0.5.23",
+          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.23.tgz",
+          "integrity": "sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==",
           "requires": {
             "moment": ">= 2.9.0"
           }
@@ -22132,6 +22128,11 @@
             "minimatch": "^3.0.0"
           }
         },
+        "murmurhash-js": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+          "integrity": "sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E="
+        },
         "mute-stream": {
           "version": "0.0.7",
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -22165,24 +22166,6 @@
           "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
           "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
         },
-        "ndarray": {
-          "version": "1.0.18",
-          "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.18.tgz",
-          "integrity": "sha1-tg06cyJOxVXQ+qeXEeUCRI/T95M=",
-          "requires": {
-            "iota-array": "^1.0.0",
-            "is-buffer": "^1.0.2"
-          }
-        },
-        "ndarray-pack": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/ndarray-pack/-/ndarray-pack-1.2.1.tgz",
-          "integrity": "sha1-jK6+qqJNXs9w/4YCBjeXfajuWFo=",
-          "requires": {
-            "cwise-compiler": "^1.1.2",
-            "ndarray": "^1.0.13"
-          }
-        },
         "nearley": {
           "version": "2.15.1",
           "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.15.1.tgz",
@@ -22204,11 +22187,6 @@
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
           "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA=="
-        },
-        "nextgen-events": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/nextgen-events/-/nextgen-events-1.1.0.tgz",
-          "integrity": "sha512-Emz5rh584fygInd3gtwP+xGyJhEnyxQa0/Xbmw8sbpXVGV/luqDnVPq1cQopYR7qg6KUlPfwWVhxrhZri1wDAw=="
         },
         "nice-try": {
           "version": "1.0.5",
@@ -22256,9 +22234,9 @@
           }
         },
         "nock": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.1.tgz",
-          "integrity": "sha512-M0aL9IDbUFURmokoXqejZQybZk8EtlYjUBjaoICVbW62uOlyPRsnEsceyOlUik4spCOt50ptwM4BTPt20ITtcQ==",
+          "version": "10.0.2",
+          "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.2.tgz",
+          "integrity": "sha512-uWrdlRzG28SXM5yqYsUHfYBRqljF8P6aTRDh6Y5kTgs/Q4GB59QWlpiegmDHQouvmX/rDyKkC/nk+k4nA+QPNw==",
           "requires": {
             "chai": "^4.1.2",
             "debug": "^4.1.0",
@@ -22285,11 +22263,6 @@
               "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
             }
           }
-        },
-        "node-bitmap": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/node-bitmap/-/node-bitmap-0.0.1.tgz",
-          "integrity": "sha1-GA6scAPgxwdhjvMTaPYvhLKmkJE="
         },
         "node-contains": {
           "version": "1.0.0",
@@ -22336,7 +22309,7 @@
           "dependencies": {
             "semver": {
               "version": "5.3.0",
-              "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
               "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
             }
           }
@@ -22378,7 +22351,7 @@
           "dependencies": {
             "events": {
               "version": "1.1.1",
-              "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
               "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
             },
             "path-browserify": {
@@ -22389,28 +22362,28 @@
           }
         },
         "node-notifier": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
-          "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.3.0.tgz",
+          "integrity": "sha512-AhENzCSGZnZJgBARsUjnQ7DnZbzyP+HxlVXuD0xqAnvL8q+OqtSX7lGg9e8nHzwXkMMXNdVeqq4E2M3EUAqX6Q==",
           "requires": {
             "growly": "^1.3.0",
-            "semver": "^5.4.1",
+            "semver": "^5.5.0",
             "shellwords": "^0.1.1",
             "which": "^1.3.0"
           }
         },
         "node-releases": {
-          "version": "1.0.0-alpha.14",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.14.tgz",
-          "integrity": "sha512-G8nnF9cP9QPP/jUmYWw/uUUhumHmkm+X/EarCugYFjYm2uXRMFeOD6CVT3RLdoyCvDUNy51nirGfUItKWs/S1g==",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.3.tgz",
+          "integrity": "sha512-ZaZWMsbuDcetpHmYeKWPO6e63pSXLb50M7lJgCbcM2nC/nQC3daNifmtp5a2kp7EWwYfhuvH6zLPWkrF8IiDdw==",
           "requires": {
             "semver": "^5.3.0"
           }
         },
         "node-sass": {
-          "version": "4.9.4",
-          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.4.tgz",
-          "integrity": "sha512-MXyurANsUoE4/6KmfMkwGcBzAnJQ5xJBGW7Ei6ea8KnUKuzHr/SguVBIi3uaUAHtZCPUYkvlJ3Ef5T5VAwVpaA==",
+          "version": "4.10.0",
+          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.10.0.tgz",
+          "integrity": "sha512-fDQJfXszw6vek63Fe/ldkYXmRYK/QS6NbvM3i5oEo9ntPDy4XX7BcKZyTKv+/kSSxRtXXc7l+MSwEmYc0CSy6Q==",
           "requires": {
             "async-foreach": "^0.1.3",
             "chalk": "^1.1.1",
@@ -22466,7 +22439,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -22581,18 +22554,15 @@
           "dependencies": {
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+              "bundled": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+              "bundled": true
             },
             "cross-spawn": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+              "bundled": true,
               "requires": {
                 "lru-cache": "^4.0.1",
                 "shebang-command": "^1.2.0",
@@ -22601,13 +22571,11 @@
             },
             "decamelize": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+              "bundled": true
             },
             "execa": {
               "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-              "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+              "bundled": true,
               "requires": {
                 "cross-spawn": "^5.0.1",
                 "get-stream": "^3.0.0",
@@ -22620,57 +22588,48 @@
             },
             "find-up": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-              "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+              "bundled": true,
               "requires": {
                 "locate-path": "^2.0.0"
               }
             },
             "get-caller-file": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-              "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+              "bundled": true
             },
             "get-stream": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+              "bundled": true
             },
             "invert-kv": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-              "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+              "bundled": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "bundled": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
             },
             "is-stream": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+              "bundled": true
             },
             "isexe": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+              "bundled": true
             },
             "lcid": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-              "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+              "bundled": true,
               "requires": {
                 "invert-kv": "^1.0.0"
               }
             },
             "locate-path": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-              "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+              "bundled": true,
               "requires": {
                 "p-locate": "^2.0.0",
                 "path-exists": "^3.0.0"
@@ -22678,8 +22637,7 @@
             },
             "lru-cache": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-              "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+              "bundled": true,
               "requires": {
                 "pseudomap": "^1.0.2",
                 "yallist": "^2.1.2"
@@ -22687,47 +22645,40 @@
             },
             "mem": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-              "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+              "bundled": true,
               "requires": {
                 "mimic-fn": "^1.0.0"
               }
             },
             "mimic-fn": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-              "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+              "bundled": true
             },
             "minimist": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+              "bundled": true
             },
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "bundled": true,
               "requires": {
                 "minimist": "0.0.8"
               }
             },
             "npm-run-path": {
               "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-              "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+              "bundled": true,
               "requires": {
                 "path-key": "^2.0.0"
               }
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+              "bundled": true
             },
             "os-locale": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-              "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+              "bundled": true,
               "requires": {
                 "execa": "^0.7.0",
                 "lcid": "^1.0.0",
@@ -22736,74 +22687,61 @@
             },
             "p-finally": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-              "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+              "bundled": true
             },
             "p-limit": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-              "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+              "bundled": true
             },
             "p-locate": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-              "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+              "bundled": true,
               "requires": {
                 "p-limit": "^1.1.0"
               }
             },
             "path-exists": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+              "bundled": true
             },
             "path-key": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+              "bundled": true
             },
             "pseudomap": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+              "bundled": true
             },
             "require-directory": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-              "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+              "bundled": true
             },
             "require-main-filename": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+              "bundled": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+              "bundled": true
             },
             "shebang-command": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+              "bundled": true,
               "requires": {
                 "shebang-regex": "^1.0.0"
               }
             },
             "shebang-regex": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-              "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+              "bundled": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+              "bundled": true
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "bundled": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -22812,34 +22750,29 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "bundled": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
             },
             "strip-eof": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-              "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+              "bundled": true
             },
             "which": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-              "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+              "bundled": true,
               "requires": {
                 "isexe": "^2.0.0"
               }
             },
             "which-module": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+              "bundled": true
             },
             "wrap-ansi": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-              "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+              "bundled": true,
               "requires": {
                 "string-width": "^1.0.1",
                 "strip-ansi": "^3.0.1"
@@ -22847,18 +22780,15 @@
             },
             "y18n": {
               "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+              "bundled": true
             },
             "yallist": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+              "bundled": true
             },
             "yargs": {
               "version": "10.0.3",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
-              "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+              "bundled": true,
               "requires": {
                 "cliui": "^3.2.0",
                 "decamelize": "^1.1.1",
@@ -22876,13 +22806,11 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                  "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                  "bundled": true
                 },
                 "cliui": {
                   "version": "3.2.0",
-                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                  "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                  "bundled": true,
                   "requires": {
                     "string-width": "^1.0.1",
                     "strip-ansi": "^3.0.1",
@@ -22891,8 +22819,7 @@
                   "dependencies": {
                     "string-width": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                      "bundled": true,
                       "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -22903,8 +22830,7 @@
                 },
                 "string-width": {
                   "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                  "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                  "bundled": true,
                   "requires": {
                     "is-fullwidth-code-point": "^2.0.0",
                     "strip-ansi": "^4.0.0"
@@ -22912,13 +22838,11 @@
                   "dependencies": {
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+                      "bundled": true
                     },
                     "strip-ansi": {
                       "version": "4.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                      "bundled": true,
                       "requires": {
                         "ansi-regex": "^3.0.0"
                       }
@@ -22929,16 +22853,14 @@
             },
             "yargs-parser": {
               "version": "8.0.0",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
-              "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
+              "bundled": true,
               "requires": {
                 "camelcase": "^4.1.0"
               },
               "dependencies": {
                 "camelcase": {
                   "version": "4.1.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-                  "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+                  "bundled": true
                 }
               }
             }
@@ -22965,10 +22887,11 @@
           }
         },
         "npm-pick-manifest": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.1.0.tgz",
-          "integrity": "sha512-q9zLP8cTr8xKPmMZN3naxp1k/NxVFsjxN6uWuO1tiw9gxg7wZWQ/b5UTfzD0ANw2q1lQxdLKTeCCksq+bPSgbQ==",
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.2.3.tgz",
+          "integrity": "sha512-+IluBC5K201+gRU85vFlUwX3PFShZAbAgDNp2ewJdWMVSppdo/Zih0ul2Ecky/X7b51J7LrrUAP+XOmOCvYZqA==",
           "requires": {
+            "figgy-pudding": "^3.5.1",
             "npm-package-arg": "^6.0.0",
             "semver": "^5.4.1"
           }
@@ -22987,16 +22910,16 @@
           }
         },
         "npm-run-all": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.3.tgz",
-          "integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+          "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
           "requires": {
-            "ansi-styles": "^3.2.0",
-            "chalk": "^2.1.0",
-            "cross-spawn": "^6.0.4",
+            "ansi-styles": "^3.2.1",
+            "chalk": "^2.4.1",
+            "cross-spawn": "^6.0.5",
             "memorystream": "^0.3.1",
             "minimatch": "^3.0.4",
-            "ps-tree": "^1.1.0",
+            "pidtree": "^0.3.0",
             "read-pkg": "^3.0.0",
             "shell-quote": "^1.6.1",
             "string.prototype.padend": "^3.0.0"
@@ -23071,9 +22994,9 @@
           }
         },
         "nth-check": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
-          "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+          "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
           "requires": {
             "boolbase": "~1.0.0"
           }
@@ -23234,14 +23157,9 @@
           }
         },
         "objectpath": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/objectpath/-/objectpath-1.2.1.tgz",
-          "integrity": "sha1-yHQzvdNSrqAU5PnAtS1wpCZSBS4="
-        },
-        "omggif": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.9.tgz",
-          "integrity": "sha1-3LcCTazVDFK00wPwSALJHAV8dl8="
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/objectpath/-/objectpath-1.2.2.tgz",
+          "integrity": "sha512-ie+GY5tJsKt7daHH6qGROf3JqxfD2XhfBPLY+HQrVuRY8MQE1ySKVSqQ/TQz/Dx7jDwuy3etQALDE1cRJAC0cg=="
         },
         "on-finished": {
           "version": "2.3.0",
@@ -23362,7 +23280,7 @@
         },
         "p-is-promise": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
         },
         "p-limit": {
@@ -23418,48 +23336,56 @@
           }
         },
         "pacote": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.1.0.tgz",
-          "integrity": "sha512-AFXaSWhOtQf3jHqEvg+ZYH/dfT8TKq6TKspJ4qEFwVVuh5aGvMIk6SNF8vqfzz+cBceDIs9drOcpBbrPai7i+g==",
+          "version": "9.2.3",
+          "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.2.3.tgz",
+          "integrity": "sha512-Y3+yY3nBRAxMlZWvr62XLJxOwCmG9UmkGZkFurWHoCjqF0cZL72cTOCRJTvWw8T4OhJS2RTg13x4oYYriauvEw==",
           "requires": {
-            "bluebird": "^3.5.1",
-            "cacache": "^11.0.2",
-            "figgy-pudding": "^3.2.1",
-            "get-stream": "^3.0.0",
-            "glob": "^7.1.2",
+            "bluebird": "^3.5.2",
+            "cacache": "^11.2.0",
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.1.0",
+            "glob": "^7.1.3",
             "lru-cache": "^4.1.3",
             "make-fetch-happen": "^4.0.1",
             "minimatch": "^3.0.4",
-            "minipass": "^2.3.3",
+            "minipass": "^2.3.5",
             "mississippi": "^3.0.0",
             "mkdirp": "^0.5.1",
             "normalize-package-data": "^2.4.0",
             "npm-package-arg": "^6.1.0",
-            "npm-packlist": "^1.1.10",
-            "npm-pick-manifest": "^2.1.0",
-            "npm-registry-fetch": "^3.0.0",
+            "npm-packlist": "^1.1.12",
+            "npm-pick-manifest": "^2.2.3",
+            "npm-registry-fetch": "^3.8.0",
             "osenv": "^0.1.5",
             "promise-inflight": "^1.0.1",
             "promise-retry": "^1.1.1",
-            "protoduck": "^5.0.0",
+            "protoduck": "^5.0.1",
             "rimraf": "^2.6.2",
             "safe-buffer": "^5.1.2",
-            "semver": "^5.5.0",
-            "ssri": "^6.0.0",
-            "tar": "^4.4.3",
-            "unique-filename": "^1.1.0",
-            "which": "^1.3.0"
+            "semver": "^5.6.0",
+            "ssri": "^6.0.1",
+            "tar": "^4.4.6",
+            "unique-filename": "^1.1.1",
+            "which": "^1.3.1"
           },
           "dependencies": {
-            "tar": {
-              "version": "4.4.6",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.6.tgz",
-              "integrity": "sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==",
+            "get-stream": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+              "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
               "requires": {
-                "chownr": "^1.0.1",
+                "pump": "^3.0.0"
+              }
+            },
+            "tar": {
+              "version": "4.4.7",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.7.tgz",
+              "integrity": "sha512-mR3MzsCdN0IEWjZRuF/J9gaWHnTwOvzjqPTcvi1xXgfKTDQRp39gRETPQEfPByAdEOGmZfx1HrRsn8estaEvtA==",
+              "requires": {
+                "chownr": "^1.1.1",
                 "fs-minipass": "^1.2.5",
-                "minipass": "^2.3.3",
-                "minizlib": "^1.1.0",
+                "minipass": "^2.3.4",
+                "minizlib": "^1.1.1",
                 "mkdirp": "^0.5.0",
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.2"
@@ -23473,9 +23399,9 @@
           }
         },
         "page": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/page/-/page-1.9.0.tgz",
-          "integrity": "sha512-vdvkkw+ow7vg/XM54hHw+r0BT9UXeGzeGupG1ICdIn7GTWe8wrr2xmo7ErlUImw22datzgUEbbqwAME18FJnJw==",
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/page/-/page-1.11.1.tgz",
+          "integrity": "sha512-JzTLZPZ1muQzx87ITX4R0EFiRdfNolFClYvAAK2f61mq2Kwut8VWvZdGC0lNMvdISG5AINkW02XVE+GjNtTiDQ==",
           "requires": {
             "path-to-regexp": "~1.2.1"
           },
@@ -23590,6 +23516,11 @@
             "error-ex": "^1.2.0"
           }
         },
+        "parse-passwd": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+          "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+        },
         "parse-year": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/parse-year/-/parse-year-1.0.0.tgz",
@@ -23686,12 +23617,13 @@
           "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
           "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
         },
-        "pause-stream": {
-          "version": "0.0.11",
-          "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-          "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+        "pbf": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.1.0.tgz",
+          "integrity": "sha512-/hYJmIsTmh7fMkHAWWXJ5b8IKLWdjdlAFb3IHkRBn1XUhIYBChVGfVwmHEAV3UfXTxsP/AKfYTXTS/dCPxJd5w==",
           "requires": {
-            "through": "~2.3"
+            "ieee754": "^1.1.6",
+            "resolve-protobuf-schema": "^2.0.0"
           }
         },
         "pbkdf2": {
@@ -23740,6 +23672,11 @@
             }
           }
         },
+        "pidtree": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
+          "integrity": "sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg=="
+        },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -23784,16 +23721,6 @@
           "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
           "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
         },
-        "pngjs": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-2.3.1.tgz",
-          "integrity": "sha1-EdHhK5y2TWPjDBQ6Mw9MH1Z9qF8="
-        },
-        "popper.js": {
-          "version": "1.14.4",
-          "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.4.tgz",
-          "integrity": "sha1-juwdj/AqWjoVLdQ0FKFce3n9abY="
-        },
         "posix-character-classes": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -23818,7 +23745,7 @@
         },
         "postcss-calc": {
           "version": "5.3.1",
-          "resolved": "http://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
           "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
           "requires": {
             "postcss": "^5.0.2",
@@ -23878,7 +23805,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -23982,7 +23909,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -24059,7 +23986,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -24076,9 +24003,9 @@
           }
         },
         "postcss-custom-properties": {
-          "version": "8.0.8",
-          "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.8.tgz",
-          "integrity": "sha512-G3U8uSxj0B4jPJ1QBF5WYeW716n5HV/wcH2lOTV1V+EI+F0T0/ZOhl32MLLTMD79bN2mE77IOoclbCoLl4QtPA==",
+          "version": "8.0.9",
+          "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.9.tgz",
+          "integrity": "sha512-/Lbn5GP2JkKhgUO2elMs4NnbUJcvHX4AaF5nuJDaNkd2chYW1KA5qtOGGgdkBEWcXtKSQfHXzT7C6grEVyb13w==",
           "requires": {
             "postcss": "^7.0.5",
             "postcss-values-parser": "^2.0.0"
@@ -24086,7 +24013,7 @@
         },
         "postcss-discard-comments": {
           "version": "2.0.4",
-          "resolved": "http://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
           "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
           "requires": {
             "postcss": "^5.0.14"
@@ -24144,7 +24071,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -24220,7 +24147,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -24238,7 +24165,7 @@
         },
         "postcss-discard-empty": {
           "version": "2.1.0",
-          "resolved": "http://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
           "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
           "requires": {
             "postcss": "^5.0.14"
@@ -24296,7 +24223,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -24314,7 +24241,7 @@
         },
         "postcss-discard-overridden": {
           "version": "0.1.1",
-          "resolved": "http://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
           "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
           "requires": {
             "postcss": "^5.0.16"
@@ -24372,7 +24299,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -24390,7 +24317,7 @@
         },
         "postcss-discard-unused": {
           "version": "2.2.3",
-          "resolved": "http://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
           "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
           "requires": {
             "postcss": "^5.0.14",
@@ -24449,7 +24376,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -24525,7 +24452,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -24550,17 +24477,17 @@
           }
         },
         "postcss-jsx": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.34.0.tgz",
-          "integrity": "sha512-UJISlEGWH/LeMYudAwq9GeqfyPW9AeRq87GHOlbquxOIakKr0Aqu6l9Cx0Fg20f3A9bKJcX1NGX4/xzIs7PlZQ==",
+          "version": "0.35.0",
+          "resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.35.0.tgz",
+          "integrity": "sha512-AU2/9QDmHYJRxTiniMt2bJ9fwCzVF6n00VnR4gdnFGHeXRW2mGwoptpuPgYjfivkdI8LlNIuo+w8TyS6a4JhJw==",
           "requires": {
-            "@babel/core": "^7.0.0",
+            "@babel/core": "^7.1.2",
             "postcss-styled": ">=0.34.0"
           }
         },
         "postcss-less": {
           "version": "1.1.5",
-          "resolved": "http://registry.npmjs.org/postcss-less/-/postcss-less-1.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-1.1.5.tgz",
           "integrity": "sha512-QQIiIqgEjNnquc0d4b6HDOSFZxbFQoy4MPpli2lSLpKhMyBkKwwca2HFqu4xzxlKID/F2fxSOowwtKpgczhF7A==",
           "requires": {
             "postcss": "^5.2.16"
@@ -24618,7 +24545,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -24670,7 +24597,7 @@
         },
         "postcss-merge-idents": {
           "version": "2.1.7",
-          "resolved": "http://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
           "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
           "requires": {
             "has": "^1.0.1",
@@ -24730,7 +24657,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -24806,7 +24733,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -24895,7 +24822,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -24918,7 +24845,7 @@
         },
         "postcss-minify-font-values": {
           "version": "1.0.5",
-          "resolved": "http://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
           "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
           "requires": {
             "object-assign": "^4.0.1",
@@ -24978,7 +24905,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -24996,7 +24923,7 @@
         },
         "postcss-minify-gradients": {
           "version": "1.0.5",
-          "resolved": "http://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
           "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
           "requires": {
             "postcss": "^5.0.12",
@@ -25055,7 +24982,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -25073,7 +25000,7 @@
         },
         "postcss-minify-params": {
           "version": "1.2.2",
-          "resolved": "http://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
           "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
           "requires": {
             "alphanum-sort": "^1.0.1",
@@ -25134,7 +25061,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -25152,7 +25079,7 @@
         },
         "postcss-minify-selectors": {
           "version": "2.1.1",
-          "resolved": "http://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
           "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
           "requires": {
             "alphanum-sort": "^1.0.2",
@@ -25213,7 +25140,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -25230,9 +25157,9 @@
           }
         },
         "postcss-modules-extract-imports": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
-          "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
+          "integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
           "requires": {
             "postcss": "^6.0.1"
           },
@@ -25334,7 +25261,7 @@
         },
         "postcss-normalize-charset": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
           "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
           "requires": {
             "postcss": "^5.0.5"
@@ -25392,7 +25319,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -25410,7 +25337,7 @@
         },
         "postcss-normalize-url": {
           "version": "3.0.8",
-          "resolved": "http://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
           "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
           "requires": {
             "is-absolute-url": "^2.0.0",
@@ -25471,7 +25398,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -25548,7 +25475,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -25566,7 +25493,7 @@
         },
         "postcss-reduce-idents": {
           "version": "2.4.0",
-          "resolved": "http://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
           "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
           "requires": {
             "postcss": "^5.0.4",
@@ -25625,7 +25552,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -25643,7 +25570,7 @@
         },
         "postcss-reduce-initial": {
           "version": "1.0.1",
-          "resolved": "http://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
           "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
           "requires": {
             "postcss": "^5.0.4"
@@ -25701,7 +25628,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -25719,7 +25646,7 @@
         },
         "postcss-reduce-transforms": {
           "version": "1.0.4",
-          "resolved": "http://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
           "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
           "requires": {
             "has": "^1.0.1",
@@ -25779,7 +25706,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -25820,9 +25747,9 @@
           }
         },
         "postcss-sass": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.3.3.tgz",
-          "integrity": "sha512-uoRhfwZJHDRI8p2KQniTx4UwzYwKgQUhmFNJ7aysL3+tgFUfmv5TPX8UPnlE5gfrq6KHUUwPJ/nISFtzwxr7iQ==",
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.3.5.tgz",
+          "integrity": "sha512-B5z2Kob4xBxFjcufFnhQ2HqJQ2y/Zs/ic5EZbCywCkxKd756Q40cIQ/veRDwSrw1BF6+4wUgmpm0sBASqVi65A==",
           "requires": {
             "gonzales-pe": "^4.2.3",
             "postcss": "^7.0.1"
@@ -25870,7 +25797,7 @@
         },
         "postcss-svgo": {
           "version": "2.1.6",
-          "resolved": "http://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
           "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
           "requires": {
             "is-svg": "^2.0.0",
@@ -25931,7 +25858,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -25954,7 +25881,7 @@
         },
         "postcss-unique-selectors": {
           "version": "2.0.2",
-          "resolved": "http://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
           "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
           "requires": {
             "alphanum-sort": "^1.0.1",
@@ -26014,7 +25941,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -26047,7 +25974,7 @@
         },
         "postcss-zindex": {
           "version": "2.2.0",
-          "resolved": "http://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
           "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
           "requires": {
             "has": "^1.0.1",
@@ -26107,7 +26034,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -26122,6 +26049,11 @@
               }
             }
           }
+        },
+        "potpack": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.1.tgz",
+          "integrity": "sha512-15vItUAbViaYrmaB/Pbw7z6qX2xENbFSTA7Ii4tgbPtasxm5v6ryKhKtL91tpWovDJzTiZqdwzhcFBCwiMVdVw=="
         },
         "prelude-ls": {
           "version": "1.1.2",
@@ -26324,11 +26256,6 @@
             }
           }
         },
-        "pretty-bytes": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.1.0.tgz",
-          "integrity": "sha512-wa5+qGVg9Yt7PB6rYm3kXlKzgzgivYTLRandezh43jjRqgyDyP+9YxfJpJiLs9yKD1WeU8/OvtToWpW7255FtA=="
-        },
         "pretty-error": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
@@ -26349,7 +26276,7 @@
         },
         "pretty-hrtime": {
           "version": "1.0.3",
-          "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
           "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
         },
         "prismjs": {
@@ -26453,12 +26380,17 @@
           "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
           "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
         },
+        "protocol-buffers-schema": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz",
+          "integrity": "sha512-Xdayp8sB/mU+sUV4G7ws8xtYMGdQnxbeIfLjyO9TZZRJdztBGhlmbI5x1qcY4TG5hBkIKGnc28i7nXxaugu88w=="
+        },
         "protoduck": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.0.tgz",
-          "integrity": "sha512-agsGWD8/RZrS4ga6v82Fxb0RHIS2RZnbsSue6A9/MBRhB/jcqOANAMNrqM9900b8duj+Gx+T/JMy5IowDoO/hQ==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
+          "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
           "requires": {
-            "genfun": "^4.0.1"
+            "genfun": "^5.0.0"
           }
         },
         "proxy-addr": {
@@ -26474,14 +26406,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
           "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
-        },
-        "ps-tree": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
-          "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
-          "requires": {
-            "event-stream": "~3.3.0"
-          }
         },
         "pseudomap": {
           "version": "1.0.2",
@@ -26594,10 +26518,15 @@
           "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
           "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
         },
+        "quickselect": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+          "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
+        },
         "raf": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
-          "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+          "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
           "requires": {
             "performance-now": "^2.1.0"
           }
@@ -26622,9 +26551,9 @@
           }
         },
         "randomatic": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
-          "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+          "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
           "requires": {
             "is-number": "^4.0.0",
             "kind-of": "^6.0.0",
@@ -26682,19 +26611,30 @@
           }
         },
         "re-resizable": {
-          "version": "4.9.0",
-          "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-4.9.0.tgz",
-          "integrity": "sha512-AkTHHC/I1+MUnabFu3/9ADwR5A+HyjiL3xgqlcgNKdyJZVb851I7sGre/4JIU7XfhaN5t+xZBvJPOuvEdvSMcw=="
+          "version": "4.10.0",
+          "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-4.10.0.tgz",
+          "integrity": "sha512-g5Q5IswKX7LM+MtYFnuzaQrTEGr/kpserqGV8V6HYkjwbV60XnJv00VlKugLHEwlQ5pgrV08spm0TjyyYVbWmQ=="
         },
         "react": {
-          "version": "16.5.2",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.5.2.tgz",
-          "integrity": "sha512-FDCSVd3DjVTmbEAjUNX6FgfAmQ+ypJfHUsqUJOYNCBUp1h8lqmtC+0mXJ+JjsWx4KAVTkk1vKd1hLQPvEviSuw==",
+          "version": "16.6.3",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
+          "integrity": "sha512-zCvmH2vbEolgKxtqXL2wmGCUxUyNheYn/C+PD1YAjfxHC54+MhdruyhO7QieQrYsYeTxrn93PM2y0jRH1zEExw==",
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
-            "schedule": "^0.5.0"
+            "scheduler": "^0.11.2"
+          },
+          "dependencies": {
+            "scheduler": {
+              "version": "0.11.2",
+              "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.2.tgz",
+              "integrity": "sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==",
+              "requires": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1"
+              }
+            }
           }
         },
         "react-addons-create-fragment": {
@@ -26732,36 +26672,6 @@
           "integrity": "sha512-d0KWFvBt+esoZUF15rL2UBB7jkeAqLU8L/Ny35oLK6fW6mIbOv/ChD+ExF4sR9PD26kVx+9hNfD0FTIqRZEyRQ==",
           "requires": {
             "hoist-non-react-statics": "^2.1.1"
-          },
-          "dependencies": {
-            "hoist-non-react-statics": {
-              "version": "2.5.5",
-              "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-              "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-            }
-          }
-        },
-        "react-color": {
-          "version": "2.14.1",
-          "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.14.1.tgz",
-          "integrity": "sha512-ssv2ArSZdhTbIs29hyfw8JW+s3G4BCx/ILkwCajWZzrcx/2ZQfRpsaLVt38LAPbxe50LLszlmGtRerA14JzzRw==",
-          "requires": {
-            "lodash": "^4.0.1",
-            "material-colors": "^1.2.1",
-            "prop-types": "^15.5.10",
-            "reactcss": "^1.2.0",
-            "tinycolor2": "^1.4.1"
-          }
-        },
-        "react-datepicker": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-1.7.0.tgz",
-          "integrity": "sha512-2cRopX0/V05wMyhAG0JGw2vmYAxDTFJ+gkT8qZ3I1U9+SGrhccdpHF0WgMlcugOL7wT7zsWxMo4tpgHjJFQZ4A==",
-          "requires": {
-            "classnames": "^2.2.5",
-            "prop-types": "^15.6.0",
-            "react-onclickoutside": "^6.7.1",
-            "react-popper": "^1.0.2"
           }
         },
         "react-dates": {
@@ -26793,20 +26703,31 @@
           }
         },
         "react-dom": {
-          "version": "16.5.2",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.5.2.tgz",
-          "integrity": "sha512-RC8LDw8feuZOHVgzEf7f+cxBr/DnKdqp56VU0lAs1f4UfKc4cU8wU4fTq/mgnvynLQo8OtlPC19NUFh/zjZPuA==",
+          "version": "16.6.3",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz",
+          "integrity": "sha512-8ugJWRCWLGXy+7PmNh8WJz3g1TaTUt1XyoIcFN+x0Zbkoz+KKdUyx1AQLYJdbFXjuF41Nmjn5+j//rxvhFjgSQ==",
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
-            "schedule": "^0.5.0"
+            "scheduler": "^0.11.2"
+          },
+          "dependencies": {
+            "scheduler": {
+              "version": "0.11.2",
+              "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.2.tgz",
+              "integrity": "sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==",
+              "requires": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1"
+              }
+            }
           }
         },
         "react-is": {
-          "version": "16.5.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.5.2.tgz",
-          "integrity": "sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ=="
+          "version": "16.6.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.0.tgz",
+          "integrity": "sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g=="
         },
         "react-lazily-render": {
           "version": "1.1.0",
@@ -26875,11 +26796,6 @@
             "moment": ">=1.6.0"
           }
         },
-        "react-onclickoutside": {
-          "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz",
-          "integrity": "sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg=="
-        },
         "react-outside-click-handler": {
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.2.2.tgz",
@@ -26889,19 +26805,6 @@
             "consolidated-events": "^1.1.1 || ^2.0.0",
             "object.values": "^1.0.4",
             "prop-types": "^15.6.1"
-          }
-        },
-        "react-popper": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.0.2.tgz",
-          "integrity": "sha512-vjZ94ki8sfCAg45MMi4uqnUUWdzbnYkb95sR2+HgiMaAPzQcy4DfDKYtYUOhhE+sdtkufWcUHLv09DmH2Js57w==",
-          "requires": {
-            "babel-runtime": "6.x.x",
-            "create-react-context": "^0.2.1",
-            "popper.js": "^1.14.1",
-            "prop-types": "^15.6.1",
-            "typed-styles": "^0.0.5",
-            "warning": "^3.0.0"
           }
         },
         "react-portal": {
@@ -26918,34 +26821,45 @@
           "integrity": "sha1-nYqSjH8sN1E8LQZOV7Pjw1bp+rs="
         },
         "react-redux": {
-          "version": "5.0.7",
-          "resolved": "http://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
-          "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.0.tgz",
+          "integrity": "sha512-CRMpEx8+ccpoVxQrQDkG1obExNYpj6dZ1Ni7lUNFB9wcxOhy02tIqpFo4IUXc0kYvCGMu6ABj9A4imEX2VGZJQ==",
           "requires": {
-            "hoist-non-react-statics": "^2.5.0",
-            "invariant": "^2.0.0",
-            "lodash": "^4.17.5",
-            "lodash-es": "^4.17.5",
+            "@babel/runtime": "^7.1.2",
+            "hoist-non-react-statics": "^3.0.0",
+            "invariant": "^2.2.4",
             "loose-envify": "^1.1.0",
-            "prop-types": "^15.6.0"
+            "prop-types": "^15.6.1",
+            "react-is": "^16.6.0",
+            "react-lifecycles-compat": "^3.0.0"
           },
           "dependencies": {
             "hoist-non-react-statics": {
-              "version": "2.5.5",
-              "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-              "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.1.0.tgz",
+              "integrity": "sha512-MYcYuROh7SBM69xHGqXEwQqDux34s9tz+sCnxJmN18kgWh6JFdTw/5YdZtqsOdZJXddE/wUpCzfEdDrJj8p0Iw==",
+              "requires": {
+                "react-is": "^16.3.2"
+              }
             }
           }
         },
         "react-test-renderer": {
-          "version": "16.5.2",
-          "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.5.2.tgz",
-          "integrity": "sha512-AGbJYbCVx1J6jdUgI4s0hNp+9LxlgzKvXl0ROA3DHTrtjAr00Po1RhDZ/eAq2VC/ww8AHgpDXULh5V2rhEqqJg==",
+          "version": "16.6.3",
+          "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.6.3.tgz",
+          "integrity": "sha512-B5bCer+qymrQz/wN03lT0LppbZUDRq6AMfzMKrovzkGzfO81a9T+PWQW6MzkWknbwODQH/qpJno/yFQLX5IWrQ==",
           "requires": {
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
-            "react-is": "^16.5.2",
-            "schedule": "^0.5.0"
+            "react-is": "^16.6.3",
+            "scheduler": "^0.11.2"
+          },
+          "dependencies": {
+            "react-is": {
+              "version": "16.6.3",
+              "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.3.tgz",
+              "integrity": "sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA=="
+            }
           }
         },
         "react-transition-group": {
@@ -26960,9 +26874,9 @@
           }
         },
         "react-virtualized": {
-          "version": "9.20.1",
-          "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.20.1.tgz",
-          "integrity": "sha512-xIWxBsyNAjceqD3hsE0nw5TcDVxKbIepsHhvS2XneHmNz0KlKxdLdGBmGZBM9ZesEmbZ5EO0Sw70TB1MeCmpbQ==",
+          "version": "9.21.0",
+          "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.21.0.tgz",
+          "integrity": "sha512-duKD2HvO33mqld4EtQKm9H9H0p+xce1c++2D5xn59Ma7P8VT7CprfAe5hwjd1OGkyhqzOZiTMlTal7LxjH5yBQ==",
           "requires": {
             "babel-runtime": "^6.26.0",
             "classnames": "^2.2.3",
@@ -26985,13 +26899,6 @@
             "object.assign": "^4.1.0",
             "object.values": "^1.0.4",
             "prop-types": "^15.6.0"
-          },
-          "dependencies": {
-            "hoist-non-react-statics": {
-              "version": "2.5.5",
-              "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-              "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-            }
           }
         },
         "react-with-styles": {
@@ -27003,13 +26910,6 @@
             "hoist-non-react-statics": "^2.5.0",
             "prop-types": "^15.6.1",
             "react-with-direction": "^1.3.0"
-          },
-          "dependencies": {
-            "hoist-non-react-statics": {
-              "version": "2.5.5",
-              "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-              "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-            }
           }
         },
         "react-with-styles-interface-css": {
@@ -27019,14 +26919,6 @@
           "requires": {
             "array.prototype.flat": "^1.2.1",
             "global-cache": "^1.2.1"
-          }
-        },
-        "reactcss": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
-          "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
-          "requires": {
-            "lodash": "^4.0.1"
           }
         },
         "read": {
@@ -27221,6 +27113,21 @@
             "strip-indent": "^1.0.1"
           }
         },
+        "redeyed": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+          "integrity": "sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=",
+          "requires": {
+            "esprima": "~1.0.4"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
+            }
+          }
+        },
         "reduce-css-calc": {
           "version": "1.3.0",
           "resolved": "http://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
@@ -27275,13 +27182,6 @@
             "lodash-es": "^4.17.10",
             "prop-types": "^15.6.1",
             "react-lifecycles-compat": "^3.0.4"
-          },
-          "dependencies": {
-            "hoist-non-react-statics": {
-              "version": "2.5.5",
-              "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-              "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-            }
           }
         },
         "redux-multi": {
@@ -27525,7 +27425,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -27653,10 +27553,27 @@
             "resolve-from": "^3.0.0"
           }
         },
+        "resolve-dir": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+          "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+          "requires": {
+            "expand-tilde": "^2.0.0",
+            "global-modules": "^1.0.0"
+          }
+        },
         "resolve-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
           "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+        },
+        "resolve-protobuf-schema": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+          "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+          "requires": {
+            "protocol-buffers-schema": "^3.3.1"
+          }
         },
         "resolve-url": {
           "version": "0.2.1",
@@ -27778,6 +27695,11 @@
           "resolved": "https://registry.npmjs.org/rungen/-/rungen-0.3.2.tgz",
           "integrity": "sha1-QAwJ6+kU57F+C27zJjQA/Cq8fLM="
         },
+        "rw": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+          "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+        },
         "rxjs": {
           "version": "6.3.3",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
@@ -27886,7 +27808,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -27945,11 +27867,12 @@
           "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
-        "schedule": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/schedule/-/schedule-0.5.0.tgz",
-          "integrity": "sha512-HUcJicG5Ou8xfR//c2rPT0lPIRR09vVvN81T9fqfVgBmhERUbDEQoYKjpBxbueJnCPpSu2ujXzOnRQt6x9o/jw==",
+        "scheduler": {
+          "version": "0.11.2",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.2.tgz",
+          "integrity": "sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==",
           "requires": {
+            "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1"
           }
         },
@@ -28094,14 +28017,6 @@
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
           "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
         },
-        "seventh": {
-          "version": "0.7.17",
-          "resolved": "https://registry.npmjs.org/seventh/-/seventh-0.7.17.tgz",
-          "integrity": "sha512-f4/IctiUWhktR2zA4Gj0b73opEFnnwPuQxBI0LNtpGTPL66Qep1Hkh+Z46KTxPmvzdLhStU/tV7EKgvM9IaWfA==",
-          "requires": {
-            "setimmediate": "^1.0.5"
-          }
-        },
         "sha.js": {
           "version": "2.4.11",
           "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
@@ -28125,6 +28040,34 @@
               "version": "5.1.0",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+            }
+          }
+        },
+        "sharkdown": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/sharkdown/-/sharkdown-0.1.0.tgz",
+          "integrity": "sha1-YdT+Up510CRCEnzJI0NiJlCZIU8=",
+          "requires": {
+            "cardinal": "~0.4.2",
+            "expect.js": "~0.2.0",
+            "minimist": "0.0.5",
+            "split": "~0.2.10",
+            "stream-spigot": "~2.1.2",
+            "through": "~2.3.4"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.5",
+              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
+              "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY="
+            },
+            "split": {
+              "version": "0.2.10",
+              "resolved": "http://registry.npmjs.org/split/-/split-0.2.10.tgz",
+              "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
+              "requires": {
+                "through": "2"
+              }
             }
           }
         },
@@ -28158,9 +28101,9 @@
           "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
         },
         "showdown": {
-          "version": "1.8.7",
-          "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.8.7.tgz",
-          "integrity": "sha512-S1wyj80vu2lZZ7xm2ijr6e3VxHxPu8WfhTH7R6nelbIQeyl2g0ioEohS0YtFim8yAFMbQ8sQuXxiKvr10rKbTg==",
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.0.tgz",
+          "integrity": "sha512-x7xDCRIaOlicbC57nMhGfKamu+ghwsdVkHMttyn+DelwzuHOx4OHCVL/UW/2QOLH7BxfCcCCVVUix3boKXJKXQ==",
           "requires": {
             "yargs": "^10.0.3"
           },
@@ -28202,17 +28145,17 @@
           "integrity": "sha512-OpUzgR+P/Qsu6ztZehr4PxvTbV4sDW91hAqc2tnz4fjuFTqErWIUdUMbnzX+19F4IEpSSfa0vCAz5xJSs0LpPw=="
         },
         "sinon": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.0.0.tgz",
-          "integrity": "sha512-8OrSYFPZ9xaECfi1ayVMd0ihYCW2OZYgX3rBczrB990gHZMM+aftvhNTJazGz/luS0Us9NWgD5P3KGQ7kYZvGg==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.1.1.tgz",
+          "integrity": "sha512-iYagtjLVt1vN3zZY7D8oH7dkjNJEjLjyuzy8daX5+3bbQl8gaohrheB9VfH1O3L6LKuue5WTJvFluHiuZ9y3nQ==",
           "requires": {
-            "@sinonjs/commons": "^1.0.2",
+            "@sinonjs/commons": "^1.2.0",
             "@sinonjs/formatio": "^3.0.0",
             "@sinonjs/samsam": "^2.1.2",
             "diff": "^3.5.0",
             "lodash.get": "^4.4.2",
             "lolex": "^3.0.0",
-            "nise": "^1.4.5",
+            "nise": "^1.4.6",
             "supports-color": "^5.5.0",
             "type-detect": "^4.0.8"
           }
@@ -28518,6 +28461,11 @@
           "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
           "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
         },
+        "sourcemap-codec": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.3.tgz",
+          "integrity": "sha512-vFrY/x/NdsD7Yc8mpTJXuao9S8lq08Z/kOITHz6b7YbfI9xL8Spe5EvSQUHOI7SbpY8bRPr0U3kKSsPuqEGSfA=="
+        },
         "spdx-correct": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
@@ -28542,9 +28490,9 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
-          "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w=="
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
+          "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg=="
         },
         "specificity": {
           "version": "0.4.1",
@@ -28581,9 +28529,9 @@
           "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
         "sshpk": {
-          "version": "1.15.1",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.1.tgz",
-          "integrity": "sha512-mSdgNUaidk+dRU5MhYtN9zebdzF2iG0cNPWy8HG+W8y+fT1JnSkh0fzzpjOa0L7P8i1Rscz38t0h4gPcKz43xA==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
+          "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
           "requires": {
             "asn1": "~0.2.3",
             "assert-plus": "^1.0.0",
@@ -28686,15 +28634,6 @@
             "readable-stream": "^2.0.2"
           }
         },
-        "stream-combiner": {
-          "version": "0.2.2",
-          "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-          "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-          "requires": {
-            "duplexer": "~0.1.1",
-            "through": "~2.3.4"
-          }
-        },
         "stream-each": {
           "version": "1.2.3",
           "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
@@ -28721,25 +28660,41 @@
           "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
           "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
         },
+        "stream-spigot": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/stream-spigot/-/stream-spigot-2.1.2.tgz",
+          "integrity": "sha1-feFF6Bn43Q20UJDRPc9zqO08wDU=",
+          "requires": {
+            "readable-stream": "~1.1.0"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+            }
+          }
+        },
         "strict-uri-encode": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
-        },
-        "string-kit": {
-          "version": "0.8.14",
-          "resolved": "https://registry.npmjs.org/string-kit/-/string-kit-0.8.14.tgz",
-          "integrity": "sha512-gnmMvvmdEjHCt3P3sO/UURX4r5UUqpreYYFtuTx2OuM3RR3/VYaFdFVlZ1FUB9hpZvV4F3ITQtDgHXpHSjDo1Q==",
-          "requires": {
-            "xregexp": "^4.2.0"
-          },
-          "dependencies": {
-            "xregexp": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.2.0.tgz",
-              "integrity": "sha512-IyMa7SVe9FyT4WbQVW3b95mTLVceHhLEezQ02+QMvmIqDnKTxk0MLWIQPSW2MXAr1zQb+9yvwYhcyQULneh3wA=="
-            }
-          }
         },
         "string-length": {
           "version": "2.0.0",
@@ -28861,9 +28816,9 @@
           "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI="
         },
         "stylelint": {
-          "version": "9.6.0",
-          "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.6.0.tgz",
-          "integrity": "sha512-Q0UcbFPRiC+3FejNyIBAWbMuKwZNAC0kvZtGQbjwA9LMKDod6xMlBsiIigQxmE3ywpmTeFj3mkG5Jj36EfC7XA==",
+          "version": "9.8.0",
+          "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.8.0.tgz",
+          "integrity": "sha512-qYYgP9UnZ6S4uaXrfEGPIMeNv21gP4t3E7BtnYfJIiHKvz7AbrCP0vj1wPgD6OFyxLT5txQxtoznfSkm2vsUkQ==",
           "requires": {
             "autoprefixer": "^9.0.0",
             "balanced-match": "^1.0.0",
@@ -28873,31 +28828,32 @@
             "execall": "^1.0.0",
             "file-entry-cache": "^2.0.0",
             "get-stdin": "^6.0.0",
+            "global-modules": "^1.0.0",
             "globby": "^8.0.0",
             "globjoin": "^0.1.4",
             "html-tags": "^2.0.0",
-            "ignore": "^4.0.0",
+            "ignore": "^5.0.4",
             "import-lazy": "^3.1.0",
             "imurmurhash": "^0.1.4",
-            "known-css-properties": "^0.8.0",
+            "known-css-properties": "^0.9.0",
             "leven": "^2.1.0",
             "lodash": "^4.17.4",
             "log-symbols": "^2.0.0",
             "mathml-tag-names": "^2.0.1",
             "meow": "^5.0.0",
-            "micromatch": "^2.3.11",
+            "micromatch": "^3.1.10",
             "normalize-selector": "^0.2.0",
             "pify": "^4.0.0",
             "postcss": "^7.0.0",
             "postcss-html": "^0.34.0",
-            "postcss-jsx": "^0.34.0",
-            "postcss-less": "^2.0.0",
+            "postcss-jsx": "^0.35.0",
+            "postcss-less": "^3.0.1",
             "postcss-markdown": "^0.34.0",
             "postcss-media-query-parser": "^0.2.3",
             "postcss-reporter": "^6.0.0",
             "postcss-resolve-nested-selector": "^0.1.1",
             "postcss-safe-parser": "^4.0.0",
-            "postcss-sass": "^0.3.0",
+            "postcss-sass": "^0.3.5",
             "postcss-scss": "^2.0.0",
             "postcss-selector-parser": "^3.1.0",
             "postcss-styled": "^0.34.0",
@@ -28905,6 +28861,7 @@
             "postcss-value-parser": "^3.3.0",
             "resolve-from": "^4.0.0",
             "signal-exit": "^3.0.2",
+            "slash": "^2.0.0",
             "specificity": "^0.4.1",
             "string-width": "^2.1.0",
             "style-search": "^0.1.0",
@@ -28913,39 +28870,6 @@
             "table": "^5.0.0"
           },
           "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-            },
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "arr-diff": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-              "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-              "requires": {
-                "arr-flatten": "^1.0.1"
-              }
-            },
-            "array-unique": {
-              "version": "0.2.1",
-              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-              "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-            },
-            "braces": {
-              "version": "1.8.5",
-              "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-              "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-              "requires": {
-                "expand-range": "^1.8.1",
-                "preserve": "^0.2.0",
-                "repeat-element": "^1.1.2"
-              }
-            },
             "camelcase-keys": {
               "version": "4.2.0",
               "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
@@ -28957,10 +28881,11 @@
               }
             },
             "cosmiconfig": {
-              "version": "5.0.6",
-              "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz",
-              "integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
+              "version": "5.0.7",
+              "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.7.tgz",
+              "integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
               "requires": {
+                "import-fresh": "^2.0.0",
                 "is-directory": "^0.3.1",
                 "js-yaml": "^3.9.0",
                 "parse-json": "^4.0.0"
@@ -28974,62 +28899,20 @@
                 "ms": "^2.1.1"
               }
             },
-            "expand-brackets": {
-              "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-              "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-              "requires": {
-                "is-posix-bracket": "^0.1.0"
-              }
-            },
-            "extglob": {
-              "version": "0.3.2",
-              "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-              "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-              "requires": {
-                "is-extglob": "^1.0.0"
-              }
-            },
             "get-stdin": {
               "version": "6.0.0",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
               "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
             },
-            "has-flag": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-            },
             "ignore": {
-              "version": "4.0.6",
-              "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-              "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+              "version": "5.0.4",
+              "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.4.tgz",
+              "integrity": "sha512-WLsTMEhsQuXpCiG173+f3aymI43SXa+fB1rSfbzyP4GkPP+ZFVuO0/3sFUGNBtifisPeDcl/uD/Y2NxZ7xFq4g=="
             },
             "indent-string": {
               "version": "3.2.0",
               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
               "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
-            },
-            "is-extglob": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-              "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-              "requires": {
-                "is-extglob": "^1.0.0"
-              }
-            },
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
             },
             "load-json-file": {
               "version": "4.0.0",
@@ -29070,26 +28953,6 @@
                 "yargs-parser": "^10.0.0"
               }
             },
-            "micromatch": {
-              "version": "2.3.11",
-              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-              "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-              "requires": {
-                "arr-diff": "^2.0.0",
-                "array-unique": "^0.2.1",
-                "braces": "^1.8.2",
-                "expand-brackets": "^0.1.4",
-                "extglob": "^0.3.1",
-                "filename-regex": "^2.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.1",
-                "kind-of": "^3.0.2",
-                "normalize-path": "^2.0.1",
-                "object.omit": "^2.0.0",
-                "parse-glob": "^3.0.4",
-                "regex-cache": "^0.4.2"
-              }
-            },
             "ms": {
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -29105,59 +28968,16 @@
               }
             },
             "pify": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.0.tgz",
-              "integrity": "sha512-zrSP/KDf9DH3K3VePONoCstgPiYJy9z0SCatZuTpOc7YdnWIqwkWdXOuwlr4uDc7em8QZRsFWsT/685x5InjYg=="
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+              "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
             },
             "postcss-less": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-2.0.0.tgz",
-              "integrity": "sha512-pPNsVnpCB13nBMOcl5GVh8JGmB0JGFjqkLUDzKdVpptFFKEe9wFdEzvh2j4lD2AD+7qcrUfw9Ta+oi5+Fw7jjQ==",
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.0.2.tgz",
+              "integrity": "sha512-+JBOampmDnuaf4w8OIEqkCiF+sOm/nWukDsC+1FTrYcIstptOISzGpYZk24Qh+Ewlmzmi53sRyiTbiGvMCDRwA==",
               "requires": {
-                "postcss": "^5.2.16"
-              },
-              "dependencies": {
-                "chalk": {
-                  "version": "1.1.3",
-                  "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                  "requires": {
-                    "ansi-styles": "^2.2.1",
-                    "escape-string-regexp": "^1.0.2",
-                    "has-ansi": "^2.0.0",
-                    "strip-ansi": "^3.0.0",
-                    "supports-color": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-                    }
-                  }
-                },
-                "postcss": {
-                  "version": "5.2.18",
-                  "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                  "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                  "requires": {
-                    "chalk": "^1.1.3",
-                    "js-base64": "^2.1.9",
-                    "source-map": "^0.5.6",
-                    "supports-color": "^3.2.3"
-                  }
-                }
-              }
-            },
-            "postcss-reporter": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.0.tgz",
-              "integrity": "sha512-5xQXm1UPWuFObjbtyQzWvQaupru8yFcFi4HUlm6OPo1o2bUszYASuqRJ7bVArb3svGCdbYtqdMBKrqR1Aoy+tw==",
-              "requires": {
-                "chalk": "^2.0.1",
-                "lodash": "^4.17.4",
-                "log-symbols": "^2.0.0",
-                "postcss": "^7.0.2"
+                "postcss": "^7.0.3"
               }
             },
             "postcss-scss": {
@@ -29211,19 +29031,6 @@
               "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
               "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
             },
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            },
             "strip-bom": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -29233,14 +29040,6 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
               "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
-            },
-            "supports-color": {
-              "version": "3.2.3",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-              "requires": {
-                "has-flag": "^1.0.0"
-              }
             },
             "trim-newlines": {
               "version": "2.0.0",
@@ -29280,6 +29079,14 @@
             "mime": "^1.4.1",
             "qs": "^6.5.1",
             "readable-stream": "^2.3.5"
+          }
+        },
+        "supercluster": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-4.1.1.tgz",
+          "integrity": "sha512-sF0FfUOPFp96DKzwWFLeQOEqqKu2PpcesxAFeFsknA/q7g7igVVn/p3NI2XHEghNSyDAqunKNKqAbqNO8+7NDQ==",
+          "requires": {
+            "kdbush": "^2.0.1"
           }
         },
         "supertest": {
@@ -29360,6 +29167,14 @@
             "string-width": "^2.1.1"
           }
         },
+        "tannin": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tannin/-/tannin-1.0.1.tgz",
+          "integrity": "sha512-dDtnwHQ63bS/Gz0ZLY+E+JCdRoTZkmoKDoC64y3hzAD2X2qrp8jSuWNUjtiYHA48mtj4Ens9xl4knAOm1t+rfQ==",
+          "requires": {
+            "@tannin/plural-forms": "^1.0.0"
+          }
+        },
         "tapable": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.0.tgz",
@@ -29393,24 +29208,10 @@
             "uuid": "^3.0.1"
           }
         },
-        "terminal-kit": {
-          "version": "1.26.3",
-          "resolved": "https://registry.npmjs.org/terminal-kit/-/terminal-kit-1.26.3.tgz",
-          "integrity": "sha512-1iVYF0yTrKtlRUYjnw0xplCJkhbECt45dIFqRCahJeiD/416tPBFqJ3NkM498gDKwyKILGPrBRJZRlUAHChzVw==",
-          "requires": {
-            "@cronvel/get-pixels": "^3.3.1",
-            "lazyness": "^1.0.1",
-            "ndarray": "^1.0.18",
-            "nextgen-events": "^1.1.0",
-            "seventh": "^0.7.15",
-            "string-kit": "^0.8.8",
-            "tree-kit": "^0.5.27"
-          }
-        },
         "terser": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-3.10.1.tgz",
-          "integrity": "sha512-GE0ShECt1/dZUZt9Kyr/IC6xXG46pTbm1C1WfzQbbnRB5LhdJlF8p5NBZ38RjspD7hEM9O5ud8aIcOFY6evl4A==",
+          "version": "3.10.11",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-3.10.11.tgz",
+          "integrity": "sha512-iruZ7j14oBbRYJC5cP0/vTU7YOWjN+J1ZskEGoF78tFzXdkK2hbCL/3TRZN8XB+MuvFhvOHMp7WkOCBO4VEL5g==",
           "requires": {
             "commander": "~2.17.1",
             "source-map": "~0.6.1",
@@ -29603,7 +29404,7 @@
         },
         "text-encoding": {
           "version": "0.6.4",
-          "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+          "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
           "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
         },
         "text-extensions": {
@@ -29669,9 +29470,14 @@
           "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
         },
         "tinymce": {
-          "version": "4.8.3",
-          "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-4.8.3.tgz",
-          "integrity": "sha512-kNEsKTqUYZRG+GTZ7tcVAktUlDeApz6d3IqnNaZXNX0CP0BsK8NPC02FCJ0EVYxdNnq6fvvknWkItmbreXD9aA=="
+          "version": "4.8.5",
+          "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-4.8.5.tgz",
+          "integrity": "sha512-1V6+PxP5Kp8H/Kuf+EOe6vyrtj1Dlj98q33DgiKGoGPTmbcQaVZWiT+lhqj8ICXKVLV3YxAieOJyJXai4SLHQg=="
+        },
+        "tinyqueue": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
+          "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA=="
         },
         "title-case-minors": {
           "version": "1.0.0",
@@ -29830,11 +29636,6 @@
           "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
           "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
         },
-        "tree-kit": {
-          "version": "0.5.27",
-          "resolved": "https://registry.npmjs.org/tree-kit/-/tree-kit-0.5.27.tgz",
-          "integrity": "sha512-0AtAzYDYaKSzeEPK3SI72lg/io5jrBxnT1gIRxEQasJycpQf5iXGh6YAl1kkh9wHmLlNRhDx0oj+GZEQHVe+cw=="
-        },
         "treeify": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
@@ -29901,15 +29702,20 @@
             "safe-buffer": "^5.0.1"
           }
         },
+        "turbo-combine-reducers": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/turbo-combine-reducers/-/turbo-combine-reducers-1.0.2.tgz",
+          "integrity": "sha512-gHbdMZlA6Ym6Ur5pSH/UWrNQMIM9IqTH6SoL1DbHpqEdQ8i+cFunSmSlFykPt0eGQwZ4d/XTHOl74H0/kFBVWw=="
+        },
         "tweetnacl": {
           "version": "0.14.5",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
           "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
         "twemoji": {
-          "version": "11.0.1",
-          "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-11.0.1.tgz",
-          "integrity": "sha512-Z0bRyZ1yO7cqa69oRhLZWmaLM0e9eeTugUXbnNQY3XPgRHJcSF8PKfp/dx3vHWtz9Y6o8fi3Ryjfpq4vBCeXjA=="
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-11.2.0.tgz",
+          "integrity": "sha512-DgTadXkRHugun6mjUf1k3ni04WC4jHOX1bN5MjuCM3nwRyIMdXIr8FmWzW5mEIZjht5jD3NaEyXC4j3POdQwyQ=="
         },
         "type-check": {
           "version": "0.3.2",
@@ -29932,11 +29738,6 @@
             "media-typer": "0.3.0",
             "mime-types": "~2.1.18"
           }
-        },
-        "typed-styles": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.5.tgz",
-          "integrity": "sha512-ht+rEe5UsdEBAa3gr64+QjUOqjOLJfWLvl5HZR5Ev9uo/OnD3p43wPeFSB1hNFc13GXQF/JU1Bn0YHLUqBRIlw=="
         },
         "typedarray": {
           "version": "0.0.6",
@@ -29965,14 +29766,35 @@
           }
         },
         "ua-parser-js": {
-          "version": "0.7.18",
-          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
-          "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+          "version": "0.7.19",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
+          "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
         },
         "uc.micro": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
           "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg=="
+        },
+        "uglify-es": {
+          "version": "3.3.9",
+          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+          "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+          "requires": {
+            "commander": "~2.13.0",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.13.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+              "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+            }
+          }
         },
         "uglify-js": {
           "version": "3.4.9",
@@ -30030,11 +29852,6 @@
                 "y18n": "^4.0.0"
               }
             },
-            "commander": {
-              "version": "2.13.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-              "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
-            },
             "mississippi": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
@@ -30083,15 +29900,6 @@
                 "safe-buffer": "^5.1.1"
               }
             },
-            "uglify-es": {
-              "version": "3.3.9",
-              "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-              "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-              "requires": {
-                "commander": "~2.13.0",
-                "source-map": "~0.6.1"
-              }
-            },
             "y18n": {
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
@@ -30126,7 +29934,7 @@
         },
         "underscore.string": {
           "version": "3.0.3",
-          "resolved": "http://registry.npmjs.org/underscore.string/-/underscore.string-3.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.0.3.tgz",
           "integrity": "sha1-Rhe4waJQz25QZPu7Nj0PqWzxRVI="
         },
         "underscore.string.fp": {
@@ -30523,6 +30331,16 @@
             "indexof": "0.0.1"
           }
         },
+        "vt-pbf": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.1.tgz",
+          "integrity": "sha512-pHjWdrIoxurpmTcbfBWXaPwSmtPAHS105253P1qyEfSTV2HJddqjM+kIHquaT/L6lVJIk9ltTGc0IxR/G47hYA==",
+          "requires": {
+            "@mapbox/point-geometry": "0.1.0",
+            "@mapbox/vector-tile": "^1.3.1",
+            "pbf": "^3.0.5"
+          }
+        },
         "w3c-hr-time": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
@@ -30587,14 +30405,14 @@
           "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
         },
         "webpack": {
-          "version": "4.20.2",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.20.2.tgz",
-          "integrity": "sha512-75WFUMblcWYcocjSLlXCb71QuGyH7egdBZu50FtBGl2Nso8CK3Ej+J7bTZz2FPFq5l6fzCisD9modB7t30ikuA==",
+          "version": "4.25.1",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.25.1.tgz",
+          "integrity": "sha512-T0GU/3NRtO4tMfNzsvpdhUr8HnzA4LTdP2zd+e5zd6CdOH5vNKHnAlO+DvzccfhPdzqRrALOFcjYxx7K5DWmvA==",
           "requires": {
-            "@webassemblyjs/ast": "1.7.8",
-            "@webassemblyjs/helper-module-context": "1.7.8",
-            "@webassemblyjs/wasm-edit": "1.7.8",
-            "@webassemblyjs/wasm-parser": "1.7.8",
+            "@webassemblyjs/ast": "1.7.11",
+            "@webassemblyjs/helper-module-context": "1.7.11",
+            "@webassemblyjs/wasm-edit": "1.7.11",
+            "@webassemblyjs/wasm-parser": "1.7.11",
             "acorn": "^5.6.2",
             "acorn-dynamic-import": "^3.0.0",
             "ajv": "^6.1.0",
@@ -30617,14 +30435,6 @@
             "webpack-sources": "^1.3.0"
           },
           "dependencies": {
-            "acorn-dynamic-import": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
-              "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
-              "requires": {
-                "acorn": "^5.0.0"
-              }
-            },
             "schema-utils": {
               "version": "0.4.7",
               "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
@@ -30732,7 +30542,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -30819,7 +30629,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -30864,6 +30674,11 @@
           "version": "0.1.9",
           "resolved": "https://registry.npmjs.org/wemoji/-/wemoji-0.1.9.tgz",
           "integrity": "sha1-QHSo2p6CdWVNwfKwVe3x3A2wM0I="
+        },
+        "wgs84": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
+          "integrity": "sha1-NP3FVZF7blfPKigu0ENxDASc3HY="
         },
         "whatwg-encoding": {
           "version": "1.0.5",
@@ -31086,30 +30901,15 @@
           }
         },
         "wpcom-proxy-request": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/wpcom-proxy-request/-/wpcom-proxy-request-5.0.0.tgz",
-          "integrity": "sha512-dHCBAWDi/DMVQ+bF2PZ+ySDuBVjobFXMHGJdqAjcGoM8H4O7f046I0qf9tvhuzcKsjBBhK8SEIdK0PU979gh9w==",
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/wpcom-proxy-request/-/wpcom-proxy-request-5.0.2.tgz",
+          "integrity": "sha512-2MTJNiadTdZIaobhv9XJiPa/7eS1CIF4Zzp0HUKee27lhCfdoMktrjF/K+WSj7LkFZvWVR37Qh7DWfRDUiNGNQ==",
           "requires": {
             "component-event": "0.1.4",
-            "debug": "~2.2.0",
+            "debug": "^3.1.0",
             "progress-event": "~1.0.0",
             "uid": "0.0.2",
             "wp-error": "^1.3.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.2.0",
-              "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-              "requires": {
-                "ms": "0.7.1"
-              }
-            },
-            "ms": {
-              "version": "0.7.1",
-              "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-            }
           }
         },
         "wpcom-xhr-request": {
@@ -31156,7 +30956,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -31551,9 +31351,9 @@
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
     },
     "yargs": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "webpack-cli": "3.1.1",
     "webpack-dev-server": "3.1.9",
     "whatwg-fetch": "^2.0.2",
-    "wp-calypso": "github:automattic/wp-calypso#5c892f28b886c821c8047f51eec1e2f0000e2971",
+    "wp-calypso": "github:automattic/wp-calypso#ef6cd7465e7c5dce08ce5bacb65677e19c7ca309",
     "wrap-loader": "^0.2.0"
   }
 }


### PR DESCRIPTION
See: https://github.com/Automattic/wp-calypso/pull/28829