### PR TITLE
Fix metabox when it's in the sidebar.

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -273,15 +273,9 @@
 	white-space: pre-wrap;
 }
 
-#woocommerce-order-label {
-	.hndle,
-	.handlediv {
-		display: none;
-	}
-
-	.inside {
-		display: block !important;
-	}
+// When metabox in sidebar display same as small screen.
+.wp-core-ui.wp-admin #side-sortables .wcc-root .shipping-label__container {
+	display: block;
 }
 
 .wp-core-ui.wp-admin #woocommerce-order-shipment-tracking {

--- a/client/apps/shipping-label/style.scss
+++ b/client/apps/shipping-label/style.scss
@@ -9,7 +9,7 @@
 		display: inline-block;
 		vertical-align: text-bottom;
 		margin-left: 10px;
-		height: 36px;
+		padding-bottom: 11px;
 		position: relative;
 		top: 3px;
 		font-style: normal;


### PR DESCRIPTION
Also make style better when located on the sidebar.
Closes #1830

Shipping label box can now be dragged back to the sidebar if so desired. Display in sidebar should be same as on small screen.