### PR TITLE
Use extensions from local repo instead of calypso so we can make changes

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,8 +34,8 @@ const cssLoaders = [
 		options: {
 			includePaths: [
 				path.resolve( __dirname, 'client' ),
+				path.resolve( __dirname, 'client', 'extensions' ),
 				path.resolve( __dirname, 'wp-calypso', 'client' ),
-				path.resolve( __dirname, 'wp-calypso', 'client', 'extensions' ),
 				path.resolve( __dirname, 'wp-calypso', 'assets', 'stylesheets' ),
 			],
 		},
@@ -169,8 +169,8 @@ module.exports = {
 			path.resolve( __dirname, 'client', 'calypso-stubs' ),
 			path.resolve( __dirname, 'client', 'calypso-stubs', 'extensions' ),
 			path.resolve( __dirname, 'node_modules' ),
+			path.resolve( __dirname, 'client', 'extensions' ),
 			path.resolve( __dirname, 'wp-calypso', 'client' ),
-			path.resolve( __dirname, 'wp-calypso', 'client', 'extensions' ),
 			path.resolve( __dirname, 'wp-calypso', 'node_modules' ),
 		],
 		symlinks: false,


### PR DESCRIPTION
After we moved the code from wp-calpyso/client/extensions to client/extensions, webpack was still using wp-calpyso/client/extensions to load some code because the path had not yet been updated. This PR updates the path so code changes in our repo actually have an effect.