### PR TITLE
Use proper package name in price summary.

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
@@ -91,9 +91,14 @@ class PriceSummary extends Component {
 			<div className="label-purchase-modal__shipping-summary-section">
 				<hr />
 				{ prices.map( ( service, index ) => {
+					const title = translate( 'Package %(index)s', {
+						args: {
+							index: index + 1,
+						}
+					} );
 					return (
 						<Fragment key={ index }>
-							{ this.renderRow( service.title, service.retailRate, index ) }
+							{ this.renderRow( title, service.retailRate, index ) }
 							{ service.addons.map( ( addon, addonIndex ) =>
 								<div key={ 'addons-' + index } className="label-purchase-modal__price-item-addons">
 									{ this.renderRow( addon.title, addon.rate, 'addon-' + addonIndex ) }


### PR DESCRIPTION
Fixes #1807 

After changes:
![image](https://user-images.githubusercontent.com/17271089/68579780-4693d680-0475-11ea-8f0e-8b8e3d9b2eee.png)
