### PR TITLE
Move create shipping label button to main content column top closes #…

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -133,7 +133,9 @@
 
 	// Custom styles
 	&:not(.label-purchase-modal) {
-		max-width: 720px;
+		max-width: 100%;
+		padding: 20px;
+		position: relative;
 	}
 
 	&.wc-connect-shipping-settings {
@@ -263,4 +265,35 @@
 
 #woocommerce-services-shipping-debug .packing-log {
 	white-space: pre-wrap;
+}
+
+#woocommerce-order-label {
+	.hndle,
+	.handlediv {
+		display: none;
+	}
+
+	.inside {
+		display: block !important;
+	}
+}
+
+.wp-core-ui.wp-admin #woocommerce-order-shipment-tracking {
+	.wcc-root.wc-connect-create-shipping-label {
+		padding: 0;
+
+		.shipping-label__container {
+			.button.is-placeholder, .button.is-primary {
+				border-width: 1px;
+				border-style: solid;
+				border-radius: 3px;
+				background: #0085ba;
+				border-color: #0073aa #006799 #006799;
+				box-shadow: 0 1px 0 #006799;
+				color: #fff;
+				text-decoration: none;
+				text-shadow: 0 -1px 1px #006799, 1px 0 1px #006799, 0 1px 1px #006799, -1px 0 1px #006799;
+			}
+		}
+	}
 }

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -367,11 +367,26 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return $payload;
 		}
 
