### PR TITLE
Fix backwards compatibility with Calypso.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.22.2 - 2019-XX-XX =
 * Add   - Preselect rate when there is only one rate available for given shipping configuration.
 * Fix   - Packages weight total value formatting. 
+* Fix   - No rates found issue in Calypso interface.
 
 = 1.22.1 - 2019-11-14 =
 * Fix   - Remove nuisance admin notification.


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/37638

For backwards compatibility with Calypso, disables the requesting of extra rates if `_via_calypso` parameter is present. The new response format introduced in `1.22.0` to include multiple rate types can not be parsed by Calypso frontend.

To test:
- Select package options and get rates in wp-admin
- Select package options and get rates in Store on WP.com Calypso interface