### PR TITLE
Fix overwriting manually entered Stripe account info

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -553,8 +553,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 
 			if ( $user_elected_to_create_stripe_account && is_plugin_active( 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php' ) ) {
-				unset( $stripe_settings['create_account'] );
-				update_option( 'woocommerce_stripe_settings', $stripe_settings );
 				$this->tracks->record_user_event( 'core_wizard_stripe_setup' );
 
 				$email = isset( $stripe_settings['email'] ) ? $stripe_settings['email'] : wp_get_current_user()->user_email;
@@ -569,6 +567,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 						WC_Connect_Options::update_option( 'banner_stripe', 'connection' );
 					}
 				}
+
+				unset( $stripe_settings['email'] );
+				unset( $stripe_settings['create_account'] );
+				update_option( 'woocommerce_stripe_settings', $stripe_settings );
 			}
 		}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -545,6 +545,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					|| ! empty( $stripe_settings['publishable_key'] )
 					|| ! empty( $stripe_settings['secret_key'] )
 				);
+
 			if ( $user_elected_to_create_stripe_account && $stripe_already_connected ) {
 				unset( $stripe_settings['email'] );
 				unset( $stripe_settings['create_account'] );
@@ -568,9 +569,15 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					}
 				}
 
-				unset( $stripe_settings['email'] );
-				unset( $stripe_settings['create_account'] );
-				update_option( 'woocommerce_stripe_settings', $stripe_settings );
+
+				// The Stripe settings have changed here - the keys were added,
+				// so we need to get a fresh copy.
+				$new_stripe_settings = get_option( 'woocommerce_stripe_settings', false );
+				if ( is_array( $new_stripe_settings ) ) {
+					unset( $new_stripe_settings['email'] );
+					unset( $new_stripe_settings['create_account'] );
+					update_option( 'woocommerce_stripe_settings', $new_stripe_settings );
+				}
 			}
 		}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -531,7 +531,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function init_core_wizard_payments_config() {
 			$stripe_settings = get_option( 'woocommerce_stripe_settings', false );
 
-			$should_create_stripe_account  = is_array( $stripe_settings )
+			$user_elected_to_create_stripe_account  = is_array( $stripe_settings )
 				&& ( isset( $stripe_settings['create_account'] ) && 'yes' === $stripe_settings['create_account'] )
 				&& ( isset( $stripe_settings['enabled'] ) && 'yes' === $stripe_settings['enabled'] );
 
@@ -545,14 +545,14 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					|| ! empty( $stripe_settings['publishable_key'] )
 					|| ! empty( $stripe_settings['secret_key'] )
 				);
-			if ( $should_create_stripe_account && $stripe_already_connected ) {
+			if ( $user_elected_to_create_stripe_account && $stripe_already_connected ) {
 				unset( $stripe_settings['email'] );
 				unset( $stripe_settings['create_account'] );
 				update_option( 'woocommerce_stripe_settings', $stripe_settings );
 				return;
 			}
 
-			if ( $should_create_stripe_account && is_plugin_active( 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php' ) ) {
+			if ( $user_elected_to_create_stripe_account && is_plugin_active( 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php' ) ) {
 				unset( $stripe_settings['create_account'] );
 				update_option( 'woocommerce_stripe_settings', $stripe_settings );
 				$this->tracks->record_user_event( 'core_wizard_stripe_setup' );


### PR DESCRIPTION
Fixes #1592 

This is a simple fix for the issue - the underlying issue of communicating in the wizard that Jetpack is required to provision the Stripe account still remains and will require design input.

To test:
* On a fresh install, open the WooCommerce wizard
* Opt-in to have a Stripe account created
* Do NOT connect Jetpack and skip the step instead
* Finish the wizard
* On the Stripe settings page enter keys of an existing account (either live or test) and save
* Connect Jetpack now
* Stripe keys should remain the same (you can test by running `jQuery('#woocommerce_stripe_test_publishable_key').val()` in dev console or similar)