### PR TITLE
Update order detail page if order is fulfilled

### DIFF
--- a/client/apps/shipping-label/view-wrapper-label.js
+++ b/client/apps/shipping-label/view-wrapper-label.js
@@ -27,6 +27,7 @@ import {
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	areLabelsFullyLoaded,
+	shouldUpdateOrderDetailPage,
 } from '../../extensions/woocommerce/woocommerce-services/state/shipping-label/selectors';
 import {
 	areLabelsEnabled,
@@ -162,6 +163,17 @@ export class ShippingLabelViewWrapper extends Component {
 		this.props.openTrackingFlow( orderId, siteId );
 	};
 
+	updateOrderDetailScreen = () => {
+		if ( window.jQuery ) {
+			window.jQuery.get( window.location.href, function( result ) {
+				const parsedResult = window.jQuery( result );
+				const updatedOrderDetails = parsedResult.find( '#order_data' );
+				const updatedOrderNotes = parsedResult.find( '#woocommerce-order-notes' );
+				window.jQuery( '#woocommerce-order-notes' ).html( updatedOrderNotes.html() );
+				window.jQuery( '#order_data' ).html( updatedOrderDetails.html() );
+			} );
+		}
+	}
 	render() {
 		const {
 			siteId,
@@ -172,6 +184,7 @@ export class ShippingLabelViewWrapper extends Component {
 			translate,
 			events,
 			moment,
+			updateOrderDetailPage,
 		} = this.props;
 
 		const shouldRenderButton = ! loaded || labelsEnabled;
@@ -189,6 +202,10 @@ export class ShippingLabelViewWrapper extends Component {
 			const latestLabel = maxBy( activeLabels, 'createdDate' );
 			const createdMoment = moment( latestLabel.createdDate );
 			createdDate = createdMoment.format( 'll' );
+		}
+
+		if ( updateOrderDetailPage ) {
+			this.updateOrderDetailScreen();
 		}
 
 		return (
@@ -246,6 +263,7 @@ export default connect(
 		const events = getActivityLogEvents( state, orderId );
 		const orderLoading = isOrderLoading( state, orderId, siteId );
 		const orderLoaded = isOrderLoaded( state, orderId, siteId );
+		const updateOrderDetailPage = shouldUpdateOrderDetailPage( state, orderId, siteId );
 
 		return {
 			siteId,
@@ -254,6 +272,7 @@ export default connect(
 			orderLoading,
 			orderLoaded,
 			labelsEnabled: areLabelsEnabled( state, siteId ),
+			updateOrderDetailPage,
 		};
 	},
 	( dispatch ) => ( {

--- a/client/apps/shipping-label/view-wrapper-label.js
+++ b/client/apps/shipping-label/view-wrapper-label.js
@@ -167,10 +167,9 @@ export class ShippingLabelViewWrapper extends Component {
 		if ( window.jQuery ) {
 			window.jQuery.get( window.location.href, function( result ) {
 				const parsedResult = window.jQuery( result );
-				const updatedOrderDetails = parsedResult.find( '#order_data' );
 				const updatedOrderNotes = parsedResult.find( '#woocommerce-order-notes' );
 				window.jQuery( '#woocommerce-order-notes' ).html( updatedOrderNotes.html() );
-				window.jQuery( '#order_data' ).html( updatedOrderDetails.html() );
+				window.jQuery('#order_status').val('wc-completed').trigger('change');
 			} );
 		}
 	}

--- a/client/extensions/woocommerce/woocommerce-services/lib/initialize-labels-state/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/initialize-labels-state/index.js
@@ -136,5 +136,6 @@ export default data => {
 			rateOptions: {},
 		},
 		openedPackageId: Object.keys( formData.selected_packages )[ 0 ] || '',
+		shouldUpdateOrderDetailPage: false,
 	};
 };

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -1346,8 +1346,14 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_CLOSE_DETAILS_DIALOG ] = state => 
 };
 
 // Reset the state when the order changes
-reducers[ WOOCOMMERCE_ORDER_UPDATE_SUCCESS ] = () => {
-	return initializeLabelsState();
+reducers[ WOOCOMMERCE_ORDER_UPDATE_SUCCESS ] = ( { fulfillOrder }, { order: { status } } ) => {
+	const initialState = initializeLabelsState();
+
+	if ( fulfillOrder && "completed" === status ) {
+		initialState[ 'shouldUpdateOrderDetailPage' ] = true;
+	}
+
+	return initialState;
 };
 
 export default keyedReducer( 'orderId', ( state = initializeLabelsState(), action ) => {

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -1350,7 +1350,7 @@ reducers[ WOOCOMMERCE_ORDER_UPDATE_SUCCESS ] = ( { fulfillOrder }, { order: { st
 	const initialState = initializeLabelsState();
 
 	if ( fulfillOrder && "completed" === status ) {
-		initialState[ 'shouldUpdateOrderDetailPage' ] = true;
+		initialState.shouldUpdateOrderDetailPage = true;
 	}
 
 	return initialState;

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -685,3 +685,8 @@ export const isLabelDataFetchError = ( state, orderId, siteId = getSelectedSiteI
 		areLocationsErrored( state, siteId )
 	);
 };
+
+export const shouldUpdateOrderDetailPage = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
+	const shippingLabel = getShippingLabel( state, orderId, siteId );
+	return shippingLabel && shippingLabel.shouldUpdateOrderDetailPage;
+};


### PR DESCRIPTION
Closes #1948.

When the order should be marked as completed when a shipping label is bought, this PR updates the order detail section and the order notes, to reflect the changes performed by the label purchase action.