### PR TITLE
Tweak conditional to select empty box properly

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -680,7 +680,7 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_PACKAGE_TYPE ] = (
 		8
 	);
 
-	if ( 'not_selected' === boxTypeId ) {
+	if ( 'not_selected' === boxTypeId || ! box ) {
 		// This is when no box is selected
 		newPackages[ packageId ] = {
 			...omit( oldPackage, 'service_id' ),


### PR DESCRIPTION
Tweak conditional to select empty box also in the case where `userMeta.last_box_id` is set but to a non-existent box.

Fixes #1759.