### PR TITLE
Add specificity to root selector to avoid conflicts in Calypsoified wp-admin.

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -33,6 +33,7 @@
 @import 'components/screen-reader-text/style';
 @import 'components/segmented-control/style';
 @import 'components/spinner/style';
+@import 'components/token-field/style';
 
 &.woocommerce {
 	@import 'woocommerce/components/bulk-select/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -33,7 +33,6 @@
 @import 'components/screen-reader-text/style';
 @import 'components/segmented-control/style';
 @import 'components/spinner/style';
-@import 'components/token-field/style';
 
 &.woocommerce {
 	@import 'woocommerce/components/bulk-select/style';

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -1,6 +1,6 @@
 @import 'shared/utils';
 
-.wcc-root {
+.wp-core-ui.wp-admin .wcc-root {
 	// Buttons
 	.button {
 		background: $gray-light;
@@ -130,7 +130,9 @@
 	}
 
 	// Custom styles
-	max-width: 720px;
+	&:not(.label-purchase-modal) {
+		max-width: 720px;
+	}
 
 	&.wc-connect-shipping-settings {
 		margin-top: 6px;
@@ -142,23 +144,19 @@
 		max-width: none;
 	}
 
-	.wp-admin & {
-		select {
-			height: auto;
-			box-shadow: none;
-			width: 100%;
-			line-height: 18px;
-			padding: 9px 32px 12px 14px;
-		}
+	select {
+		height: auto;
+		box-shadow: none;
+		width: 100%;
+		line-height: 18px;
+		padding: 9px 32px 12px 14px;
 	}
 
-	.wp-core-ui & {
-		.button {
-			height: auto;
+	.button {
+		height: auto;
 
-			&:focus {
-				box-shadow: none;
-			}
+		&:focus {
+			box-shadow: none;
 		}
 	}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -122,7 +122,7 @@ module.exports = {
 						options: {
 							before: [
 								"@import 'shared/utils';",
-								'.wcc-root {',
+								'.wp-core-ui.wp-admin .wcc-root {',
 							],
 							after: '}',
 						},


### PR DESCRIPTION
This PR seeks to fix style conflicts when running within a "Calypsoified" `/wp-admin`. See: p58i-7nL-p2 (`#comment-40377`)

To test:
* `npm run dist`
* Clear local style cache
* Verify that all WCS screens and components have the correct styling (be sure to test hover, click, tooltips, etc)