### PR TITLE
Fall back to values if normalized is null

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -328,7 +328,7 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_CONFIRM_ADDRESS_SUGGESTION ] = (
 		isNormalized: true,
 	};
 
-	if ( groupState.selectNormalized ) {
+	if ( groupState.selectNormalized && groupState.normalized ) {
 		groupState.values = groupState.normalized;
 	} else {
 		groupState.normalized = groupState.values;


### PR DESCRIPTION
When `normalizeAddress` and its API is not called to normalize the address, the `normalize` property would be `null`. In the case when we modify an address and click "Use address as entered", our reducer will try to use this `null` `normalized` property which cause the error for #1744. 

Only use the `normalized` prop when it is not falsy, otherwise, fallback to `values`

Closes #1744 