### PR TITLE
Change isSubmitting state to false once printing button is shown

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -1090,6 +1090,7 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SHOW_PRINT_CONFIRMATION ] = (
 			needsPrintConfirmation: true,
 			fileData,
 			labelsToPrint: labels,
+			isSubmitting: false,
 		},
 	};
 };

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/reducer.js
@@ -29,6 +29,7 @@ import {
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_PURCHASE_RESPONSE,
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_PACKAGE_SIGNATURE,
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_UPDATE_PACKAGE_WEIGHT,
+	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SHOW_PRINT_CONFIRMATION,
 } from '../../action-types';
 
 const orderId = 1;
@@ -506,5 +507,42 @@ describe( 'Label purchase form reducer', () => {
 			isNormalized: true,
 			normalized: initialState[ orderId ].form[ group ].values,
 		} );
+	} );
+
+	it( 'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SHOW_PRINT_CONFIRMATION should allow user to close modal without printing', () => {
+		const action = {
+			type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SHOW_PRINT_CONFIRMATION,
+			orderId,
+			siteId,
+			fileData: {
+				mimeType: "application/pdf",
+				b64Content: "JVBERi0xLjMKJf////8KNyAwIG9iago8PAovUHJlZGljdG9yID",
+				success: true
+			},
+			labels: [
+				{
+					label_id: 20,
+					tracking: "9449000897846035789833",
+					refundable_amount: 3.86,
+					created: 1585252278995,
+					carrier_id: "usps",
+					service_name: "USPS - Media Mail",
+					status: "PURCHASED",
+					package_name: "Box",
+					product_names: ["Coffee mug"],
+					receipt_item_id: 24134904,
+					created_date: 1585252283000,
+					main_receipt_id: 19614621,
+					rate: 3.86,
+					currency: "USD"
+				}
+			],
+		};
+		const state = reducer( initialState, action );
+
+		expect( state[ orderId ].form.isSubmitting ).to.equal( false );
+		expect( state[ orderId ].form.needsPrintConfirmation ).to.equal( true );
+		expect( state[ orderId ].form.fileData ).to.equal( action.fileData );
+		expect( initialState[ orderId ].labels ).to.deep.equal( state[ orderId ].labels );
 	} );
 } );


### PR DESCRIPTION
Closes #1950

Allow modal to close if "Create shipping label" goes through the "print" button flow.

In our reducer, `isSubmitting` is set to true when we are purchasing or processing refund. `isSubmitting` is set to `false` once these are done. We also set `isSubmitting` to false in `WOOCOMMERCE_SERVICES_SHIPPING_LABEL_EXIT_PRINTING_FLOW`. 

But when we have this "Print" button step in between printing and exiting, the `isSubmitting` is still set to true, causing the modal to not being able to close. Fix this by setting `isSubmitting: false`.