### PR TITLE
Ignore county when country is UK for automated tax

### DIFF
--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -868,6 +868,10 @@ class WC_Connect_TaxJar_Integration {
 				'to_city' => $to_city,
 			);
 
+			if ( $to_country === 'GB') {
+				$location['to_state'] = '';
+			}
+
 			// Add line item tax rates
 			foreach ( $taxes['line_items'] as $line_item_key => $line_item ) {
 				$line_item_key_chunks = explode( '-', $line_item_key );

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -868,7 +868,7 @@ class WC_Connect_TaxJar_Integration {
 				'to_city' => $to_city,
 			);
 
-			if ( $to_country === 'GB') {
+			if ( 'GB' === $to_country ) {
 				$location['to_state'] = '';
 			}
 


### PR DESCRIPTION
When country is UK, the shipping address allow county to be a text field. This text field does not respect a "state code" format (ie. 2 letters). This creates a problem with WooCommerce core's tax code. While the core team is working on the issue, we are going to patch this by disabling county in the tax field for automated tax. County is optional and this change will not break tax rate.

### Notes
County is optional field for UK. https://developers.taxjar.com/api/reference/#post-calculate-sales-tax-for-an-order
![image](https://user-images.githubusercontent.com/572862/73769925-c3fb7a00-4738-11ea-9881-678454c3d6c7.png)
By removing the county field, WooCommerce core will insert this entry as `*` which can match any county.
![image](https://user-images.githubusercontent.com/572862/73770101-1046ba00-4739-11ea-90d2-a78de3e01ef9.png)

### To test
1. Set store address to an UK address, https://localhost/wp-admin/admin.php?page=wc-settings&tab=general. We can use the ones from the issue, (e.g. 63 Elford Crescent, Plympton, Plymouth, UK, PL74BT)
2. Add an item, go to the checkout page. Use shipping addresses:
- 2 Chestnut Hall Avenue, Maghaberry, Moira, County Armagh, BT67 0GG
- 40 Whitehall Way, Rockingham, Rotherham, South yorkshire, S61 4HW
- 19 Carisbrooke Close, EASTBOURNE, East Sussex, BN23 8EQ
3. Refresh the checkout page a few times
4. Verify `VAT` shows up as 20% tax of the product cost
5. Go to https://localhost/wp-admin/admin.php?page=wc-settings&tab=tax&section=standard, there should only be 1 entry per address. 

Closes #1600 