### PR TITLE
Fix tests by updating some, and adjusting code for others

### DIFF
--- a/client/apps/shipping-label/view-wrapper-label.js
+++ b/client/apps/shipping-label/view-wrapper-label.js
@@ -63,7 +63,7 @@ class ShippingLabelViewWrapper extends Component {
 			'is-placeholder': ! loaded,
 		} );
 
-		if ( false === events ) {
+		if ( ! loaded ) {
 			return (
 				<Button
 					className={ 'shipping-label__button-loading' }

--- a/client/extensions/woocommerce/state/sites/orders/activity-log/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/activity-log/selectors.js
@@ -126,10 +126,6 @@ export const getActivityLogEvents = ( state, orderId, siteId = getSelectedSiteId
 		content: note.note,
 	} ) );
 
-	if ( null === order ) {
-		return false;
-	}
-
 	getOrderRefunds( state, orderId, siteId ).forEach( refund => {
 		events.push( {
 			key: refund.id,

--- a/client/extensions/woocommerce/woocommerce-services/state/packages/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/packages/reducer.js
@@ -83,7 +83,6 @@ reducers[ WOOCOMMERCE_SERVICES_PACKAGES_SET_MODAL_ERRORS ] = ( state, action ) =
 reducers[ WOOCOMMERCE_SERVICES_PACKAGES_UPDATE_PACKAGES_FIELD ] = ( state, action ) => {
 	const mergedPackageData = Object.assign( {}, state.packageData, action.values );
 	const newPackageData = omitBy( mergedPackageData, isNullOrEmpty );
-	newPackageData.max_weight = 0;
 	return Object.assign( {}, state, {
 		packageData: newPackageData,
 		pristine: false,

--- a/client/extensions/woocommerce/woocommerce-services/state/packages/test/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/packages/test/reducer.js
@@ -297,7 +297,7 @@ describe( 'Packages form reducer', () => {
 			service: [ 'box', 'box1', 'box2' ],
 			otherService: [],
 		} );
-		expect( result.currentlyEditingPredefinedPackages ).to.eql( null );
+		expect( result.currentlyEditingPredefinedPackages ).to.eql( { service: [ 'box', 'box1', 'box2' ], otherService: [] } );
 		expect( result.pristine ).to.eql( false );
 		expect( result.showModal ).to.eql( false );
 	} );

--- a/client/extensions/woocommerce/woocommerce-services/state/packages/test/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/packages/test/reducer.js
@@ -112,7 +112,6 @@ describe( 'Packages form reducer', () => {
 			modalErrors: {},
 			showModal: false,
 			showOuterDimensions: false,
-			currentlyEditingPredefinedPackages: null,
 		} );
 	} );
 

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -435,16 +435,15 @@ export const hasSelectedRates = ( { values: selectedRates, available: allRates }
 
 export const getRatesErrors = ( { values: selectedRates, available: allRates } ) =>
 	mapValues( allRates, ( rate, boxId ) => {
-		if ( ! isEmpty( rate.errors ) ) {
-			const messages = rate.errors.map( err => err.userMessage || err.message ).filter( Boolean );
+		if ( ! isEmpty( rate.default.errors ) ) {
+			const messages = rate.default.errors.map( err => err.userMessage || err.message ).filter( Boolean );
 			return messages.length
 				? messages
 				: [ "We couldn't get a rate for this package, please try again." ];
 		}
-
-		if ( selectedRates[ boxId ] ) {
+		if ( selectedRates[ boxId ] && selectedRates[ boxId ].serviceId ) {
 			return [];
-		} else if ( isEmpty( rate.rates ) ) {
+		} else if ( isEmpty( rate.default.rates ) ) {
 			return [
 				translate(
 					'No rates available, please double check dimensions and weight or try using different packaging.'

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
@@ -113,6 +113,7 @@ describe( 'Shipping label Actions', () => {
 						type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP,
 						orderId,
 						siteId,
+						expanded: null
 					} )
 				).to.equal( true );
 			} );
@@ -123,6 +124,7 @@ describe( 'Shipping label Actions', () => {
 						type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP,
 						orderId,
 						siteId,
+						expanded: null
 					} )
 				).to.equal( false );
 			} );
@@ -151,6 +153,7 @@ describe( 'Shipping label Actions', () => {
 						type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP,
 						orderId,
 						siteId,
+						expanded: null
 					} )
 				).to.equal( true );
 			} );
@@ -161,6 +164,7 @@ describe( 'Shipping label Actions', () => {
 						type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP,
 						orderId,
 						siteId,
+						expanded: null
 					} )
 				).to.equal( false );
 			} );
