### PR TITLE
Improved wording for the Stripe Connect UI when disconnected

### DIFF
--- a/classes/class-wc-connect-stripe.php
+++ b/classes/class-wc-connect-stripe.php
@@ -289,10 +289,18 @@ if ( ! class_exists( 'WC_Connect_Stripe' ) ) {
 			ob_start();
 			do_action( 'enqueue_wc_connect_script', 'wc-connect-stripe-connect-account' );
 
+			// Display a different title based on the connection status.
+			$account_details = $this->api->get_stripe_account_details();
+			if ( ! is_wp_error( $account_details ) ) {
+				$title = __( 'Stripe Account (connected to WooCommerce Services)', 'woocommerce-services' );
+			} else {
+				$title = __( 'Connect via WooCommerce Services', 'woocommerce-services' );
+			}
+
 			$new_settings = array(
 				'connection_status' => array(
 					'type'        => 'title',
-					'title'       => __( 'Stripe Account (connected to WooCommerce Services)', 'woocommerce-services' ),
+					'title'       => $title,
 					'description' => ob_get_clean(),
 				),
 			);

--- a/client/apps/stripe-connect-account/view-wrapper.js
+++ b/client/apps/stripe-connect-account/view-wrapper.js
@@ -74,7 +74,7 @@ class StripeConnectAccountWrapper extends Component {
 		}
 
 		if ( oauthURL ) {
-			return translate( 'To automatically copy keys from a Stripe account, {{a}}connect{{/a}} it to your store.', {
+			return translate( "You’ve got WooCommerce Services installed. If you’d like, we can automatically copy keys from your Stripe account for you. {{a}}Click here{{/a}} to connect your Stripe account using WooCommerce Services.", {
 				components: { a: <a href={ oauthURL } /> },
 			} );
 		}


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/1559, related to p7bbVw-31G-p2

## Changes proposed in this PR

- Change the title of the setting from `Stripe Account (connected to WooCommerce Services)` to `Connect via WooCommerce Services` if an account is not connected at all, or if it has not been connected through WCS.
- Change the text when an account has not been connected through WCS to `You’ve got WooCommerce Services installed. If you’d like, we can automatically copy keys from your Stripe account for you. Click here to connect your Stripe account using WooCommerce Services.`

## Testing instructions

- Install WCS on a fresh instance (or a disconnected one) and check if the strings, mentioned above, are displayed.
- On a connected website, make sure that the setting name is not `Connect via WooCommerce Services`.