### PR TITLE
Use relative path for asset if prod

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,7 +58,7 @@ module.exports = {
 		path: path.join( __dirname, 'dist' ),
 		filename: '[name].js',
 		devtoolModuleFilenameTemplate: 'app:///[resource-path]',
-		publicPath: 'http://localhost:8085/',
+		publicPath: isDev ? 'http://localhost:8085/' : '/wp-content/plugins/woocommerce-services/dist/',
 	},
 	optimization: {
 		minimize: ! isDev,


### PR DESCRIPTION
### Changes
I updated the `publicPath` using the approach suggested here: https://github.com/Automattic/woocommerce-services/issues/1758#issuecomment-547945950. I couldn't find a good way to output the current `dist` folder relative to Wordpress's path by using node's `path.relative` `path.resolve` (https://nodejs.org/api/path.html). So I ended up using '/wp-content/plugins/woocommerce-services/dist/' instead. 

### To test "development mode"
1. run `npm run start`
2. create shipping label
3. Make sure USPS logo loads
4. inspect DOM to verify that the url is indeed `localhost:8085`

### To test "production mode"
1. run `npm run dist`
2. create shipping label
3. Make sure USPS logo loads
4. inspect DOM to verify that the url is indeed `/wp-content/plugins/woocommerce-services/dist/`

Closes #1758 