### PR TITLE
Initial implementation of ShippingSummary

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -22,6 +22,7 @@ import {
 	pick,
 	sumBy,
 	uniqBy,
+	isNull,
 } from 'lodash';
 
 /**
@@ -154,12 +155,13 @@ export const fetchLabelsData = ( orderId, siteId ) => dispatch => {
 		);
 };
 
-export const toggleStep = ( orderId, siteId, stepName ) => {
+export const toggleStep = ( orderId, siteId, stepName, expanded = null ) => {
 	return {
 		type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP,
 		siteId,
 		orderId,
 		stepName,
+		expanded
 	};
 };
 

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -22,7 +22,6 @@ import {
 	pick,
 	sumBy,
 	uniqBy,
-	isNull,
 } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -16,6 +16,7 @@ import {
 	sortBy,
 	sumBy,
 	without,
+	isBoolean,
 } from 'lodash';
 
 /**
@@ -161,14 +162,14 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_EXIT_TRACKING_FLOW ] = state => {
 	};
 };
 
-reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP ] = ( state, { stepName } ) => {
+reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP ] = ( state, { stepName, expanded = null } ) => {
 	return {
 		...state,
 		form: {
 			...state.form,
 			[ stepName ]: {
 				...state.form[ stepName ],
-				expanded: ! state.form[ stepName ].expanded,
+				expanded: isBoolean( expanded ) ? expanded : ! state.form[ stepName ].expanded,
 			},
 		},
 	};

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
@@ -88,7 +88,7 @@ class PriceSummary extends Component {
 		const { prices, discount, total } = priceBreakdown;
 
 		return (
-			<div>
+			<div className="label-purchase-modal__shipping-summary-section">
 				<hr />
 				{ prices.map( ( service, index ) => {
 					return (
@@ -103,7 +103,7 @@ class PriceSummary extends Component {
 					);
 				} ) }
 				{ 0 < discount
-					? this.renderRow( translate( 'Your discount' ), -discount, 'discount', false, true )
+					? this.renderRow( translate( 'You save' ), -discount, 'discount', false, true )
 					: null }
 				{ this.renderRow( translate( 'Total' ), total, 'total', true ) }
 			</div>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
@@ -89,6 +89,7 @@ class PriceSummary extends Component {
 
 		return (
 			<div>
+				<hr />
 				{ prices.map( ( service, index ) => {
 					return (
 						<Fragment key={ index }>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/shipping-summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/shipping-summary.js
@@ -41,7 +41,9 @@ const ShippingSummary = props => {
 						</div>
 						<div>
 							{ origin.values.address }
+							{ /* eslint-disable jsx-a11y/anchor-is-valid */ }
 							<a href="#" onClick={ () => props.toggleStep( orderId, siteId, 'origin', true ) }>Edit</a>
+							{ /* eslint-enable jsx-a11y/anchor-is-valid */ }
 						</div>
 					</div>
 				) : null }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/shipping-summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/shipping-summary.js
