### PR TITLE
Fix a glitch when closing the "Add Package" popover

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/packages/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/packages/reducer.js
@@ -71,7 +71,6 @@ reducers[ WOOCOMMERCE_SERVICES_PACKAGES_DISMISS_MODAL ] = state => {
 		modalErrors: {},
 		showModal: false,
 		showOuterDimensions: false,
-		currentlyEditingPredefinedPackages: null,
 	} );
 };
 


### PR DESCRIPTION
There's no need to reset the list of predefined packages when the modal
is dismissed, since it's repopulated whenever the modal is open.

Thanks to @bor0 for pointing out the root cause!