### PR TITLE
Fix checkmark alignment in settings by overriding wp-admin style

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -53,6 +53,7 @@
 		font-size: 16px;
 		font-weight: 600;
 		line-height: 0px;
+		float: none;
 	}
 
 	%form-field {


### PR DESCRIPTION
Avoids slight misalignment in WooCommerce » Settings » Shipping » WooCommerce Services screen:

Before | After
-- | --
<img width="248" alt="screen shot 2019-02-20 at 5 06 18 pm" src="https://user-images.githubusercontent.com/1867547/53128045-e8634400-3531-11e9-97dc-dd06942d1f41.png"> | <img width="243" alt="screen shot 2019-02-20 at 5 07 14 pm" src="https://user-images.githubusercontent.com/1867547/53128084-fdd86e00-3531-11e9-9827-e8019bf607dd.png">
<img width="265" alt="screen shot 2019-02-20 at 5 05 51 pm" src="https://user-images.githubusercontent.com/1867547/53128020-cf5a9300-3531-11e9-9d57-28626015925f.png"> | <img width="264" alt="screen shot 2019-02-20 at 5 05 14 pm" src="https://user-images.githubusercontent.com/1867547/53128022-d08bc000-3531-11e9-8e91-a6f1568db31b.png">

The issue was due to a `float` style being set in wp-admin [[#](https://core.trac.wordpress.org/browser/trunk/src/wp-admin/css/forms.css#L124)], and the fix is to override it.

This change causes inconsistency in vertical alignment between checked and unchecked states in the Add a package » Service package view – this will be fixed in https://github.com/Automattic/woocommerce-services/pull/1581.