### PR TITLE
Remove duplicated propType

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/sidebar.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/sidebar.js
@@ -96,8 +96,7 @@ Sidebar.propTypes = {
 	emailDetails: PropTypes.bool.isRequired,
 	order: PropTypes.object.isRequired,
 	hasLabelsPaymentMethod: PropTypes.bool.isRequired,
-	setFulfillOrderOption: PropTypes.func.isRequired,
-	updatePaperSize: PropTypes.func.isRequired,
+	setFulfillOrderOption: PropTypes.func.isRequired
 };
 
 const mapStateToProps = ( state, { orderId, siteId } ) => {


### PR DESCRIPTION
Remove duplicated propType to resolve ` error  Duplicate key 'updatePaperSize'  no-dupe-keys` error when running `npm run start`

Close https://github.com/Automattic/woocommerce-services/issues/1967