### PR TITLE
Add save action for service packages

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/packages/package-dialog.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/package-dialog.js
@@ -52,9 +52,41 @@ const PackageDialog = props => {
 	const isAddingCustom = 'add-custom' === mode;
 	const isAddingPredefined = 'add-predefined' === mode;
 
+	const triggerImmediateSave = () => {
+		const onSaveSuccess = () => {
+			if ( typeof props.onSaveSuccess === 'function' && 'name' in packageData ) {
+				props.onSaveSuccess( packageData.name );
+			}
+			return props.successNotice( translate( 'Your shipping packages have been saved.' ) );
+		}
+
+		const onSaveFailure = () => {
+			return props.errorNotice( translate( 'Unable to save your shipping packages. Please try again.' ) );
+		}
+
+		const onPaymentMethodMissing = () => {
+			return props.errorNotice(
+				translate( 'A payment method is required to print shipping labels.' ),
+				{
+					duration: 4000,
+				}
+			);
+		}
+
+		props.createWcsShippingSaveActionList(
+			onSaveSuccess,
+			onSaveFailure,
+			onPaymentMethodMissing,
+			true
+		);
+	};
+
 	const onSave = () => {
 		if ( isAddingPredefined ) {
 			savePredefinedPackages( siteId );
+			if ( props.persistOnSave ) {
+				triggerImmediateSave();
+			}
 			return;
 		}
 
@@ -85,33 +117,7 @@ const PackageDialog = props => {
 
 		savePackage( siteId, filteredPackageData );
 		if ( props.persistOnSave ) {
-
-			const onSaveSuccess = () => {
-				if ( typeof props.onSaveSuccess === 'function' ) {
-					props.onSaveSuccess( packageData.name );
-				}
-				return props.successNotice( translate( 'Your shipping package have been saved.' ) );
-			}
-
-			const onSaveFailure = () => {
-				return props.errorNotice( translate( 'Unable to save your shipping package. Please try again.' ) );
-			}
-
-			const onPaymentMethodMissing = () => {
-				return props.errorNotice(
-					translate( 'A payment method is required to print shipping labels.' ),
-					{
-						duration: 4000,
-					}
-				);
-			}
-
-			props.createWcsShippingSaveActionList(
-				onSaveSuccess,
-				onSaveFailure,
-				onPaymentMethodMissing,
-				true
-			);
+			triggerImmediateSave();
 		}
 	};
 


### PR DESCRIPTION
Fixes #1735 

Service package selection changes were not being saved on the order page. 

This change triggers the save action after clicking `Add packages`:
![2019-10-24 12 57 46](https://user-images.githubusercontent.com/6209518/67520581-fd164f80-f65d-11e9-91a9-f3f37e6a93f4.gif)
