### PR TITLE
Hide WC shipping options on WCS settings screen

### DIFF
--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -40,6 +40,7 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 				return;
 			}
 
+			add_filter( 'woocommerce_get_settings_shipping', '__return_empty_array' );
 			$this->output_shipping_settings_screen();
 		}
 


### PR DESCRIPTION
As of https://github.com/woocommerce/woocommerce/pull/21719 (slated for WC 3.6), "Shipping options" appear for unknown section slugs unless the settings are explicitly filtered.

As a result, they are showing up at the bottom of the WooCommerce Services settings screen – which performs an action to output a container but doesn't touch the default output:

<img width="977" alt="screen shot 2019-02-12 at 3 43 38 pm" src="https://user-images.githubusercontent.com/1867547/52667186-26cb8400-2ede-11e9-9ecb-25b97d26fd85.png">

This change simply filters those settings out, causing nothing to render below the React container.