### PR TITLE
Show full price breakdown to make pricing less confusing.

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -153,6 +153,7 @@ export const getTotalPriceBreakdown = ( state, orderId, siteId = getSelectedSite
 			const price = {
 				title: foundRate.title,
 				retailRate: foundRate.retail_rate,
+				rate: foundRate.rate,
 				addons: [],
 			}
 			if ( signatureRequired && null !== foundRateSignatureRequired ) {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
@@ -86,14 +86,15 @@ class PriceSummary extends Component {
 		}
 
 		const { prices, discount, total } = priceBreakdown;
-
+		
 		return (
 			<div className="label-purchase-modal__shipping-summary-section">
 				<hr />
 				{ prices.map( ( service, index ) => {
 					return (
 						<Fragment key={ index }>
-							{ this.renderRow( service.title, service.retailRate, index ) }
+							{ ( service.retailRate !== service.rate ) ? this.renderRow( service.title, service.retailRate, index ) : null }
+							{ this.renderRow( translate( "Your price"), service.rate, 'rate-' + index ) }
 							{ service.addons.map( ( addon, addonIndex ) =>
 								<div key={ 'addons-' + index } className="label-purchase-modal__price-item-addons">
 									{ this.renderRow( addon.title, addon.rate, 'addon-' + addonIndex ) }


### PR DESCRIPTION
Improve how prices are presented. 
Fixes #1801

4 cases:

1. No saving on price, no signature:
![image](https://user-images.githubusercontent.com/17271089/68490524-6cd52e80-0249-11ea-903d-c8ea3c9b722d.png)

2. No saving on price, with signature:
![image](https://user-images.githubusercontent.com/17271089/68490558-7e1e3b00-0249-11ea-9505-97d911d675d8.png)

3. With price saving, no signature:
![image](https://user-images.githubusercontent.com/17271089/68490595-9b530980-0249-11ea-8613-ed99c5900295.png)

4. With price saving, with signature:
![image](https://user-images.githubusercontent.com/17271089/68490643-ab6ae900-0249-11ea-9986-ef950f2ddc8f.png)
