### PR TITLE
Use plurals properly

### DIFF
--- a/client/apps/shipping-label/view-wrapper-label.js
+++ b/client/apps/shipping-label/view-wrapper-label.js
@@ -102,7 +102,7 @@ class ShippingLabelViewWrapper extends Component {
 			}
 
 			// If not all items are packaged (but some are, per condition above), show both buttons
-			if ( productsPackaged !== items ) {
+			if ( productsPackaged < items ) {
 				return (
 					<div className="shipping-label__multiple-buttons-container">
 						<Button
@@ -117,7 +117,7 @@ class ShippingLabelViewWrapper extends Component {
 						<Button
 							onClick={ this.handleTrackPackagesButtonClick }
 						>
-							{ translate( 'Track Packages' ) }
+							{ translate( 'Track Package', 'Track Packages', { count: activeLabels.length } ) }
 						</Button>
 					</div>
 				);
@@ -125,7 +125,7 @@ class ShippingLabelViewWrapper extends Component {
 
 			// All items are packaged, show track button and create shipping label button to allow redo fulfillment
 			return (
-				<span> 
+				<span>
 					<span className="shipping-label__redo-shipping-button">
 						<Button
 							borderless
@@ -137,7 +137,7 @@ class ShippingLabelViewWrapper extends Component {
 					<Button
 						onClick={ this.handleTrackPackagesButtonClick }
 					>
-						{ translate( 'Track Packages' ) }
+						{ translate( 'Track Package', 'Track Packages', { count: activeLabels.length } ) }
 					</Button>
 				</span>
 			);

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
@@ -47,9 +47,7 @@ const LabelPurchaseModal = props => {
 			<div className="label-purchase-modal__content">
 				<div className="label-purchase-modal__header">
 					<FormSectionHeading>
-						{ 1 === Object.keys(props.form.packages.selected).length
-							? translate( 'Create shipping label' )
-							: translate( 'Create shipping labels' ) }
+						{ translate( 'Create shipping label', 'Create shipping labels', { count: Object.keys( props.form.packages.selected ).length } ) }
 					</FormSectionHeading>
 					<Button className="label-purchase-modal__close-button" onClick={ onClose }>
 						<Gridicon icon="cross" />

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-section/purchase-button.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-section/purchase-button.js
@@ -32,7 +32,7 @@ const getPurchaseButtonLabel = props => {
 		return translate( 'Purchasing…' );
 	}
 
-	return translate( 'Buy shipping labels' );
+	return translate( 'Buy shipping label', 'Buy shipping labels', { count: Object.keys( form.packages.selected ).length } );
 };
 
 const PurchaseButton = props => {


### PR DESCRIPTION
closes #1883
translate allow for 2 parameters to hold the plural case and allow for proper translations to be made.
See https://github.com/Automattic/wp-calypso/tree/master/packages/i18n-calypso#pluralization