@@ -194,6 +198,7 @@ describe( 'Shipping label Actions', () => {
 						type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP,
 						orderId,
 						siteId,
+						expanded: null
 					} )
 				).to.equal( true );
 			} );
@@ -204,6 +209,7 @@ describe( 'Shipping label Actions', () => {
 						type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP,
 						orderId,
 						siteId,
+						expanded: null
 					} )
 				).to.equal( false );
 			} );
@@ -232,6 +238,7 @@ describe( 'Shipping label Actions', () => {
 						type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP,
 						orderId,
 						siteId,
+						expanded: null
 					} )
 				).to.equal( true );
 			} );
@@ -242,6 +249,7 @@ describe( 'Shipping label Actions', () => {
 						type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP,
 						orderId,
 						siteId,
+						expanded: null
 					} )
 				).to.equal( false );
 			} );
@@ -350,6 +358,7 @@ describe( 'Shipping label Actions', () => {
 						stepName: 'destination',
 						orderId,
 						siteId,
+						expanded: null
 					} )
 				).to.equal( true );
 			} );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/reducer.js
@@ -457,7 +457,7 @@ describe( 'Label purchase form reducer', () => {
 		expect( state[ orderId ].form.packages.selected.weight_0_custom1.signature ).to.eql( 'yes' );
 		expect( state[ orderId ].form.packages.saved ).to.be.false;
 		expect( state[ orderId ].form.rates.available ).to.be.an( 'object' ).that.is.empty;
-		expect( state[ orderId ].form.rates.values.weight_0_custom1 ).to.eql( '' );
+		expect( state[ orderId ].form.rates.values.weight_0_custom1 ).to.eql( { serviceId: '', signatureRequired: false } );
 	} );
 
 	it( 'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_UPDATE_PACKAGE_WEIGHT updates package weight option and clears rates', () => {
@@ -475,7 +475,7 @@ describe( 'Label purchase form reducer', () => {
 			.true;
 		expect( state[ orderId ].form.packages.saved ).to.be.false;
 		expect( state[ orderId ].form.rates.available ).to.be.an( 'object' ).that.is.empty;
-		expect( state[ orderId ].form.rates.values.weight_0_custom1 ).to.eql( '' );
+		expect( state[ orderId ].form.rates.values.weight_0_custom1 ).to.eql( { serviceId: '', signatureRequired: false } );
 	} );
 
 	it( 'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_CONFIRM_ADDRESS_SUGGESTION saves the address and proceeds to the next step', () => {

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/selectors.js
@@ -14,108 +14,120 @@ describe( '#getRatesErrors', () => {
 	// when there are selected rates
 	// the values match `service_id` in the rate object
 	const firstBoxSelectedValues = {
-		box_1: 'Priority',
+		serviceId: 'Priority', signatureRequired: false,
 	};
 	const secondBoxSelectedValues = {
-		box_2: 'Express',
+		serviceId: 'Express', signatureRequired: false,
 	};
 
 	// rates when there are no server errors, for each box
 	const firstBoxRatesWithNoServerErrors = {
 		box_1: {
-			shipment_id: 'shp_1',
-			rates: [
-				{
-					rate_id: 'rate_box_1_a',
-					service_id: 'Priority',
-					carrier_id: 'usps',
-					title: 'USPS - Priority Mail',
-					rate: 10,
-					is_selected: true,
-				},
-				{
-					rate_id: 'rate_box_1_b',
-					service_id: 'Express',
-					carrier_id: 'usps',
-					title: 'USPS - Express Mail',
-					rate: 11,
-					is_selected: false,
-				},
-			],
-			errors: [],
+			default: {
+				shipment_id: 'shp_1',
+				rates: [
+					{
+						rate_id: 'rate_box_1_a',
+						service_id: 'Priority',
+						carrier_id: 'usps',
+						title: 'USPS - Priority Mail',
+						rate: 10,
+						is_selected: true,
+					},
+					{
+						rate_id: 'rate_box_1_b',
+						service_id: 'Express',
+						carrier_id: 'usps',
+						title: 'USPS - Express Mail',
+						rate: 11,
+						is_selected: false,
+					},
+				],
+				errors: [],
+			}
 		},
 	};
 	const secondBoxRatesWithNoServerErrors = {
 		box_2: {
-			shipment_id: 'shp_2',
-			rates: [
-				{
-					rate_id: 'rate_box_2_a',
-					service_id: 'Priority',
-					carrier_id: 'usps',
-					title: 'USPS - Priority Mail',
-					rate: 20,
-					is_selected: false,
-				},
-				{
-					rate_id: 'rate_box_2_b',
-					service_id: 'Express',
-					carrier_id: 'usps',
-					title: 'USPS - Express Mail',
-					rate: 21,
-					is_selected: true,
-				},
-			],
-			errors: [],
+			default: {
+				shipment_id: 'shp_2',
+				rates: [
+					{
+						rate_id: 'rate_box_2_a',
+						service_id: 'Priority',
+						carrier_id: 'usps',
+						title: 'USPS - Priority Mail',
+						rate: 20,
+						is_selected: false,
+					},
+					{
+						rate_id: 'rate_box_2_b',
+						service_id: 'Express',
+						carrier_id: 'usps',
+						title: 'USPS - Express Mail',
+						rate: 21,
+						is_selected: true,
+					},
+				],
+				errors: [],
+			}
 		},
 	};
 
 	// rates when there are server errors
 	const firstBoxRatesWithError = {
 		box_1: {
-			rates: [],
-			errors: [
-				{
-					code: 'ERROR 1',
-					message: 'There was an error!',
-				},
-			],
+			default: {
+				rates: [],
+				errors: [
+					{
+						code: 'ERROR 1',
+						message: 'There was an error!',
+					},
+				],
+			}
 		},
 	};
 	const firstBoxRatesWithUserMessageError = {
 		box_1: {
-			rates: [],
-			errors: [
-				{
-					code: 'ERROR 1',
-					userMessage: 'This is a friendly error message!',
-				},
-			],
+			default: {
+				rates: [],
+				errors: [
+					{
+						code: 'ERROR 1',
+						userMessage: 'This is a friendly error message!',
+					},
+				],
+			}
 		},
 	};
 	const firstBoxRatesWithErrorButNoErrorMessage = {
 		box_1: {
-			rates: [],
-			errors: [
-				{
-					code: 'ERROR 1',
-				},
-			],
+			default: {
+				rates: [],
+				errors: [
+					{
+						code: 'ERROR 1',
+					},
+				],
+			}
 		},
 	};
 	const firstBoxRatesWithMultipleErrors = {
 		box_1: {
-			rates: [],
-			errors: [
-				{
-					code: 'ERROR A',
-					message: 'Error 1',
-				},
-				{
-					code: 'ERROR B',
-					message: 'Error 2',
-				},
-			],
+			default: {
+				rates: [],
+				errors: [
+					{
+						code: 'ERROR A',
+						message: 'Error 1',
+					},
+					{
+						code: 'ERROR B',
+						message: 'Error 2',
+					},
+				],
+			}
 		},
 	};
 
@@ -130,7 +142,7 @@ describe( '#getRatesErrors', () => {
 		// rates with a message prop in the error object
 		const rates = {
 			values: {
-				box_1: '',
+				box_1: { serviceId: '', signatureRequired: false }
 			},
 			available: firstBoxRatesWithError,
 		};
@@ -171,7 +183,7 @@ describe( '#getRatesErrors', () => {
 		describe( 'multiple errors', () => {
 			const ratesWithMultipleErrors = {
 				values: {
-					box_1: '',
+					box_1: { serviceId: '', signatureRequired: false }
 				},
 				available: firstBoxRatesWithMultipleErrors,
 			};
@@ -190,7 +202,9 @@ describe( '#getRatesErrors', () => {
 
 		describe( 'rate is selected', () => {
 			const rates = {
-				values: Object.assign( {}, firstBoxSelectedValues ),
+				values: {
+					box_1: Object.assign( {}, firstBoxSelectedValues ),
+				},
 				available: firstBoxRatesWithNoServerErrors,
 			};
 			const result = getRatesErrors( rates );
@@ -205,7 +219,7 @@ describe( '#getRatesErrors', () => {
 		describe( 'rate is not selected', () => {
 			const rates = {
 				values: {
-					box_1: '',
+					box_1: { serviceId: '', signatureRequired: false }
 				},
 				available: firstBoxRatesWithNoServerErrors,
 			};
@@ -223,7 +237,7 @@ describe( '#getRatesErrors', () => {
 		describe( 'rate is selected for box 2', () => {
 			const rates = {
 				values: {
-					box_1: '',
+					box_1: { serviceId: '', signatureRequired: false },
 					box_2: Object.assign( {}, secondBoxSelectedValues ),
 				},
 				available: Object.assign( {}, firstBoxRatesWithError, secondBoxRatesWithNoServerErrors ),
@@ -241,8 +255,8 @@ describe( '#getRatesErrors', () => {
 		describe( 'rate not selected for box 2', () => {
 			const rates = {
 				values: {
-					box_1: '',
-					box_2: '',
+					box_1: { serviceId: '', signatureRequired: false },
+					box_2: { serviceId: '', signatureRequired: false }
 				},
 				available: Object.assign( {}, firstBoxRatesWithError, secondBoxRatesWithNoServerErrors ),
 			};
@@ -327,7 +341,7 @@ describe( 'Shipping label selectors', () => {
 			form: {
 				rates: {
 					values: {
-						default_box: '',
+						default_box: { serviceId: '', signatureRequired: false },
 					},
 					available: {},
 				},
@@ -342,21 +356,23 @@ describe( 'Shipping label selectors', () => {
 			form: {
 				rates: {
 					values: {
-						default_box: '',
+						default_box: { serviceId: '', signatureRequired: false },
 					},
 					available: {
 						default_box: {
-							rates: [
-								{
-									carrier_id: 'usps',
-									is_selected: false,
-									rate: 6.61,
-									rate_id: 'rate_f2afdd2045d84b8394a47730cf264bfa',
-									retail_rate: 7.8,
-									service_id: 'Priority',
-									title: 'USPS - Priority Mail',
-								},
-							],
+							default: {
+								rates: [
+									{
+										carrier_id: 'usps',
+										is_selected: false,
+										rate: 6.61,
+										rate_id: 'rate_f2afdd2045d84b8394a47730cf264bfa',
+										retail_rate: 7.8,
+										service_id: 'Priority',
+										title: 'USPS - Priority Mail',
+									},
+								],
+							}
 						},
 					},
 				},
@@ -371,28 +387,30 @@ describe( 'Shipping label selectors', () => {
 			form: {
 				rates: {
 					values: {
-						default_box: 'Priority',
+						default_box: { serviceId: 'Priority', signatureRequired: false }
 					},
 					available: {
 						default_box: {
-							rates: [
-								{
-									carrier_id: 'usps',
-									is_selected: false,
-									rate: 6.61,
-									rate_id: 'rate_f2afdd2045d84b8394a47730cf264bfa',
-									retail_rate: 7.8,
-									service_id: 'Priority',
-									title: 'USPS - Priority Mail',
-								},
-							],
+							default: {
+								rates: [
+									{
+										carrier_id: 'usps',
+										is_selected: false,
+										rate: 6.61,
+										rate_id: 'rate_f2afdd2045d84b8394a47730cf264bfa',
+										retail_rate: 7.8,
+										service_id: 'Priority',
+										title: 'USPS - Priority Mail',
+									},
+								],
+							}
 						},
 					},
 				},
 			},
 		} );
 		const result = getTotalPriceBreakdown( state, orderId, siteId );
-		expect( result.prices ).to.eql( [ { title: 'USPS - Priority Mail', retailRate: 7.8 } ] );
+		expect( result.prices ).to.eql( [ { title: 'USPS - Priority Mail', retailRate: 7.8, addons: [] } ] );
 		expect( result.discount ).to.eql( 1.19 );
 		expect( result.total ).to.eql( 6.61 );
 	} );
@@ -402,42 +420,46 @@ describe( 'Shipping label selectors', () => {
 			form: {
 				rates: {
 					values: {
-						box1: 'Priority',
-						box2: '',
+						box1: { serviceId: 'Priority', signatureRequired: false },
+						box2: { serviceId: '', signatureRequired: false },
 					},
 					available: {
 						box1: {
-							rates: [
-								{
-									carrier_id: 'usps',
-									is_selected: false,
-									rate: 6.61,
-									rate_id: 'rate_f2afdd2045d84b8394a47730cf264bfa',
-									retail_rate: 7.8,
-									service_id: 'Priority',
-									title: 'USPS - Priority Mail',
-								},
-							],
+							default: {
+								rates: [
+									{
+										carrier_id: 'usps',
+										is_selected: false,
+										rate: 6.61,
+										rate_id: 'rate_f2afdd2045d84b8394a47730cf264bfa',
+										retail_rate: 7.8,
+										service_id: 'Priority',
+										title: 'USPS - Priority Mail',
+									},
+								],
+							}
 						},
 						box2: {
-							rates: [
-								{
-									carrier_id: 'usps',
-									is_selected: false,
-									rate: 21.18,
-									rate_id: 'rate_f2afdd2045d84b8394a47730cf264bfb',
-									retail_rate: 23.85,
-									service_id: 'Express',
-									title: 'USPS - Express Mail',
-								},
-							],
+							default: {
+								rates: [
+									{
+										carrier_id: 'usps',
+										is_selected: false,
+										rate: 21.18,
+										rate_id: 'rate_f2afdd2045d84b8394a47730cf264bfb',
+										retail_rate: 23.85,
+										service_id: 'Express',
+										title: 'USPS - Express Mail',
+									},
+								],
+							}
 						},
 					},
 				},
 			},
 		} );
 		const result = getTotalPriceBreakdown( state, orderId, siteId );
-		expect( result.prices ).to.eql( [ { title: 'USPS - Priority Mail', retailRate: 7.8 } ] );
+		expect( result.prices ).to.eql( [ { title: 'USPS - Priority Mail', retailRate: 7.8, addons: [] } ] );
 		expect( result.discount ).to.eql( 1.19 );
 		expect( result.total ).to.eql( 6.61 );
 	} );
@@ -447,35 +469,39 @@ describe( 'Shipping label selectors', () => {
 			form: {
 				rates: {
 					values: {
-						box1: 'Priority',
-						box2: 'Express',
+						box1: { serviceId: 'Priority', signatureRequired: false },
+						box2: { serviceId: 'Express', signatureRequired: false }
 					},
 					available: {
 						box1: {
-							rates: [
-								{
-									carrier_id: 'usps',
-									is_selected: false,
-									rate: 6.61,
-									rate_id: 'rate_f2afdd2045d84b8394a47730cf264bfa',
-									retail_rate: 7.8,
-									service_id: 'Priority',
-									title: 'USPS - Priority Mail',
-								},
-							],
+							default: {
+								rates: [
+									{
+										carrier_id: 'usps',
+										is_selected: false,
+										rate: 6.61,
+										rate_id: 'rate_f2afdd2045d84b8394a47730cf264bfa',
+										retail_rate: 7.8,
+										service_id: 'Priority',
+										title: 'USPS - Priority Mail',
+									},
+								],
+							}
 						},
 						box2: {
-							rates: [
-								{
-									carrier_id: 'usps',
-									is_selected: false,
-									rate: 21.18,
-									rate_id: 'rate_f2afdd2045d84b8394a47730cf264bfb',
-									retail_rate: 23.85,
-									service_id: 'Express',
-									title: 'USPS - Express Mail',
-								},
-							],
+							default: {
+								rates: [
+									{
+										carrier_id: 'usps',
+										is_selected: false,
+										rate: 21.18,
+										rate_id: 'rate_f2afdd2045d84b8394a47730cf264bfb',
+										retail_rate: 23.85,
+										service_id: 'Express',
+										title: 'USPS - Express Mail',
+									},
+								],
+							}
 						},
 					},
 				},
@@ -483,8 +509,8 @@ describe( 'Shipping label selectors', () => {
 		} );
 		const result = getTotalPriceBreakdown( state, orderId, siteId );
 		expect( result.prices ).to.eql( [
-			{ title: 'USPS - Priority Mail', retailRate: 7.8 },
-			{ title: 'USPS - Express Mail', retailRate: 23.85 },
+			{ title: 'USPS - Priority Mail', retailRate: 7.8, addons: [] },
+			{ title: 'USPS - Express Mail', retailRate: 23.85, addons: [] },
 		] );
 		expect( result.discount ).to.eql( 3.86 );
 		expect( result.total ).to.eql( 27.79 );

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/package-dialog.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/package-dialog.js
@@ -95,7 +95,7 @@ const PackageDialog = props => {
 			inner_dimensions: inputFilters.dimensions( packageData.inner_dimensions ),
 			outer_dimensions: inputFilters.dimensions( packageData.outer_dimensions ),
 			box_weight: inputFilters.number( packageData.box_weight ),
-			max_weight: inputFilters.number( packageData.max_weight ),
+			max_weight: 0,
 		} );
 
 		const errors = checkInputs( filteredPackageData, boxNames, packageSchema );


### PR DESCRIPTION
Fixes #1748.

It is important to re-test these:

#1740 (button is blank during loading on order screen) cc @roykho 
#1669 (you're able to save of Package Dialog) cc myself
#1721 (I adjusted `getRatesErrors` to use new data structure, make sure it doesn't break anything) cc @c-shultz 

For the other fixes this PR is just adjusting the tests to correctly match the data structure.