### PR TITLE
Stripe - Store the account keys to determine the connection status

### DIFF
--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -52,6 +52,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				'banner_stripe',
 				'banner_ppec',
 				'stripe_keys',
+				'stripe_status_migrated',
 			);
 		}
 

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -51,6 +51,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				'stripe_state',
 				'banner_stripe',
 				'banner_ppec',
+				'stripe_keys',
 			);
 		}
 

--- a/classes/class-wc-connect-stripe.php
+++ b/classes/class-wc-connect-stripe.php
@@ -258,6 +258,8 @@ if ( ! class_exists( 'WC_Connect_Stripe' ) ) {
 			unset( $options[ 'account_id' ] );
 			unset( $options[ 'test_account_id' ] );
 
+			update_option( self::SETTINGS_OPTION, $options );
+
 			WC_Connect_Options::delete_option( self::CONNECTED_KEYS_OPTION );
 		}
 


### PR DESCRIPTION
Fixes #1605 

Improves detection of when the site is connected to stripe via oauth. Also handles the scenario where someone manually edits the API keys, i.e. stops displaying the account as connected.

To test:
* Checkout `master` and connect the account via the wizard (`/wp-admin/admin.php?page=wc-setup&step=payment`) or oauth if you have https available
* The Stripe settings page should show the account info and "connected to WooCommerce Services" header
* Checkout this branch and refresh the Stripe settings page
* The account info and the right header should still be there
* Deauthorize the account
* The account info should be gone and the header should prompt to connect
* Connect the account (either via wizard or oauth, see step 1)
* Manually edit one of the API keys and save
* The account info should not be displayed and the banner should prompt to connect