### PR TITLE
Hide paper selection until valid payment method is selected.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Services Changelog ***
 
+= 1.22.4 - 2020-XX-XX =
+* Fix   - Hide paper selection until valid payment method is selected.
+
 = 1.22.3 - 2020-01-22 =
 * Add   - Preselect rate when there is only one rate available for given shipping configuration.
 * Add   - Paper size selection into purchase modal sidebar and reprint modal which was previously removed.

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/sidebar.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/sidebar.js
@@ -31,6 +31,7 @@ import {
 	shouldFulfillOrder,
 	shouldEmailDetails,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
+import { getSelectedPaymentMethodId } from 'woocommerce/woocommerce-services/state/label-settings/selectors'
 
 const Sidebar = props => {
 	const {
@@ -42,6 +43,7 @@ const Sidebar = props => {
 		translate,
 		fulfillOrder,
 		emailDetails,
+		hasLabelsPaymentMethod,
 	} = props;
 
 	const onEmailDetailsChange = () => props.setEmailDetailsOption( orderId, siteId, ! emailDetails );
@@ -62,14 +64,14 @@ const Sidebar = props => {
 			</FormLabel>
 			<hr />
 			<div className="label-purchase-modal__purchase-container">
-				<Dropdown
+				{ hasLabelsPaymentMethod ? <Dropdown
 					id={ 'paper_size' }
 					valuesMap={ getPaperSizes( form.origin.values.country ) }
 					title={ translate( 'Paper size' ) }
 					value={ paperSize }
 					updateValue={ onPaperSizeChange }
 					error={ errors.paperSize }
-				/>
+				/> : null }
 				<PurchaseSection siteId={ siteId } orderId={ orderId } />
 			</div>
 		</div>
@@ -91,6 +93,7 @@ const mapStateToProps = ( state, { orderId, siteId } ) => {
 	return {
 		paperSize: shippingLabel.paperSize,
 		form: shippingLabel.form,
+		hasLabelsPaymentMethod: Boolean( getSelectedPaymentMethodId( state, siteId ) ),
 		errors: loaded && getFormErrors( state, orderId, siteId ).sidebar,
 		fulfillOrder: loaded && shouldFulfillOrder( state, orderId, siteId ),
 		emailDetails: loaded && shouldEmailDetails( state, orderId, siteId ),


### PR DESCRIPTION
This fixes: #1877 
![image](https://user-images.githubusercontent.com/17271089/72974602-94ab4b80-3dcf-11ea-9bbb-b949ac5d2197.png)

The paper selector is no longer there when the payment method is not selected.