### PR TITLE
WIP: Connect JetPack from shipping label modal

### DIFF
--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -26,7 +26,11 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 				$shipping_tabs = array();
 			}
 
-			$shipping_tabs[ 'woocommerce-services-settings' ] = __( 'WooCommerce Services', 'woocommerce-services' );
+			// Remove "WooCommerce Service" from shipping tabs if it's not connected.
+			if ( WC_Connect_Jetpack::is_active() ) {
+				$shipping_tabs[ 'woocommerce-services-settings' ] = __( 'WooCommerce Services', 'woocommerce-services' );
+			}
+
 			return $shipping_tabs;
 		}
 

--- a/client/apps/shipping-label/view-wrapper-label.js
+++ b/client/apps/shipping-label/view-wrapper-label.js
@@ -45,12 +45,27 @@ class ShippingLabelViewWrapper extends Component {
 		orderId: PropTypes.number.isRequired,
 	};
 
+	constructor(props) {
+		super(props);
+		this.state = {
+			hasJetpackAccount: wcConnectData.jetpack_status === "connected" || wcConnectData.jetpack_status === "dev"
+		};
+	}
+
 	componentDidMount() {
 		const { siteId, orderId, orderLoading, orderLoaded } = this.props;
 
 		if ( siteId && orderId && ! orderLoading && ! orderLoaded) {
 			this.props.fetchOrder( siteId, orderId );
 		}
+
+		window.addEventListener('message', (event) => {
+			if ( 'close' === event.data ) {
+				this.setState({
+					hasJetpackAccount: true
+				});
+			}
+		});
 	}
 
 	renderLabelButton = () => {
@@ -193,7 +208,7 @@ class ShippingLabelViewWrapper extends Component {
 				</div>
 				<div>
 					<QueryLabels orderId={ orderId } siteId={ siteId } origin={ "labels" } />
-					<LabelPurchaseModal orderId={ orderId } siteId={ siteId } />
+					<LabelPurchaseModal orderId={ orderId } siteId={ siteId } hasJetpackAccount={ this.state.hasJetpackAccount }/>
 					<TrackingModal orderId={ orderId } siteId={ siteId } />
 					{ shouldRenderButton && this.renderLabelButton() }
 				</div>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
@@ -29,6 +29,8 @@ import {
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 
 const LabelPurchaseBody = (props) => {
+	const { translate } = props;
+
 	return (
 	<div className="label-purchase-modal__body">
 		<div className="label-purchase-modal__main-section">

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
@@ -27,6 +27,7 @@ import {
 	isLoaded,
 	isCustomsFormRequired,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
+import TextField from 'woocommerce/woocommerce-services/components/text-field';
 
 const LabelPurchaseModal = props => {
 	const { loaded, translate } = props;
@@ -37,6 +38,77 @@ const LabelPurchaseModal = props => {
 
 
 	const onClose = () => props.exitPrintingFlow( props.orderId, props.siteId, false );
+	const hasJetpackAccount = false;
+
+	const labelPurchaseBody = () => {
+		return (
+		<div className="label-purchase-modal__body">
+			<div className="label-purchase-modal__main-section">
+				<AddressStep
+					type="origin"
+					title={ translate( 'Origin address' ) }
+					siteId={ props.siteId }
+					orderId={ props.orderId }
+				/>
+				<AddressStep
+					type="destination"
+					title={ translate( 'Destination address' ) }
+					siteId={ props.siteId }
+					orderId={ props.orderId }
+				/>
+				<PackagesStep siteId={ props.siteId } orderId={ props.orderId } />
+				{ props.isCustomsFormRequired && (
+					<CustomsStep siteId={ props.siteId } orderId={ props.orderId } />
+				) }
+				<RatesStep siteId={ props.siteId } orderId={ props.orderId } />
+			</div>
+			<Sidebar siteId={ props.siteId } orderId={ props.orderId } />
+		</div>
+		);
+	}
+
+	const createJetpackAccountBody = () => {
+		return (
+			<>
+				<h3 class="form-section-heading">Create a Jetpack account</h3>
+				<p>Your Jetpack account will enable you to start using the benefits offered by Jetpack & WooCommerce Services.</p>
+				<TextField
+					id="email"
+					title="Email address"
+					value="Email address"
+				/>
+
+				<TextField
+					id="username"
+					title="Choose a username"
+					value="username"
+				/>
+
+				<TextField
+					id="password"
+					title="Choose a password"
+					value="password"
+				/>
+
+				<p>by creating an account via any of the options below, you agree to our Terms of Service</p>
+				<Button
+					className="asd"
+					primary
+				>
+					{ translate( 'Create your account and connect' ) }
+				</Button>
+
+				<p>Or connect your existing profiler to get started faster</p>
+				<Button
+					className="asd"
+				>
+					{ translate( 'Connect with Google' ) }
+				</Button>
+
+				<p>Log in with an existing Jetpack or Wordpress.com account</p>
+			</>
+		);
+	}
 
 	return (
 		<Dialog
@@ -53,28 +125,8 @@ const LabelPurchaseModal = props => {
 						<Gridicon icon="cross" />
 					</Button>
 				</div>
-				<div className="label-purchase-modal__body">
-					<div className="label-purchase-modal__main-section">
-						<AddressStep
-							type="origin"
-							title={ translate( 'Origin address' ) }
-							siteId={ props.siteId }
-							orderId={ props.orderId }
-						/>
-						<AddressStep
-							type="destination"
-							title={ translate( 'Destination address' ) }
-							siteId={ props.siteId }
-							orderId={ props.orderId }
-						/>
-						<PackagesStep siteId={ props.siteId } orderId={ props.orderId } />
-						{ props.isCustomsFormRequired && (
-							<CustomsStep siteId={ props.siteId } orderId={ props.orderId } />
-						) }
-						<RatesStep siteId={ props.siteId } orderId={ props.orderId } />
-					</div>
-					<Sidebar siteId={ props.siteId } orderId={ props.orderId } />
-				</div>
+
+				{ (hasJetpackAccount) ? labelPurchaseBody() : createJetpackAccountBody() }
 			</div>
 		</Dialog>
 	);

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
@@ -37,7 +37,10 @@ const LabelPurchaseModal = props => {
 
 
 	const onClose = () => props.exitPrintingFlow( props.orderId, props.siteId, false );
-	const hasJetpackAccount = wcConnectData.jetpack_status === "connected" || wcConnectData.jetpack_status === "dev";
+	let dialogClasses = "woocommerce label-purchase-modal label-purchase-modal__sidebar_background wcc-root";
+	if (props.hasJetpackAccount) {
+		dialogClasses = dialogClasses + " label-purchase-modal__sidebar_background";
+	}
 
 	const labelPurchaseBody = () => {
 		return (
@@ -87,7 +90,7 @@ const LabelPurchaseModal = props => {
 
 	return (
 		<Dialog
-			additionalClassNames="woocommerce label-purchase-modal wcc-root"
+			additionalClassNames={ dialogClasses }
 			isVisible={ props.showPurchaseDialog }
 			onClose={ onClose }
 		>
@@ -101,7 +104,7 @@ const LabelPurchaseModal = props => {
 					</Button>
 				</div>
 
-				{ (hasJetpackAccount) ? labelPurchaseBody() : createJetpackAccountBody() }
+				{ (props.hasJetpackAccount) ? labelPurchaseBody() : createJetpackAccountBody() }
 			</div>
 		</Dialog>
 	);
@@ -110,6 +113,7 @@ const LabelPurchaseModal = props => {
 LabelPurchaseModal.propTypes = {
 	siteId: PropTypes.number.isRequired,
 	orderId: PropTypes.number.isRequired,
+	hasJetpackAccount: PropTypes.bool.isRequired
 };
 
 const mapStateToProps = ( state, { orderId, siteId } ) => {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
@@ -35,14 +35,13 @@ const LabelPurchaseModal = props => {
 		return null;
 	}
 
-
 	const onClose = () => props.exitPrintingFlow( props.orderId, props.siteId, false );
 	let dialogClasses = "woocommerce label-purchase-modal label-purchase-modal__sidebar_background wcc-root";
 	if (props.hasJetpackAccount) {
 		dialogClasses = dialogClasses + " label-purchase-modal__sidebar_background";
 	}
 
-	const labelPurchaseBody = () => {
+	const LabelPurchaseBody = (props) => {
 		return (
 		<div className="label-purchase-modal__body">
 			<div className="label-purchase-modal__main-section">
@@ -69,7 +68,7 @@ const LabelPurchaseModal = props => {
 		);
 	}
 
-	const createJetpackAccountBody = () => {
+	const JetpackConnectBody = (props) => {
 		return (
 			<>
 				<div className="label-purchase-modal__header">
@@ -77,12 +76,7 @@ const LabelPurchaseModal = props => {
 				</div>
 				<iframe
 					src={wcConnectData.jetpack_auth_url}
-					className="jp-jetpack-connect__iframe"
-					style={{
-						background: 'white',
-						height: '100%',
-						'padding-top': '30px'
-					}}
+					className="label-purchase-modal__jetpack-connect"
 				></iframe>
 			</>
 		);
@@ -104,7 +98,7 @@ const LabelPurchaseModal = props => {
 					</Button>
 				</div>
 
-				{ (props.hasJetpackAccount) ? labelPurchaseBody() : createJetpackAccountBody() }
+				{ (props.hasJetpackAccount) ? <LabelPurchaseBody {...props} /> : <JetpackConnectBody {...props} /> }
 			</div>
 		</Dialog>
 	);
@@ -114,6 +108,14 @@ LabelPurchaseModal.propTypes = {
 	siteId: PropTypes.number.isRequired,
 	orderId: PropTypes.number.isRequired,
 	hasJetpackAccount: PropTypes.bool.isRequired
+};
+
+LabelPurchaseBody.propTypes = {
+	...LabelPurchaseModal.propTypes
+};
+
+JetpackConnectBody.propTypes = {
+	...LabelPurchaseModal.propTypes
 };
 
 const mapStateToProps = ( state, { orderId, siteId } ) => {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
@@ -27,7 +27,6 @@ import {
 	isLoaded,
 	isCustomsFormRequired,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
-import TextField from 'woocommerce/woocommerce-services/components/text-field';
 
 const LabelPurchaseModal = props => {
 	const { loaded, translate } = props;
@@ -70,42 +69,18 @@ const LabelPurchaseModal = props => {
 	const createJetpackAccountBody = () => {
 		return (
 			<>
-				<h3 class="form-section-heading">Create a Jetpack account</h3>
-				<p>Your Jetpack account will enable you to start using the benefits offered by Jetpack & WooCommerce Services.</p>
-				<TextField
-					id="email"
-					title="Email address"
-					value="Email "
-				/>
-
-				<TextField
-					id="username"
-					title="Choose a username"
-					value="username"
-				/>
-
-				<TextField
-					id="password"
-					title="Choose a password"
-					value="password"
-				/>
-
-				<p>by creating an account via any of the options below, you agree to our Terms of Service</p>
-				<Button
-					className="asd"
-					primary
-				>
-					{ translate( 'Create your account and connect' ) }
-				</Button>
-
-				<p>Or connect your existing profiler to get started faster</p>
-				<Button
-					className="asd"
-				>
-					{ translate( 'Connect with Google' ) }
-				</Button>
-
-				<p>Log in with an existing Jetpack or Wordpress.com account</p>
+				<div className="label-purchase-modal__header">
+					<h3 className="form-section-heading">Create a Jetpack account</h3>
+				</div>
+				<iframe
+					src={wcConnectData.jetpack_auth_url}
+					className="jp-jetpack-connect__iframe"
+					style={{
+						background: 'white',
+						height: '100%',
+						'padding-top': '30px'
+					}}
+				></iframe>
 			</>
 		);
 	}

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
@@ -38,7 +38,7 @@ const LabelPurchaseModal = props => {
 
 
 	const onClose = () => props.exitPrintingFlow( props.orderId, props.siteId, false );
-	const hasJetpackAccount = false;
+	const hasJetpackAccount = wcConnectData.jetpack_status === "connected" || wcConnectData.jetpack_status === "dev";
 
 	const labelPurchaseBody = () => {
 		return (
@@ -75,7 +75,7 @@ const LabelPurchaseModal = props => {
 				<TextField
 					id="email"
 					title="Email address"
-					value="Email address"
+					value="Email "
 				/>
 
 				<TextField

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
@@ -58,10 +58,12 @@ const LabelPurchaseBody = (props) => {
 }
 
 const JetpackConnectBody = (props) => {
+	const { translate } = props;
+
 	return (
 		<>
 			<div className="label-purchase-modal__header">
-				<h3 className="form-section-heading">Create a Jetpack account</h3>
+				<h3 className="form-section-heading label-purchase-jetpack-connect__header">{ translate( 'Create a Jetpack account' ) }</h3>
 			</div>
 			<iframe
 				src={wcConnectData.jetpack_auth_url}

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
@@ -28,6 +28,47 @@ import {
 	isCustomsFormRequired,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 
+const LabelPurchaseBody = (props) => {
+	return (
+	<div className="label-purchase-modal__body">
+		<div className="label-purchase-modal__main-section">
+			<AddressStep
+				type="origin"
+				title={ translate( 'Origin address' ) }
+				siteId={ props.siteId }
+				orderId={ props.orderId }
+			/>
+			<AddressStep
+				type="destination"
+				title={ translate( 'Destination address' ) }
+				siteId={ props.siteId }
+				orderId={ props.orderId }
+			/>
+			<PackagesStep siteId={ props.siteId } orderId={ props.orderId } />
+			{ props.isCustomsFormRequired && (
+				<CustomsStep siteId={ props.siteId } orderId={ props.orderId } />
+			) }
+			<RatesStep siteId={ props.siteId } orderId={ props.orderId } />
+		</div>
+		<Sidebar siteId={ props.siteId } orderId={ props.orderId } />
+	</div>
+	);
+}
+
+const JetpackConnectBody = (props) => {
+	return (
+		<>
+			<div className="label-purchase-modal__header">
+				<h3 className="form-section-heading">Create a Jetpack account</h3>
+			</div>
+			<iframe
+				src={wcConnectData.jetpack_auth_url}
+				className="label-purchase-modal__jetpack-connect"
+			></iframe>
+		</>
+	);
+}
+
 const LabelPurchaseModal = props => {
 	const { loaded, translate } = props;
 
@@ -39,47 +80,6 @@ const LabelPurchaseModal = props => {
 	let dialogClasses = "woocommerce label-purchase-modal label-purchase-modal__sidebar_background wcc-root";
 	if (props.hasJetpackAccount) {
 		dialogClasses = dialogClasses + " label-purchase-modal__sidebar_background";
-	}
-
-	const LabelPurchaseBody = (props) => {
-		return (
-		<div className="label-purchase-modal__body">
-			<div className="label-purchase-modal__main-section">
-				<AddressStep
-					type="origin"
-					title={ translate( 'Origin address' ) }
-					siteId={ props.siteId }
-					orderId={ props.orderId }
-				/>
-				<AddressStep
-					type="destination"
-					title={ translate( 'Destination address' ) }
-					siteId={ props.siteId }
-					orderId={ props.orderId }
-				/>
-				<PackagesStep siteId={ props.siteId } orderId={ props.orderId } />
-				{ props.isCustomsFormRequired && (
-					<CustomsStep siteId={ props.siteId } orderId={ props.orderId } />
-				) }
-				<RatesStep siteId={ props.siteId } orderId={ props.orderId } />
-			</div>
-			<Sidebar siteId={ props.siteId } orderId={ props.orderId } />
-		</div>
-		);
-	}
-
-	const JetpackConnectBody = (props) => {
-		return (
-			<>
-				<div className="label-purchase-modal__header">
-					<h3 className="form-section-heading">Create a Jetpack account</h3>
-				</div>
-				<iframe
-					src={wcConnectData.jetpack_auth_url}
-					className="label-purchase-modal__jetpack-connect"
-				></iframe>
-			</>
-		);
 	}
 
 	return (

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -248,3 +248,9 @@
 .label-purchase-modal__shipping-summary-section {
 	padding-bottom: 15px;
 }
+
+.label-purchase-modal__jetpack-connect {
+	background: var( --color-white );
+	height: 100%;
+	padding-top: 30px;
+}

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -12,13 +12,15 @@
 	background: $studio-gray-0;
   	box-shadow: rgba(151,150,150,.5) 2px 2px 7px;
 
-    // Make sidebar have white background which extends to top of modal.
-    @include breakpoint( '>660px' ) {
-        background: linear-gradient(to right, $studio-gray-0 0%,$studio-gray-0 calc(60% - 32px),var( --color-white ) calc(60% - 32px),var( --color-white ) 100%)
-    }
-    @include breakpoint( '>960px' ) {
-        background: linear-gradient(to right, $studio-gray-0 0%,$studio-gray-0 calc(70% - 48px),var( --color-white ) calc(70% - 48px),var( --color-white ) 100%)
-    }
+	// Make sidebar have white background which extends to top of modal.
+	&.label-purchase-modal__sidebar_background {
+		@include breakpoint( '>660px' ) {
+			background: linear-gradient(to right, $studio-gray-0 0%,$studio-gray-0 calc(60% - 32px),var( --color-white ) calc(60% - 32px),var( --color-white ) 100%)
+		}
+		@include breakpoint( '>960px' ) {
+			background: linear-gradient(to right, $studio-gray-0 0%,$studio-gray-0 calc(70% - 48px),var( --color-white ) calc(70% - 48px),var( --color-white ) 100%)
+		}
+	}
 
 	.dialog__content {
 		flex-grow: 1;

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -254,3 +254,7 @@
 	height: 100%;
 	padding-top: 30px;
 }
+
+.label-purchase-jetpack-connect__header {
+	text-align: center;
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "automattic/jetpack-connection": "^1.8"
+    }
+}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1405,6 +1405,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				'nonce'                 => wp_create_nonce( 'wp_rest' ),
 				'baseURL'               => get_rest_url(),
 				'wcs_server_connection' => $is_alive,
+				'jetpack_status' => $this->nux->get_jetpack_install_status()
 			);
 
 			wp_localize_script( 'wc_connect_admin', 'wcConnectData', $payload );

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -453,16 +453,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			add_action( 'admin_init', array( $this, 'admin_enqueue_scripts' ) );
 			add_action( 'admin_init', array( $this->nux, 'set_up_nux_notices' ) );
-
-			// Plugin should be enabled if dev mode or connected + TOS
-			$jetpack_status = $this->nux->get_jetpack_install_status();
-			$is_jetpack_connected = WC_Connect_Nux::JETPACK_CONNECTED === $jetpack_status;
-			$is_jetpack_dev_mode = WC_Connect_Nux::JETPACK_DEV === $jetpack_status;
-
-			if (  ! $is_jetpack_connected && ! $is_jetpack_dev_mode ) {
-				return;
-			}
-
 			add_action( 'rest_api_init', array( $this, 'tos_rest_init' ) );
 
 			if ( ! $tos_accepted ) {


### PR DESCRIPTION
Users using WCS without connecting to JetPack won't be able to print labels. This PR adds  `jetpack-connection` as a dependency and integrate the jetpack login process into the shipping label page. 
