### PR TITLE
Adds .pot generation to tasks/i81n.js

### DIFF
--- a/tasks/i18n.js
+++ b/tasks/i18n.js
@@ -9,3 +9,11 @@ i18nCli( {
 	textdomain: 'woocommerce-services',
 } );
 
+i18nCli( {
+	inputPaths: [ 'dist/woocommerce-services.js' ],
+	output: 'i18n/languages/woocommerce-services.pot',
+	format: 'pot',
+	phpArrayName: 'i18nStrings',
+	projectName: 'woocommerce-services',
+	textdomain: 'woocommerce-services',
+} );


### PR DESCRIPTION
Generates the .pot file using the already linked calypso-i18n cli libraries.

Closes #1785.