-		public function meta_box( $post ) {
+		/**
+		 * Filter items needing shipping callback.
+		 *
+		 * @since  3.0.0
+		 * @param  array $item Item to check for shipping.
+		 * @return bool
+		 */
+		protected function filter_items_needing_shipping( $item ) {
+			$product = $item->get_product();
+			return $product && $product->needs_shipping();
+		}
+
+		public function meta_box( $post, $args ) {
 			$order = wc_get_order( $post );
 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
+			$items = array_filter( $order->get_items(), array( $this, 'filter_items_needing_shipping' ) );
 			$payload = array(
 				'orderId' => $order_id,
+				'context' => $args['args']['context'],
+				'items'   => ! empty( $items ) ? count( $items ) : 0,
 			);
 
 			do_action( 'enqueue_wc_connect_script', 'wc-connect-create-shipping-label', $payload );

--- a/client/apps/shipping-label/index.js
+++ b/client/apps/shipping-label/index.js
@@ -6,7 +6,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import ShippingLabelViewWrapper from './view-wrapper';
+import ShippingLabelViewWrapper from './view-wrapper-label';
+import ShipmentTrackingViewWrapper from './view-wrapper-tracking';
 import reduxMiddleware from './redux-middleware';
 // from calypso
 import notices from 'state/notices/reducer';
@@ -21,7 +22,7 @@ import locations from '../../extensions/woocommerce/state/data-layer/data/locati
 import locationsReducer from '../../extensions/woocommerce/state/sites/data/locations/reducer';
 import { mergeHandlers } from 'state/action-watchers/utils';
 
-export default ( { orderId } ) => {
+export default ( { orderId, context, items } ) => {
 	return {
 		getReducer() {
 			return combineReducers( {
@@ -84,7 +85,10 @@ export default ( { orderId } ) => {
 		},
 
 		View: () => (
-			<ShippingLabelViewWrapper orderId={ orderId } />
+			( 'shipment_tracking' === context ) ?
+				<ShipmentTrackingViewWrapper orderId={ orderId } />
+			:
+				<ShippingLabelViewWrapper orderId={ orderId } items={ items } />
 		),
 	};
 };

--- a/client/apps/shipping-label/style.scss
+++ b/client/apps/shipping-label/style.scss
@@ -12,6 +12,7 @@
 		height: 36px;
 		position: relative;
 		top: 3px;
+		font-style: normal;
 	}
 
 	.shipping-label__payment .gridicon.notice__icon {

--- a/client/apps/shipping-label/style.scss
+++ b/client/apps/shipping-label/style.scss
@@ -1,6 +1,18 @@
 .shipping-label__container {
 	margin-bottom: 0;
 	text-align: center;
+	display: flex;
+	justify-content: space-between;
+
+	em {
+		font-size: 18px;
+		display: inline-block;
+		vertical-align: text-bottom;
+		margin-left: 10px;
+		height: 36px;
+		position: relative;
+		top: 3px;
+	}
 
 	.shipping-label__payment .gridicon.notice__icon {
 		align-self: flex-start;
@@ -71,4 +83,10 @@
 	font-weight: normal;
 	font-size: 13px;
 	line-height: 19px;
+}
+
+@media (max-width: 1080px) {
+	.shipping-label__container {
+		display: block;
+	}
 }

--- a/client/apps/shipping-label/view-wrapper-label.js
+++ b/client/apps/shipping-label/view-wrapper-label.js
@@ -28,10 +28,6 @@ import {
 import {
 	areLabelsEnabled,
 } from '../../extensions/woocommerce/woocommerce-services/state/label-settings/selectors';
-
-import {
-	getActivityLogEvents,
-} from '../../extensions/woocommerce/state/sites/orders/activity-log/selectors';
 import { fetchOrder } from '../../extensions/woocommerce/state/sites/orders/actions';
 
 class ShippingLabelViewWrapper extends Component {

--- a/client/apps/shipping-label/view-wrapper-label.js
+++ b/client/apps/shipping-label/view-wrapper-label.js
@@ -21,8 +21,6 @@ import {
 	setEmailDetailsOption,
 	setFulfillOrderOption,
 } from '../../extensions/woocommerce/woocommerce-services/state/shipping-label/actions';
-import GlobalNotices from 'components/global-notices';
-import notices from 'notices';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	areLabelsFullyLoaded,

--- a/client/apps/shipping-label/view-wrapper-label.js
+++ b/client/apps/shipping-label/view-wrapper-label.js
@@ -113,13 +113,11 @@ export default connect(
 	( state, { orderId } ) => {
 		const siteId = getSelectedSiteId( state );
 		const loaded = areLabelsFullyLoaded( state, orderId, siteId );
-		const events = getActivityLogEvents( state, orderId );
 
 		return {
 			siteId,
 			loaded,
 			labelsEnabled: areLabelsEnabled( state, siteId ),
-			events,
 		};
 	},
 	( dispatch ) => ( {

--- a/client/apps/shipping-label/view-wrapper-tracking.js
+++ b/client/apps/shipping-label/view-wrapper-tracking.js
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+// from calypso
+import QueryLabels from '../../extensions/woocommerce/woocommerce-services/components/query-labels';
+import GlobalNotices from 'components/global-notices';
+import notices from 'notices';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import ActivityLog from '../../extensions/woocommerce/app/order/order-activity-log/events';
+import {
+	getActivityLogEvents,
+} from '../../extensions/woocommerce/state/sites/orders/activity-log/selectors';
+import { fetchOrder } from '../../extensions/woocommerce/state/sites/orders/actions';
+
+class ShipmentTrackingViewWrapper extends Component {
+	static propTypes = {
+		orderId: PropTypes.number.isRequired,
+	};
+
+	componentDidMount() {
+		const { siteId, orderId } = this.props;
+
+		if ( siteId && orderId ) {
+			this.props.fetchOrder( siteId, orderId );
+		}
+	}
+
+	renderActivityLog = () => {
+		const {
+			siteId,
+			orderId,
+			events,
+			translate,
+		} = this.props;
+
+		if ( 0 === events.length ) {
+			return translate( 'No tracking information available at this time' );
+		}
+
+		return (
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+			<div className="shipment-tracking__dummy-class order-activity-log">
+				<ActivityLog orderId={ orderId } siteId={ siteId } />
+			</div>
+		);
+	};
+
+	render() {
+		const {
+			siteId,
+			orderId,
+		} = this.props;
+
+		return (
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+			<div className="shipment-tracking__container">
+				<GlobalNotices notices={ notices.list } />
+				<QueryLabels orderId={ orderId } siteId={ siteId } />
+				{ this.renderActivityLog() }
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state, { orderId } ) => {
+		const siteId = getSelectedSiteId( state );
+		const events = getActivityLogEvents( state, orderId );
+
+		return {
+			siteId,
+			events,
+		};
+	},
+	( dispatch ) => ( {
+		...bindActionCreators( {
+			fetchOrder,
+		}, dispatch ),
+	} ),
+)( localize( ShipmentTrackingViewWrapper ) );

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1249,7 +1249,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		public function add_meta_boxes( $post_type, $post ) {
 			if ( $this->shipping_label->should_show_meta_box() ) {
-				add_meta_box( 'woocommerce-order-label', __( 'Shipping Label', 'woocommerce-services' ), array( $this->shipping_label, 'meta_box' ), null, 'side', 'default' );
+				add_meta_box( 'woocommerce-order-shipment-tracking', __( 'Shipment Tracking', 'woocommerce-services' ), array( $this->shipping_label, 'meta_box' ), null, 'side', 'default', array( 'context' => 'shipment_tracking' ) );
+
+				add_meta_box( 'woocommerce-order-label', __( 'Shipping Label', 'woocommerce-services' ), array( $this->shipping_label, 'meta_box' ), null, 'normal', 'high', array( 'context' => 'shipping_label' ) );
 			}
 
 			if ( $this->should_show_shipping_debug_meta_box( $post ) ) {


### PR DESCRIPTION
…1644

Fixes #1644 

This PR moves the "create label" button into middle column top. Decided to push this up early incase it was a blocker.

The only remaining things to change is the button color and the default meta box "toggle/title" on load. I will create new issues for those.