### PR TITLE
Whitelist free signature confirmation for Express service.

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
@@ -52,10 +52,21 @@ class ShippingRate extends Component {
 		} = this.props;
 		let requiredSignatureCost = null;
 		let details = 'Includes tracking';
+		let requiredSignatureCostText;
 
 		if ( null !== rateObjectSignatureRequired ) {
 			requiredSignatureCost = rateObjectSignatureRequired.rate - rateObject.rate;
+			if ( requiredSignatureCost > 0 ) {
+				requiredSignatureCostText = translate( '+%(price)s',
+					{ args: { price: formatCurrency( requiredSignatureCost, 'USD') } }
+				);
+			} else {
+				requiredSignatureCostText = translate( 'free' );
+			}
 		}
+
+		// USPS express service includes signature confirmation for free.
+		const signatureRequirementAllowed = requiredSignatureCost > 0 || ( 'Express' === service_id );
 
 		switch ( carrier_id ) {
 			case 'usps':
@@ -81,11 +92,11 @@ class ShippingRate extends Component {
 						<div className="rates-step__shipping-rate-description-title">{ title }</div>
 						<div className="rates-step__shipping-rate-description-details">
 							{ details }
-							{ null !== requiredSignatureCost && requiredSignatureCost > 0 ? (
+							{ null !== requiredSignatureCost && signatureRequirementAllowed ? (
 								<CheckboxControl
 									label={ translate(
-										'Signature Required (+%(price)s)',
-										{ args: { price: formatCurrency( requiredSignatureCost, 'USD') } }
+										'Signature required (%(price)s)',
+										{ args: { price: requiredSignatureCostText } }
 									) }
 									disabled={ ! isSelected }
 									checked={ signatureRequired }


### PR DESCRIPTION
Fixes #1771 

Allows 'free' signature confirmation for USPS Express service. All other signature rates that are the same as non-signature rates are assumed to be invalid rate options. I believe this logic should handle all the cases we're concerned with.

<img width="1547" alt="image" src="https://user-images.githubusercontent.com/6209518/68257903-be7f7e00-ffe9-11e9-860d-876464f436bd.png">

/cc @budzanowski 
