### PR TITLE
Release version 1.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-services",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "scripts": {
     "start": "cross-env NODE_ENV=development DISABLE_FEATURES=code-splitting CALYPSO_CLIENT=true webpack-dev-server --hot --inline --watch --content-base dist --port 8085",
     "dist": "cross-env NODE_ENV=production DISABLE_FEATURES=code-splitting,wpcom-user-bootstrap CALYPSO_CLIENT=true webpack",

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: automattic, woothemes, allendav, kellychoffman, jkudish, jeffstieler, nabsul, robobot3000, danreylop, mikeyarce, shaunkuschel, orangesareorange, pauldechov, dappermountain, radogeorgiev
 Tags: shipping, stamps, usps, woocommerce, taxes, payment, stripe
 Requires at least: 4.6
-Tested up to: 5.0
-Stable tag: 1.18.0
+Tested up to: 5.0.3
+Stable tag: 1.19.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -82,16 +82,23 @@ As of the WooCommerce 3.5 release, WooCommerce Services no longer provides shipp
 
 == Changelog ==
 
+= 1.19.0 =
+
+* Communicate HTTPS requirement when connecting to Stripe
+* Avoid showing 'Shipping options' at the bottom of the WooCommerce Services shipping settings page
+* Fix a small misalignment of checkmarks in our checkboxes
+* Fix the WC native tax override function by adding a missing return statement
+
 = 1.18.0 =
 
-- Add compatibility with WordPress 5.0
-- Add compatibility with the WordPress.com eCommerce plan
-- Add packing logs to the front-end (with debug enabled) and back-end (order detail screens)
-- When purchasing a shipping label, allow addresses to be entered without verification
-- Make the shipping label purchase process more robust, allowing retries when the label image failed to download
-- UI improvements to the shipping label address form
-- Allow connecting a Stripe account directly from the Stripe settings page
-- Updated behavior of the shipping phone field in order to prevent conflicts with other plugins
+* Add compatibility with WordPress 5.0
+* Add compatibility with the WordPress.com eCommerce plan
+* Add packing logs to the front-end (with debug enabled) and back-end (order detail screens)
+* When purchasing a shipping label, allow addresses to be entered without verification
+* Make the shipping label purchase process more robust, allowing retries when the label image failed to download
+* UI improvements to the shipping label address form
+* Allow connecting a Stripe account directly from the Stripe settings page
+* Updated behavior of the shipping phone field in order to prevent conflicts with other plugins
 
 = 1.17.1 =
 * Fix the issue with disappearing shipping method settings when Stripe extension is enabled

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -7,9 +7,9 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-services
  * Domain Path: /i18n/languages/
- * Version: 1.18.0
+ * Version: 1.19.0
  * WC requires at least: 3.0.0
- * WC tested up to: 3.5.2
+ * WC tested up to: 3.5.5
  *
  * Copyright (c) 2017 Automattic
  *


### PR DESCRIPTION
Update `package.json`, `woocommerce-services.php`, and `readme.txt` with the new version number, tested up to version numbers, and the changelog.