### PR TITLE
1.21.1: Update for WooCommerce 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ matrix:
      env: WP_VERSION=4.8 WC_VERSION=2.6.14
    - php: 7.0
      env: WP_VERSION=latest WC_VERSION=2.6.14
+     # By default, travis attempts PHPUnit 7.5.0 for PHP 7.0 - that version works on 7.1 and 7.2 only
+     # Install and use PHPUnit 6.4 instead (and because WP itself is not PHPUnit 7 ready)
+     script: curl -sSfL -o ~/.phpenv/versions/7.1/bin/phpunit https://phar.phpunit.de/phpunit-6.4.phar && phpunit
    - php: 7.1
      env: WP_VERSION=latest WC_VERSION=3.0.3
      # By default, travis attempts PHPUnit 8.0.4 for PHP 7.1 - that version works on 7.2 and 7.3 only

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ matrix:
    - php: 7.1
      env: WP_VERSION=latest WC_VERSION=3.0.3
      # By default, travis attempts PHPUnit 8.0.4 for PHP 7.1 - that version works on 7.2 and 7.3 only
-     # Install and use PHPUnit 7.5 instead
-     script: curl -sSfL -o ~/.phpenv/versions/7.1/bin/phpunit https://phar.phpunit.de/phpunit-7.5.phar && phpunit
+     # Install and use PHPUnit 6.4 instead (and because WP itself is not PHPUnit 7 ready)
+     script: curl -sSfL -o ~/.phpenv/versions/7.1/bin/phpunit https://phar.phpunit.de/phpunit-6.4.phar && phpunit
    - php: 7.2
      env: WP_VERSION=4.4 WC_VERSION=2.6.14
      # Older versions of WP are not compatible with PHPUnit 6+. Manually install PHPUnit 5.

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
      sudo: true
      dist: precise
    - php: 5.4
+     dist: trusty
      env: WP_VERSION=4.6 WC_VERSION=3.1.2
    - php: 5.5
      env: WP_VERSION=4.7 WC_VERSION=3.0.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
      env: WP_VERSION=latest WC_VERSION=2.6.14
      # By default, travis attempts PHPUnit 7.5.0 for PHP 7.0 - that version works on 7.1 and 7.2 only
      # Install and use PHPUnit 6.4 instead (and because WP itself is not PHPUnit 7 ready)
-     script: curl -sSfL -o ~/.phpenv/versions/7.1/bin/phpunit https://phar.phpunit.de/phpunit-6.4.phar && phpunit
+     script: curl -sSfL -o ~/.phpenv/versions/7.0/bin/phpunit https://phar.phpunit.de/phpunit-6.4.phar && phpunit
    - php: 7.1
      env: WP_VERSION=latest WC_VERSION=3.0.3
      # By default, travis attempts PHPUnit 8.0.4 for PHP 7.1 - that version works on 7.2 and 7.3 only

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
      dist: trusty
      env: WP_VERSION=4.6 WC_VERSION=3.1.2
    - php: 5.5
+     dist: trusty
      env: WP_VERSION=4.7 WC_VERSION=3.0.9
    - php: 5.6
      env: WP_VERSION=4.8 WC_VERSION=2.6.14

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ matrix:
      env: WP_VERSION=latest WC_VERSION=2.6.14
    - php: 7.1
      env: WP_VERSION=latest WC_VERSION=3.0.3
+     # By default, travis attempts PHPUnit 8.0.4 for PHP 7.1 - that version works on 7.2 and 7.3 only
+     # Install and use PHPUnit 7.5 instead
+     script: curl -sSfL -o ~/.phpenv/versions/7.1/bin/phpunit https://phar.phpunit.de/phpunit-7.5.phar && phpunit
    - php: 7.2
      env: WP_VERSION=4.4 WC_VERSION=2.6.14
      # Older versions of WP are not compatible with PHPUnit 6+. Manually install PHPUnit 5.

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ matrix:
    - language: node_js
      before_script: ""
 
+services:
+   - mysql
+
 # Clones WordPress and configures our testing environment.
 before_script: bash tests/bin/install-wc-tests.sh wordpress_test root '' localhost $WP_VERSION $WC_VERSION
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-services",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3859,7 +3859,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3877,11 +3878,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3894,15 +3897,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4005,7 +4011,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4015,6 +4022,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4027,17 +4035,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4054,6 +4065,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4126,7 +4138,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4136,6 +4149,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4211,7 +4225,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4241,6 +4256,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4258,6 +4274,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4296,11 +4313,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -4837,7 +4856,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4855,11 +4875,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4872,15 +4894,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4983,7 +5008,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4993,6 +5019,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5005,17 +5032,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5032,6 +5062,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5104,7 +5135,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5114,6 +5146,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5189,7 +5222,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5219,6 +5253,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5236,6 +5271,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5274,11 +5310,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-services",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "scripts": {
     "start": "cross-env NODE_ENV=development DISABLE_FEATURES=code-splitting CALYPSO_CLIENT=true webpack-dev-server --hot --inline --watch --content-base dist --port 8085",
     "prepare": "cd wp-calypso && npm ci && cd ..",

--- a/readme.txt
+++ b/readme.txt
@@ -86,6 +86,7 @@ As of the WooCommerce 3.5 release, WooCommerce Services no longer provides shipp
 = 1.21.1 =
 
 * Update WooCommerce compatibility to 3.7
+* Support namespaced Jetpack methods
 
 = 1.21.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: shipping, stamps, usps, woocommerce, taxes, payment, stripe
 Requires at least: 4.6
 Requires PHP: 5.3
 Tested up to: 5.2
-Stable tag: 1.21.0
+Stable tag: 1.21.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -82,6 +82,10 @@ As of the WooCommerce 3.5 release, WooCommerce Services no longer provides shipp
 7. Checking and exporting the label purchase reports
 
 == Changelog ==
+
+= 1.21.1 =
+
+* Update WooCommerce compatibility to 3.7
 
 = 1.21.0 =
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -7,11 +7,11 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-services
  * Domain Path: /i18n/languages/
- * Version: 1.21.0
+ * Version: 1.21.1
  * WC requires at least: 3.0.0
- * WC tested up to: 3.6.*
+ * WC tested up to: 3.7
  *
- * Copyright (c) 2017 Automattic
+ * Copyright (c) 2017-2019 Automattic
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Closes #1632 

Also fixes our Travis CI setup so tests pass :P 

To test
- install and activate WooCommerce 3.7 RC1 or higher
- `rm -rf node_modules`
- `git submodule update --init`
- `npm install`
- `npm run dist`
- `npm test`
- `npm run release` to create the plugin zip
- install and activate this plugin from that zip
- connect jetpack if needed

- install and activate the staging plugin and ensure you can buy a test label OR...
- ensure you can buy an actual label and then refund yourself