### PR TITLE
Fix zip code error preventing checkout

### DIFF
--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -976,6 +976,17 @@ class WC_Connect_TaxJar_Integration {
 		if ( false === $response ) {
 			$response = $this->smartcalcs_request( $json );
 
+			// Copied over from the original smartcalcs_request
+			if ( is_wp_error( $response ) ) {
+				$this->_error( 'Error retrieving the tax rates. Received (' . $response->get_error_code() . '): ' . $response->get_error_message() );
+				return;
+			} elseif ( 200 == $response['response']['code'] ) {
+				return $response;
+			} else {
+				$this->_error( 'Error retrieving the tax rates. Received (' . $response['response']['code'] . '): ' . $response['body'] );
+				return;
+			}
+
 			if ( 200 == wp_remote_retrieve_response_code( $response ) ) {
 				set_transient( $cache_key, $response, $this->cache_time );
 			}
@@ -1007,13 +1018,9 @@ class WC_Connect_TaxJar_Integration {
 			'body' => $json,
 		) );
 
-		if ( is_wp_error( $response ) ) {
-			$this->_error( 'Error retrieving the tax rates. Received (' . $response->get_error_code() . '): ' . $response->get_error_message() );
-		} elseif ( 200 == $response['response']['code'] ) {
-			return $response;
-		} else {
-			$this->_error( 'Error retrieving the tax rates. Received (' . $response['response']['code'] . '): ' . $response['body'] );
-		}
+		// Instead of doing something with the error, return the result
+		// of the API call and decide in each scenario what to do with it
+		return $response;
 	}
 
 	/**


### PR DESCRIPTION
This is a partial solution to #1576

# The steps to repro this are:
1. Enable automated taxes in `wp-admin/admin.php?page=wc-settings&tab=tax`
2. Disable shipping calculator in `wp-admin/admin.php?page=wc-settings&tab=shipping&section=options`  - i.e uncheck the option `Enable the shipping calculator on the cart page`
3. Add product to cart
4. Go to checkout
5. Enter 90210 for zipcode, FL for state
6. Go back to cart
7. Try to go to checkout again. See that you cannot

# Here's an explanation of why the problem happens:
Whenever we fetch taxes from TaxJar and get an error, we check to see if this error should be just logged, or shown to the customer who's checking out.

We need to display the error we receive in two cases of customer input error:
1. The zipcode does not match the state (e.g. `90210` (a California zipcode) and the state `Florida`)
2. The zipcode is nonsense (e.g. `dkfjdk12121`)

We add a WC notice of the type "error" in these two cases https://github.com/Automattic/woocommerce-services/blob/979854d66a823fb61d8320eef7ce0df70616904b/classes/class-wc-connect-taxjar-integration.php#L288

When WC tries to load the checkout page, we make such an API request to TaxJar and possibly get this error.

When WC sees any errors on the checkout page before loading it, it loads the cart-errors page instead in https://github.com/woocommerce/woocommerce/blob/ef05bfccfc01bb2c621ef1293e61f7c57950670f/includes/shortcodes/class-wc-shortcode-checkout.php#L270

So... whenever the customer can't edit the address on the cart page (step # 2 in steps to repro), and the address is wrong according to TaxJar (step # 5 in steps to repro), and we try to let the customer know this using an error notice, then they can't do anything about it.

# There are a few problems with this approach:
1. It does not allow users to edit an address when using the PayPal Checkout buy now button. Probably a better solution is to 
2. We are updating a lot of TaxJar functions. We are moving further away from the code TaxJar has. This is problematic. At the very least, we should maintain our own fork so it's not so hard to merge their code back in to ours, and there's a better log of what's going on at each merge.
3. This isn't a huge problem per se, but when going to the checkout page for the first time with a bad zip code, we don't display the error. We should probably validate the address when it's updated as well (maybe with the `woocommerce_after_save_address_validation` hook, not 100% sure on that).

# Some other ideas, untested:
i. What about adding an address edit link to the cart page if the user has disabled the shipping calculator? Similar to the link WC add when the shipping calculator:
<img width="291" alt="shipping-calculator-1" src="https://user-images.githubusercontent.com/11487924/53307765-c20f1280-3869-11e9-9a5d-99acf06e7b4c.png">
<img width="305" alt="shipping-calculator-2" src="https://user-images.githubusercontent.com/11487924/53307767-c3403f80-3869-11e9-8f20-ed69e9e1e13d.png">
ii. How about not letting users disble the shipping calculator when automated taxes are enabled? Seems drastic, but we've done similar things - for example not allowing to enter prices inclusive of tax. If we go this route, we need to somehow let our current users know that we're doing this.
