### PR TITLE
Jetpack::is_staging_site() is deprectated in Jetpack 8.1

### DIFF
--- a/classes/class-wc-connect-jetpack.php
+++ b/classes/class-wc-connect-jetpack.php
@@ -31,6 +31,10 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 		 * @return bool
 		 */
 		public static function is_staging_site() {
+			if ( method_exists( '\\Automattic\\Jetpack\\Status', 'is_staging_site' ) ) {
+				return ( new \Automattic\Jetpack\Status )->is_staging_site();
+			}
+
 			if ( method_exists( 'Jetpack', 'is_staging_site' ) ) {
 				return Jetpack::is_staging_site();
 			}


### PR DESCRIPTION
have to use \Automattic\Jetpack\Status::is_staging_site() when it exists

Test on Jetpack 7 and Jetpack 8.1+. No deprecation notices should show.