### PR TITLE
Update WC tested version and release 1.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-services",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "scripts": {
     "start": "cross-env NODE_ENV=development DISABLE_FEATURES=code-splitting CALYPSO_CLIENT=true webpack-dev-server --hot --inline --watch --content-base dist --port 8085",
     "dist": "cross-env NODE_ENV=production DISABLE_FEATURES=code-splitting,wpcom-user-bootstrap CALYPSO_CLIENT=true webpack",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes, allendav, kellychoffman, jkudish, jeffstiel
 Tags: shipping, stamps, usps, woocommerce, taxes, payment, stripe
 Requires at least: 4.6
 Tested up to: 5.0.3
-Stable tag: 1.19.0
+Stable tag: 1.19.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -81,6 +81,11 @@ As of the WooCommerce 3.5 release, WooCommerce Services no longer provides shipp
 7. Checking and exporting the label purchase reports
 
 == Changelog ==
+
+= 1.19.1 =
+
+* Update WooCommerce compatiblity to 3.6
+* Improved wording for the Stripe Connect UI when disconnected
 
 = 1.19.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -86,6 +86,7 @@ As of the WooCommerce 3.5 release, WooCommerce Services no longer provides shipp
 
 * Update WooCommerce compatiblity to 3.6
 * Improved wording for the Stripe Connect UI when disconnected
+* Improve detection of when a Stripe account is connected
 
 = 1.19.0 =
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -7,9 +7,9 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-services
  * Domain Path: /i18n/languages/
- * Version: 1.19.0
+ * Version: 1.19.1
  * WC requires at least: 3.0.0
- * WC tested up to: 3.5.5
+ * WC tested up to: 3.6.1
  *
  * Copyright (c) 2017 Automattic
  *

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -9,7 +9,7 @@
  * Domain Path: /i18n/languages/
  * Version: 1.19.1
  * WC requires at least: 3.0.0
- * WC tested up to: 3.6.1
+ * WC tested up to: 3.6.*
  *
  * Copyright (c) 2017 Automattic
  *


### PR DESCRIPTION
Fixes #1603

I smoke tested with 3.6.1 using the following steps:
* remove node_modules and reinstall
* `npm run release`
* use the compiled plugin
* tested checkout rates, shipping settings, tax settings, status page, label purchases

No problems found.