### PR TITLE
Fix last box id for individually packed items.

### DIFF
--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -48,6 +48,7 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 		}
 
 		$last_box_id = get_user_meta( get_current_user_id(), 'wc_connect_last_box_id', true );
+		$last_box_id = $last_box_id === "individual" ? "" : $last_box_id;
 
 		return new WP_REST_Response( array(
 			'success'  => true,

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -54,7 +54,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 			}
 		}
 
-		if ( ! empty( $last_box_id ) ) {
+		if ( ! empty( $last_box_id ) && $last_box_id !== "individual" ) {
 			update_user_meta( get_current_user_id(), 'wc_connect_last_box_id', $last_box_id );
 		}
 


### PR DESCRIPTION
Don't save and don't provide "individual" as last box id.

I think that this actually fixes:
Fixes: https://github.com/Automattic/woocommerce-services/issues/1864

This solves this screen:
![image](https://user-images.githubusercontent.com/17271089/71181465-7b652b80-2274-11ea-9abd-fa786c440f3c.png)

It happens when user has sent a package as individually packaged. Later moved to another order. that has different items.