@@ -1,0 +1,108 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { localize } from 'i18n-calypso';
+import { isEqual } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getShippingLabel,
+	isLoaded,
+	getFormErrors,
+} from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
+import {
+	toggleStep,
+} from 'woocommerce/woocommerce-services/state/shipping-label/actions';
+import { hasNonEmptyLeaves } from 'woocommerce/woocommerce-services/lib/utils/tree';
+
+const ShippingSummary = props => {
+	const { translate, normalizationStatus, form, orderId, siteId } = props;
+	const { origin, rates } = form;
+	const labelCount = Object.keys( rates.values ).length;
+
+	return (
+		<div>
+			<div className="label-purchase-modal__shipping-summary-header">
+				{ translate( 'Shipping summary' ) }
+			</div>
+			<div className="label-purchase-modal__shipping-summary-info">
+				{ normalizationStatus.isSuccess ? (
+					<div className="label-purchase-modal__shipping-summary-street">
+						{ translate( 'Shipping from %(address)s', {
+							args: { address: origin.values.address },
+						} ) }
+						<a href="#" onClick={ () => props.toggleStep( orderId, siteId, 'origin', true ) }>Edit</a>
+					</div>
+				) : null }
+			</div>
+			<div className="label-purchase-modal__shipping-summarry-labels">
+				{ labelCount + ' ' + translate( 'shipping label ready', 'shipping labels ready', { count: labelCount } ) }
+			</div>
+		</div>
+	);
+}
+
+ShippingSummary.propTypes = {
+	siteId: PropTypes.number.isRequired,
+	orderId: PropTypes.number.isRequired,
+};
+
+const getNormalizationStatus = ( {
+	normalizationInProgress,
+	errors,
+	isNormalized,
+	values,
+	normalized,
+} ) => {
+	if ( normalizationInProgress ) {
+		return { isProgress: true };
+	}
+	if ( hasNonEmptyLeaves( errors ) || ( isNormalized && ! normalized ) || ! isNormalized ) {
+		return { isError: true };
+	}
+	if ( isNormalized ) {
+		return isEqual( values, normalized ) ? { isSuccess: true } : { isWarning: true };
+	}
+	return {};
+};
+
+const mapStateToProps = ( state, { orderId, siteId } ) => {
+	const loaded = isLoaded( state, orderId, siteId );
+	const shippingLabel = getShippingLabel( state, orderId, siteId );
+
+	const form = shippingLabel.form.origin;
+	const errors = loaded && getFormErrors( state, orderId, siteId ).origin;
+
+	return {
+		orderId,
+		siteId,
+		errors,
+		form: shippingLabel.form,
+		expanded: form.expanded,
+		normalizationStatus: getNormalizationStatus( { ...form, errors } ),
+	};
+};
+
+const mapDispatchToProps = dispatch => {
+	return bindActionCreators(
+		{
+			toggleStep,
+		},
+		dispatch
+	);
+};
+
+export default localize(
+	connect(
+		mapStateToProps,
+		mapDispatchToProps
+	)( ShippingSummary )
+);

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/shipping-summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/shipping-summary.js
@@ -29,7 +29,7 @@ const ShippingSummary = props => {
 	const labelCount = Object.keys( rates.values ).length;
 
 	return (
-		<div>
+		<div className="label-purchase-modal__shipping-summary-section">
 			<div className="label-purchase-modal__shipping-summary-header">
 				{ translate( 'Shipping summary' ) }
 			</div>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/shipping-summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/shipping-summary.js
@@ -36,10 +36,13 @@ const ShippingSummary = props => {
 			<div className="label-purchase-modal__shipping-summary-info">
 				{ normalizationStatus.isSuccess ? (
 					<div className="label-purchase-modal__shipping-summary-street">
-						{ translate( 'Shipping from %(address)s', {
-							args: { address: origin.values.address },
-						} ) }
-						<a href="#" onClick={ () => props.toggleStep( orderId, siteId, 'origin', true ) }>Edit</a>
+						<div>
+							{ translate( 'Shipping from' ) }
+						</div>
+						<div>
+							{ origin.values.address }
+							<a href="#" onClick={ () => props.toggleStep( orderId, siteId, 'origin', true ) }>Edit</a>
+						</div>
 					</div>
 				) : null }
 			</div>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/sidebar.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/sidebar.js
@@ -15,6 +15,7 @@ import { localize } from 'i18n-calypso';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormLabel from 'components/forms/form-label';
 import PriceSummary from './price-summary';
+import ShippingSummary from './shipping-summary';
 import PurchaseSection from './purchase-section';
 import {
 	setEmailDetailsOption,
@@ -42,6 +43,7 @@ const Sidebar = props => {
 
 	return (
 		<div className="label-purchase-modal__sidebar">
+			<ShippingSummary siteId={ siteId } orderId={ orderId } />
 			<PriceSummary siteId={ siteId } orderId={ orderId } />
 			<FormLabel className="label-purchase-modal__option-email-customer">
 				<FormCheckbox checked={ emailDetails } onChange={ onEmailDetailsChange } />

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -72,7 +72,8 @@
 
 	@include breakpoint( '>660px' ) {
 		flex-basis: 40%;
-		padding: 24px;
+		padding: 0 24px 24px;
+		margin-top: -20px;
 		margin-left: 24px;
 		background: var( --color-white );
 	}
@@ -222,4 +223,21 @@
 		align-self: flex-start;
 		margin-top: -7px;
 	}
+}
+
+.label-purchase-modal__shipping-summary-header {
+	font-size: 16px;
+	font-weight: bold;
+}
+
+.label-purchase-modal__shipping-summary-street {
+	color: #636d75;
+	margin-top: 15px;
+	a {
+		margin-left: 7px;
+	}
+}
+
+.label-purchase-modal__shipping-summarry-labels {
+	margin-top: 15px;
 }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -232,12 +232,16 @@
 
 .label-purchase-modal__shipping-summary-street {
 	color: #636d75;
-	margin-top: 15px;
+	margin-top: 18px;
 	a {
 		margin-left: 7px;
 	}
 }
 
 .label-purchase-modal__shipping-summarry-labels {
-	margin-top: 15px;
+	margin-top: 18px;
+}
+
+.label-purchase-modal__shipping-summary-section {
+	padding-bottom: 15px;
 }


### PR DESCRIPTION
Fixes #1737.

Adds shipping summary:
<img width="713" alt="image" src="https://user-images.githubusercontent.com/6209518/67815715-ef4d3980-fa64-11e9-8758-d2473c5ac96c.png">
