### PR TITLE
Accept payment method via label purchase endpoint

### DIFF
--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -103,6 +103,13 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			$this->update_account_settings( $account_settings );
 		}
 
+		public function can_user_manage_payment_methods() {
+			global $current_user;
+			$master_user = WC_Connect_Jetpack::get_master_user();
+			return WC_Connect_Jetpack::is_development_mode() ||
+				( is_a( $master_user, 'WP_User' ) && $current_user->ID === $master_user->ID );
+		}
+
 		public function get_origin_address() {
 			$wc_address_fields = array();
 			$wc_address_fields['company'] = get_bloginfo( 'name' );

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -52,7 +52,7 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 			'storeOptions' => $this->settings_store->get_store_options(),
 			'formData' => $this->settings_store->get_account_settings(),
 			'formMeta' => array(
-				'can_manage_payments' => $this->can_user_manage_payment_methods(),
+				'can_manage_payments' => $this->settings_store->can_user_manage_payment_methods(),
 				'can_edit_settings' => true,
 				'master_user_name' => $master_user_name,
 				'master_user_login' => $master_user_login,
@@ -67,8 +67,8 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 	public function post( $request ) {
 		$settings = $request->get_json_params();
 
-		if ( ! $this->can_user_manage_payment_methods() ) {
-			// Ignore the user-provided payment method ID if he doesn't have permission to change it
+		if ( ! $this->settings_store->can_user_manage_payment_methods() ) {
+			// Ignore the user-provided payment method ID if they don't have permission to change it
 			$old_settings = $this->settings_store->get_account_settings();
 			$settings['selected_payment_method_id'] = $old_settings['selected_payment_method_id'];
 		}
@@ -91,12 +91,5 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 		}
 
 		return new WP_REST_Response( array( 'success' => true ), 200 );
-	}
-
-	private function can_user_manage_payment_methods() {
-		global $current_user;
-		$master_user = WC_Connect_Jetpack::get_master_user();
-		return WC_Connect_Jetpack::is_development_mode() ||
-			( is_a( $master_user, 'WP_User' ) && $current_user->ID === $master_user->ID );
 	}
 }

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -34,9 +34,13 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 	public function post( $request ) {
 		$settings = $request->get_json_params();
 		$order_id = $request[ 'order_id' ];
-
-		$settings[ 'payment_method_id' ] = $this->settings_store->get_selected_payment_method_id();
 		$settings[ 'order_id' ] = $order_id;
+
+		if ( empty( $settings[ 'payment_method_id' ] ) || ! $this->settings_store->can_user_manage_payment_methods() ) {
+			$settings[ 'payment_method_id' ] = $this->settings_store->get_selected_payment_method_id();
+		} else {
+			$this->settings_store->set_selected_payment_method_id( $settings[ 'payment_method_id' ] );
+		}
 
 		$service_names = array();
 		foreach ( $settings[ 'packages' ] as $index => $package ) {


### PR DESCRIPTION
Required for https://github.com/Automattic/wp-calypso/issues/30170

If a payment method isn't passed with the initial label purchase request, or the user _lacks permissions to manipulate it_, fall back on existing behavior of using stored default. Otherwise, use the provided payment method (passed as `payment_method_id` param) for the payment, and store it as a future default (see https://github.com/Automattic/wp-calypso/pull/22890#issuecomment-379033700).

(Besides this logic itself, the code change involves moving `can_user_manage_payment_methods` from  the settings API endpoint controller to the settings store.)

Can test by setting `formData.payment_method_id` prior to [this call](https://github.com/Automattic/wp-calypso/blob/8ad80271e0e97f627d1fafb99c74dc28ef823143/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js#L1043-L1044).