### PR TITLE
Update shipping label button to primary

### DIFF
--- a/client/apps/shipping-label/view-wrapper.js
+++ b/client/apps/shipping-label/view-wrapper.js
@@ -116,6 +116,7 @@ class ShippingLabelViewWrapper extends Component {
 
 		const className = classNames( 'shipping-label__new-label-button', {
 			'is-placeholder': ! loaded,
+			'is-primary': loaded,
 		} );
 
 		return (

--- a/client/apps/shipping-label/view-wrapper.js
+++ b/client/apps/shipping-label/view-wrapper.js
@@ -122,7 +122,7 @@ class ShippingLabelViewWrapper extends Component {
 			<Button
 				className={ className }
 				onClick={ this.handleButtonClick } >
-				{ translate( 'Create new label' ) }
+				{ translate( 'Create shipping label' ) }
 			</Button>
 		);
 	};


### PR DESCRIPTION
The button type was updated to primary, changing its colour, and the text was updated to `Create shipping label`. The translations were updated, since some text was changed.

Here's how I updated the translation files:

`npm run i18n`
`npm run i18njson`

Is that enough/correct? If so, I'll add it to the documentation

Before:

<img width="306" alt="button-before" src="https://user-images.githubusercontent.com/11487924/55361646-dae09880-54a5-11e9-8ccf-322a3f5ec0a4.png">

After:

<img width="304" alt="button-after" src="https://user-images.githubusercontent.com/11487924/55361652-dd42f280-54a5-11e9-980d-91bc45fdb6ee.png">

Todo:
- [ ] add translation instructions to docs ([here's a reference to follow up on](https://github.com/Automattic/woocommerce-services/pull/1019#discussion_r119542518))

cc @aleftick 