### PR TITLE
Release v1.20

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-services",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-services",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "scripts": {
     "start": "cross-env NODE_ENV=development DISABLE_FEATURES=code-splitting CALYPSO_CLIENT=true webpack-dev-server --hot --inline --watch --content-base dist --port 8085",
     "prepare": "cd wp-calypso && npm ci && cd ..",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, woothemes, allendav, kellychoffman, jkudish, jeffstiel
 Tags: shipping, stamps, usps, woocommerce, taxes, payment, stripe
 Requires at least: 4.6
 Tested up to: 5.0.3
-Stable tag: 1.19.0
+Stable tag: 1.20.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -81,6 +81,15 @@ As of the WooCommerce 3.5 release, WooCommerce Services no longer provides shipp
 7. Checking and exporting the label purchase reports
 
 == Changelog ==
+
+= 1.20.0 =
+
+* Update WooCommerce compatiblity to 3.6
+* Improved wording for the Stripe Connect UI when disconnected
+* Improve detection of when a Stripe account is connected
+* Avoid overwriting Stripe keys after they've already been entered, and WooCommerce Services is connected for the first time
+* Enable notices about WooCommerce Services to be displayed, for example when taxes were incorrectly calculated
+* Update the 'print label' button text and style
 
 = 1.19.0 =
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -7,9 +7,9 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-services
  * Domain Path: /i18n/languages/
- * Version: 1.19.0
+ * Version: 1.20.0
  * WC requires at least: 3.0.0
- * WC tested up to: 3.5.5
+ * WC tested up to: 3.6.*
  *
  * Copyright (c) 2017 Automattic
  *


### PR DESCRIPTION
✅Updated `package.json`, `woocommerce-services.php`, and `readme.txt`
✅Create a changelog section in `readme.txt`

### What's with all the extra changes?
This PR includes changes from #1594 and #1615 for testing purposes since it's ready to be merged, and just needs to be tested.

# Testing

To test please use the staging server instead of production using

`define( 'WOOCOMMERCE_CONNECT_SERVER_URL', 'https://api-staging.woocommerce.com/' );`

This is because this change is required in order for requests not to break:

https://github.com/Automattic/woocommerce-connect-server/commit/a529d68d1293a57291c74c44058e89b8578d5783

Settings requests now send a new parameter due to this commit:

https://github.com/Automattic/woocommerce-services/pull/1608/files#diff-57dabbbbd8e057f1082af23aa58d3f5aR535

## Try these things:
- [x] getting the stripe keys from the OBW
- [x] requesting a rate on checkout
- [x] buying a label
- [x] seeing a tax rate

# Steps to merge and to release:
1. ~Merge #1594~ Done
2. ~Merge #1615~ Done
3. Merge this PR in if there are no conflicts
4. ~Merge server `master` into `production`~ Done
5. Release the plugin with the rest of the steps
