### PR TITLE
Prevent multiple stripe oauth init requests when the site is not on ssl

### DIFF
--- a/client/apps/stripe-connect-account/style.scss
+++ b/client/apps/stripe-connect-account/style.scss
@@ -4,6 +4,7 @@
 	}
 
 	.stripe__connect-account-body {
+		max-width: 545px;
 		border: 1px solid #ccc;
 		line-height: 1.5;
 	}
@@ -26,8 +27,4 @@
 		@extend .stripe__connect-account-body;
 		@include placeholder();
 	}
-}
-
-&.wc-connect-stripe-connect-account {
-	max-width: 545px;
 }

--- a/client/apps/stripe-connect-account/view-wrapper.js
+++ b/client/apps/stripe-connect-account/view-wrapper.js
@@ -49,7 +49,6 @@ class StripeConnectAccountWrapper extends Component {
 	render() {
 		const {
 			isLoading,
-			isOAuthInitializing,
 			stripeConnectAccount,
 			stripeError,
 			isDeauthorizing,
@@ -57,14 +56,6 @@ class StripeConnectAccountWrapper extends Component {
 			oauthURL,
 			translate,
 		} = this.props;
-
-		if ( ! isOAuthInitializing && stripeError ) {
-			return (
-				<div className="stripe-connect-account__placeholder-container">
-					{ stripeError }
-				</div>
-			);
-		}
 
 		if ( isLoading ) {
 			return (
@@ -83,13 +74,13 @@ class StripeConnectAccountWrapper extends Component {
 		}
 
 		if ( oauthURL ) {
-			return (
-				<div className="stripe-connect-account__connect-action">
-					{ translate( 'To automatically copy keys from a Stripe account, {{a}}connect{{/a}} it to your store.', {
-						components: { a: <a href={ oauthURL } /> },
-					} ) }
-				</div>
-			);
+			return translate( 'To automatically copy keys from a Stripe account, {{a}}connect{{/a}} it to your store.', {
+				components: { a: <a href={ oauthURL } /> },
+			} );
+		}
+
+		if ( stripeError ) {
+			return stripeError;
 		}
 
 		return (

--- a/client/apps/stripe-connect-account/view-wrapper.js
+++ b/client/apps/stripe-connect-account/view-wrapper.js
@@ -60,9 +60,9 @@ class StripeConnectAccountWrapper extends Component {
 
 		if ( ! isOAuthInitializing && stripeError ) {
 			return (
-				<Notice showDismiss={ false } isCompact>
+				<div className="stripe-connect-account__placeholder-container">
 					{ stripeError }
-				</Notice>
+				</div>
 			);
 		}
 


### PR DESCRIPTION
Fixes #1558 

Attempts to generate OAuth url only once and then shows the error if it failed:
<img width="636" alt="screen shot 2018-12-10 at 15 47 28" src="https://user-images.githubusercontent.com/800604/49743556-f32c6d80-fc92-11e8-9c8f-26901192753b.png">

To test:
* On a site that's using HTTP navigate to the stripe settings page with dev tools open
* Verify that only one `oauth/init` request is sent and then the error appears
* Either upload the plugin to a site using HTTPS (such as wpcom) or modify `class-wc-rest-connect-stripe-oauth-init-controller.php` to always return some url
* Verify that the connection prompt appears as expected