### PR TITLE
Fix CORS policy for devServer.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -84,6 +84,9 @@ module.exports = {
 			warnings: false,
 		},
 		disableHostCheck: true,
+		headers: {
+			'Access-Control-Allow-Origin': '*'
+		}
 	},
 	externals: {
 		'jquery': 'jQuery',


### PR DESCRIPTION
Fixes #1665 
Testing:
1. Open page with WCS JS code.
2. Start woocommerce-services-plugins, using dev setup ( `npm run start` )
3. Make changes to the code
4. Observe changes.
