### PR TITLE
Fix/shipment banner text

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 *** WooCommerce Services Changelog ***
 
-= 1.22.4 - 2020-XX-XX =
+= 1.23.0 - 2020-XX-XX =
 * Fix   - Hide paper selection until valid payment method is selected.
+* Tweak - Shipping banner wording improvements.
 
 = 1.22.3 - 2020-01-22 =
 * Add   - Preselect rate when there is only one rate available for given shipping configuration.

--- a/client/apps/shipping-label/style.scss
+++ b/client/apps/shipping-label/style.scss
@@ -5,14 +5,17 @@
 	justify-content: space-between;
 
 	em {
-		font-size: 18px;
+		font-size: 15px;
 		display: inline-block;
 		vertical-align: text-bottom;
 		margin-left: 10px;
 		padding-bottom: 11px;
 		position: relative;
-		top: 3px;
 		font-style: normal;
+		font-weight: bold;
+	}
+	.shipping-label__banner-fulfilled-date {
+		font-weight: normal;
 	}
 
 	.shipping-label__payment .gridicon.notice__icon {

--- a/client/apps/shipping-label/test/view-wrapper-label.js
+++ b/client/apps/shipping-label/test/view-wrapper-label.js
@@ -13,6 +13,7 @@ import { moment, translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { ShippingLabelViewWrapper } from '../view-wrapper-label';
+import Button from 'components/button';
 
 configure( { adapter: new Adapter() } );
 
@@ -34,7 +35,7 @@ const labelEventsTwoPurchased = [
 		labelIndex: 2,
 		productNames: [ '' ],
 		createdDate: 1551113177000,
-	}
+	},
 ];
 
 function createViewWrapperLabelWrapper( {
@@ -48,7 +49,7 @@ function createViewWrapperLabelWrapper( {
 	const props = {
 		orderId: 1000,
 		siteId: 10,
-		loaded: loaded || true,
+		loaded: ( undefined !== loaded ) ? loaded : true,
 		labelsEnabled: labelsEnabled || true,
 		items: items || 1,
 		events: events || {},
@@ -61,6 +62,19 @@ function createViewWrapperLabelWrapper( {
 }
 
 describe( 'ShippingLabelViewWrapper', () => {
+	describe( 'for not yet loaded', () => {
+		const viewWrapperLabel = createViewWrapperLabelWrapper( { loaded: false } );
+		it( 'renders loading button', function() {
+			expect( viewWrapperLabel.find( '.shipping-label__button-loading' ) ).to.have.length( 1 );
+		} );
+	} );
+
+	describe( 'for loaded', () => {
+		const viewWrapperLabel = createViewWrapperLabelWrapper( {} );
+		it( 'renders create label button', function() {
+			expect( viewWrapperLabel.find( '.shipping-label__new-label-button' ) ).to.have.length( 1 );
+		} );
+	} );
 
 	describe( 'for 1 item unfulfilled', () => {
 		const viewWrapperLabel = createViewWrapperLabelWrapper( {} );
@@ -84,13 +98,45 @@ describe( 'ShippingLabelViewWrapper', () => {
 		it( 'renders singular fulfilled message', function() {
 			expect( viewWrapperLabel.find( '.shipping-label__banner-fulfilled-message' ) ).to.contain.text( '1 item was fulfilled on Feb 24, 2020' );
 		} );
+
+		it( 'renders redo label button', function() {
+			expect( viewWrapperLabel.find( '.shipping-label__redo-shipping-button' ) ).to.have.length( 1 );
+		} );
+
+		it( 'renders track label button', function() {
+			expect( viewWrapperLabel.find( 'Button' ).last().dive() ).to.contain.text( 'Track Packages' );
+		} );
 	} );
 
-	describe( 'for 2 items fulfilled', () => {
+	describe( 'for two items fulfilled by two labels', () => {
 		const viewWrapperLabel = createViewWrapperLabelWrapper( { items:2, events: labelEventsTwoPurchased } );
 
-		it( 'renders singular fulfilled message', function() {
+		it( 'renders plural fulfilled message', function() {
 			expect( viewWrapperLabel.find( '.shipping-label__banner-fulfilled-message' ) ).to.contain.text( '2 items were fulfilled on Feb 24, 2020' );
+		} );
+
+		it( 'renders redo label button', function() {
+			expect( viewWrapperLabel.find( '.shipping-label__redo-shipping-button' ) ).to.have.length( 1 );
+		} );
+
+		it( 'renders track label button', function() {
+			expect( viewWrapperLabel.find( 'Button' ).last().dive() ).to.contain.text( 'Track Packages' );
+		} );
+	} );
+
+	describe( 'for 1 item fulfilled by 2 labels', () => {
+		const viewWrapperLabel = createViewWrapperLabelWrapper( { items:1, events: labelEventsTwoPurchased } );
+
+		it( 'renders singular fulfilled message', function() {
+			expect( viewWrapperLabel.find( '.shipping-label__banner-fulfilled-message' ) ).to.contain.text( '1 item was fulfilled on Feb 24, 2020' );
+		} );
+
+		it( 'renders redo label button', function() {
+			expect( viewWrapperLabel.find( '.shipping-label__redo-shipping-button' ) ).to.have.length( 1 );
+		} );
+
+		it( 'renders track label button', function() {
+			expect( viewWrapperLabel.find( 'Button' ).last().dive() ).to.contain.text( 'Track Packages' );
 		} );
 	} );
 } );

--- a/client/apps/shipping-label/test/view-wrapper-label.js
+++ b/client/apps/shipping-label/test/view-wrapper-label.js
@@ -1,0 +1,96 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { configure, shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16'
+import { moment, translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { ShippingLabelViewWrapper } from '../view-wrapper-label';
+
+configure( { adapter: new Adapter() } );
+
+global.wcConnectData = {
+	nonce: 1,
+	baseURL: 'http://localhost/',
+	wcs_server_connection: 1,
+};
+
+const labelEventsTwoPurchased = [
+	{
+		type: 'LABEL_PURCHASED',
+		labelIndex: 1,
+		productNames: [ '' ],
+		createdDate: 1582613177000, //Feb. 24, 2020
+	},
+	{
+		type: 'LABEL_PURCHASED',
+		labelIndex: 2,
+		productNames: [ '' ],
+		createdDate: 1551113177000,
+	}
+];
+
+function createViewWrapperLabelWrapper( {
+	loaded,
+	labelsEnabled,
+	items,
+	events,
+	order
+} ) {
+
+	const props = {
+		orderId: 1000,
+		siteId: 10,
+		loaded: loaded || true,
+		labelsEnabled: labelsEnabled || true,
+		items: items || 1,
+		events: events || {},
+		fetchOrder: () => order || {},
+		moment,
+		translate,
+	};
+
+	return shallow( <ShippingLabelViewWrapper { ...props } /> );
+}
+
+describe( 'ShippingLabelViewWrapper', () => {
+
+	describe( 'for 1 item unfulfilled', () => {
+		const viewWrapperLabel = createViewWrapperLabelWrapper( {} );
+
+		it( 'renders singular ready to to be fulfilled message', function() {
+			expect( viewWrapperLabel.find( '.shipping-label__banner-fulfilled-message' ) ).to.contain.text( '1 item is ready' );
+		} );
+	} );
+
+	describe( 'for 2 items unfulfilled', () => {
+		const viewWrapperLabel = createViewWrapperLabelWrapper( { items: 2 } );
+
+		it( 'renders plural ready to to be fulfilled message', function() {
+			expect( viewWrapperLabel.find( '.shipping-label__banner-fulfilled-message' ) ).to.contain.text( '2 items are ready' );
+		} );
+	} );
+
+	describe( 'for 1 item fulfilled', () => {
+		const viewWrapperLabel = createViewWrapperLabelWrapper( { events: labelEventsTwoPurchased } );
+
+		it( 'renders singular fulfilled message', function() {
+			expect( viewWrapperLabel.find( '.shipping-label__banner-fulfilled-message' ) ).to.contain.text( '1 item was fulfilled on Feb 24, 2020' );
+		} );
+	} );
+
+	describe( 'for 2 items fulfilled', () => {
+		const viewWrapperLabel = createViewWrapperLabelWrapper( { items:2, events: labelEventsTwoPurchased } );
+
+		it( 'renders singular fulfilled message', function() {
+			expect( viewWrapperLabel.find( '.shipping-label__banner-fulfilled-message' ) ).to.contain.text( '2 items were fulfilled on Feb 24, 2020' );
+		} );
+	} );
+} );

--- a/client/apps/shipping-label/view-wrapper-label.js
+++ b/client/apps/shipping-label/view-wrapper-label.js
@@ -41,7 +41,7 @@ import {
  } from '../../extensions/woocommerce/state/sites/orders/selectors';
 import { withLocalizedMoment } from 'components/localized-moment';
 
-class ShippingLabelViewWrapper extends Component {
+export class ShippingLabelViewWrapper extends Component {
 	static propTypes = {
 		orderId: PropTypes.number.isRequired,
 	};

--- a/client/apps/shipping-label/view-wrapper-label.js
+++ b/client/apps/shipping-label/view-wrapper-label.js
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
-import { sumBy, differenceBy, filter } from 'lodash';
+import { sumBy, differenceBy, filter, maxBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -39,6 +39,7 @@ import {
 	isOrderLoaded,
 	isOrderLoading
  } from '../../extensions/woocommerce/state/sites/orders/selectors';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 class ShippingLabelViewWrapper extends Component {
 	static propTypes = {
@@ -53,11 +54,10 @@ class ShippingLabelViewWrapper extends Component {
 		}
 	}
 
-	renderLabelButton = () => {
+	renderLabelButton = ( activeLabels, productsPackaged ) => {
 		const {
 			loaded,
 			translate,
-			events,
 			items,
 		} = this.props;
 
@@ -80,11 +80,6 @@ class ShippingLabelViewWrapper extends Component {
 
 		// eslint-disable-next-line no-undef
 		if ( wcConnectData.wcs_server_connection ) {
-
-			const labels = filter( events, { type: 'LABEL_PURCHASED' } );
-			const refunds = filter( events, { type: 'LABEL_REFUND_REQUESTED' } );
-			const activeLabels = differenceBy( labels, refunds, "labelIndex" );
-			const productsPackaged = sumBy( activeLabels, (l) => l.productNames.length );
 
 			// If there are no purchased labels, just show Create labels button
 			if ( ! activeLabels.length ) {
@@ -181,21 +176,69 @@ class ShippingLabelViewWrapper extends Component {
 			labelsEnabled,
 			items,
 			translate,
+			events,
+			moment,
 		} = this.props;
 
 		const shouldRenderButton = ! loaded || labelsEnabled;
 
+		const labels = filter( events, { type: 'LABEL_PURCHASED' } );
+		const refunds = filter( events, { type: 'LABEL_REFUND_REQUESTED' } );
+		const activeLabels = differenceBy( labels, refunds, "labelIndex" );
+		const productsPackaged = sumBy( activeLabels, (l) => l.productNames.length );
+
+		// Calculate if order fulfilled and find latest date.
+		let orderFulfilled = false;
+		let createdDate;
+		if ( activeLabels.length > 0 && items <= productsPackaged ) {
+			orderFulfilled = true;
+			const latestLabel = maxBy( activeLabels, 'createdDate' );
+			const createdMoment = moment( latestLabel.createdDate );
+			createdDate = createdMoment.format( 'll' );
+		}
+
 		return (
 			<div className="shipping-label__container">
-				<div>
+				<div className="shipping-label__banner-fulfilled-message">
 					<Gridicon size={36} icon="shipping" />
-					<em>{ items + ' ' + translate( 'item is ready for shipment', 'items are ready for shipment', { count: items } ) }</em>
+					{ loaded && ( orderFulfilled ?
+							(
+								<em>
+									{ translate(
+										'%(itemCount)d item was fulfilled on {{span}}%(createdDate)s{{/span}}',
+										'%(itemCount)d items were fulfilled on {{span}}%(createdDate)s{{/span}}',
+										{
+											count: items,
+											args: {
+												createdDate,
+												itemCount: items,
+											},
+											components: {
+												span: <span className="shipping-label__banner-fulfilled-date" />,
+											},
+										}
+									) }
+								</em>
+						) : (
+								<em>
+									{ translate(
+										'%(itemCount)d item is ready to be fulfilled',
+										'%(itemCount)d items are ready to be fulfilled',
+										{
+											count: items,
+											args: {
+												itemCount: items,
+											},
+										}
+									) }
+								</em> )
+					) }
 				</div>
 				<div>
 					<QueryLabels orderId={ orderId } siteId={ siteId } origin={ "labels" } />
 					<LabelPurchaseModal orderId={ orderId } siteId={ siteId } />
 					<TrackingModal orderId={ orderId } siteId={ siteId } />
-					{ shouldRenderButton && this.renderLabelButton() }
+					{ shouldRenderButton && this.renderLabelButton( activeLabels, productsPackaged ) }
 				</div>
 			</div>
 		);
@@ -228,4 +271,4 @@ export default connect(
 			fetchOrder,
 		}, dispatch ),
 	} ),
-)( localize( ShippingLabelViewWrapper ) );
+)( localize( withLocalizedMoment( ShippingLabelViewWrapper ) ) );

--- a/client/apps/shipping-label/view-wrapper-label.js
+++ b/client/apps/shipping-label/view-wrapper-label.js
@@ -97,7 +97,7 @@ class ShippingLabelViewWrapper extends Component {
 			}
 
 			// If not all items are packaged (but some are, per condition above), show both buttons
-			if ( productsPackaged !== items ) {
+			if ( productsPackaged < items ) {
 				return (
 					<div className="shipping-label__multiple-buttons-container">
 						<Button

--- a/tests/client/jest.config.js
+++ b/tests/client/jest.config.js
@@ -12,11 +12,12 @@ module.exports = {
 		'<rootDir>/tests/',
 		'<rootDir>/client/',
 		'<rootDir>/client/extensions/',
-		'<rootDir>/wp-calypso/client'
+		'<rootDir>/wp-calypso/client',
+		'<rootDir>/wp-calypso/node_modules'
 	],
 	rootDir: './../../',
 	roots: [ '<rootDir>/client/' ],
-	testEnvironment: 'node',
+	testEnvironment: 'jsdom',
 	transformIgnorePatterns: [
 		'node_modules[\\/\\\\](?!flag-icon-css|redux-form|simple-html-tokenizer|draft-js)',
 	],


### PR DESCRIPTION
Fixes #1907 
e.g.
<img width="973" alt="image" src="https://user-images.githubusercontent.com/6209518/74992305-89623480-53fc-11ea-856a-ac904bc218c4.png">

Changes:
- Adds a "..was fulfilled on [date]" text for when labels have been printed
- Changes "ready for shipment" text to "ready to be fulfilled"
- Adds some unit tests
- Fixes a minor display bug for when more labels have been printed than there are items, see this line: https://github.com/Automattic/woocommerce-services/pull/1929/files#diff-8f8dbbc4401617f036a73a1e18b2b074R100

To test:
- Run `npm run test-client`
- For single and multiple item orders:
   - Check banner display for fresh order with no labels
   - Check banner display after one label has been printed
   - Check banner display after multiple labels have been printed.

Props to @brezocordero and @tommyshellberg for working on this with me!