### PR TITLE
Add margin top to total to match figma design

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -189,6 +189,7 @@
 	&.label-purchase-modal__price-item-total {
 		font-weight: bold;
 		margin-bottom: 0;
+		margin-top: 24px;
 	}
 }
 


### PR DESCRIPTION
Add margin top to match figma design.

### Question
I am guessing it requires a new line thus i am using 24px. 24 pixel is the line height in the figma design link https://www.figma.com/file/jo5qL6bf67c5Z7DyxUpMgf/WCS-Middle-ground?node-id=69%3A0. Please let me know otherwise.

### Fix
Currently:
![image](https://user-images.githubusercontent.com/572862/67972163-c0090a80-fbd3-11e9-8c82-a0228f6cf854.png)

After fixed:
![image](https://user-images.githubusercontent.com/572862/67972444-4f162280-fbd4-11e9-8501-6df7f85f57a4.png)

Closes #1769 