### PR TITLE
Pass new API version number so we can properly version the API

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -8,9 +8,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 
 	abstract class WC_Connect_API_Client {
+		const API_VERSION = WOOCOMMERCE_CONNECT_SERVER_API_VERSION;
 
 		/**
-		 * @var WC_Connect_Services_Validator
+		 * @var WC_Connect_Service_Schemas_Validator
 		 */
 		protected $validator;
 
@@ -292,7 +293,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		/** Heartbeat test.
-		 * 
+		 *
 		 * @return true|WP_Error
 		 */
 		public function is_alive() {
@@ -300,7 +301,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		/** Heartbeat test with a transient cache.
-		 * 
+		 *
 		 * @return true|WP_Error
 		 */
 		public function is_alive_cached() {
@@ -466,7 +467,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			$lang = $locale_elements[ 0 ];
 			$headers[ 'Accept-Language' ] = $locale . ',' . $lang;
 			$headers[ 'Content-Type' ] = 'application/json; charset=utf-8';
-			$headers[ 'Accept' ] = 'application/vnd.woocommerce-connect.v1';
+			$headers[ 'Accept' ] = 'application/vnd.woocommerce-connect.v' . static::API_VERSION;
 			$headers[ 'Authorization' ] = $authorization;
 			return $headers;
 		}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -47,6 +47,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 	define( 'WOOCOMMERCE_CONNECT_SCHEMA_AGE_ERROR_THRESHOLD', 3 * DAY_IN_SECONDS );
 	define( 'WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH', 32 );
 
+	if ( ! defined( 'WOOCOMMERCE_CONNECT_SERVER_API_VERSION ' ) ) {
+		define( 'WOOCOMMERCE_CONNECT_SERVER_API_VERSION', '2');
+	}
+
 	// Check for CI environment variable to trigger test mode.
 	if ( false !== getenv( 'WOOCOMMERCE_SERVICES_CI_TEST_MODE', true ) ) {
 		if ( ! defined( 'WOOCOMMERCE_SERVICES_LOCAL_TEST_MODE' ) ) {


### PR DESCRIPTION
Required for https://github.com/Automattic/woocommerce-connect-server/pull/1348 and should be released much sooner than the server changes so ideally the majority of sites would be using V2 before we update the server. 