### PR TITLE
Preselect rate when there is only one rate available.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Services Changelog ***
 
+= 1.22.2 - 2019-XX-XX =
+* Add   - Preselect rate when there is only one rate available for given shipping configuration.
+
 = 1.22.1 - 2019-11-14 =
 * Fix   - Remove nuisance admin notification.
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
@@ -150,7 +150,6 @@ const RatesStep = props => {
 		values,
 		available,
 		errors,
-		expanded,
 		ratesTotal,
 		translate,
 	} = props;

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
@@ -159,6 +159,20 @@ const RatesStep = props => {
 	const updateRateHandler = ( packageId, serviceId, signatureRequired ) =>
 		props.updateRate( orderId, siteId, packageId, serviceId, signatureRequired );
 
+	// Preselect rates for packages that have only one rate available.
+	forEach( form.packages.selected, ( selectedRate, pckgId ) => {
+		// Skip preselection for already selected values.
+		if( values[ pckgId ] !== "" ) {
+			return;
+		}
+
+		if ( ( ! isEmpty( available ) ) && ( pckgId in available ) && ( available[ pckgId ].default.rates.length === 1 ) ) {
+			const signatureRequired = false; // Don't preselect signature.
+			const { service_id } = available[ pckgId ].default.rates[ 0 ];
+			updateRateHandler( pckgId, service_id, signatureRequired );
+		}
+	} );
+
 	return (
 		<StepContainer
 			title={ translate( 'Shipping rates' ) }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
-import { find, isEmpty, mapValues, some } from 'lodash';
+import { find, forEach, isEmpty, mapValues, some } from 'lodash';
 import formatCurrency from '@automattic/format-currency';
 import Gridicon from 'gridicons';
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
@@ -177,7 +177,7 @@ const RatesStep = props => {
 		<StepContainer
 			title={ translate( 'Shipping rates' ) }
 			summary={ summary }
-			expanded={ expanded }
+			expanded={ ! isEmpty( available ) }
 			toggleStep={ toggleStepHandler }
 			{ ...getRatesStatus( props ) }
 		>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
@@ -162,11 +162,11 @@ const RatesStep = props => {
 	// Preselect rates for packages that have only one rate available.
 	forEach( form.packages.selected, ( selectedRate, pckgId ) => {
 		// Skip preselection for already selected values.
-		if( values[ pckgId ] !== "" ) {
+		if( "" !==  values[ pckgId ] ) {
 			return;
 		}
 
-		if ( ( ! isEmpty( available ) ) && ( pckgId in available ) && ( available[ pckgId ].default.rates.length === 1 ) ) {
+		if ( ( ! isEmpty( available ) ) && ( pckgId in available ) && ( 1 === available[ pckgId ].default.rates.length ) ) {
 			const signatureRequired = false; // Don't preselect signature.
 			const { service_id } = available[ pckgId ].default.rates[ 0 ];
 			updateRateHandler( pckgId, service_id, signatureRequired );


### PR DESCRIPTION
Fixes #1823.

An additional change was made around rates selection step expand/collapse logic. If there was only one rate and it was preselected the rates step was collapsing and thus hiding the signature select dropdown. I think ( this is a design decision ) that keeping the step always open makes sense as the merchant knows more clearly what was automatically selected. 