### PR TITLE
Use localStorage for common requests.

### DIFF
--- a/client/extensions/woocommerce/state/sites/data/locations/actions.js
+++ b/client/extensions/woocommerce/state/sites/data/locations/actions.js
@@ -7,8 +7,15 @@ import {
 	WOOCOMMERCE_LOCATIONS_REQUEST,
 	WOOCOMMERCE_LOCATIONS_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
+import { loadSettingFromLocalStorage, storeSettingInLocalStorage } from '../../../../woocommerce-services/api/localStorage';
+
 
 export function fetchLocations( siteId ) {
+	const localStorageSettings = loadSettingFromLocalStorage( siteId, 'continents', 60000 );
+	if( undefined !== localStorageSettings ) {
+		return sucess( siteId, localStorageSettings );
+	}
+
 	return {
 		type: WOOCOMMERCE_LOCATIONS_REQUEST,
 		siteId,
@@ -20,10 +27,15 @@ export function locationsFailure( siteId, error = false ) {
 	return setError( siteId, action, error );
 }
 
-export function locationsReceive( siteId, data ) {
+function sucess( siteId, data ) {
 	return {
 		type: WOOCOMMERCE_LOCATIONS_REQUEST_SUCCESS,
 		siteId,
 		data,
 	};
+}
+
+export function locationsReceive( siteId, data ) {
+	storeSettingInLocalStorage( siteId, 'continents', data );
+	return sucess( siteId, data );
 }

--- a/client/extensions/woocommerce/woocommerce-services/api/localStorage.js
+++ b/client/extensions/woocommerce/woocommerce-services/api/localStorage.js
@@ -1,0 +1,22 @@
+export const loadSettingFromLocalStorage = ( siteId, name, allowedAge ) => {
+	try {
+		const serializedState = localStorage.getItem( 'wcs-' + name + '-siteId-' + siteId );
+		if (serializedState === null) {
+		return undefined;
+		}
+		const settings = JSON.parse(serializedState);
+		const age = Date.now() - settings.localStorageTimestamp;
+		if( allowedAge < age ) {
+			return undefined;
+		}
+		delete settings.localStorageTimestamp;
+		return settings;
+	} catch (err) {
+		return undefined;
+	}
+};
+
+export const storeSettingInLocalStorage = ( siteId, name, settings ) => {
+	settings.localStorageTimestamp = Date.now();
+	localStorage.setItem( 'wcs-' + name + '-siteId-' + siteId , JSON.stringify( settings ) );
+}


### PR DESCRIPTION
Each view of the order page requires fetching of following objects using AJAX request:
settings, continents, packages. Since the objects do not change in general, and if they change we should be able to know when we could optimize to user experience by temporary caching those values in the browsers localStorage. This PR is a quick demonstration of how this could work.
Values are stored for 1 minute so when we do a second loading of the same page it should go much faster.

The strategy of data retention should be different in the final solution - this one is just for demo purposes.