### PR TITLE
Modify changelog typo [Jatpack to Jetpack]

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Services Changelog ***
 
 = 1.22.4 - 2020-03-02 =
-* Fix   - Stop using deprecated method Jatpack::is_staging_site() when Jatpack
+* Fix   - Stop using deprecated method Jetpack::is_staging_site() when Jetpack
 8.1 is installed.
 
 = 1.22.3 - 2020-01-22 =


### PR DESCRIPTION
The changelog had a typo. Jetpack was spelled as Jatpack and it was brought up by a user on the forums. :)