### PR TITLE
Update dependency to wp-calypso master

### DIFF
--- a/client/lib/utils/local-storage.js
+++ b/client/lib/utils/local-storage.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 //import from calypso
-import localStorageModule from 'lib/local-storage';
+import localStorageModule from 'lib/local-storage-polyfill';
 localStorageModule();
 
 export const MAX_AGE = 86400000;

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "webpack-cli": "3.1.1",
     "webpack-dev-server": "^3.1.14",
     "whatwg-fetch": "^2.0.2",
-    "wp-calypso": "github:automattic/wp-calypso#1997e8a24c274b28af9ca63d8335c0913e5f5e55",
+    "wp-calypso": "github:automattic/wp-calypso#c782ff5da13931490700a218be88f8c6df43bffb",
     "wrap-loader": "^0.2.0"
   }
 }


### PR DESCRIPTION
This PR is meant to track a working build against wp-calypso master, so that subsequent to https://github.com/Automattic/woocommerce-services/pull/1581 we can set up `wp-calypso` as a git submodule and use master once again.

That can either be done in a separate PR or in this one (by @DanReyLop if you're interested, or anyone else) – and anyone is welcome to contribute future fixes to this branch.

Keeping the build in shape:
- https://github.com/Automattic/woocommerce-services/commit/4e0144a0a60e4255dd835d6b64b173132f4ae2fa renames an imported module, adjusting to the change in https://github.com/Automattic/wp-calypso/pull/30569