### PR TITLE
Use version number to generate asset filename

### DIFF
--- a/tasks/i18n.js
+++ b/tasks/i18n.js
@@ -1,7 +1,7 @@
 const i18nCli = require( 'i18n-calypso/cli' );
 
 i18nCli( {
-	inputPaths: [ 'dist/woocommerce-services.js' ],
+	inputPaths: [ 'dist/woocommerce-services-' + process.env.npm_package_version + '.js' ],
 	output: 'i18n/strings.php',
 	format: 'php',
 	phpArrayName: 'i18nStrings',
@@ -10,7 +10,7 @@ i18nCli( {
 } );
 
 i18nCli( {
-	inputPaths: [ 'dist/woocommerce-services.js' ],
+	inputPaths: [ 'dist/woocommerce-services-' + process.env.npm_package_version + '.js' ],
 	output: 'i18n/languages/woocommerce-services.pot',
 	format: 'pot',
 	phpArrayName: 'i18nStrings',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,7 +56,7 @@ module.exports = {
 	},
 	output: {
 		path: path.join( __dirname, 'dist' ),
-		filename: '[name].js',
+		filename: '[name]-' + process.env.npm_package_version + '.js',
 		devtoolModuleFilenameTemplate: 'app:///[resource-path]',
 		publicPath: 'http://localhost:8085/',
 	},
@@ -194,7 +194,7 @@ module.exports = {
 			'fetch': 'imports-loader?this=>global!exports-loader?global.fetch!whatwg-fetch',
 		} ),
 		new MiniCssExtractPlugin( {
-			filename: '[name].css',
+			filename: '[name]-' + process.env.npm_package_version + '.css',
 		} ),
 		new webpack.DefinePlugin( {
 			'process.env.NODE_ENV': isDev ? '"development"' : '"production"',

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1162,17 +1162,15 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * Registers the React UI bundle
 		 */
 		public function admin_enqueue_scripts() {
-			// Note: This will break outside of wp-admin, if/when we put user-facing JS/CSS we'll have to figure out another way to version them
+			// Note: This will break outside of wp-admin, if/when we put user-facing JS/CSS we'll have to figure out another way to version them.
 			$plugin_data = get_plugin_data( __FILE__, false, false );
 			$plugin_version = $plugin_data[ 'Version' ];
 
-			// Use the same version as Jetpack
-			$jetpack_version = defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '0';
-			wp_register_style( 'wc_connect_admin', $this->wc_connect_base_url . 'woocommerce-services.css', array(), $plugin_version );
-			wp_register_script( 'wc_connect_admin', $this->wc_connect_base_url . 'woocommerce-services.js', array(), $plugin_version, true );
-			wp_register_script( 'wc_services_admin_pointers', $this->wc_connect_base_url . 'woocommerce-services-admin-pointers.js', array( 'wp-pointer', 'jquery' ), $plugin_version );
-			wp_register_style( 'wc_connect_banner', $this->wc_connect_base_url . 'woocommerce-services-banner.css', array(), $plugin_version );
-			wp_register_script( 'wc_connect_banner', $this->wc_connect_base_url . 'woocommerce-services-banner.js', array( 'updates' ), $plugin_version );
+			wp_register_style( 'wc_connect_admin', $this->wc_connect_base_url . 'woocommerce-services-' . $plugin_version . '.css', array(), null );
+			wp_register_script( 'wc_connect_admin', $this->wc_connect_base_url . 'woocommerce-services-' . $plugin_version . '.js', array(), null, true );
+			wp_register_script( 'wc_services_admin_pointers', $this->wc_connect_base_url . 'woocommerce-services-admin-pointers-' . $plugin_version . '.js', array( 'wp-pointer', 'jquery' ), null );
+			wp_register_style( 'wc_connect_banner', $this->wc_connect_base_url . 'woocommerce-services-banner-' . $plugin_version . '.css', array(), null );
+			wp_register_script( 'wc_connect_banner', $this->wc_connect_base_url . 'woocommerce-services-banner-' . $plugin_version . '.js', array( 'updates' ), null );
 
 			$i18n_json = $this->get_i18n_json();
 			/** @var array $i18nStrings defined in i18n/strings.php */


### PR DESCRIPTION
Closes #1856

Renames all files in dist/ to something like woocommerce-services-1.22.2.js.

This is my preferred solution to the caching problem we have with over optimizations done by some plugins. It'll be fine so long as we keep the version in packages.json up-to-date.

Test. Run plugin in dev mode make sure basic functions work.
run `npm run release`
Ensure plugin in release/woocomerce-services.zip can be installed and activated and basic functions work. Be sure to turn off dev constants like `WOOCOMMERCE_CONNECT_DEV_SERVER_URL`


