### PR TITLE
Add PHP 5.3 requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,6 @@ language: php
 # Define our matrix of build configurations to test against.
 matrix:
   include:
-   - php: 5.2
-     env: WP_VERSION=4.4 WC_VERSION=2.6.14
-     sudo: true
-     dist: precise
-   - php: 5.2
-     env: WP_VERSION=5.1 WC_VERSION=3.3.3
-     sudo: true
-     dist: precise
    - php: 5.3
      env: WP_VERSION=4.5 WC_VERSION=3.2.6
      sudo: true

--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,7 @@
 Contributors: automattic, woothemes, allendav, kellychoffman, jkudish, jeffstieler, nabsul, robobot3000, danreylop, mikeyarce, shaunkuschel, orangesareorange, pauldechov, dappermountain, radogeorgiev
 Tags: shipping, stamps, usps, woocommerce, taxes, payment, stripe
 Requires at least: 4.6
+Requires PHP: 5.3
 Tested up to: 5.2
 Stable tag: 1.21.0
 License: GPLv2 or later


### PR DESCRIPTION
#1634 introduces namespaces, which are required by Jetpack 7.5

We need to require at least PHP 5.3 if we want to integrate with the latest Jetpack functionalities and make sure this plugin doesn't break. This PR adds this requirement and removes PHP 5.2 from Travis config.