### PR TITLE
Add missing return to calculate_tax method

### DIFF
--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -902,6 +902,8 @@ class WC_Connect_TaxJar_Integration {
 				);
 			}
 		} // End if().
+
+		return $taxes;
 	} // End calculate_tax().
 
 	/**


### PR DESCRIPTION
When investigating #1355 I noticed that during one of the tax code migrations we missed [one line](https://github.com/taxjar/taxjar-woocommerce-plugin/blob/898ffba09f4ac5422333d8914b9be3412bc6b3b0/includes/class-wc-taxjar-integration.php#L424).

This, in turn, [made one of the other fixes not work and fail silently](https://github.com/taxjar/taxjar-woocommerce-plugin/blob/898ffba09f4ac5422333d8914b9be3412bc6b3b0/includes/class-wc-taxjar-integration.php#L806).