### PR TITLE
decode html entities to avoid &#039; from appearing on the label

### DIFF
--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -112,7 +112,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 
 		public function get_origin_address() {
 			$wc_address_fields = array();
-			$wc_address_fields['company'] = get_bloginfo( 'name' );
+			$wc_address_fields['company'] = html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES ); // HTML entities may be saved in the option.
 			$wc_address_fields['name'] = wp_get_current_user()->display_name;
 			$wc_address_fields['phone'] = '';
 

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -137,7 +137,9 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			}
 
 			$stored_address_fields = WC_Connect_Options::get_option( 'origin_address', array() );
-			return array_merge( $wc_address_fields, $stored_address_fields );
+			$merged_fields = array_merge( $wc_address_fields, $stored_address_fields );
+			$merged_fields['company'] = html_entity_decode( $merged_fields['company'], ENT_QUOTES ); // Decode again for any existing stores that had some html entities saved in the option.
+			return $merged_fields;
 		}
 
 		public function get_preferred_paper_size() {


### PR DESCRIPTION
closes #1862

To test: 
add a ' to your Site Title in WP -> Settings -> General.
Delete any saved origin address in the option `woocommerce_connect_origin_address` 
Create a new label.
&#039; should not appear on the label.