### PR TITLE
Limit 5 rates per package 

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
@@ -110,7 +110,6 @@ class PackageShippingRates extends Component {
 					</div>
 				) : null }
 				{ Object.values(
-					// TODO: figure out why this doesn't work
 					mapValues( this.state.visiblePackageRates, ( ( serviceRateObject ) => {
 						const { service_id } = serviceRateObject;
 						const rateObjectSignatureRequired = find( signatureRates, r => service_id === r.service_id );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
@@ -140,7 +140,13 @@ class PackageShippingRates extends Component {
 						/>
 					} ) )
 				) }
-				<button onClick={ this.handleShowMore } >Show more</button>
+
+				{ this.state.packageRates.length > 0 ? (
+					<div className="rates-step__package-container-rates-show-more" role="button" onClick={ this.handleShowMore }
+						>Show more rates
+					</div>
+				) : null }
+
 				{ packageErrors.slice( 1 ).map( ( error, index ) => {
 					// Print the rest of the errors (if any) below the dropdown
 					return <FieldError type="server-error" key={ index } text={ error } />;

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
@@ -65,7 +65,7 @@ class PackageShippingRates extends Component {
 		super(props);
 
 		this.state = {
-			packageRates: this.props.availableRates.default.rates,
+			packageRates: JSON.parse(JSON.stringify(this.props.availableRates.default.rates)),
 			visiblePackageRates: []
 		}
 
@@ -125,8 +125,7 @@ class PackageShippingRates extends Component {
 				) : null }
 				{ Object.values(
 					// TODO: figure out why this doesn't work
-					// mapValues( this.state.visiblePackageRates, ( ( serviceRateObject ) => {
-					mapValues( this.props.availableRates.default.rates, ( ( serviceRateObject ) => {
+					mapValues( this.state.visiblePackageRates, ( ( serviceRateObject ) => {
 						const { service_id } = serviceRateObject;
 						const rateObjectSignatureRequired = find( signatureRates, r => service_id === r.service_id );
 						return <ShippingRate

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { mapValues, find } from 'lodash';
@@ -29,70 +29,75 @@ const renderRateNotice = translate => {
 	);
 };
 
-export const ShippingRates = ( {
-	id,
-	selectedRates, // Store owner selected rates, not customer
-	availableRates,
-	selectedPackages,
-	allPackages,
-	updateRate,
-	errors,
-	shouldShowRateNotice,
-	translate,
-} ) => {
-	const packageNames = getPackageDescriptions( selectedPackages, allPackages, true );
-	const hasSinglePackage = 1 === Object.keys( selectedPackages ).length;
+class ShippingRates extends Component {
+	constructor(props) {
+		super(props);
+	}
 
-	const renderSinglePackage = ( pckg, pckgId ) => {
-		if ( ! ( pckgId in availableRates ) ) {
-			return null;
-		}
-		const selectedRate = selectedRates[ pckgId ] || '';
-		const packageRates = availableRates[ pckgId ].default.rates;
-		let signatureRates = null;
-		if ( 'signature_required' in availableRates[ pckgId ] ) {
-			signatureRates = availableRates[ pckgId ].signature_required.rates || null;
-		}
-		const packageErrors = errors[ pckgId ] || [];
+	render() {
+		const {
+			id,
+			selectedRates, // Store owner selected rates, not customer
+			availableRates,
+			selectedPackages,
+			allPackages,
+			updateRate,
+			errors,
+			shouldShowRateNotice,
+			translate
+		} = this.props;
+		const packageNames = getPackageDescriptions( selectedPackages, allPackages, true );
+		const hasSinglePackage = 1 === Object.keys( selectedPackages ).length;
 
-		const onRateUpdate = ( serviceId, signatureRequired ) => updateRate( pckgId, serviceId, signatureRequired );
-		return (
-			<div key={ pckgId } className="rates-step__package-container">
+		const renderSinglePackage = ( pckg, pckgId ) => {
+			if ( ! ( pckgId in availableRates ) ) {
+				return null;
+			}
+			const selectedRate = selectedRates[ pckgId ] || '';
+			const packageRates = availableRates[ pckgId ].default.rates;
+			let signatureRates = null;
+			if ( 'signature_required' in availableRates[ pckgId ] ) {
+				signatureRates = availableRates[ pckgId ].signature_required.rates || null;
+			}
+			const packageErrors = errors[ pckgId ] || [];
 
-				{ ! hasSinglePackage ? (
-					<div className="rates-step__package-container-rates-header">
-						{ translate( 'Choose rate: %(pckg)s', { args: { pckg: packageNames[ pckgId ] } } ) }
-					</div>
-				) : null }
-				{ Object.values(
-					mapValues( packageRates, ( ( serviceRateObject ) => {
-						const { service_id } = serviceRateObject;
-						const rateObjectSignatureRequired = find( signatureRates, r => service_id === r.service_id );
-						return <ShippingRate
-							id={ id + '_' + pckgId }
-							key={ id + '_' + pckgId + '_' + service_id }
-							rateObject={ serviceRateObject }
-							rateObjectSignatureRequired={ rateObjectSignatureRequired }
-							updateValue={ onRateUpdate }
-							isSelected={ service_id === selectedRate.serviceId }
-						/>
-					} ) )
-				) }
-				{ packageErrors.slice( 1 ).map( ( error, index ) => {
-					// Print the rest of the errors (if any) below the dropdown
-					return <FieldError type="server-error" key={ index } text={ error } />;
-				} ) }
-			</div>
-		);
-	};
+			const onRateUpdate = ( serviceId, signatureRequired ) => updateRate( pckgId, serviceId, signatureRequired );
 
-	return (
-		<div>
+			return (
+				<div key={ pckgId } className="rates-step__package-container">
+					{ ! hasSinglePackage ? (
+						<div className="rates-step__package-container-rates-header">
+							{ translate( 'Choose rate: %(pckg)s', { args: { pckg: packageNames[ pckgId ] } } ) }
+						</div>
+					) : null }
+					{ Object.values(
+						mapValues( packageRates, ( ( serviceRateObject ) => {
+							const { service_id } = serviceRateObject;
+							const rateObjectSignatureRequired = find( signatureRates, r => service_id === r.service_id );
+							return <ShippingRate
+								id={ id + '_' + pckgId }
+								key={ id + '_' + pckgId + '_' + service_id }
+								rateObject={ serviceRateObject }
+								rateObjectSignatureRequired={ rateObjectSignatureRequired }
+								updateValue={ onRateUpdate }
+								isSelected={ service_id === selectedRate.serviceId }
+							/>
+						} ) )
+					) }
+					{ packageErrors.slice( 1 ).map( ( error, index ) => {
+						// Print the rest of the errors (if any) below the dropdown
+						return <FieldError type="server-error" key={ index } text={ error } />;
+					} ) }
+				</div>
+			);
+		};
+
+		return <div>
 			{ shouldShowRateNotice && renderRateNotice( translate ) }
 			{ Object.values( mapValues( selectedPackages, renderSinglePackage ) ) }
 		</div>
-	);
-};
+	}
+}
 
 ShippingRates.propTypes = {
 	id: PropTypes.string.isRequired,

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
@@ -87,10 +87,11 @@ class PackageShippingRates extends Component {
 			updateRate,
 			translate,
 			pckg,
-			pckgId
+			pckgId,
+			hasSinglePackage,
+			packageNames,
+			packageErrors
 		} = this.props;
-
-		const hasSinglePackage = this.props.hasSinglePackage;
 
 		if ( ! availableRates ) {
 			return null;
@@ -98,7 +99,6 @@ class PackageShippingRates extends Component {
 
 		// this.state.packageRates = availableRates[ pckgId ].default.rates;
 		const packageRates = availableRates.default.rates;
-		const packageNames = this.props.packageNames;
 
 		console.log(this.state.packageRates);
 		// this.state.visiblePackageRates = this.state.visiblePackageRates.concat(this.state.packageRates.splice(0, 1))
@@ -107,7 +107,6 @@ class PackageShippingRates extends Component {
 		if ( 'signature_required' in availableRates ) {
 			signatureRates = availableRates.signature_required.rates || null;
 		}
-		const packageErrors = this.props.packageErrors;
 
 		const onRateUpdate = ( serviceId, signatureRequired ) => updateRate( pckgId, serviceId, signatureRequired );
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
@@ -37,13 +37,11 @@ class ShippingRates extends Component {
 		const hasSinglePackage = 1 === Object.keys( this.props.selectedPackages ).length;
 
 		const shippingRates = Object.keys(this.props.selectedPackages).map((pckgId) => {
-			const pckg = this.props.selectedPackages.pckgId
 			return <PackageShippingRates
 				key={pckgId}
 				id={this.props.id}
 				updateRate={this.props.updateRate}
 				translate={this.props.translate}
-				pckg={pckg}
 				pckgId={pckgId}
 				selectedRate={this.props.selectedRates[ pckgId ] || ''}  // Store owner selected rates, not customer
 				availableRates={this.props.availableRates[ pckgId ]}
@@ -68,13 +66,8 @@ class PackageShippingRates extends Component {
 			visiblePackageRates: []
 		}
 
+		this.state.visiblePackageRates = this.state.visiblePackageRates.concat(this.state.packageRates.splice(0, MAX_VISIBLE_RATE))
 		this.handleShowMore = this.handleShowMore.bind(this);
-	}
-
-	componentDidMount() {
-		this.setState({
-			visiblePackageRates: this.state.visiblePackageRates.concat(this.state.packageRates.splice(0, MAX_VISIBLE_RATE))
-		});
 	}
 
 	handleShowMore() {
@@ -90,7 +83,6 @@ class PackageShippingRates extends Component {
 			availableRates,
 			updateRate,
 			translate,
-			pckg,
 			pckgId,
 			hasSinglePackage,
 			packageNames,
@@ -134,8 +126,13 @@ class PackageShippingRates extends Component {
 				) }
 
 				{ this.state.packageRates.length > 0 ? (
-					<div className="rates-step__package-container-rates-show-more" role="button" onClick={ this.handleShowMore }
-						>Show more rates
+					<div
+						className="rates-step__package-container-rates-show-more"
+						role="button"
+						onClick={ this.handleShowMore }
+						onKeyDown={ this.handleShowMore }
+						tabIndex="0">
+					Show more rates
 					</div>
 				) : null }
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
@@ -29,6 +29,8 @@ const renderRateNotice = translate => {
 	);
 };
 
+const MAX_VISIBLE_RATE = 5; // Maximum number of rates to display in the shipping label modal
+
 class ShippingRates extends Component {
 	render() {
 		console.log(this.props.selectedPackages, this.props.availableRates);
@@ -74,14 +76,14 @@ class PackageShippingRates extends Component {
 
 	componentDidMount() {
 		this.setState({
-			visiblePackageRates: this.state.visiblePackageRates.concat(this.state.packageRates.splice(0, 1))
+			visiblePackageRates: this.state.visiblePackageRates.concat(this.state.packageRates.splice(0, MAX_VISIBLE_RATE))
 		});
 	}
 
 	handleShowMore() {
 		console.log("on click ====>", this.state.visiblePackageRates, this.state.packageRates);
 		this.setState({
-			visiblePackageRates: this.state.visiblePackageRates.concat(this.state.packageRates.splice(0, 1))
+			visiblePackageRates: this.state.visiblePackageRates.concat(this.state.packageRates.splice(0, MAX_VISIBLE_RATE))
 		});
 	}
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
@@ -40,6 +40,7 @@ class ShippingRates extends Component {
 			console.log("inside shipping rates loop", this.props.selectedPackages);
 			const pckg = this.props.selectedPackages.pckgId
 			return <PackageShippingRates
+				key={pckgId}
 				id={this.props.id}
 				updateRate={this.props.updateRate}
 				translate={this.props.translate}
@@ -64,18 +65,23 @@ class PackageShippingRates extends Component {
 		super(props);
 
 		this.state = {
-			packageRates: [],
+			packageRates: this.props.availableRates.default.rates,
 			visiblePackageRates: []
 		}
 
 		this.handleShowMore = this.handleShowMore.bind(this);
 	}
 
+	componentDidMount() {
+		this.setState({
+			visiblePackageRates: this.state.visiblePackageRates.concat(this.state.packageRates.splice(0, 1))
+		});
+	}
+
 	handleShowMore() {
-		this.setState((state) => {
-			return {
-				visiblePackageRates: state.visiblePackageRates.concat(this.state.packageRates.splice(0, 1))
-			};
+		console.log("on click ====>", this.state.visiblePackageRates, this.state.packageRates);
+		this.setState({
+			visiblePackageRates: this.state.visiblePackageRates.concat(this.state.packageRates.splice(0, 1))
 		});
 	}
 
@@ -97,9 +103,6 @@ class PackageShippingRates extends Component {
 			return null;
 		}
 
-		// this.state.packageRates = availableRates[ pckgId ].default.rates;
-		const packageRates = availableRates.default.rates;
-
 		console.log(this.state.packageRates);
 		// this.state.visiblePackageRates = this.state.visiblePackageRates.concat(this.state.packageRates.splice(0, 1))
 
@@ -108,7 +111,10 @@ class PackageShippingRates extends Component {
 			signatureRates = availableRates.signature_required.rates || null;
 		}
 
-		const onRateUpdate = ( serviceId, signatureRequired ) => updateRate( pckgId, serviceId, signatureRequired );
+		const onRateUpdate = ( serviceId, signatureRequired ) => {
+			console.log("on rate update", pckgId, serviceId, signatureRequired);
+			return updateRate( pckgId, serviceId, signatureRequired );
+		}
 
 		return (
 			<div key={ pckgId } className="rates-step__package-container">
@@ -118,7 +124,9 @@ class PackageShippingRates extends Component {
 					</div>
 				) : null }
 				{ Object.values(
-					mapValues( packageRates, ( ( serviceRateObject ) => {
+					// TODO: figure out why this doesn't work
+					// mapValues( this.state.visiblePackageRates, ( ( serviceRateObject ) => {
+					mapValues( this.props.availableRates.default.rates, ( ( serviceRateObject ) => {
 						const { service_id } = serviceRateObject;
 						const rateObjectSignatureRequired = find( signatureRates, r => service_id === r.service_id );
 						return <ShippingRate

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
@@ -30,14 +30,63 @@ const renderRateNotice = translate => {
 };
 
 class ShippingRates extends Component {
+	render() {
+		console.log(this.props.selectedPackages, this.props.availableRates);
+
+		const packageNames = getPackageDescriptions( this.props.selectedPackages, this.props.allPackages, true );
+
+		const shippingRates = Object.keys(this.props.selectedPackages).map((pckgId) => {
+			console.log("inside shipping rates loop", this.props.selectedPackages);
+			const hasSinglePackage = 1 === Object.keys( selectedPackages ).length;
+			const pckg = this.props.selectedPackages.pckgId
+
+
+			return <PackageShippingRates
+				{...this.props}
+				pckg={pckg}
+				pckgId={pckgId}
+				selectedRate={this.props.selectedRates[ pckgId ] || ''}  // Store owner selected rates, not customer
+				availableRates={this.props.availableRates[ pckgId ]}
+				packageErrors = {this.props.errors[ pckgId ] || []}
+				packageNames = {packageNames[ pckgId ]}
+			/>
+		});
+		return <div>
+			{ this.props.shouldShowRateNotice && renderRateNotice( this.props.translate ) }
+			{ shippingRates }
+		</div>
+	}
+}
+
+class PackageShippingRates extends Component {
 	constructor(props) {
 		super(props);
+
+		this.state = {
+			packageRates: [],
+			visiblePackageRates: []
+		}
+
+		this.handleShowMore = this.handleShowMore.bind(this);
+		this.renderSinglePackage = this.renderSinglePackage.bind(this);
+	}
+
+	handleShowMore() {
+		this.setState((state) => {
+			return {
+				visiblePackageRates: state.visiblePackageRates.concat(this.state.packageRates.splice(0, 1))
+			};
+		});
 	}
 
 	render() {
+		return this.renderSinglePackage(this.props.pckg, this.props.pckgId);
+	}
+
+	renderSinglePackage ( pckg, pckgId ) {
 		const {
 			id,
-			selectedRates, // Store owner selected rates, not customer
+			selectedRate,
 			availableRates,
 			selectedPackages,
 			allPackages,
@@ -46,57 +95,57 @@ class ShippingRates extends Component {
 			shouldShowRateNotice,
 			translate
 		} = this.props;
-		const packageNames = getPackageDescriptions( selectedPackages, allPackages, true );
+
 		const hasSinglePackage = 1 === Object.keys( selectedPackages ).length;
 
-		const renderSinglePackage = ( pckg, pckgId ) => {
-			if ( ! ( pckgId in availableRates ) ) {
-				return null;
-			}
-			const selectedRate = selectedRates[ pckgId ] || '';
-			const packageRates = availableRates[ pckgId ].default.rates;
-			let signatureRates = null;
-			if ( 'signature_required' in availableRates[ pckgId ] ) {
-				signatureRates = availableRates[ pckgId ].signature_required.rates || null;
-			}
-			const packageErrors = errors[ pckgId ] || [];
+		if ( ! availableRates ) {
+			return null;
+		}
 
-			const onRateUpdate = ( serviceId, signatureRequired ) => updateRate( pckgId, serviceId, signatureRequired );
+		// this.state.packageRates = availableRates[ pckgId ].default.rates;
+		const packageRates = availableRates.default.rates;
+		const packageNames = this.props.packageNames;
 
-			return (
-				<div key={ pckgId } className="rates-step__package-container">
-					{ ! hasSinglePackage ? (
-						<div className="rates-step__package-container-rates-header">
-							{ translate( 'Choose rate: %(pckg)s', { args: { pckg: packageNames[ pckgId ] } } ) }
-						</div>
-					) : null }
-					{ Object.values(
-						mapValues( packageRates, ( ( serviceRateObject ) => {
-							const { service_id } = serviceRateObject;
-							const rateObjectSignatureRequired = find( signatureRates, r => service_id === r.service_id );
-							return <ShippingRate
-								id={ id + '_' + pckgId }
-								key={ id + '_' + pckgId + '_' + service_id }
-								rateObject={ serviceRateObject }
-								rateObjectSignatureRequired={ rateObjectSignatureRequired }
-								updateValue={ onRateUpdate }
-								isSelected={ service_id === selectedRate.serviceId }
-							/>
-						} ) )
-					) }
-					{ packageErrors.slice( 1 ).map( ( error, index ) => {
-						// Print the rest of the errors (if any) below the dropdown
-						return <FieldError type="server-error" key={ index } text={ error } />;
-					} ) }
-				</div>
-			);
-		};
+		console.log(this.state.packageRates);
+		// this.state.visiblePackageRates = this.state.visiblePackageRates.concat(this.state.packageRates.splice(0, 1))
 
-		return <div>
-			{ shouldShowRateNotice && renderRateNotice( translate ) }
-			{ Object.values( mapValues( selectedPackages, renderSinglePackage ) ) }
-		</div>
-	}
+		let signatureRates = null;
+		if ( 'signature_required' in availableRates ) {
+			signatureRates = availableRates.signature_required.rates || null;
+		}
+		const packageErrors = this.props.packageErrors;
+
+		const onRateUpdate = ( serviceId, signatureRequired ) => updateRate( pckgId, serviceId, signatureRequired );
+
+		return (
+			<div key={ pckgId } className="rates-step__package-container">
+				{ ! hasSinglePackage ? (
+					<div className="rates-step__package-container-rates-header">
+						{ translate( 'Choose rate: %(pckg)s', { args: { pckg: packageNames } } ) }
+					</div>
+				) : null }
+				{ Object.values(
+					mapValues( packageRates, ( ( serviceRateObject ) => {
+						const { service_id } = serviceRateObject;
+						const rateObjectSignatureRequired = find( signatureRates, r => service_id === r.service_id );
+						return <ShippingRate
+							id={ id + '_' + pckgId }
+							key={ id + '_' + pckgId + '_' + service_id }
+							rateObject={ serviceRateObject }
+							rateObjectSignatureRequired={ rateObjectSignatureRequired }
+							updateValue={ onRateUpdate }
+							isSelected={ service_id === selectedRate.serviceId }
+						/>
+					} ) )
+				) }
+				<button onClick={ this.handleShowMore } >Show more</button>
+				{ packageErrors.slice( 1 ).map( ( error, index ) => {
+					// Print the rest of the errors (if any) below the dropdown
+					return <FieldError type="server-error" key={ index } text={ error } />;
+				} ) }
+			</div>
+		);
+	};
 }
 
 ShippingRates.propTypes = {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
@@ -41,7 +41,6 @@ class ShippingRates extends Component {
 			const pckg = this.props.selectedPackages.pckgId
 			return <PackageShippingRates
 				id={this.props.id}
-				availableRates={this.props.availableRates}
 				updateRate={this.props.updateRate}
 				translate={this.props.translate}
 				pckg={pckg}
@@ -70,7 +69,6 @@ class PackageShippingRates extends Component {
 		}
 
 		this.handleShowMore = this.handleShowMore.bind(this);
-		this.renderSinglePackage = this.renderSinglePackage.bind(this);
 	}
 
 	handleShowMore() {
@@ -82,16 +80,14 @@ class PackageShippingRates extends Component {
 	}
 
 	render() {
-		return this.renderSinglePackage(this.props.pckg, this.props.pckgId);
-	}
-
-	renderSinglePackage ( pckg, pckgId ) {
 		const {
 			id,
 			selectedRate,
 			availableRates,
 			updateRate,
-			translate
+			translate,
+			pckg,
+			pckgId
 		} = this.props;
 
 		const hasSinglePackage = this.props.hasSinglePackage;

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
@@ -33,13 +33,10 @@ const MAX_VISIBLE_RATE = 5; // Maximum number of rates to display in the shippin
 
 class ShippingRates extends Component {
 	render() {
-		console.log(this.props.selectedPackages, this.props.availableRates);
-
 		const packageNames = getPackageDescriptions( this.props.selectedPackages, this.props.allPackages, true );
 		const hasSinglePackage = 1 === Object.keys( this.props.selectedPackages ).length;
 
 		const shippingRates = Object.keys(this.props.selectedPackages).map((pckgId) => {
-			console.log("inside shipping rates loop", this.props.selectedPackages);
 			const pckg = this.props.selectedPackages.pckgId
 			return <PackageShippingRates
 				key={pckgId}
@@ -81,7 +78,6 @@ class PackageShippingRates extends Component {
 	}
 
 	handleShowMore() {
-		console.log("on click ====>", this.state.visiblePackageRates, this.state.packageRates);
 		this.setState({
 			visiblePackageRates: this.state.visiblePackageRates.concat(this.state.packageRates.splice(0, MAX_VISIBLE_RATE))
 		});
@@ -105,16 +101,12 @@ class PackageShippingRates extends Component {
 			return null;
 		}
 
-		console.log(this.state.packageRates);
-		// this.state.visiblePackageRates = this.state.visiblePackageRates.concat(this.state.packageRates.splice(0, 1))
-
 		let signatureRates = null;
 		if ( 'signature_required' in availableRates ) {
 			signatureRates = availableRates.signature_required.rates || null;
 		}
 
 		const onRateUpdate = ( serviceId, signatureRequired ) => {
-			console.log("on rate update", pckgId, serviceId, signatureRequired);
 			return updateRate( pckgId, serviceId, signatureRequired );
 		}
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
@@ -34,21 +34,23 @@ class ShippingRates extends Component {
 		console.log(this.props.selectedPackages, this.props.availableRates);
 
 		const packageNames = getPackageDescriptions( this.props.selectedPackages, this.props.allPackages, true );
+		const hasSinglePackage = 1 === Object.keys( this.props.selectedPackages ).length;
 
 		const shippingRates = Object.keys(this.props.selectedPackages).map((pckgId) => {
 			console.log("inside shipping rates loop", this.props.selectedPackages);
-			const hasSinglePackage = 1 === Object.keys( selectedPackages ).length;
 			const pckg = this.props.selectedPackages.pckgId
-
-
 			return <PackageShippingRates
-				{...this.props}
+				id={this.props.id}
+				availableRates={this.props.availableRates}
+				updateRate={this.props.updateRate}
+				translate={this.props.translate}
 				pckg={pckg}
 				pckgId={pckgId}
 				selectedRate={this.props.selectedRates[ pckgId ] || ''}  // Store owner selected rates, not customer
 				availableRates={this.props.availableRates[ pckgId ]}
 				packageErrors = {this.props.errors[ pckgId ] || []}
 				packageNames = {packageNames[ pckgId ]}
+				hasSinglePackage = { hasSinglePackage }
 			/>
 		});
 		return <div>
@@ -88,15 +90,11 @@ class PackageShippingRates extends Component {
 			id,
 			selectedRate,
 			availableRates,
-			selectedPackages,
-			allPackages,
 			updateRate,
-			errors,
-			shouldShowRateNotice,
 			translate
 		} = this.props;
 
-		const hasSinglePackage = 1 === Object.keys( selectedPackages ).length;
+		const hasSinglePackage = this.props.hasSinglePackage;
 
 		if ( ! availableRates ) {
 			return null;

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
@@ -20,6 +20,12 @@
 	margin-bottom: 20px;
 }
 
+.rates-step__package-container-rates-show-more {
+	text-align: center;
+	cursor: pointer;
+	color:#008A20;
+}
+
 .notice.rates-step__notice {
 	margin: -24px -24px 24px;
 	width: inherit;


### PR DESCRIPTION
Added "Show More" button to the ShippingRates component. The button will trigger an event which will update a state change on 2 arrays: 
- packageNames //represents all available rates 
- visiblePackageRates //represent rates that are showing to the user

Every time "show more" is clicked, item in `packageNames` will flow into `visiblePackageRates`. "Show more" button will disappear when `packageNames` is empty.

### To test locally with show more button
1. You can force "Show more" button to show up by changing 5 to 1. Change `MAX_VISIBLE_RATE` to 1
2. You should see "Show more" button
3. Clicking rates should update pricing summary

### Test case where there are not enough rates to have "Show more" button
1. You can either find a postal code that has less than 5 rates, or change `MAX_VISIBLE_RATE` to something like 20

### To multiple packages should have its own "Show more" button 
1. Create shipping label with multiple products
2. package them into different packges
3. Each should have its own "Show more" button.

Closes #1778 