### PR TITLE
Removes duplicated url constants

### DIFF
--- a/client/api/url.js
+++ b/client/api/url.js
@@ -1,34 +1,10 @@
 /**
  * External dependencies
  */
-import _ from 'lodash';
-
 const namespace = 'wc/v1/connect/';
-
-export const accountSettings = () => namespace + 'account/settings';
-
-export const packages = () => namespace + 'packages';
-
-export const orderLabels = ( orderId ) => `${ namespace }label/${ orderId }`;
-
-export const getLabelRates = ( orderId ) => `${ namespace }label/${ orderId }/rates`;
-
-export const labelStatus = ( orderId, labelId ) => `${ namespace }label/${ orderId }/${ labelId }`;
-
-export const labelRefund = ( orderId, labelId ) => `${ namespace }label/${ orderId }/${ labelId }/refund`;
 
 export const labelsPrint = () => `${ namespace }label/print`;
 
 export const labelTestPrint = () => `${ namespace }label/preview`;
-
-export const addressNormalization = () => `${ namespace }normalize-address`;
-
-export const settingsForm = ( formType, methodId, instanceId ) => {
-	const path = _.filter( [ formType, methodId, instanceId ] ).join( '/' );
-
-	return namespace + path;
-};
-
-export const dismissShippingSettingsNuxNotice = () => `${ namespace }services/dismiss_notice`;
 
 export const selfHelp = () => `${ namespace }self-help`;

--- a/client/extensions/woocommerce/woocommerce-services/api/url.js
+++ b/client/extensions/woocommerce/woocommerce-services/api/url.js
@@ -6,7 +6,7 @@ export const getLabelRates = orderId => `connect/label/${ orderId }/rates`;
 export const labelStatus = ( orderId, labelId ) => `connect/label/${ orderId }/${ labelId }`;
 export const labelRefund = ( orderId, labelId ) => `connect/label/${ orderId }/${ labelId }/refund`;
 export const labelsPrint = () => 'connect/label/print';
-export const labelsTestPrint = () => 'connect/label/preview';
+export const labelTestPrint = () => 'connect/label/preview';
 export const addressNormalization = () => 'connect/normalize-address';
 export const serviceSettings = ( methodId, instanceId = 0 ) =>
 	`connect/services/${ methodId }/${ instanceId }`;


### PR DESCRIPTION
Fixes #1722 

Most of the urls defined in `client/api/url.js` were overloaded by the ones in `client/extensions/woocommerce/woocommerce-services/api/url.js`, which are the ones actually being used by the app.

To test it, just open every JS App in the extension and ensure all api calls are performed correctly.