### PR TITLE
Fix the "Invalid host/origin header" when running the webpack dev server

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -81,6 +81,7 @@ module.exports = {
 			errors: true,
 			warnings: false,
 		},
+		disableHostCheck: true,
 	},
 	externals: {
 		'jquery': 'jQuery',


### PR DESCRIPTION
After the `webpack-dev-server` dependency was updated in #1568 the dev console started being flooded with "Invalid host/origin header" error message:
<img width="774" alt="screenshot 2019-02-08 at 16 22 42" src="https://user-images.githubusercontent.com/800604/52491387-e6f35c80-2bbe-11e9-9299-2bb9d6cce7cb.png">

I fixed it by modifying the config as suggested in this [SO answer](https://stackoverflow.com/questions/43619644/i-am-getting-an-invalid-host-header-message-when-running-my-react-app-in-a-we). There are some security concerns mentioned there, but they don't apply to us, since we're running the dev server only when developing and always ship the compiled bundle.