### PR TITLE
Expose wcs redux stores 

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -125,4 +125,6 @@ Array.from( document.getElementsByClassName( 'wcc-root' ) ).forEach( ( container
 	);
 } );
 
-window.wcsAppStores = createdStores;
+window.wcsGetAppStore = function( storeKey ) {
+	return createdStores[ storeKey ];
+}

--- a/client/main.js
+++ b/client/main.js
@@ -124,3 +124,5 @@ Array.from( document.getElementsByClassName( 'wcc-root' ) ).forEach( ( container
 		container
 	);
 } );
+
+window.wcsAppStores = createdStores;


### PR DESCRIPTION
Place redux stores in a global called wcsAppStores so the store can be interacted with by external dependencies.

This will allow us to open the shipping label modal by dispatching an action as was done in this PoC: https://gist.github.com/c-shultz/f15f124c45afdc4201ba033fef9c35ee#file-wcs-autoload-php-L94