### PR TITLE
Delay the initial label status call by 1 seconds

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -757,6 +757,10 @@ const getPDFFileName = ( orderId, isReprint = false ) => {
 
 // retireves the single label status, and retries up to 3 times on timeout
 const labelStatusTask = ( orderId, siteId, labelId, retryCount ) => {
+	let timeout = 1000;
+	if ( retryCount === 0) {
+		timeout = 3000;
+	}
 	return api
 		.get( siteId, api.url.labelStatus( orderId, labelId ) )
 		.then( statusResponse => statusResponse.label )
@@ -767,7 +771,7 @@ const labelStatusTask = ( orderId, siteId, labelId, retryCount ) => {
 			return new Promise( resolve => {
 				setTimeout(
 					() => resolve( labelStatusTask( orderId, siteId, labelId, retryCount + 1 ) ),
-					1000
+					timeout
 				);
 			} );
 		} );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -759,7 +759,7 @@ const getPDFFileName = ( orderId, isReprint = false ) => {
 const labelStatusTask = ( orderId, siteId, labelId, retryCount ) => {
 	let timeout = 1000;
 	if ( retryCount === 0) {
-		timeout = 3000;
+		timeout = 2000;
 	}
 	return api
 		.get( siteId, api.url.labelStatus( orderId, labelId ) )


### PR DESCRIPTION
Applying the first solution suggested in the issue https://github.com/Automattic/woocommerce-services/issues/1900. 

Since the request hardly completes in 1 second, the polling for the first couple of seconds aren't necessarily. Instead, delay the first call by a factor of 2 and then continue to poll per second. 

**Impact:**
Minimum label purchase time will change from `1` second to `2` seconds. This may delay some purchasing. Based on some data on the server side, the request seems to take between 1 to 2 seconds. 

Closes #1900 
