### PR TITLE
Show create label button in 'busy' state until data loads.

### DIFF
--- a/client/apps/shipping-label/view-wrapper-label.js
+++ b/client/apps/shipping-label/view-wrapper-label.js
@@ -51,12 +51,14 @@ class ShippingLabelViewWrapper extends Component {
 
 		const className = classNames( 'shipping-label__new-label-button', {
 			'is-placeholder': ! loaded,
-			'is-primary': loaded,
 		} );
 
 		return (
 			<Button
 				className={ className }
+				primary
+				busy= { ! loaded }
+				disabled= { ! loaded }
 				onClick={ this.handleButtonClick } >
 				{ translate( 'Create shipping label' ) }
 			</Button>


### PR DESCRIPTION
Fixes #1664 

While data is loading from server, the `Create shipping label` button is shown in busy state to indicate that data is being loaded.


### Before:
(the orange colored button must be a glitch in the gif capture, because it was pink when I originally took this)
![image](https://user-images.githubusercontent.com/6209518/65086628-7dbb9f00-d980-11e9-933a-8d06c4350896.gif)

### After:
![2019-10-08 12 07 53](https://user-images.githubusercontent.com/6209518/66425501-80a62e80-ea18-11e9-9342-22986de8e712.gif)
