### PR TITLE
Change construct which does not work in PHP 5.3

### DIFF
--- a/classes/class-wc-connect-jetpack.php
+++ b/classes/class-wc-connect-jetpack.php
@@ -32,7 +32,8 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 		 */
 		public static function is_staging_site() {
 			if ( method_exists( '\\Automattic\\Jetpack\\Status', 'is_staging_site' ) ) {
-				return ( new \Automattic\Jetpack\Status )->is_staging_site();
+				$status = new \Automattic\Jetpack\Status();
+				return $status->is_staging_site();
 			}
 
 			if ( method_exists( 'Jetpack', 'is_staging_site' ) ) {


### PR DESCRIPTION
Introduced in https://github.com/Automattic/woocommerce-services/pull/1931 and just noticed on an unrelated build error. 