### PR TITLE
Fix build errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,10 @@
 module.exports = require( './wp-calypso/.eslintrc' );
 
-module.exports.env = { jest: true };
-module.exports.globals = {
+module.exports.env.jest = true;
+Object.assign( module.exports.globals, {
     page: true,
     browser: true,
     context: true,
     jestPuppeteer: true,
     process: true
-};
+} );


### PR DESCRIPTION
closes #1937

I believe the changes were needed so e2e would pass but they overrode some parts of ./wp-calypso/.eslintrc. 

This just appends the required keys.