### PR TITLE
Hide WC shipping options when showing WCS settings (again)

### DIFF
--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -13,7 +13,7 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 			$this->label = _x( 'WooCommerce Services', 'The WooCommerce Services brandname', 'woocommerce-services' );
 
 			add_filter( 'woocommerce_get_sections_shipping', array( $this, 'get_sections' ), 30 );
-			add_action( 'woocommerce_settings_shipping', array( $this, 'output_settings_screen' ) );
+			add_action( 'woocommerce_settings_shipping', array( $this, 'output_settings_screen' ), 5 );
 		}
 
 		/**


### PR DESCRIPTION
Fixes action priority so that the filter emptying the WC settings is added in time.

Not sure what's changed, but the `woocommerce_settings_shipping` actions had the same priority so it wasn't guaranteed that the `woocommerce_get_settings_shipping` filter (from https://github.com/Automattic/woocommerce-services/pull/1577) would be added in time – and it wasn't, for me:

<img width="804" alt="Screen Shot 2019-08-12 at 11 32 52 AM" src="https://user-images.githubusercontent.com/1867547/62877414-fb8ee980-bcf4-11e9-9fae-93b7a88113c1.png">
