### PR TITLE
Fix multi-package support

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/index.js
@@ -13,6 +13,7 @@ import { find, isEmpty } from 'lodash';
 /**
  * Internal dependencies
  */
+import PackageList from './list';
 import PackageInfo from './package-info';
 import MoveItemDialog from './move-item';
 import AddItemDialog from './add-item';
@@ -100,6 +101,7 @@ const PackagesStep = props => {
 			toggleStep={ toggleStepHandler }
 		>
 			<div className="packages-step__contents">
+				<PackageList siteId={ props.siteId } orderId={ props.orderId } />
 				<PackageInfo siteId={ props.siteId } orderId={ props.orderId } />
 			</div>
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/list.js
@@ -1,0 +1,127 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import getPackageDescriptions from './get-package-descriptions';
+import { openPackage } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
+import {
+	getShippingLabel,
+	isLoaded,
+	getFormErrors,
+} from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
+import { getAllPackageDefinitions } from 'woocommerce/woocommerce-services/state/packages/selectors';
+
+const PackageList = props => {
+	const { orderId, siteId, selected, all, errors, packageId, translate } = props;
+
+	const renderCountOrError = ( isError, count ) => {
+		if ( isError ) {
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+			return <Gridicon icon="notice-outline" className="is-error" size={ 18 } />;
+		}
+
+		if ( undefined === count ) {
+			return null;
+		}
+
+		return <span className="packages-step__list-package-count">{ count }</span>;
+	};
+
+	const renderPackageListItem = ( pckgId, name, count ) => {
+		const isError = 0 < Object.keys( errors[ pckgId ] || {} ).length;
+		const onOpenClick = () => props.openPackage( orderId, siteId, pckgId );
+		return (
+			<div className="packages-step__list-item" key={ pckgId }>
+				<Button
+					borderless
+					className={ classNames( 'packages-step__list-package', {
+						'is-selected': packageId === pckgId,
+					} ) }
+					onClick={ onOpenClick }
+				>
+					<span className="packages-step__list-package-name">{ name }</span>
+					{ renderCountOrError( isError, count ) }
+				</Button>
+			</div>
+		);
+	};
+
+	const renderPackageListHeader = ( key, text ) => {
+		return (
+			<div className="packages-step__list-item packages-step__list-header" key={ key }>
+				{ text }
+			</div>
+		);
+	};
+
+	const packageLabels = getPackageDescriptions( selected, all, false );
+	const packed = [];
+	const individual = [];
+
+	Object.keys( selected ).forEach( pckgId => {
+		const pckg = selected[ pckgId ];
+
+		if ( 'individual' === pckg.box_id ) {
+			individual.push( renderPackageListItem( pckgId, pckg.items[ 0 ].name ) );
+		} else {
+			packed.push( renderPackageListItem( pckgId, packageLabels[ pckgId ], pckg.items.length ) );
+		}
+	} );
+
+	if ( packed.length || individual.length ) {
+		packed.unshift(
+			renderPackageListHeader( 'boxed-header', translate( 'Packages to be Shipped' ) )
+		);
+	}
+
+	return (
+		<div className="packages-step__list">
+			{ packed }
+			{ individual }
+		</div>
+	);
+};
+
+PackageList.propTypes = {
+	siteId: PropTypes.number.isRequired,
+	orderId: PropTypes.number.isRequired,
+	selected: PropTypes.object.isRequired,
+	all: PropTypes.object.isRequired,
+	packageId: PropTypes.string.isRequired,
+	errors: PropTypes.object,
+	openPackage: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = ( state, { orderId, siteId } ) => {
+	const loaded = isLoaded( state, orderId, siteId );
+	const shippingLabel = getShippingLabel( state, orderId, siteId );
+	const errors = loaded && getFormErrors( state, orderId, siteId ).packages;
+	return {
+		errors,
+		packageId: shippingLabel.openedPackageId,
+		selected: shippingLabel.form.packages.selected,
+		all: getAllPackageDefinitions( state, siteId ),
+	};
+};
+
+const mapDispatchToProps = dispatch => {
+	return bindActionCreators( { openPackage }, dispatch );
+};
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( PackageList ) );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
@@ -14,6 +14,7 @@ import { mapValues, find } from 'lodash';
 import FieldError from 'woocommerce/woocommerce-services/components/field-error';
 import Notice from 'components/notice';
 import ShippingRate from './shipping-rate';
+import getPackageDescriptions from '../packages-step/get-package-descriptions';
 
 const renderRateNotice = translate => {
 	return (
@@ -33,11 +34,14 @@ export const ShippingRates = ( {
 	selectedRates, // Store owner selected rates, not customer
 	availableRates,
 	selectedPackages,
+	allPackages,
 	updateRate,
 	errors,
 	shouldShowRateNotice,
 	translate,
 } ) => {
+	const packageNames = getPackageDescriptions( selectedPackages, allPackages, true );
+	const hasSinglePackage = 1 === Object.keys( selectedPackages ).length;
 
 	const renderSinglePackage = ( pckg, pckgId ) => {
 		if ( ! ( pckgId in availableRates ) ) {
@@ -54,6 +58,12 @@ export const ShippingRates = ( {
 		const onRateUpdate = ( serviceId, signatureRequired ) => updateRate( pckgId, serviceId, signatureRequired );
 		return (
 			<div key={ pckgId } className="rates-step__package-container">
+
+				{ ! hasSinglePackage ? (
+					<div className="rates-step__package-container-rates-header">
+						{ translate( 'Choose rate: %(pckg)s', { args: { pckg: packageNames[ pckgId ] } } ) }
+					</div>
+				) : null }
 				{ Object.values(
 					mapValues( packageRates, ( ( serviceRateObject ) => {
 						const { service_id } = serviceRateObject;

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
@@ -15,6 +15,11 @@
 	margin-top: -1em;
 }
 
+.rates-step__package-container-rates-header {
+	font-weight: bold;
+	margin-bottom: 20px;
+}
+
 .notice.rates-step__notice {
 	margin: -24px -24px 24px;
 	width: inherit;


### PR DESCRIPTION
Closes #1743 
Brings back original package selection design:
<img width="1541" alt="image" src="https://user-images.githubusercontent.com/6209518/67889292-cb90fe80-fb0b-11e9-8026-fee6ab49a784.png">

Adds section headers to rates lists for separate packages:
<img width="1531" alt="image" src="https://user-images.githubusercontent.com/6209518/67896831-655fa800-fb1a-11e9-96dd-79618166b69c.png">

