### PR TITLE
Align Nux notice with new button position

### DIFF
--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -152,13 +152,13 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			if ( $this->shipping_label->should_show_meta_box() ) {
 				$pointers[] = array(
 					'id' => 'wc_services_labels_metabox',
-					'target' => '#woocommerce-order-label',
+					'target' => '#woocommerce-order-label .button',
 					'options' => array(
 						'content' => sprintf( '<h3>%s</h3><p>%s</p>',
 							__( 'Discounted Shipping Labels' ,'woocommerce-services' ),
 							__( "When you're ready, purchase and print discounted labels from USPS right here.", 'woocommerce-services' )
 						),
-						'position' => array( 'edge' => 'right', 'align' => 'left' ),
+						'position' => array( 'edge' => 'top', 'align' => 'left' ),
 					),
 					'dim' => true,
 				);


### PR DESCRIPTION
After moving the *Purchase label* button to the new position at the top the Nux notice is a little misaligned this will reposition it under the button. 
Before 
![Screenshot from 2019-10-18 22-09-23](https://user-images.githubusercontent.com/1534605/67138234-21ed6b80-f1f5-11e9-8e8b-4365447c9cad.png)
After
![Screenshot from 2019-10-18 22-11-37](https://user-images.githubusercontent.com/1534605/67138236-27e34c80-f1f5-11e9-89d0-f0484662ac87.png)

