### PR TITLE
[WIP] Fix/issue 1876

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -447,13 +447,13 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_MOVE_ITEM ] = (
 
 	const originItems = [ ...newPackages[ originPackageId ].items ];
 	const movedItem = originItems.splice( movedItemIndex, 1 )[ 0 ];
-	const moveItemToExistingPackage = (existingPackages, packageId, item) => {
-		const targetItems = [ ...existingPackages[ packageId ].items ];
-		targetItems.push( item );
-		existingPackages[ packageId ] = {
-			...existingPackages[ packageId ],
+	const moveItemToExistingPackage = () => {
+		const targetItems = [ ...newPackages[ targetPackageId ].items ];
+		targetItems.push( movedItem );
+		newPackages[ targetPackageId ] = {
+			...newPackages[ targetPackageId ],
 			items: targetItems,
-			weight: round( existingPackages[ packageId ].weight + item.weight, 8 ),
+			weight: round( newPackages[ targetPackageId ].weight + movedItem.weight, 8 ),
 		};
 	};
 
@@ -504,11 +504,11 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_MOVE_ITEM ] = (
 				items: [ movedItem ],
 			};
 		} else {
-			moveItemToExistingPackage(newPackages, targetPackageId, movedItem);
+			moveItemToExistingPackage();
 		}
 	} else if ( targetPackageId ) {
 		//move to an existing package
-		moveItemToExistingPackage(newPackages, targetPackageId, movedItem);
+		moveItemToExistingPackage();
 	}
 
 	if ( 0 === newPackages[ originPackageId ].items.length ) {

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -447,13 +447,13 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_MOVE_ITEM ] = (
 
 	const originItems = [ ...newPackages[ originPackageId ].items ];
 	const movedItem = originItems.splice( movedItemIndex, 1 )[ 0 ];
-	const moveItemToExistingPackage = (newPackages, targetPackageId, movedItem) => {
-		const targetItems = [ ...newPackages[ targetPackageId ].items ];
-		targetItems.push( movedItem );
-		newPackages[ targetPackageId ] = {
-			...newPackages[ targetPackageId ],
+	const moveItemToExistingPackage = (existingPackages, packageId, item) => {
+		const targetItems = [ ...existingPackages[ packageId ].items ];
+		targetItems.push( item );
+		existingPackages[ packageId ] = {
+			...existingPackages[ packageId ],
 			items: targetItems,
-			weight: round( newPackages[ targetPackageId ].weight + movedItem.weight, 8 ),
+			weight: round( existingPackages[ packageId ].weight + item.weight, 8 ),
 		};
 	};
 
@@ -492,7 +492,7 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_MOVE_ITEM ] = (
 		};
 	} else if ( 'unpack_item' === targetPackageId ) {
 		// Remove an item by putting them into "unpack items"
-		const addedPackageId = "unpack_item";
+		addedPackageId = "unpack_item";
 		if ( ! newPackages[ addedPackageId ] ) {
 			newPackages[ addedPackageId ] = {
 				height: 0,

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -481,6 +481,18 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_MOVE_ITEM ] = (
 			box_id: 'not_selected',
 			items: [ movedItem ],
 		};
+	} else if ( 'unpack_item' === targetPackageId ) {
+		// Remove an item by putting them into "unpack items"
+		const addedPackageId = "unpack_item";
+		newPackages[ addedPackageId ] = {
+			height: 0,
+			length: 0,
+			width: 0,
+			weight: movedItem.weight,
+			id: addedPackageId,
+			box_id: 'unpack_item',
+			items: [ movedItem ],
+		};
 	} else if ( targetPackageId ) {
 		//move to an existing package
 		const targetItems = [ ...newPackages[ targetPackageId ].items ];

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/list.js
@@ -70,12 +70,15 @@ const PackageList = props => {
 	const packageLabels = getPackageDescriptions( selected, all, false );
 	const packed = [];
 	const individual = [];
+	const notPacked = [];
 
 	Object.keys( selected ).forEach( pckgId => {
 		const pckg = selected[ pckgId ];
 
 		if ( 'individual' === pckg.box_id ) {
 			individual.push( renderPackageListItem( pckgId, pckg.items[ 0 ].name ) );
+		} else if ( 'unpack_item' === pckg.box_id ) {
+			notPacked.push( renderPackageListItem( pckgId, "Unpackaged items" ) );
 		} else {
 			packed.push( renderPackageListItem( pckgId, packageLabels[ pckgId ], pckg.items.length ) );
 		}
@@ -91,6 +94,7 @@ const PackageList = props => {
 		<div className="packages-step__list">
 			{ packed }
 			{ individual }
+			{ notPacked }
 		</div>
 	);
 };

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/move-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/move-item.js
@@ -73,7 +73,7 @@ const MoveItemDialog = props => {
 		const elements = [];
 		Object.keys( selected ).forEach( pckgId => {
 			const pckg = selected[ pckgId ];
-			if ( pckgId === openedPackageId || 'individual' === pckg.box_id ) {
+			if ( pckgId === openedPackageId || 'individual' === pckg.box_id || 'unpack_item' === pckg.box_id ) {
 				return;
 			}
 
@@ -88,7 +88,7 @@ const MoveItemDialog = props => {
 	};
 
 	const renderRemoveFromPackageOption = () => {
-		return renderRadioButton( '', translate( 'Remove from package' ) );
+		return renderRadioButton( 'unpack_item', translate( 'Remove from package' ) );
 	};
 
 	const renderIndividualOption = () => {
@@ -129,10 +129,7 @@ const MoveItemDialog = props => {
 			label: translate( 'Submit' ),
 			isPrimary: true,
 			disabled: targetPackageId === openedPackageId, // Result of targetPackageId initialization
-			onClick: () =>
-				( targetPackageId
-					? props.moveItem( orderId, siteId, openedPackageId, movedItemIndex, targetPackageId )
-					: props.removeItem( orderId, siteId, openedPackageId, movedItemIndex ) ),
+			onClick: () => props.moveItem( orderId, siteId, openedPackageId, movedItemIndex, targetPackageId )
 		},
 	];
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/package-info.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/package-info.js
@@ -122,6 +122,41 @@ const PackageInfo = props => {
 		props.updatePackageWeight( orderId, siteId, packageId, event.target.value );
 	};
 
+	const renderPackageDetail = () => {
+		if ( pckg.box_id === 'unpack_item' ) {
+			return '';
+		}
+
+		return (
+			<div>
+				<PackageSelect
+					siteId={ siteId }
+					orderId={ orderId }
+					isIndividualPackage={ isIndividualPackage }
+					pckgErrors={ pckgErrors }
+					pckg={ pckg }
+					packageId={ packageId }
+					lastBoxId={ userMeta.last_box_id }
+				/>
+
+				<div className="packages-step__package-weight">
+					<FormLabel htmlFor={ `weight_${ packageId }` }>{ translate( 'Total Weight (with package)' ) }</FormLabel>
+					<FormTextInputWithAffixes
+						id={ `weight_${ packageId }` }
+						placeholder={ translate( '0' ) }
+						value={ pckg.weight || '' }
+						onChange={ onWeightChange }
+						isError={ Boolean( pckgErrors.weight ) }
+						type="number"
+						noWrap
+						suffix={ weightUnit }
+					/>
+					{ pckgErrors.weight && <FieldError text={ pckgErrors.weight } /> }
+				</div>
+			</div>
+		);
+	};
+
 	return (
 		<div className="packages-step__package">
 			<div>
@@ -138,31 +173,7 @@ const PackageInfo = props => {
 				</div>
 				{ renderItems() }
 			</div>
-
-			<PackageSelect
-				siteId={ siteId }
-				orderId={ orderId }
-				isIndividualPackage={ isIndividualPackage }
-				pckgErrors={ pckgErrors }
-				pckg={ pckg }
-				packageId={ packageId }
-				lastBoxId={ userMeta.last_box_id }
-			/>
-
-			<div className="packages-step__package-weight">
-				<FormLabel htmlFor={ `weight_${ packageId }` }>{ translate( 'Total Weight (with package)' ) }</FormLabel>
-				<FormTextInputWithAffixes
-					id={ `weight_${ packageId }` }
-					placeholder={ translate( '0' ) }
-					value={ pckg.weight || '' }
-					onChange={ onWeightChange }
-					isError={ Boolean( pckgErrors.weight ) }
-					type="number"
-					noWrap
-					suffix={ weightUnit }
-				/>
-				{ pckgErrors.weight && <FieldError text={ pckgErrors.weight } /> }
-			</div>
+			{ renderPackageDetail() }
 		</div>
 	);
 };


### PR DESCRIPTION
## Work in progress, do not merge

This PR no longer remove the package item. Instead, when "remove from package" is clicked, it moves the item to "Unpackaged Items" so that it can move to another package(s).

Issue: https://github.com/Automattic/woocommerce-services/issues/1876

## TODO
- Currently in this PR, "Unpackaged Items" are still treated as a "package", so it will still have a label. We will have to add something like `if (package === 'unpack_item') then <ignore package>` so that label can ignore this package.  