### PR TITLE
Replace alarming Stripe settings notice with helpful text

### DIFF
--- a/classes/class-wc-connect-stripe.php
+++ b/classes/class-wc-connect-stripe.php
@@ -290,7 +290,7 @@ if ( ! class_exists( 'WC_Connect_Stripe' ) ) {
 			$new_settings = array(
 				'connection_status' => array(
 					'type'        => 'title',
-					'title'       => __( 'Connected Stripe account', 'woocommerce-services' ),
+					'title'       => __( 'Stripe Account (connected to WooCommerce Services)', 'woocommerce-services' ),
 					'description' => ob_get_clean(),
 				),
 			);

--- a/client/apps/stripe-connect-account/view-wrapper.js
+++ b/client/apps/stripe-connect-account/view-wrapper.js
@@ -60,7 +60,7 @@ class StripeConnectAccountWrapper extends Component {
 		}
 
 		if ( ! stripeConnectAccount.connectedUserID ) {
-			return translate( 'Stripe account keys may be configured below.' );
+			return translate( 'No account connected via WooCommerce Services. Stripe account keys may be configured below.' );
 		}
 
 		return (

--- a/client/apps/stripe-connect-account/view-wrapper.js
+++ b/client/apps/stripe-connect-account/view-wrapper.js
@@ -60,11 +60,7 @@ class StripeConnectAccountWrapper extends Component {
 		}
 
 		if ( ! stripeConnectAccount.connectedUserID ) {
-			return (
-				<Notice showDismiss={ false } isCompact>
-					{ translate( 'No account connected via WooCommerce Services.' ) }
-				</Notice>
-			);
+			return translate( 'Stripe account keys may be configured below.' );
 		}
 
 		return (


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/1526

(Note: previously considered in scope for https://github.com/Automattic/woocommerce-services/pull/1513 but was likely a poor match for the issue's priority. This PR serves as a stop-gap ahead of that one.)

For the case when there is no connected Stripe account (see https://github.com/Automattic/woocommerce-services/pull/1497), this change removes the "No account connected via WooCommerce Services." info notice and replaces it with a line of text directing the merchant down the screen to manually set up keys:

> Stripe account keys may be configured below.

`master` | this PR
-- | --
<img width="820" src="https://user-images.githubusercontent.com/1867547/49177809-2595ac80-f31c-11e8-8aa5-852d29653ad3.png"> | <img width="820" src="https://user-images.githubusercontent.com/1867547/49177819-29293380-f31c-11e8-9e98-047196d24bdd.png">

I was tempted to keep the "No account connected via WooCommerce Services." message as a parenthetical, but I suppose it would still result in more confusion than clarity.

I believe the new text is adequate but would certainly welcome feedback, and if necessary can also tweak the message conditionally on whether keys are already saved, though it would add some complexity.

(The reason we don't just hide the whole "Connected Stripe account" bit is that we don't know if an account is connected without making a request to the WCS server, which we weren't willing to hold up the page load for, so that element is already present, filtered into the settings.)

cc @jobthomas 