### PR TITLE
Changing the shipping_phone field to avoid conflicts

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1221,7 +1221,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		function add_shipping_phone_to_checkout( $fields ) {
-			$fields[ 'shipping_phone' ] = array(
+			$defaults = array(
 				'label'        => __( 'Phone', 'woocommerce-services' ),
 				'type'         => 'tel',
 				'required'     => false,
@@ -1230,6 +1230,21 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				'validate'     => array( 'phone' ),
 				'autocomplete' => 'tel',
 			);
+
+			// Use existing settings if the field exists
+			$field = isset( $fields['shipping_phone'] )
+				? array_merge( $defaults, $fields['shipping_phone'] )
+				: $defaults;
+
+			// Enforce phone type, autocomplete, and validation.
+			$field['type']         = 'tel';
+			$field['autocomplete'] = 'tel';
+			if ( ! in_array( 'tel', $field['validate'], true ) ) {
+				$field['validate'][] = 'tel';
+			}
+
+			// Add to the list
+			$fields['shipping_phone'] = $field;
 			return $fields;
 		}
 


### PR DESCRIPTION
## Purpose

As @adelineyaw explained in #1544, WooCommerce Services overwrites the shipping phone even if it is already created by another plugin.

The addition of the phone field and the reasons for it may be found here: https://github.com/Automattic/woocommerce-services/pull/693

In this PR I am checking whether a `shipping_phone` field already exists and if it does, I am using the values from it, while enforcing `tel` as field, autocompletion and validation type.

## Instructions to test

1. Install WCS and the "Checkout Fields Editor" extension.
2. Add/enable a `phone` field in the shipping section.
3. Test the checkout page and monitor whether changes like label, required and etc. are appearing properly.

Fixes #1544 