### PR TITLE
Add e2e test for toggling shipping label

### DIFF
--- a/tests/e2e-tests/fixtures/account_settings.js
+++ b/tests/e2e-tests/fixtures/account_settings.js
@@ -1,0 +1,64 @@
+const AccountWithNoCreditCard = {
+	"success": true,
+	"storeOptions": {
+		"currency_symbol": "$",
+		"dimension_unit": "cm",
+		"weight_unit": "kg",
+		"origin_country": "US"
+	},
+	"formData": {
+		"selected_payment_method_id": 0,
+		"enabled": true,
+		"email_receipts": true,
+		"paper_size": "legal"
+	},
+	"formMeta": {
+		"can_manage_payments": true,
+		"can_edit_settings": true,
+		"master_user_name": "johndoe",
+		"master_user_login": "johndoe",
+		"master_user_wpcom_login": "johndoe",
+		"master_user_email": "john.doe@automattic.com",
+		"payment_methods": [],
+		"warnings": {
+			"payment_methods": false
+		}
+	},
+	"userMeta": {
+		"last_box_id": "Box"
+	}
+}
+
+const VisaCard5959 = {
+	"payment_method_id": 9273191,
+	"name": "John Doe",
+	"card_type": "visa",
+	"card_digits": "5959",
+	"expiry": "2025-12-31"
+}
+
+const Mastercard2862 = {
+	"payment_method_id": 6717123,
+	"name": "John Doe",
+	"card_type": "mastercard",
+	"card_digits": "2862",
+	"expiry": "2025-12-31"
+}
+
+const AccountWithOneCreditCard = {
+	...AccountWithNoCreditCard
+};
+AccountWithOneCreditCard.formData.selected_payment_method_id = 9273191;
+AccountWithOneCreditCard.formMeta.payment_methods.push(VisaCard5959);
+
+const AccountWithTwoCreditCard = {
+	...AccountWithOneCreditCard
+};
+AccountWithOneCreditCard.formData.selected_payment_method_id = 6717123; // set default card
+AccountWithTwoCreditCard.formMeta.payment_methods.push(Mastercard2862);
+
+module.exports = {
+	AccountWithNoCreditCard,
+	AccountWithOneCreditCard,
+	AccountWithTwoCreditCard
+};

--- a/tests/e2e-tests/fixtures/account_settings.js
+++ b/tests/e2e-tests/fixtures/account_settings.js
@@ -45,20 +45,20 @@ const Mastercard2862 = {
 	"expiry": "2025-12-31"
 }
 
-const AccountWithOneCreditCard = {
-	...AccountWithNoCreditCard
-};
+const AccountWithOneCreditCard = JSON.parse(JSON.stringify(AccountWithNoCreditCard));  //parse-stringify for deep cloning
 AccountWithOneCreditCard.formData.selected_payment_method_id = 9273191;
 AccountWithOneCreditCard.formMeta.payment_methods.push(VisaCard5959);
 
-const AccountWithTwoCreditCard = {
-	...AccountWithOneCreditCard
-};
-AccountWithOneCreditCard.formData.selected_payment_method_id = 6717123; // set default card
+const AccountWithTwoCreditCard = JSON.parse(JSON.stringify(AccountWithOneCreditCard));
+AccountWithTwoCreditCard.formData.selected_payment_method_id = 6717123; // set default card
 AccountWithTwoCreditCard.formMeta.payment_methods.push(Mastercard2862);
+
+const AccountWithTwoCreditCardAndNoDefault = JSON.parse(JSON.stringify(AccountWithNoCreditCard));
+AccountWithTwoCreditCardAndNoDefault.formMeta.payment_methods.push(VisaCard5959, Mastercard2862);
 
 module.exports = {
 	AccountWithNoCreditCard,
 	AccountWithOneCreditCard,
-	AccountWithTwoCreditCard
+	AccountWithTwoCreditCard,
+	AccountWithTwoCreditCardAndNoDefault
 };

--- a/tests/e2e-tests/fixtures/account_settings.js
+++ b/tests/e2e-tests/fixtures/account_settings.js
@@ -34,12 +34,12 @@ const VisaCard5959 = {
 	"name": "John Doe",
 	"card_type": "visa",
 	"card_digits": "5959",
-	"expiry": "2025-12-31"
+	"expiry": "2030-06-10"
 }
 
 const Mastercard2862 = {
 	"payment_method_id": 6717123,
-	"name": "John Doe",
+	"name": "Jane Smith",
 	"card_type": "mastercard",
 	"card_digits": "2862",
 	"expiry": "2025-12-31"

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -5,27 +5,52 @@ import { clickReactButton } from '../../utils/index';
 import { StoreOwnerFlow } from "../../utils/flows";
 import { AccountWithNoCreditCard, AccountWithOneCreditCard, AccountWithTwoCreditCard } from "../../fixtures/account_settings";
 
-// describe( 'Saving shipping label settings', () => {
-// 	it( 'Can toggle shipping labels' , async () => {
-// 		let slug = 'woocommerce-services';
-// 		await StoreOwnerFlow.login();
-// 		await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
-//         await page.waitForSelector('.form-toggle__switch');
-//         await expect(page).toClick('.form-toggle__switch');
-//         await page.waitForSelector('.label-settings__cards-label form-label', {
-//             hidden: true
-//         });
-//         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
-//         // Clicking save should persist the hidden state of the section.
-//         await page.waitForSelector('.label-settings__cards-label form-label', {
-//             hidden: true
-//         });
+// Click save and wait until it's saved.
+const saveAndWait = async () => {
+    await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
+    await page.waitForSelector('[class="button is-primary"]');
+};
 
-//         // Enable
-//         await expect(page).toClick('.form-toggle__switch');
-//         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
-//     });
-// } );
+describe( 'Saving shipping label settings', () => {
+	it( 'Can toggle shipping labels' , async () => {
+		await StoreOwnerFlow.login();
+		await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        await page.waitForSelector('.form-toggle__switch');
+        await expect(page).toClick('.form-toggle__switch');
+        await page.waitForSelector('.card.label-settings__labels-container', {
+            visible: false
+        });
+        await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
+        // Clicking save should persist the visible state of the section.
+        await page.waitForSelector('.card.label-settings__labels-container', {
+            visible: false
+        });
+
+        // Enable
+        await expect(page).toClick('.form-toggle__switch');
+        await saveAndWait();
+    });
+
+    it ('Should be able to select a different paper size', async () => {
+        await page.select('select.form-select', 'label');
+        await saveAndWait();
+        // TODO: Refresh page to see if it is selected.
+        // await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+
+        let paperSize = await page.$('select.form-select');
+        let selectedOption = await (await paperSize.getProperty('value')).jsonValue();
+        expect(selectedOption).toBe('label');
+
+        await page.select('select.form-select', 'legal');
+        await saveAndWait();
+        // TODO: Refresh page to see if it is selected.
+        // await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+
+        paperSize = await page.$('select.form-select');
+        selectedOption = await (await paperSize.getProperty('value')).jsonValue();
+        expect(selectedOption).toBe('legal');
+    });
+} );
 
 describe( 'Shipping label payment method', () => {
     afterEach(() => {

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -24,205 +24,205 @@ const waitForSelectorAndText = async (selector, text) => {
     );
 };
 
-// describe( 'Saving shipping label settings', () => {
-//     console.log( "Running 'Saving shipping label settings'" );
+describe( 'Saving shipping label settings', () => {
+    console.log( "Running 'Saving shipping label settings'" );
 
-// 	it( 'Can toggle shipping labels' , async () => {
-// 		await StoreOwnerFlow.login();
-// 		await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
-//         await page.waitForSelector('.form-toggle__switch');
-//         await expect(page).toClick('.form-toggle__switch');
-//         await page.waitForSelector('.card.label-settings__labels-container', {
-//             visible: false
-//         });
-//         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
-//         // Clicking save should persist the visible state of the section.
-//         await page.waitForSelector('.card.label-settings__labels-container', {
-//             visible: false
-//         });
+	it( 'Can toggle shipping labels' , async () => {
+		await StoreOwnerFlow.login();
+		await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        await page.waitForSelector('.form-toggle__switch');
+        await expect(page).toClick('.form-toggle__switch');
+        await page.waitForSelector('.card.label-settings__labels-container', {
+            visible: false
+        });
+        await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
+        // Clicking save should persist the visible state of the section.
+        await page.waitForSelector('.card.label-settings__labels-container', {
+            visible: false
+        });
 
-//         // Toggle it back to enable so the following tests can run.
-//         await expect(page).toClick('.form-toggle__switch');
-//         await saveAndWait();
-//     });
+        // Toggle it back to enable so the following tests can run.
+        await expect(page).toClick('.form-toggle__switch');
+        await saveAndWait();
+    });
 
-//     it ('Should be able to select a different paper size', async () => {
-//         // Save it as legal
-//         await page.select('select.form-select', 'legal');
-//         await saveAndWait();
-//         await expect(page).toMatchElement('.notice.is-success .notice__text', { text: 'Your shipping settings have been saved.' });
+    it ('Should be able to select a different paper size', async () => {
+        // Save it as legal
+        await page.select('select.form-select', 'legal');
+        await saveAndWait();
+        await expect(page).toMatchElement('.notice.is-success .notice__text', { text: 'Your shipping settings have been saved.' });
 
-//         let paperSize = await page.$('select.form-select');
-//         let selectedOption = await (await paperSize.getProperty('value')).jsonValue();
-//         expect(selectedOption).toBe('legal');
+        let paperSize = await page.$('select.form-select');
+        let selectedOption = await (await paperSize.getProperty('value')).jsonValue();
+        expect(selectedOption).toBe('legal');
 
-//         // Save it back to label
-//         await page.select('select.form-select', 'label');
-//         await saveAndWait();
-//         await expect(page).toMatchElement('.notice.is-success .notice__text', { text: 'Your shipping settings have been saved.' });
+        // Save it back to label
+        await page.select('select.form-select', 'label');
+        await saveAndWait();
+        await expect(page).toMatchElement('.notice.is-success .notice__text', { text: 'Your shipping settings have been saved.' });
 
-//         paperSize = await page.$('select.form-select');
-//         selectedOption = await (await paperSize.getProperty('value')).jsonValue();
-//         expect(selectedOption).toBe('label');
-//     });
-// } );
+        paperSize = await page.$('select.form-select');
+        selectedOption = await (await paperSize.getProperty('value')).jsonValue();
+        expect(selectedOption).toBe('label');
+    });
+} );
 
-// describe( 'Shipping label payment method', () => {
-//     console.log( "Running 'Shipping label payment method'" );
+describe( 'Shipping label payment method', () => {
+    console.log( "Running 'Shipping label payment method'" );
 
-//     let response;
+    let response;
 
-//     const accountSettingsRequestListener = (request) => {
-//         if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
-//             request.respond({
-//                 status: 200,
-//                 contentType: 'application/json; charset=UTF-8',
-//                 body: JSON.stringify(response)
-//             });
-//         } else {
-//             request.continue();
-//         }
-//     };
+    const accountSettingsRequestListener = (request) => {
+        if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
+            request.respond({
+                status: 200,
+                contentType: 'application/json; charset=UTF-8',
+                body: JSON.stringify(response)
+            });
+        } else {
+            request.continue();
+        }
+    };
 
-//     const mockAccountSettingAPI = async (mockResponse) => {
-//         response = mockResponse;
-//         page.on('request', accountSettingsRequestListener);
-//     };
+    const mockAccountSettingAPI = async (mockResponse) => {
+        response = mockResponse;
+        page.on('request', accountSettingsRequestListener);
+    };
 
-//     afterEach(() => {
-//         response = '';
-//         page.removeListener('request', accountSettingsRequestListener);
-//     });
+    afterEach(() => {
+        response = '';
+        page.removeListener('request', accountSettingsRequestListener);
+    });
 
-//     /**
-//      * Not really a test case. But needed to run this once, prior to all test case in this describe.
-//      */
-//     it('should turn on request interception after all credit card test ran', async () => {
-//         await page.setRequestInterception(true);
-//     });
+    /**
+     * Not really a test case. But needed to run this once, prior to all test case in this describe.
+     */
+    it('should turn on request interception after all credit card test ran', async () => {
+        await page.setRequestInterception(true);
+    });
 
-//     it('should show "Add a credit card" button if Wordpress has no credit card', async () => {
-//         // Intercept API before making any HTTP request
-//         await mockAccountSettingAPI(AccountWithNoCreditCard);
+    it('should show "Add a credit card" button if Wordpress has no credit card', async () => {
+        // Intercept API before making any HTTP request
+        await mockAccountSettingAPI(AccountWithNoCreditCard);
 
-//         // Go to settings page after setting up interception.
-//         await StoreOwnerFlow.login();
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        // Go to settings page after setting up interception.
+        await StoreOwnerFlow.login();
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         // Test
-//         await waitForSelectorAndText('.button.is-compact', 'Add a credit card');
-//     });
+        // Test
+        await waitForSelectorAndText('.button.is-compact', 'Add a credit card');
+    });
 
-//     it('should show "Choose a different card" button if Wordpress.com has a credit card', async () => {
-//         // Intercept API before making any HTTP request
-//         await mockAccountSettingAPI(AccountWithOneCreditCard);
+    it('should show "Choose a different card" button if Wordpress.com has a credit card', async () => {
+        // Intercept API before making any HTTP request
+        await mockAccountSettingAPI(AccountWithOneCreditCard);
 
-//         // No need to login again, refresh page
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        // No need to login again, refresh page
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         // Test
-//         await waitForSelectorAndText('.button.is-borderless', 'Choose a different card');
-//         await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
-//         await expect(page).toMatchElement('.label-settings__card-number', {
-//             text: 'VISA ****5959'
-//         });
-//         await expect(page).toMatchElement('.label-settings__card-name', {
-//             text: 'John Doe'
-//         });
-//     });
+        // Test
+        await waitForSelectorAndText('.button.is-borderless', 'Choose a different card');
+        await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
+        await expect(page).toMatchElement('.label-settings__card-number', {
+            text: 'VISA ****5959'
+        });
+        await expect(page).toMatchElement('.label-settings__card-name', {
+            text: 'John Doe'
+        });
+    });
 
-//     it('should show 2 credit cards with the right information if Wordpress.com has 2 credit cards', async () => {
-//         // Intercept API before making any HTTP request
-//         await mockAccountSettingAPI(AccountWithTwoCreditCard);
+    it('should show 2 credit cards with the right information if Wordpress.com has 2 credit cards', async () => {
+        // Intercept API before making any HTTP request
+        await mockAccountSettingAPI(AccountWithTwoCreditCard);
 
-//         // No need to login again, refresh page
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        // No need to login again, refresh page
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         // Test
-//         await waitForSelectorAndText('.button.is-borderless', 'Choose a different card' );
-//         await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
+        // Test
+        await waitForSelectorAndText('.button.is-borderless', 'Choose a different card' );
+        await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
 
-//         // Verify "Add another credit card" is present after clicking 'Choose a different card'
-//         await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
+        // Verify "Add another credit card" is present after clicking 'Choose a different card'
+        await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
 
-//         // The index is based on the order in the settings' API. Inside the payment_methods prop.
-//         // This API end point is mocked, check fixtures/account_settings.js for ordering.
-//         const VISA_CARD_INDEX = 0;
-//         const MASTERCARD_INDEX = 1;
+        // The index is based on the order in the settings' API. Inside the payment_methods prop.
+        // This API end point is mocked, check fixtures/account_settings.js for ordering.
+        const VISA_CARD_INDEX = 0;
+        const MASTERCARD_INDEX = 1;
 
-//         const cardNumbers = await page.$$('.label-settings__card-number');
-//         const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardNumber).toEqual('VISA ****5959');
-//         const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardNumber).toEqual('MasterCard ****2862');
+        const cardNumbers = await page.$$('.label-settings__card-number');
+        const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardNumber).toEqual('VISA ****5959');
+        const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardNumber).toEqual('MasterCard ****2862');
 
-//         const cardNames = await page.$$('.label-settings__card-name');
-//         const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardName).toEqual('John Doe');
-//         const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardName).toEqual('Jane Smith');
+        const cardNames = await page.$$('.label-settings__card-name');
+        const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardName).toEqual('John Doe');
+        const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardName).toEqual('Jane Smith');
 
-//         const cardExpiryDates = await page.$$('.label-settings__card-date');
-//         const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
-//         const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
+        const cardExpiryDates = await page.$$('.label-settings__card-date');
+        const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
+        const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
 
-//         // Verify the default box is checked.
-//         const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
-//         const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
-//         expect(firstCardDefaultCheckbox).toBeFalsy();
-//         const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
-//         expect(secondCardDefaultCheckbox).toBeTruthy();
-//     });
+        // Verify the default box is checked.
+        const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
+        const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
+        expect(firstCardDefaultCheckbox).toBeFalsy();
+        const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
+        expect(secondCardDefaultCheckbox).toBeTruthy();
+    });
 
-//     it('should have no default card checked if there are multiple cards in Wordpress.com', async () => {
-//         await mockAccountSettingAPI(AccountWithTwoCreditCardAndNoDefault);
+    it('should have no default card checked if there are multiple cards in Wordpress.com', async () => {
+        await mockAccountSettingAPI(AccountWithTwoCreditCardAndNoDefault);
 
-//         // No need to login again, refresh page
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        // No need to login again, refresh page
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         // Verify "Add another credit card" is present after clicking 'Choose a different card'
-//         await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
+        // Verify "Add another credit card" is present after clicking 'Choose a different card'
+        await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
 
-//         // The index is based on the order in the settings' API. Inside the payment_methods prop.
-//         // This API end point is mocked, check fixtures/account_settings.js for ordering.
-//         const VISA_CARD_INDEX = 0;
-//         const MASTERCARD_INDEX = 1;
+        // The index is based on the order in the settings' API. Inside the payment_methods prop.
+        // This API end point is mocked, check fixtures/account_settings.js for ordering.
+        const VISA_CARD_INDEX = 0;
+        const MASTERCARD_INDEX = 1;
 
-//         const cardNumbers = await page.$$('.label-settings__card-number');
-//         const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardNumber).toEqual('VISA ****5959');
-//         const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardNumber).toEqual('MasterCard ****2862');
+        const cardNumbers = await page.$$('.label-settings__card-number');
+        const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardNumber).toEqual('VISA ****5959');
+        const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardNumber).toEqual('MasterCard ****2862');
 
-//         const cardNames = await page.$$('.label-settings__card-name');
-//         const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardName).toEqual('John Doe');
-//         const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardName).toEqual('Jane Smith');
+        const cardNames = await page.$$('.label-settings__card-name');
+        const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardName).toEqual('John Doe');
+        const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardName).toEqual('Jane Smith');
 
-//         const cardExpiryDates = await page.$$('.label-settings__card-date');
-//         const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
-//         const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
+        const cardExpiryDates = await page.$$('.label-settings__card-date');
+        const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
+        const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
 
-//         // Verify that no default box is checked.
-//         const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
-//         const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
-//         expect(firstCardDefaultCheckbox).toBeFalsy();
-//         const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
-//         expect(secondCardDefaultCheckbox).toBeFalsy();
-//     });
+        // Verify that no default box is checked.
+        const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
+        const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
+        expect(firstCardDefaultCheckbox).toBeFalsy();
+        const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
+        expect(secondCardDefaultCheckbox).toBeFalsy();
+    });
 
-//     /**
-//      * Not really a test case. But needed to run this once, after all test case ran in this describe.
-//      */
-//     it('should turn off request interception after all credit card test ran', async () => {
-//         await page.setRequestInterception(false);
-//     });
-// });
+    /**
+     * Not really a test case. But needed to run this once, after all test case ran in this describe.
+     */
+    it('should turn off request interception after all credit card test ran', async () => {
+        await page.setRequestInterception(false);
+    });
+});
 
 describe( 'Packaging', () => {
     let metricSystemValue = ''; // either "in" or "cm".

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -24,224 +24,224 @@ const waitForSelectorAndText = async (selector, text) => {
     );
 };
 
-describe( 'Saving shipping label settings', () => {
-    console.log( "Running 'Saving shipping label settings'" );
+// describe( 'Saving shipping label settings', () => {
+//     console.log( "Running 'Saving shipping label settings'" );
 
-	it( 'Can toggle shipping labels' , async () => {
-		await StoreOwnerFlow.login();
-		await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
-        await page.waitForSelector('.form-toggle__switch');
-        await expect(page).toClick('.form-toggle__switch');
-        await page.waitForSelector('.card.label-settings__labels-container', {
-            visible: false
-        });
-        await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
-        // Clicking save should persist the visible state of the section.
-        await page.waitForSelector('.card.label-settings__labels-container', {
-            visible: false
-        });
+// 	it( 'Can toggle shipping labels' , async () => {
+// 		await StoreOwnerFlow.login();
+// 		await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         await page.waitForSelector('.form-toggle__switch');
+//         await expect(page).toClick('.form-toggle__switch');
+//         await page.waitForSelector('.card.label-settings__labels-container', {
+//             visible: false
+//         });
+//         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
+//         // Clicking save should persist the visible state of the section.
+//         await page.waitForSelector('.card.label-settings__labels-container', {
+//             visible: false
+//         });
 
-        // Toggle it back to enable so the following tests can run.
-        await expect(page).toClick('.form-toggle__switch');
-        await saveAndWait();
-    });
+//         // Toggle it back to enable so the following tests can run.
+//         await expect(page).toClick('.form-toggle__switch');
+//         await saveAndWait();
+//     });
 
-    it ('Should be able to select a different paper size', async () => {
-        // Save it as legal
-        await page.select('select.form-select', 'legal');
-        await saveAndWait();
-        await expect(page).toMatchElement('.notice.is-success .notice__text', { text: 'Your shipping settings have been saved.' });
+//     it ('Should be able to select a different paper size', async () => {
+//         // Save it as legal
+//         await page.select('select.form-select', 'legal');
+//         await saveAndWait();
+//         await expect(page).toMatchElement('.notice.is-success .notice__text', { text: 'Your shipping settings have been saved.' });
 
-        let paperSize = await page.$('select.form-select');
-        let selectedOption = await (await paperSize.getProperty('value')).jsonValue();
-        expect(selectedOption).toBe('legal');
+//         let paperSize = await page.$('select.form-select');
+//         let selectedOption = await (await paperSize.getProperty('value')).jsonValue();
+//         expect(selectedOption).toBe('legal');
 
-        // Save it back to label
-        await page.select('select.form-select', 'label');
-        await saveAndWait();
-        await expect(page).toMatchElement('.notice.is-success .notice__text', { text: 'Your shipping settings have been saved.' });
+//         // Save it back to label
+//         await page.select('select.form-select', 'label');
+//         await saveAndWait();
+//         await expect(page).toMatchElement('.notice.is-success .notice__text', { text: 'Your shipping settings have been saved.' });
 
-        paperSize = await page.$('select.form-select');
-        selectedOption = await (await paperSize.getProperty('value')).jsonValue();
-        expect(selectedOption).toBe('label');
-    });
-} );
+//         paperSize = await page.$('select.form-select');
+//         selectedOption = await (await paperSize.getProperty('value')).jsonValue();
+//         expect(selectedOption).toBe('label');
+//     });
+// } );
 
-describe( 'Shipping label payment method', () => {
-    console.log( "Running 'Shipping label payment method'" );
+// describe( 'Shipping label payment method', () => {
+//     console.log( "Running 'Shipping label payment method'" );
 
-    let response;
+//     let response;
 
-    const accountSettingsRequestListener = (request) => {
-        if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
-            request.respond({
-                status: 200,
-                contentType: 'application/json; charset=UTF-8',
-                body: JSON.stringify(response)
-            });
-        } else {
-            request.continue();
-        }
-    };
+//     const accountSettingsRequestListener = (request) => {
+//         if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
+//             request.respond({
+//                 status: 200,
+//                 contentType: 'application/json; charset=UTF-8',
+//                 body: JSON.stringify(response)
+//             });
+//         } else {
+//             request.continue();
+//         }
+//     };
 
-    const mockAccountSettingAPI = async (mockResponse) => {
-        response = mockResponse;
-        page.on('request', accountSettingsRequestListener);
-    };
+//     const mockAccountSettingAPI = async (mockResponse) => {
+//         response = mockResponse;
+//         page.on('request', accountSettingsRequestListener);
+//     };
 
-    afterEach(() => {
-        response = '';
-        page.removeListener('request', accountSettingsRequestListener);
-    });
+//     afterEach(() => {
+//         response = '';
+//         page.removeListener('request', accountSettingsRequestListener);
+//     });
 
-    /**
-     * Not really a test case. But needed to run this once, prior to all test case in this describe.
-     */
-    it('should turn on request interception after all credit card test ran', async () => {
-        await page.setRequestInterception(true);
-    });
+//     /**
+//      * Not really a test case. But needed to run this once, prior to all test case in this describe.
+//      */
+//     it('should turn on request interception after all credit card test ran', async () => {
+//         await page.setRequestInterception(true);
+//     });
 
-    it('should show "Add a credit card" button if Wordpress has no credit card', async () => {
-        // Intercept API before making any HTTP request
-        await mockAccountSettingAPI(AccountWithNoCreditCard);
+//     it('should show "Add a credit card" button if Wordpress has no credit card', async () => {
+//         // Intercept API before making any HTTP request
+//         await mockAccountSettingAPI(AccountWithNoCreditCard);
 
-        // Go to settings page after setting up interception.
-        await StoreOwnerFlow.login();
-        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         // Go to settings page after setting up interception.
+//         await StoreOwnerFlow.login();
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        // Test
-        await waitForSelectorAndText('.button.is-compact', 'Add a credit card');
-    });
+//         // Test
+//         await waitForSelectorAndText('.button.is-compact', 'Add a credit card');
+//     });
 
-    it('should show "Choose a different card" button if Wordpress.com has a credit card', async () => {
-        // Intercept API before making any HTTP request
-        await mockAccountSettingAPI(AccountWithOneCreditCard);
+//     it('should show "Choose a different card" button if Wordpress.com has a credit card', async () => {
+//         // Intercept API before making any HTTP request
+//         await mockAccountSettingAPI(AccountWithOneCreditCard);
 
-        // No need to login again, refresh page
-        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         // No need to login again, refresh page
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        // Test
-        await waitForSelectorAndText('.button.is-borderless', 'Choose a different card');
-        await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
-        await expect(page).toMatchElement('.label-settings__card-number', {
-            text: 'VISA ****5959'
-        });
-        await expect(page).toMatchElement('.label-settings__card-name', {
-            text: 'John Doe'
-        });
-    });
+//         // Test
+//         await waitForSelectorAndText('.button.is-borderless', 'Choose a different card');
+//         await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
+//         await expect(page).toMatchElement('.label-settings__card-number', {
+//             text: 'VISA ****5959'
+//         });
+//         await expect(page).toMatchElement('.label-settings__card-name', {
+//             text: 'John Doe'
+//         });
+//     });
 
-    it('should show 2 credit cards with the right information if Wordpress.com has 2 credit cards', async () => {
-        // Intercept API before making any HTTP request
-        await mockAccountSettingAPI(AccountWithTwoCreditCard);
+//     it('should show 2 credit cards with the right information if Wordpress.com has 2 credit cards', async () => {
+//         // Intercept API before making any HTTP request
+//         await mockAccountSettingAPI(AccountWithTwoCreditCard);
 
-        // No need to login again, refresh page
-        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         // No need to login again, refresh page
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        // Test
-        await waitForSelectorAndText('.button.is-borderless', 'Choose a different card' );
-        await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
+//         // Test
+//         await waitForSelectorAndText('.button.is-borderless', 'Choose a different card' );
+//         await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
 
-        // Verify "Add another credit card" is present after clicking 'Choose a different card'
-        await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
+//         // Verify "Add another credit card" is present after clicking 'Choose a different card'
+//         await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
 
-        // The index is based on the order in the settings' API. Inside the payment_methods prop.
-        // This API end point is mocked, check fixtures/account_settings.js for ordering.
-        const VISA_CARD_INDEX = 0;
-        const MASTERCARD_INDEX = 1;
+//         // The index is based on the order in the settings' API. Inside the payment_methods prop.
+//         // This API end point is mocked, check fixtures/account_settings.js for ordering.
+//         const VISA_CARD_INDEX = 0;
+//         const MASTERCARD_INDEX = 1;
 
-        const cardNumbers = await page.$$('.label-settings__card-number');
-        const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardNumber).toEqual('VISA ****5959');
-        const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardNumber).toEqual('MasterCard ****2862');
+//         const cardNumbers = await page.$$('.label-settings__card-number');
+//         const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardNumber).toEqual('VISA ****5959');
+//         const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardNumber).toEqual('MasterCard ****2862');
 
-        const cardNames = await page.$$('.label-settings__card-name');
-        const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardName).toEqual('John Doe');
-        const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardName).toEqual('Jane Smith');
+//         const cardNames = await page.$$('.label-settings__card-name');
+//         const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardName).toEqual('John Doe');
+//         const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardName).toEqual('Jane Smith');
 
-        const cardExpiryDates = await page.$$('.label-settings__card-date');
-        const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
-        const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
+//         const cardExpiryDates = await page.$$('.label-settings__card-date');
+//         const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
+//         const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
 
-        // Verify the default box is checked.
-        const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
-        const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
-        expect(firstCardDefaultCheckbox).toBeFalsy();
-        const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
-        expect(secondCardDefaultCheckbox).toBeTruthy();
-    });
+//         // Verify the default box is checked.
+//         const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
+//         const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
+//         expect(firstCardDefaultCheckbox).toBeFalsy();
+//         const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
+//         expect(secondCardDefaultCheckbox).toBeTruthy();
+//     });
 
-    it('should have no default card checked if there are multiple cards in Wordpress.com', async () => {
-        await mockAccountSettingAPI(AccountWithTwoCreditCardAndNoDefault);
+//     it('should have no default card checked if there are multiple cards in Wordpress.com', async () => {
+//         await mockAccountSettingAPI(AccountWithTwoCreditCardAndNoDefault);
 
-        // No need to login again, refresh page
-        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         // No need to login again, refresh page
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        // Verify "Add another credit card" is present after clicking 'Choose a different card'
-        await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
+//         // Verify "Add another credit card" is present after clicking 'Choose a different card'
+//         await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
 
-        // The index is based on the order in the settings' API. Inside the payment_methods prop.
-        // This API end point is mocked, check fixtures/account_settings.js for ordering.
-        const VISA_CARD_INDEX = 0;
-        const MASTERCARD_INDEX = 1;
+//         // The index is based on the order in the settings' API. Inside the payment_methods prop.
+//         // This API end point is mocked, check fixtures/account_settings.js for ordering.
+//         const VISA_CARD_INDEX = 0;
+//         const MASTERCARD_INDEX = 1;
 
-        const cardNumbers = await page.$$('.label-settings__card-number');
-        const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardNumber).toEqual('VISA ****5959');
-        const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardNumber).toEqual('MasterCard ****2862');
+//         const cardNumbers = await page.$$('.label-settings__card-number');
+//         const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardNumber).toEqual('VISA ****5959');
+//         const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardNumber).toEqual('MasterCard ****2862');
 
-        const cardNames = await page.$$('.label-settings__card-name');
-        const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardName).toEqual('John Doe');
-        const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardName).toEqual('Jane Smith');
+//         const cardNames = await page.$$('.label-settings__card-name');
+//         const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardName).toEqual('John Doe');
+//         const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardName).toEqual('Jane Smith');
 
-        const cardExpiryDates = await page.$$('.label-settings__card-date');
-        const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
-        const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
+//         const cardExpiryDates = await page.$$('.label-settings__card-date');
+//         const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
+//         const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
 
-        // Verify that no default box is checked.
-        const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
-        const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
-        expect(firstCardDefaultCheckbox).toBeFalsy();
-        const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
-        expect(secondCardDefaultCheckbox).toBeFalsy();
-    });
+//         // Verify that no default box is checked.
+//         const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
+//         const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
+//         expect(firstCardDefaultCheckbox).toBeFalsy();
+//         const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
+//         expect(secondCardDefaultCheckbox).toBeFalsy();
+//     });
 
-    /**
-     * Not really a test case. But needed to run this once, after all test case ran in this describe.
-     */
-    it('should turn off request interception after all credit card test ran', async () => {
-        await page.setRequestInterception(false);
-    });
-});
+//     /**
+//      * Not really a test case. But needed to run this once, after all test case ran in this describe.
+//      */
+//     it('should turn off request interception after all credit card test ran', async () => {
+//         await page.setRequestInterception(false);
+//     });
+// });
 
 describe( 'Packaging', () => {
     console.log("Running 'packaging'");
 
-    it( 'Can add package' , async () => {
-        console.log("Started 'Can add package'");
+    it( '> Can add package' , async () => {
+        console.log(">> Started 'Can add package'");
         const packageName = 'Package Box 5x5x5';
 
-        console.log("Login");
+        console.log(">> Login");
 		await StoreOwnerFlow.login();
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
         // Wait for "Add package" to finish loading, click to pop up modal
-        console.log('Wait for "Add package" to finish loading, click to pop up modal');
+        console.log('>> Wait for "Add package" to finish loading, click to pop up modal');
         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
         await expect( page ).toClick( '.button', { text: 'Add package' } );
 
         // Create a new package
-        console.log('Create a new package');
+        console.log('>> Create a new package');
         await waitForSelectorAndText( '.packages__add-edit-title.form-section-heading', 'Add a package' );
         await expect( page ).toFill( '.packages__properties-group #name', packageName );
         await expect( page ).toFill( '.form-text-input.form-dimensions-input__length', '5' );
@@ -251,25 +251,29 @@ describe( 'Packaging', () => {
         await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Add package' } )
 
         // Verify package shows up in list
-        console.log('Verify package shows up in list');
+        console.log('>> Verify package shows up in list');
+        const detailsName = await page.$$('.packages__packages-row .packages__packages-row-details-name');
+        const detailValue = await (await detailsName[0].getProperty('innerText')).jsonValue();
+        console.log('>> details name: ', detailValue);
+
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 cm" });
 
         // Save package
-        console.log('Save package');
+        console.log('>> Save package');
         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
         await saveAndWait();
 
         // Refresh page and make sure it is saved.
-        console.log('Refresh page and make sure it is saved.');
+        console.log('>> Refresh page and make sure it is saved.');
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 cm" });
-        console.log("Finished 'Can add package'");
+        console.log(">> Finished 'Can add package'");
     });
 
-    it( 'Can edit package' , async () => {
+    it( '> Can edit package' , async () => {
         console.log("Started 'Can edit package'");
         const packageName = 'Package Box 10x10x10';
 
@@ -289,10 +293,12 @@ describe( 'Packaging', () => {
         await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Done' } )
 
         // Verify package shows up in list
+        console.log('>> Verify package shows up in list');
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 cm" });
 
         // Save package
+        console.log('>> Save package');
         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
         await saveAndWait();
 
@@ -304,7 +310,7 @@ describe( 'Packaging', () => {
         console.log("Started 'Finish edit package'");
     });
 
-    it( 'Can delete package' , async () => {
+    it( '> Can delete package' , async () => {
         console.log("Started 'Can delete package'");
         const packageName = 'Package Box 10x10x10';
 
@@ -319,10 +325,12 @@ describe( 'Packaging', () => {
         await expect( page ).toClick( '.button.packages__delete.is-scary.is-borderless', { text: 'Delete this package' } )
 
         // Verify package is no longer in the list.
+        console.log('>> Verify package shows up in list');
         await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
         await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 cm" });
 
         // Save package
+        console.log('>> Save package');
         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
         await saveAndWait();
 

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -225,6 +225,8 @@ const waitForSelectorAndText = async (selector, text) => {
 // });
 
 describe( 'Packaging', () => {
+    let metricSystemValue = ''; // either "in" or "cm".
+
     console.log("Running 'packaging'");
 
     it( '> Can add package' , async () => {
@@ -250,6 +252,10 @@ describe( 'Packaging', () => {
         await expect( page ).toFill( '.form-text-input-with-affixes #box_weight', '0.5' );
         await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Add package' } )
 
+        // Set this once globally, all following test will use this metric
+        const metricSystem = await page.$$('.form-text-input-with-affixes .form-text-input-with-affixes__suffix');
+        metricSystemValue = await (await metricSystem[0].getProperty('innerText')).jsonValue();
+
         // Verify package shows up in list
         console.log('>> Verify package shows up in list');
         const detailsName = await page.$$('.packages__packages-row .packages__packages-row-details-name');
@@ -262,7 +268,7 @@ describe( 'Packaging', () => {
         const detailsDimension = await page.$$('.packages__packages-row .packages__packages-row-dimensions');
         const detailsDimensionValue = await (await detailsDimension[1].getProperty('innerText')).jsonValue();
         console.log('>> details dimension value: "' + detailsDimensionValue + '"');
-        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 cm" });
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 " + metricSystemValue });
 
         // Save package
         console.log('>> Save package');
@@ -274,7 +280,7 @@ describe( 'Packaging', () => {
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 cm" });
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 " + metricSystemValue });
         console.log(">> Finished 'Can add package'");
     });
 
@@ -300,7 +306,7 @@ describe( 'Packaging', () => {
         // Verify package shows up in list
         console.log('>> Verify package shows up in list');
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 cm" });
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
 
         // Save package
         console.log('>> Save package');
@@ -311,7 +317,7 @@ describe( 'Packaging', () => {
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 cm" });
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
         console.log("Started 'Finish edit package'");
     });
 
@@ -332,7 +338,7 @@ describe( 'Packaging', () => {
         // Verify package is no longer in the list.
         console.log('>> Verify package shows up in list');
         await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-        await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 cm" });
+        await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
 
         // Save package
         console.log('>> Save package');
@@ -342,7 +348,7 @@ describe( 'Packaging', () => {
         // Refresh page and make sure it is deleted.
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
         await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-        await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 cm" });
+        await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
         console.log("Started 'Finish delete package'");
     });
 });

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -228,7 +228,7 @@ describe( 'Shipping label payment method', () => {
 describe( 'Packaging', () => {
     let metricSystemValue = ''; // either "in" or "cm".
 
-    it( '> Can add package' , async () => {
+    it( 'Can add package' , async () => {
         const packageName = 'Package Box 5x5x5';
 
 		await StoreOwnerFlow.login();
@@ -266,7 +266,7 @@ describe( 'Packaging', () => {
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 " + metricSystemValue });
     });
 
-    it( '> Can edit package' , async () => {
+    it( 'Can edit package' , async () => {
         const packageName = 'Package Box 10x10x10';
 
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
@@ -299,7 +299,7 @@ describe( 'Packaging', () => {
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
     });
 
-    it( '> Can delete package' , async () => {
+    it( 'Can delete package' , async () => {
         const packageName = 'Package Box 10x10x10';
 
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { clickReactButton } from '../../utils/index';
 import { StoreOwnerFlow } from "../../utils/flows";
 import { AccountWithNoCreditCard, AccountWithOneCreditCard, AccountWithTwoCreditCard, AccountWithTwoCreditCardAndNoDefault } from "../../fixtures/account_settings";
 
@@ -13,10 +12,13 @@ const saveAndWait = async () => {
 
 /**
  * This function will wait for a button with any CSS selector + text value.
+ *
+ * @param {string} selector CSS selector
+ * @param {string} text The text value of the element we want to search for. ie. button's value, div's innertext.
  */
 const waitForSelectorAndText = async (selector, text) => {
     return await page.waitForFunction(
-        (selector, text) => Array.from(document.querySelectorAll(selector)).find(el => el.textContent === text),
+        (cssSelector, innerTextContent) => Array.from(document.querySelectorAll(cssSelector)).find(el => el.textContent === innerTextContent),
         {},
         selector, text
     );

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -230,10 +230,8 @@ describe( 'Packaging', () => {
     console.log("Running 'packaging'");
 
     it( '> Can add package' , async () => {
-        console.log(">> Started 'Can add package'");
         const packageName = 'Package Box 5x5x5';
 
-        console.log(">> Login");
 		await StoreOwnerFlow.login();
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
@@ -258,16 +256,7 @@ describe( 'Packaging', () => {
 
         // Verify package shows up in list
         console.log('>> Verify package shows up in list');
-        const detailsName = await page.$$('.packages__packages-row .packages__packages-row-details-name');
-        const detailValue = await (await detailsName[0].getProperty('innerText')).jsonValue();
-        console.log('>> details name: ', detailValue);
-
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-        console.log('>> details name matched.');
-
-        const detailsDimension = await page.$$('.packages__packages-row .packages__packages-row-dimensions');
-        const detailsDimensionValue = await (await detailsDimension[1].getProperty('innerText')).jsonValue();
-        console.log('>> details dimension value: "' + detailsDimensionValue + '"');
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 " + metricSystemValue });
 
         // Save package

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -18,7 +18,7 @@ const saveAndWait = async () => {
  */
 const waitForSelectorAndText = async (selector, text) => {
     return await page.waitForFunction(
-        (cssSelector, innerTextContent) => Array.from(document.querySelectorAll(cssSelector)).find(el => el.textContent.trim() === innerTextContent.trim()),
+        (cssSelector, innerTextContent) => !!Array.from(document.querySelectorAll(cssSelector)).find(el => el.textContent.trim() === innerTextContent.trim()),
         {},
         selector, text
     );
@@ -65,141 +65,147 @@ describe( 'Saving shipping label settings', () => {
     });
 } );
 
-// describe( 'Shipping label payment method', () => {
-//     afterEach(() => {
-//         page.removeAllListeners('request');
-//     });
+describe( 'Shipping label payment method', () => {
+    let response;
 
-//     const mockAccountSettingAPI = async (response) => {
-//         await page.setRequestInterception(true);
-//         page.on('request', request => {
-//             if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
-//                 request.respond({
-//                     status: 200,
-//                     contentType: 'application/json; charset=UTF-8',
-//                     body: JSON.stringify(response)
-//                 });
-//             } else {
-//                 request.continue();
-//             }
-//         });
-//     };
+    const accountSettingsRequestListener = (request) => {
+        if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
+            request.respond({
+                status: 200,
+                contentType: 'application/json; charset=UTF-8',
+                body: JSON.stringify(response)
+            });
+        } else {
+            request.continue();
+        }
+    };
 
-//     it('should show "Add a credit card" button if Wordpress has no credit card', async () => {
-//         // Intercept API before making any HTTP request
-//         await mockAccountSettingAPI(AccountWithNoCreditCard);
+    const mockAccountSettingAPI = async (mockResponse) => {
+        response = mockResponse;
+        await page.setRequestInterception(true);
+        page.on('request', accountSettingsRequestListener);
+    };
 
-//         // Go to settings page after setting up interception.
-//         await StoreOwnerFlow.login();
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+    afterEach(() => {
+        response = '';
+        page.removeListener('request', accountSettingsRequestListener);
+    });
 
-//         // Test
-//         await waitForSelectorAndText('.button.is-compact', 'Add a credit card');
-//     });
+    it('should show "Add a credit card" button if Wordpress has no credit card', async () => {
+        // Intercept API before making any HTTP request
+        await mockAccountSettingAPI(AccountWithNoCreditCard);
 
-//     it('should show "Choose a different card" button if Wordpress.com has a credit card', async () => {
-//         // Intercept API before making any HTTP request
-//         await mockAccountSettingAPI(AccountWithOneCreditCard);
+        // Go to settings page after setting up interception.
+        await StoreOwnerFlow.login();
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         // No need to login again, refresh page
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        // Test
+        await waitForSelectorAndText('.button.is-compact', 'Add a credit card');
+    });
 
-//         // Test
-//         await waitForSelectorAndText('.button.is-borderless', 'Choose a different card');
-//         await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
-//         await expect(page).toMatchElement('.label-settings__card-number', {
-//             text: 'VISA ****5959'
-//         });
-//         await expect(page).toMatchElement('.label-settings__card-name', {
-//             text: 'John Doe'
-//         });
-//     });
+    it('should show "Choose a different card" button if Wordpress.com has a credit card', async () => {
+        // Intercept API before making any HTTP request
+        await mockAccountSettingAPI(AccountWithOneCreditCard);
 
-//     it('should show 2 credit cards with the right information if Wordpress.com has 2 credit cards', async () => {
-//         // Intercept API before making any HTTP request
-//         await mockAccountSettingAPI(AccountWithTwoCreditCard);
+        // No need to login again, refresh page
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         // No need to login again, refresh page
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        // Test
+        await waitForSelectorAndText('.button.is-borderless', 'Choose a different card');
+        await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
+        await expect(page).toMatchElement('.label-settings__card-number', {
+            text: 'VISA ****5959'
+        });
+        await expect(page).toMatchElement('.label-settings__card-name', {
+            text: 'John Doe'
+        });
+    });
 
-//         // Test
-//         await waitForSelectorAndText('.button.is-borderless', 'Choose a different card' );
-//         await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
+    it('should show 2 credit cards with the right information if Wordpress.com has 2 credit cards', async () => {
+        // Intercept API before making any HTTP request
+        await mockAccountSettingAPI(AccountWithTwoCreditCard);
 
-//         // Verify "Add another credit card" is present after clicking 'Choose a different card'
-//         await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
+        // No need to login again, refresh page
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         // The index is based on the order in the settings' API. Inside the payment_methods prop.
-//         // This API end point is mocked, check fixtures/account_settings.js for ordering.
-//         const VISA_CARD_INDEX = 0;
-//         const MASTERCARD_INDEX = 1;
+        // Test
+        await waitForSelectorAndText('.button.is-borderless', 'Choose a different card' );
+        await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
 
-//         const cardNumbers = await page.$$('.label-settings__card-number');
-//         const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardNumber).toEqual('VISA ****5959');
-//         const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardNumber).toEqual('MasterCard ****2862');
+        // Verify "Add another credit card" is present after clicking 'Choose a different card'
+        await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
 
-//         const cardNames = await page.$$('.label-settings__card-name');
-//         const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardName).toEqual('John Doe');
-//         const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardName).toEqual('Jane Smith');
+        // The index is based on the order in the settings' API. Inside the payment_methods prop.
+        // This API end point is mocked, check fixtures/account_settings.js for ordering.
+        const VISA_CARD_INDEX = 0;
+        const MASTERCARD_INDEX = 1;
 
-//         const cardExpiryDates = await page.$$('.label-settings__card-date');
-//         const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
-//         const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
+        const cardNumbers = await page.$$('.label-settings__card-number');
+        const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardNumber).toEqual('VISA ****5959');
+        const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardNumber).toEqual('MasterCard ****2862');
 
-//         // Verify the default box is checked.
-//         const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
-//         const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
-//         expect(firstCardDefaultCheckbox).toBeFalsy();
-//         const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
-//         expect(secondCardDefaultCheckbox).toBeTruthy();
-//     });
+        const cardNames = await page.$$('.label-settings__card-name');
+        const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardName).toEqual('John Doe');
+        const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardName).toEqual('Jane Smith');
 
-//     it('should have no default card checked if there are multiple cards in Wordpress.com', async () => {
-//         await mockAccountSettingAPI(AccountWithTwoCreditCardAndNoDefault);
+        const cardExpiryDates = await page.$$('.label-settings__card-date');
+        const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
+        const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
 
-//         // No need to login again, refresh page
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        // Verify the default box is checked.
+        const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
+        const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
+        expect(firstCardDefaultCheckbox).toBeFalsy();
+        const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
+        expect(secondCardDefaultCheckbox).toBeTruthy();
+    });
 
-//         // Verify "Add another credit card" is present after clicking 'Choose a different card'
-//         await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
+    it('should have no default card checked if there are multiple cards in Wordpress.com', async () => {
+        await mockAccountSettingAPI(AccountWithTwoCreditCardAndNoDefault);
 
-//         // The index is based on the order in the settings' API. Inside the payment_methods prop.
-//         // This API end point is mocked, check fixtures/account_settings.js for ordering.
-//         const VISA_CARD_INDEX = 0;
-//         const MASTERCARD_INDEX = 1;
+        // No need to login again, refresh page
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         const cardNumbers = await page.$$('.label-settings__card-number');
-//         const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardNumber).toEqual('VISA ****5959');
-//         const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardNumber).toEqual('MasterCard ****2862');
+        // Verify "Add another credit card" is present after clicking 'Choose a different card'
+        await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
 
-//         const cardNames = await page.$$('.label-settings__card-name');
-//         const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardName).toEqual('John Doe');
-//         const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardName).toEqual('Jane Smith');
+        // The index is based on the order in the settings' API. Inside the payment_methods prop.
+        // This API end point is mocked, check fixtures/account_settings.js for ordering.
+        const VISA_CARD_INDEX = 0;
+        const MASTERCARD_INDEX = 1;
 
-//         const cardExpiryDates = await page.$$('.label-settings__card-date');
-//         const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
-//         const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
+        const cardNumbers = await page.$$('.label-settings__card-number');
+        const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardNumber).toEqual('VISA ****5959');
+        const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardNumber).toEqual('MasterCard ****2862');
 
-//         // Verify that no default box is checked.
-//         const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
-//         const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
-//         expect(firstCardDefaultCheckbox).toBeFalsy();
-//         const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
-//         expect(secondCardDefaultCheckbox).toBeFalsy();
-//     });
-// });
+        const cardNames = await page.$$('.label-settings__card-name');
+        const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardName).toEqual('John Doe');
+        const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardName).toEqual('Jane Smith');
+
+        const cardExpiryDates = await page.$$('.label-settings__card-date');
+        const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
+        const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
+
+        // Verify that no default box is checked.
+        const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
+        const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
+        expect(firstCardDefaultCheckbox).toBeFalsy();
+        const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
+        expect(secondCardDefaultCheckbox).toBeFalsy();
+    });
+});
 
 describe( 'Packaging', () => {
     it( 'Can add package' , async () => {

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -65,6 +65,10 @@ describe( 'Saving shipping label settings', () => {
         selectedOption = await (await paperSize.getProperty('value')).jsonValue();
         expect(selectedOption).toBe('label');
     });
+
+    it ('Should show the correct email receipts message', async () => {
+        await expect(page).toMatchElement('.label-settings__credit-card-description', { text: /Email the label purchase receipts to \w+ \(\w+\) at .+\@.+/ });
+    });
 } );
 
 describe( 'Shipping label payment method', () => {

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -22,183 +22,183 @@ const waitForButton = async (selector, buttonText) => {
     );
 };
 
-// describe( 'Saving shipping label settings', () => {
-// 	it( 'Can toggle shipping labels' , async () => {
-// 		await StoreOwnerFlow.login();
-// 		await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
-//         await page.waitForSelector('.form-toggle__switch');
-//         await expect(page).toClick('.form-toggle__switch');
-//         await page.waitForSelector('.card.label-settings__labels-container', {
-//             visible: false
-//         });
-//         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
-//         // Clicking save should persist the visible state of the section.
-//         await page.waitForSelector('.card.label-settings__labels-container', {
-//             visible: false
-//         });
+describe( 'Saving shipping label settings', () => {
+	it( 'Can toggle shipping labels' , async () => {
+		await StoreOwnerFlow.login();
+		await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        await page.waitForSelector('.form-toggle__switch');
+        await expect(page).toClick('.form-toggle__switch');
+        await page.waitForSelector('.card.label-settings__labels-container', {
+            visible: false
+        });
+        await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
+        // Clicking save should persist the visible state of the section.
+        await page.waitForSelector('.card.label-settings__labels-container', {
+            visible: false
+        });
 
-//         // Enable
-//         await expect(page).toClick('.form-toggle__switch');
-//         await saveAndWait();
-//     });
+        // Enable
+        await expect(page).toClick('.form-toggle__switch');
+        await saveAndWait();
+    });
 
-//     it ('Should be able to select a different paper size', async () => {
-//         await page.select('select.form-select', 'label');
-//         await saveAndWait();
-//         // TODO: Refresh page to see if it is selected.
-//         // await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+    it ('Should be able to select a different paper size', async () => {
+        await page.select('select.form-select', 'label');
+        await saveAndWait();
+        // TODO: Refresh page to see if it is selected.
+        // await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         let paperSize = await page.$('select.form-select');
-//         let selectedOption = await (await paperSize.getProperty('value')).jsonValue();
-//         expect(selectedOption).toBe('label');
+        let paperSize = await page.$('select.form-select');
+        let selectedOption = await (await paperSize.getProperty('value')).jsonValue();
+        expect(selectedOption).toBe('label');
 
-//         await page.select('select.form-select', 'legal');
-//         await saveAndWait();
-//         // TODO: Refresh page to see if it is selected.
-//         // await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        await page.select('select.form-select', 'legal');
+        await saveAndWait();
+        // TODO: Refresh page to see if it is selected.
+        // await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         paperSize = await page.$('select.form-select');
-//         selectedOption = await (await paperSize.getProperty('value')).jsonValue();
-//         expect(selectedOption).toBe('legal');
-//     });
-// } );
+        paperSize = await page.$('select.form-select');
+        selectedOption = await (await paperSize.getProperty('value')).jsonValue();
+        expect(selectedOption).toBe('legal');
+    });
+} );
 
-// describe( 'Shipping label payment method', () => {
-//     afterEach(() => {
-//         page.removeAllListeners('request');
-//     });
+describe( 'Shipping label payment method', () => {
+    afterEach(() => {
+        page.removeAllListeners('request');
+    });
 
-//     const mockAccountSettingAPI = async (response) => {
-//         await page.setRequestInterception(true);
-//         page.on('request', request => {
-//             if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
-//                 request.respond({
-//                     status: 200,
-//                     contentType: 'application/json; charset=UTF-8',
-//                     body: JSON.stringify(response)
-//                 });
-//             } else {
-//                 request.continue();
-//             }
-//         });
-//     };
+    const mockAccountSettingAPI = async (response) => {
+        await page.setRequestInterception(true);
+        page.on('request', request => {
+            if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
+                request.respond({
+                    status: 200,
+                    contentType: 'application/json; charset=UTF-8',
+                    body: JSON.stringify(response)
+                });
+            } else {
+                request.continue();
+            }
+        });
+    };
 
-//     it('should show "Choose a different card" button if Wordpress.com has a credit card', async () => {
-//         // Intercept API before making any HTTP request
-//         await mockAccountSettingAPI(AccountWithOneCreditCard);
+    it('should show "Choose a different card" button if Wordpress.com has a credit card', async () => {
+        // Intercept API before making any HTTP request
+        await mockAccountSettingAPI(AccountWithOneCreditCard);
 
-//         // Go to settings page after setting up interception.
-//         await StoreOwnerFlow.login();
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        // Go to settings page after setting up interception.
+        await StoreOwnerFlow.login();
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         // Test
-//         await page.waitForSelector('.button.is-borderless', { text: 'Choose a different card' } );
-//         await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
-//         await expect(page).toMatchElement('.label-settings__card-number', {
-//             text: 'VISA ****5959'
-//         });
-//         await expect(page).toMatchElement('.label-settings__card-name', {
-//             text: 'John Doe'
-//         });
-//     });
+        // Test
+        await page.waitForSelector('.button.is-borderless', { text: 'Choose a different card' } );
+        await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
+        await expect(page).toMatchElement('.label-settings__card-number', {
+            text: 'VISA ****5959'
+        });
+        await expect(page).toMatchElement('.label-settings__card-name', {
+            text: 'John Doe'
+        });
+    });
 
-//     it('should show "Add a credit card" button if Wordpress has no credit card', async () => {
-//         // Intercept API before making any HTTP request
-//         await mockAccountSettingAPI(AccountWithNoCreditCard);
+    it('should show "Add a credit card" button if Wordpress has no credit card', async () => {
+        // Intercept API before making any HTTP request
+        await mockAccountSettingAPI(AccountWithNoCreditCard);
 
-//         // No need to login again, refresh page
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        // No need to login again, refresh page
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         // Test
-//         await page.waitForSelector('.button.is-compact', { text: 'Add a credit card' } );
-//     });
+        // Test
+        await page.waitForSelector('.button.is-compact', { text: 'Add a credit card' } );
+    });
 
-//     it('should show 2 credit cards with the right information if Wordpress.com has 2 credit cards', async () => {
-//         // Intercept API before making any HTTP request
-//         await mockAccountSettingAPI(AccountWithTwoCreditCard);
+    it('should show 2 credit cards with the right information if Wordpress.com has 2 credit cards', async () => {
+        // Intercept API before making any HTTP request
+        await mockAccountSettingAPI(AccountWithTwoCreditCard);
 
-//         // No need to login again, refresh page
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        // No need to login again, refresh page
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         // Test
-//         await page.waitForSelector('.button.is-borderless', { text: 'Choose a different card' } );
-//         await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
+        // Test
+        await page.waitForSelector('.button.is-borderless', { text: 'Choose a different card' } );
+        await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
 
-//         // Verify "Add another credit card" is present after clicking 'Choose a different card'
-//         await page.waitForSelector('.button.is-compact', { text: 'Add another credit card' } );
+        // Verify "Add another credit card" is present after clicking 'Choose a different card'
+        await page.waitForSelector('.button.is-compact', { text: 'Add another credit card' } );
 
-//         // The index is based on the order in the settings' API. Inside the payment_methods prop.
-//         // This API end point is mocked, check fixtures/account_settings.js for ordering.
-//         const VISA_CARD_INDEX = 0;
-//         const MASTERCARD_INDEX = 1;
+        // The index is based on the order in the settings' API. Inside the payment_methods prop.
+        // This API end point is mocked, check fixtures/account_settings.js for ordering.
+        const VISA_CARD_INDEX = 0;
+        const MASTERCARD_INDEX = 1;
 
-//         const cardNumbers = await page.$$('.label-settings__card-number');
-//         const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardNumber).toEqual('VISA ****5959');
-//         const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardNumber).toEqual('MasterCard ****2862');
+        const cardNumbers = await page.$$('.label-settings__card-number');
+        const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardNumber).toEqual('VISA ****5959');
+        const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardNumber).toEqual('MasterCard ****2862');
 
-//         const cardNames = await page.$$('.label-settings__card-name');
-//         const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardName).toEqual('John Doe');
-//         const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardName).toEqual('Jane Smith');
+        const cardNames = await page.$$('.label-settings__card-name');
+        const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardName).toEqual('John Doe');
+        const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardName).toEqual('Jane Smith');
 
-//         const cardExpiryDates = await page.$$('.label-settings__card-date');
-//         const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
-//         const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
+        const cardExpiryDates = await page.$$('.label-settings__card-date');
+        const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
+        const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
 
-//         // Verify the default box is checked.
-//         const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
-//         const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
-//         expect(firstCardDefaultCheckbox).toBeFalsy();
-//         const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
-//         expect(secondCardDefaultCheckbox).toBeTruthy();
-//     });
+        // Verify the default box is checked.
+        const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
+        const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
+        expect(firstCardDefaultCheckbox).toBeFalsy();
+        const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
+        expect(secondCardDefaultCheckbox).toBeTruthy();
+    });
 
-//     it('should have no default card checked if there are multiple cards in Wordpress.com', async () => {
-//         await mockAccountSettingAPI(AccountWithTwoCreditCardAndNoDefault);
+    it('should have no default card checked if there are multiple cards in Wordpress.com', async () => {
+        await mockAccountSettingAPI(AccountWithTwoCreditCardAndNoDefault);
 
-//         // Go to settings page after setting up interception.
-//         await StoreOwnerFlow.login();
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        // Go to settings page after setting up interception.
+        await StoreOwnerFlow.login();
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         // Verify "Add another credit card" is present after clicking 'Choose a different card'
-//         await page.waitForSelector('.button.is-compact', { text: 'Add another credit card' } );
+        // Verify "Add another credit card" is present after clicking 'Choose a different card'
+        await page.waitForSelector('.button.is-compact', { text: 'Add another credit card' } );
 
-//         // The index is based on the order in the settings' API. Inside the payment_methods prop.
-//         // This API end point is mocked, check fixtures/account_settings.js for ordering.
-//         const VISA_CARD_INDEX = 0;
-//         const MASTERCARD_INDEX = 1;
+        // The index is based on the order in the settings' API. Inside the payment_methods prop.
+        // This API end point is mocked, check fixtures/account_settings.js for ordering.
+        const VISA_CARD_INDEX = 0;
+        const MASTERCARD_INDEX = 1;
 
-//         const cardNumbers = await page.$$('.label-settings__card-number');
-//         const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardNumber).toEqual('VISA ****5959');
-//         const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardNumber).toEqual('MasterCard ****2862');
+        const cardNumbers = await page.$$('.label-settings__card-number');
+        const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardNumber).toEqual('VISA ****5959');
+        const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardNumber).toEqual('MasterCard ****2862');
 
-//         const cardNames = await page.$$('.label-settings__card-name');
-//         const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardName).toEqual('John Doe');
-//         const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardName).toEqual('Jane Smith');
+        const cardNames = await page.$$('.label-settings__card-name');
+        const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardName).toEqual('John Doe');
+        const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardName).toEqual('Jane Smith');
 
-//         const cardExpiryDates = await page.$$('.label-settings__card-date');
-//         const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
-//         const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
+        const cardExpiryDates = await page.$$('.label-settings__card-date');
+        const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
+        const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
 
-//         // Verify that no default box is checked.
-//         const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
-//         const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
-//         expect(firstCardDefaultCheckbox).toBeFalsy();
-//         const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
-//         expect(secondCardDefaultCheckbox).toBeFalsy();
-//     });
-// });
+        // Verify that no default box is checked.
+        const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
+        const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
+        expect(firstCardDefaultCheckbox).toBeFalsy();
+        const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
+        expect(secondCardDefaultCheckbox).toBeFalsy();
+    });
+});
 
 describe( 'Packaging', () => {
     it( 'Can add package' , async () => {

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -228,6 +228,7 @@ describe( 'Packaging', () => {
     console.log("Running 'packaging'");
 
     it( 'Can add package' , async () => {
+        console.log("Started 'Can add package'");
         const packageName = 'Package Box 5x5x5';
 
 		await StoreOwnerFlow.login();
@@ -260,9 +261,11 @@ describe( 'Packaging', () => {
         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 cm" });
+        console.log("Finished 'Can add package'");
     });
 
     it( 'Can edit package' , async () => {
+        console.log("Started 'Can edit package'");
         const packageName = 'Package Box 10x10x10';
 
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
@@ -293,9 +296,11 @@ describe( 'Packaging', () => {
         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 cm" });
+        console.log("Started 'Finish edit package'");
     });
 
     it( 'Can delete package' , async () => {
+        console.log("Started 'Can delete package'");
         const packageName = 'Package Box 10x10x10';
 
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
@@ -320,5 +325,6 @@ describe( 'Packaging', () => {
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
         await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
         await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 cm" });
+        console.log("Started 'Finish delete package'");
     });
 });

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -2,26 +2,13 @@
  * Internal dependencies
  */
 import { StoreOwnerFlow } from "../../utils/flows";
+import { waitForSelectorAndText } from "../../utils/index";
 import { AccountWithNoCreditCard, AccountWithOneCreditCard, AccountWithTwoCreditCard, AccountWithTwoCreditCardAndNoDefault } from "../../fixtures/account_settings";
 
 // Click save and wait until it's saved.
 const saveAndWait = async () => {
     await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
     await page.waitForSelector('[class="button is-primary"]');
-};
-
-/**
- * This function will wait for a button with any CSS selector + text value.
- *
- * @param {string} selector CSS selector
- * @param {string} text The text value of the element we want to search for. ie. button's value, div's innertext.
- */
-const waitForSelectorAndText = async (selector, text) => {
-    return await page.waitForFunction(
-        (cssSelector, innerTextContent) => !!Array.from(document.querySelectorAll(cssSelector)).find(el => el.textContent.trim() === innerTextContent.trim()),
-        {},
-        selector, text
-    );
 };
 
 describe( 'Saving shipping label settings', () => {

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -82,13 +82,19 @@ describe( 'Shipping label payment method', () => {
 
     const mockAccountSettingAPI = async (mockResponse) => {
         response = mockResponse;
-        await page.setRequestInterception(true);
         page.on('request', accountSettingsRequestListener);
     };
 
     afterEach(() => {
         response = '';
         page.removeListener('request', accountSettingsRequestListener);
+    });
+
+    /**
+     * Not really a test case. But needed to run this once, prior to all test case in this describe.
+     */
+    it('should turn on request interception after all credit card test ran', async () => {
+        await page.setRequestInterception(true);
     });
 
     it('should show "Add a credit card" button if Wordpress has no credit card', async () => {
@@ -204,6 +210,13 @@ describe( 'Shipping label payment method', () => {
         expect(firstCardDefaultCheckbox).toBeFalsy();
         const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
         expect(secondCardDefaultCheckbox).toBeFalsy();
+    });
+
+    /**
+     * Not really a test case. But needed to run this once, after all test case ran in this describe.
+     */
+    it('should turn off request interception after all credit card test ran', async () => {
+        await page.setRequestInterception(false);
     });
 });
 

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -344,4 +344,27 @@ describe( 'Packaging', () => {
         await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
         console.log("Started 'Finish delete package'");
     });
+
+    it ( 'Can select and add service package', async () => {
+        const packageName = 'Flat Rate Envelope'; // This is provided in services_data_mock_with_card.json
+
+        console.log("Started 'Can select and add service package'");
+
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+
+        // Wait for "Add package" to finish loading, then click "Add package"
+        await waitForSelectorAndText('.button:not([disabled])', 'Add package');
+        await expect( page ).toClick( '.button', { text: 'Add package' } );
+
+        // Click the "Service package" tab, pick and add a service package.
+        await expect( page ).toClick( '.segmented-control__link.item-index-1' );
+        await expect( page ).toClick( '.foldable-card__action.foldable-card__expand');
+        await expect( page ).toClick( '.foldable-card__content :first-child .packages__packages-row-actions input');
+        await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Add package' } )
+
+        // Verify the package was added to the list
+        console.log('>> Verify package shows up in list');
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "12.5 x 9.5 x 0.5 " + metricSystemValue });
+    });
 });

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -67,304 +67,307 @@ describe( 'Saving shipping label settings', () => {
     });
 
     it ('Should show the correct email receipts message', async () => {
+        const cardDesc = await page.$$('.label-settings__credit-card-description');
+        const cardDescValue = await (await cardDesc[2].getProperty('innerText')).jsonValue();
+        console.log(">>> email receipts", cardDescValue);
         await expect(page).toMatchElement('.label-settings__credit-card-description', { text: /Email the label purchase receipts to \w+ \(\w+\) at .+\@.+/ });
     });
 } );
 
-describe( 'Shipping label payment method', () => {
-    console.log( "Running 'Shipping label payment method'" );
+// describe( 'Shipping label payment method', () => {
+//     console.log( "Running 'Shipping label payment method'" );
 
-    let response;
+//     let response;
 
-    const accountSettingsRequestListener = (request) => {
-        if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
-            request.respond({
-                status: 200,
-                contentType: 'application/json; charset=UTF-8',
-                body: JSON.stringify(response)
-            });
-        } else {
-            request.continue();
-        }
-    };
+//     const accountSettingsRequestListener = (request) => {
+//         if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
+//             request.respond({
+//                 status: 200,
+//                 contentType: 'application/json; charset=UTF-8',
+//                 body: JSON.stringify(response)
+//             });
+//         } else {
+//             request.continue();
+//         }
+//     };
 
-    const mockAccountSettingAPI = async (mockResponse) => {
-        response = mockResponse;
-        page.on('request', accountSettingsRequestListener);
-    };
+//     const mockAccountSettingAPI = async (mockResponse) => {
+//         response = mockResponse;
+//         page.on('request', accountSettingsRequestListener);
+//     };
 
-    afterEach(() => {
-        response = '';
-        page.removeListener('request', accountSettingsRequestListener);
-    });
+//     afterEach(() => {
+//         response = '';
+//         page.removeListener('request', accountSettingsRequestListener);
+//     });
 
-    /**
-     * Not really a test case. But needed to run this once, prior to all test case in this describe.
-     */
-    it('should turn on request interception after all credit card test ran', async () => {
-        await page.setRequestInterception(true);
-    });
+//     /**
+//      * Not really a test case. But needed to run this once, prior to all test case in this describe.
+//      */
+//     it('should turn on request interception after all credit card test ran', async () => {
+//         await page.setRequestInterception(true);
+//     });
 
-    it('should show "Add a credit card" button if Wordpress has no credit card', async () => {
-        // Intercept API before making any HTTP request
-        await mockAccountSettingAPI(AccountWithNoCreditCard);
+//     it('should show "Add a credit card" button if Wordpress has no credit card', async () => {
+//         // Intercept API before making any HTTP request
+//         await mockAccountSettingAPI(AccountWithNoCreditCard);
 
-        // Go to settings page after setting up interception.
-        await StoreOwnerFlow.login();
-        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         // Go to settings page after setting up interception.
+//         await StoreOwnerFlow.login();
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        // Test
-        await waitForSelectorAndText('.button.is-compact', 'Add a credit card');
-    });
+//         // Test
+//         await waitForSelectorAndText('.button.is-compact', 'Add a credit card');
+//     });
 
-    it('should show "Choose a different card" button if Wordpress.com has a credit card', async () => {
-        // Intercept API before making any HTTP request
-        await mockAccountSettingAPI(AccountWithOneCreditCard);
+//     it('should show "Choose a different card" button if Wordpress.com has a credit card', async () => {
+//         // Intercept API before making any HTTP request
+//         await mockAccountSettingAPI(AccountWithOneCreditCard);
 
-        // No need to login again, refresh page
-        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         // No need to login again, refresh page
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        // Test
-        await waitForSelectorAndText('.button.is-borderless', 'Choose a different card');
-        await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
-        await expect(page).toMatchElement('.label-settings__card-number', {
-            text: 'VISA ****5959'
-        });
-        await expect(page).toMatchElement('.label-settings__card-name', {
-            text: 'John Doe'
-        });
-    });
+//         // Test
+//         await waitForSelectorAndText('.button.is-borderless', 'Choose a different card');
+//         await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
+//         await expect(page).toMatchElement('.label-settings__card-number', {
+//             text: 'VISA ****5959'
+//         });
+//         await expect(page).toMatchElement('.label-settings__card-name', {
+//             text: 'John Doe'
+//         });
+//     });
 
-    it('should show 2 credit cards with the right information if Wordpress.com has 2 credit cards', async () => {
-        // Intercept API before making any HTTP request
-        await mockAccountSettingAPI(AccountWithTwoCreditCard);
+//     it('should show 2 credit cards with the right information if Wordpress.com has 2 credit cards', async () => {
+//         // Intercept API before making any HTTP request
+//         await mockAccountSettingAPI(AccountWithTwoCreditCard);
 
-        // No need to login again, refresh page
-        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         // No need to login again, refresh page
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        // Test
-        await waitForSelectorAndText('.button.is-borderless', 'Choose a different card' );
-        await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
+//         // Test
+//         await waitForSelectorAndText('.button.is-borderless', 'Choose a different card' );
+//         await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
 
-        // Verify "Add another credit card" is present after clicking 'Choose a different card'
-        await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
+//         // Verify "Add another credit card" is present after clicking 'Choose a different card'
+//         await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
 
-        // The index is based on the order in the settings' API. Inside the payment_methods prop.
-        // This API end point is mocked, check fixtures/account_settings.js for ordering.
-        const VISA_CARD_INDEX = 0;
-        const MASTERCARD_INDEX = 1;
+//         // The index is based on the order in the settings' API. Inside the payment_methods prop.
+//         // This API end point is mocked, check fixtures/account_settings.js for ordering.
+//         const VISA_CARD_INDEX = 0;
+//         const MASTERCARD_INDEX = 1;
 
-        const cardNumbers = await page.$$('.label-settings__card-number');
-        const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardNumber).toEqual('VISA ****5959');
-        const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardNumber).toEqual('MasterCard ****2862');
+//         const cardNumbers = await page.$$('.label-settings__card-number');
+//         const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardNumber).toEqual('VISA ****5959');
+//         const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardNumber).toEqual('MasterCard ****2862');
 
-        const cardNames = await page.$$('.label-settings__card-name');
-        const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardName).toEqual('John Doe');
-        const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardName).toEqual('Jane Smith');
+//         const cardNames = await page.$$('.label-settings__card-name');
+//         const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardName).toEqual('John Doe');
+//         const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardName).toEqual('Jane Smith');
 
-        const cardExpiryDates = await page.$$('.label-settings__card-date');
-        const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
-        const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
+//         const cardExpiryDates = await page.$$('.label-settings__card-date');
+//         const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
+//         const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
 
-        // Verify the default box is checked.
-        const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
-        const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
-        expect(firstCardDefaultCheckbox).toBeFalsy();
-        const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
-        expect(secondCardDefaultCheckbox).toBeTruthy();
-    });
+//         // Verify the default box is checked.
+//         const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
+//         const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
+//         expect(firstCardDefaultCheckbox).toBeFalsy();
+//         const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
+//         expect(secondCardDefaultCheckbox).toBeTruthy();
+//     });
 
-    it('should have no default card checked if there are multiple cards in Wordpress.com', async () => {
-        await mockAccountSettingAPI(AccountWithTwoCreditCardAndNoDefault);
+//     it('should have no default card checked if there are multiple cards in Wordpress.com', async () => {
+//         await mockAccountSettingAPI(AccountWithTwoCreditCardAndNoDefault);
 
-        // No need to login again, refresh page
-        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         // No need to login again, refresh page
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        // Verify "Add another credit card" is present after clicking 'Choose a different card'
-        await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
+//         // Verify "Add another credit card" is present after clicking 'Choose a different card'
+//         await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
 
-        // The index is based on the order in the settings' API. Inside the payment_methods prop.
-        // This API end point is mocked, check fixtures/account_settings.js for ordering.
-        const VISA_CARD_INDEX = 0;
-        const MASTERCARD_INDEX = 1;
+//         // The index is based on the order in the settings' API. Inside the payment_methods prop.
+//         // This API end point is mocked, check fixtures/account_settings.js for ordering.
+//         const VISA_CARD_INDEX = 0;
+//         const MASTERCARD_INDEX = 1;
 
-        const cardNumbers = await page.$$('.label-settings__card-number');
-        const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardNumber).toEqual('VISA ****5959');
-        const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardNumber).toEqual('MasterCard ****2862');
+//         const cardNumbers = await page.$$('.label-settings__card-number');
+//         const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardNumber).toEqual('VISA ****5959');
+//         const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardNumber).toEqual('MasterCard ****2862');
 
-        const cardNames = await page.$$('.label-settings__card-name');
-        const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardName).toEqual('John Doe');
-        const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardName).toEqual('Jane Smith');
+//         const cardNames = await page.$$('.label-settings__card-name');
+//         const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardName).toEqual('John Doe');
+//         const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardName).toEqual('Jane Smith');
 
-        const cardExpiryDates = await page.$$('.label-settings__card-date');
-        const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
-        const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
+//         const cardExpiryDates = await page.$$('.label-settings__card-date');
+//         const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
+//         const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
 
-        // Verify that no default box is checked.
-        const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
-        const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
-        expect(firstCardDefaultCheckbox).toBeFalsy();
-        const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
-        expect(secondCardDefaultCheckbox).toBeFalsy();
-    });
+//         // Verify that no default box is checked.
+//         const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
+//         const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
+//         expect(firstCardDefaultCheckbox).toBeFalsy();
+//         const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
+//         expect(secondCardDefaultCheckbox).toBeFalsy();
+//     });
 
-    /**
-     * Not really a test case. But needed to run this once, after all test case ran in this describe.
-     */
-    it('should turn off request interception after all credit card test ran', async () => {
-        await page.setRequestInterception(false);
-    });
-});
+//     /**
+//      * Not really a test case. But needed to run this once, after all test case ran in this describe.
+//      */
+//     it('should turn off request interception after all credit card test ran', async () => {
+//         await page.setRequestInterception(false);
+//     });
+// });
 
-describe( 'Packaging', () => {
-    let metricSystemValue = ''; // either "in" or "cm".
+// describe( 'Packaging', () => {
+//     let metricSystemValue = ''; // either "in" or "cm".
 
-    console.log("Running 'packaging'");
+//     console.log("Running 'packaging'");
 
-    it( '> Can add package' , async () => {
-        const packageName = 'Package Box 5x5x5';
+//     it( '> Can add package' , async () => {
+//         const packageName = 'Package Box 5x5x5';
 
-		await StoreOwnerFlow.login();
-        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+// 		await StoreOwnerFlow.login();
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        // Wait for "Add package" to finish loading, click to pop up modal
-        console.log('>> Wait for "Add package" to finish loading, click to pop up modal');
-        await waitForSelectorAndText('.button:not([disabled])', 'Add package');
-        await expect( page ).toClick( '.button', { text: 'Add package' } );
+//         // Wait for "Add package" to finish loading, click to pop up modal
+//         console.log('>> Wait for "Add package" to finish loading, click to pop up modal');
+//         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
+//         await expect( page ).toClick( '.button', { text: 'Add package' } );
 
-        // Create a new package
-        console.log('>> Create a new package');
-        await waitForSelectorAndText( '.packages__add-edit-title.form-section-heading', 'Add a package' );
-        await expect( page ).toFill( '.packages__properties-group #name', packageName );
-        await expect( page ).toFill( '.form-text-input.form-dimensions-input__length', '5' );
-        await expect( page ).toFill( '.form-text-input.form-dimensions-input__width', '5' );
-        await expect( page ).toFill( '.form-text-input.form-dimensions-input__height', '5' );
-        await expect( page ).toFill( '.form-text-input-with-affixes #box_weight', '0.5' );
-        await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Add package' } )
+//         // Create a new package
+//         console.log('>> Create a new package');
+//         await waitForSelectorAndText( '.packages__add-edit-title.form-section-heading', 'Add a package' );
+//         await expect( page ).toFill( '.packages__properties-group #name', packageName );
+//         await expect( page ).toFill( '.form-text-input.form-dimensions-input__length', '5' );
+//         await expect( page ).toFill( '.form-text-input.form-dimensions-input__width', '5' );
+//         await expect( page ).toFill( '.form-text-input.form-dimensions-input__height', '5' );
+//         await expect( page ).toFill( '.form-text-input-with-affixes #box_weight', '0.5' );
+//         await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Add package' } )
 
-        // Set this once globally, all following test will use this metric
-        const metricSystem = await page.$$('.form-text-input-with-affixes .form-text-input-with-affixes__suffix');
-        metricSystemValue = await (await metricSystem[0].getProperty('innerText')).jsonValue();
+//         // Set this once globally, all following test will use this metric
+//         const metricSystem = await page.$$('.form-text-input-with-affixes .form-text-input-with-affixes__suffix');
+//         metricSystemValue = await (await metricSystem[0].getProperty('innerText')).jsonValue();
 
-        // Verify package shows up in list
-        console.log('>> Verify package shows up in list');
-        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 " + metricSystemValue });
+//         // Verify package shows up in list
+//         console.log('>> Verify package shows up in list');
+//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 " + metricSystemValue });
 
-        // Save package
-        console.log('>> Save package');
-        await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
-        await saveAndWait();
+//         // Save package
+//         console.log('>> Save package');
+//         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
+//         await saveAndWait();
 
-        // Refresh page and make sure it is saved.
-        console.log('>> Refresh page and make sure it is saved.');
-        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
-        await waitForSelectorAndText('.button:not([disabled])', 'Add package');
-        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 " + metricSystemValue });
-        console.log(">> Finished 'Can add package'");
-    });
+//         // Refresh page and make sure it is saved.
+//         console.log('>> Refresh page and make sure it is saved.');
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
+//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 " + metricSystemValue });
+//         console.log(">> Finished 'Can add package'");
+//     });
 
-    it( '> Can edit package' , async () => {
-        console.log("Started 'Can edit package'");
-        const packageName = 'Package Box 10x10x10';
+//     it( '> Can edit package' , async () => {
+//         console.log("Started 'Can edit package'");
+//         const packageName = 'Package Box 10x10x10';
 
-        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        // Wait for "Add package" to finish loading, click "edit" once this session is loaded
-        await waitForSelectorAndText('.button:not([disabled])', 'Add package');
-        await expect( page ).toClick( '.button.is-compact', { text: 'Edit' } );
+//         // Wait for "Add package" to finish loading, click "edit" once this session is loaded
+//         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
+//         await expect( page ).toClick( '.button.is-compact', { text: 'Edit' } );
 
-        // Edit package
-        await waitForSelectorAndText( '.packages__add-edit-title.form-section-heading', 'Edit package' );
-        await expect( page ).toFill( '.packages__properties-group #name', packageName );
-        await expect( page ).toFill( '.form-text-input.form-dimensions-input__length', '10' );
-        await expect( page ).toFill( '.form-text-input.form-dimensions-input__width', '10' );
-        await expect( page ).toFill( '.form-text-input.form-dimensions-input__height', '10' );
-        await expect( page ).toFill( '.form-text-input-with-affixes #box_weight', '0.8' );
-        await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Done' } )
+//         // Edit package
+//         await waitForSelectorAndText( '.packages__add-edit-title.form-section-heading', 'Edit package' );
+//         await expect( page ).toFill( '.packages__properties-group #name', packageName );
+//         await expect( page ).toFill( '.form-text-input.form-dimensions-input__length', '10' );
+//         await expect( page ).toFill( '.form-text-input.form-dimensions-input__width', '10' );
+//         await expect( page ).toFill( '.form-text-input.form-dimensions-input__height', '10' );
+//         await expect( page ).toFill( '.form-text-input-with-affixes #box_weight', '0.8' );
+//         await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Done' } )
 
-        // Verify package shows up in list
-        console.log('>> Verify package shows up in list');
-        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
+//         // Verify package shows up in list
+//         console.log('>> Verify package shows up in list');
+//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
 
-        // Save package
-        console.log('>> Save package');
-        await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
-        await saveAndWait();
+//         // Save package
+//         console.log('>> Save package');
+//         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
+//         await saveAndWait();
 
-        // Refresh page and make sure it is updated.
-        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
-        await waitForSelectorAndText('.button:not([disabled])', 'Add package');
-        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
-        console.log("Started 'Finish edit package'");
-    });
+//         // Refresh page and make sure it is updated.
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
+//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
+//         console.log("Started 'Finish edit package'");
+//     });
 
-    it( '> Can delete package' , async () => {
-        console.log("Started 'Can delete package'");
-        const packageName = 'Package Box 10x10x10';
+//     it( '> Can delete package' , async () => {
+//         console.log("Started 'Can delete package'");
+//         const packageName = 'Package Box 10x10x10';
 
-        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        // Wait for "Add package" to finish loading, click "edit" once this session is loaded
-        await waitForSelectorAndText('.button:not([disabled])', 'Add package');
-        await expect( page ).toClick( '.button.is-compact', { text: 'Edit' } );
+//         // Wait for "Add package" to finish loading, click "edit" once this session is loaded
+//         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
+//         await expect( page ).toClick( '.button.is-compact', { text: 'Edit' } );
 
-        // Delete package
-        await page.waitForSelector( '.packages__add-edit-title.form-section-heading', { text: 'Edit package' } );
-        await expect( page ).toClick( '.button.packages__delete.is-scary.is-borderless', { text: 'Delete this package' } )
+//         // Delete package
+//         await page.waitForSelector( '.packages__add-edit-title.form-section-heading', { text: 'Edit package' } );
+//         await expect( page ).toClick( '.button.packages__delete.is-scary.is-borderless', { text: 'Delete this package' } )
 
-        // Verify package is no longer in the list.
-        console.log('>> Verify package shows up in list');
-        await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-        await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
+//         // Verify package is no longer in the list.
+//         console.log('>> Verify package shows up in list');
+//         await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+//         await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
 
-        // Save package
-        console.log('>> Save package');
-        await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
-        await saveAndWait();
+//         // Save package
+//         console.log('>> Save package');
+//         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
+//         await saveAndWait();
 
-        // Refresh page and make sure it is deleted.
-        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
-        await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-        await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
-        console.log("Started 'Finish delete package'");
-    });
+//         // Refresh page and make sure it is deleted.
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+//         await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
+//         console.log("Started 'Finish delete package'");
+//     });
 
-    it ( 'Can select and add service package', async () => {
-        const packageName = 'Flat Rate Envelope'; // This is provided in services_data_mock_with_card.json
+//     it ( 'Can select and add service package', async () => {
+//         const packageName = 'Flat Rate Envelope'; // This is provided in services_data_mock_with_card.json
 
-        console.log("Started 'Can select and add service package'");
+//         console.log("Started 'Can select and add service package'");
 
-        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        // Wait for "Add package" to finish loading, then click "Add package"
-        await waitForSelectorAndText('.button:not([disabled])', 'Add package');
-        await expect( page ).toClick( '.button', { text: 'Add package' } );
+//         // Wait for "Add package" to finish loading, then click "Add package"
+//         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
+//         await expect( page ).toClick( '.button', { text: 'Add package' } );
 
-        // Click the "Service package" tab, pick and add a service package.
-        await expect( page ).toClick( '.segmented-control__link.item-index-1' );
-        await expect( page ).toClick( '.foldable-card__action.foldable-card__expand');
-        await expect( page ).toClick( '.foldable-card__content :first-child .packages__packages-row-actions input');
-        await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Add package' } )
+//         // Click the "Service package" tab, pick and add a service package.
+//         await expect( page ).toClick( '.segmented-control__link.item-index-1' );
+//         await expect( page ).toClick( '.foldable-card__action.foldable-card__expand');
+//         await expect( page ).toClick( '.foldable-card__content :first-child .packages__packages-row-actions input');
+//         await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Add package' } )
 
-        // Verify the package was added to the list
-        console.log('>> Verify package shows up in list');
-        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "12.5 x 9.5 x 0.5 " + metricSystemValue });
-    });
-});
+//         // Verify the package was added to the list
+//         console.log('>> Verify package shows up in list');
+//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "12.5 x 9.5 x 0.5 " + metricSystemValue });
+//     });
+// });

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -73,8 +73,7 @@ describe( 'Shipping label payment method', () => {
     //     await page.waitForSelector('.button.is-compact', { text: 'Add a credit card' } );
     // });
 
-    it('should show "Choose a different card" button if Wordpress.com has 2 credit cards', async () => {
-        console.log(AccountWithTwoCreditCard);
+    it('should show 2 credit cards with the right information f Wordpress.com has 2 credit cards', async () => {
         await page.setRequestInterception(true);
         page.on('request', request => {
             if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
@@ -92,11 +91,35 @@ describe( 'Shipping label payment method', () => {
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
         await page.waitForSelector('.button.is-borderless', { text: 'Choose a different card' } );
         await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
-        await expect(page).toMatchElement('.label-settings__card-number', {
-            text: 'MasterCard ****2862'
-        });
-        await expect(page).toMatchElement('.label-settings__card-name', {
-            text: 'John Doe'
-        });
+
+        // The index is based on the order in the settings' API. Inside the payment_methods prop.
+        // This API end point is mocked, check fixtures/account_settings.js for ordering.
+        const VISA_CARD_INDEX = 0;
+        const MASTERCARD_INDEX = 1;
+
+        const cardNumbers = await page.$$('.label-settings__card-number');
+        const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardNumber).toEqual('VISA ****5959');
+        const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardNumber).toEqual('MasterCard ****2862');
+
+        const cardNames = await page.$$('.label-settings__card-name');
+        const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardName).toEqual('John Doe');
+        const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardName).toEqual('Jane Smith');
+
+        const cardExpiryDates = await page.$$('.label-settings__card-date');
+        const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
+        const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
+
+        // Verify the default box is checked.
+        const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
+        const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
+        expect(firstCardDefaultCheckbox).toBeFalsy();
+        const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
+        expect(secondCardDefaultCheckbox).toBeTruthy();
     });
 });

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -3,7 +3,7 @@
  */
 import { clickReactButton } from '../../utils/index';
 import { StoreOwnerFlow } from "../../utils/flows";
-import { AccountWithNoCreditCard, AccountWithOneCreditCard, AccountWithTwoCreditCard } from "../../fixtures/account_settings";
+import { AccountWithNoCreditCard, AccountWithOneCreditCard, AccountWithTwoCreditCard, AccountWithTwoCreditCardAndNoDefault } from "../../fixtures/account_settings";
 
 // Click save and wait until it's saved.
 const saveAndWait = async () => {
@@ -11,46 +11,46 @@ const saveAndWait = async () => {
     await page.waitForSelector('[class="button is-primary"]');
 };
 
-describe( 'Saving shipping label settings', () => {
-	it( 'Can toggle shipping labels' , async () => {
-		await StoreOwnerFlow.login();
-		await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
-        await page.waitForSelector('.form-toggle__switch');
-        await expect(page).toClick('.form-toggle__switch');
-        await page.waitForSelector('.card.label-settings__labels-container', {
-            visible: false
-        });
-        await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
-        // Clicking save should persist the visible state of the section.
-        await page.waitForSelector('.card.label-settings__labels-container', {
-            visible: false
-        });
+// describe( 'Saving shipping label settings', () => {
+// 	it( 'Can toggle shipping labels' , async () => {
+// 		await StoreOwnerFlow.login();
+// 		await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         await page.waitForSelector('.form-toggle__switch');
+//         await expect(page).toClick('.form-toggle__switch');
+//         await page.waitForSelector('.card.label-settings__labels-container', {
+//             visible: false
+//         });
+//         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
+//         // Clicking save should persist the visible state of the section.
+//         await page.waitForSelector('.card.label-settings__labels-container', {
+//             visible: false
+//         });
 
-        // Enable
-        await expect(page).toClick('.form-toggle__switch');
-        await saveAndWait();
-    });
+//         // Enable
+//         await expect(page).toClick('.form-toggle__switch');
+//         await saveAndWait();
+//     });
 
-    it ('Should be able to select a different paper size', async () => {
-        await page.select('select.form-select', 'label');
-        await saveAndWait();
-        // TODO: Refresh page to see if it is selected.
-        // await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//     it ('Should be able to select a different paper size', async () => {
+//         await page.select('select.form-select', 'label');
+//         await saveAndWait();
+//         // TODO: Refresh page to see if it is selected.
+//         // await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        let paperSize = await page.$('select.form-select');
-        let selectedOption = await (await paperSize.getProperty('value')).jsonValue();
-        expect(selectedOption).toBe('label');
+//         let paperSize = await page.$('select.form-select');
+//         let selectedOption = await (await paperSize.getProperty('value')).jsonValue();
+//         expect(selectedOption).toBe('label');
 
-        await page.select('select.form-select', 'legal');
-        await saveAndWait();
-        // TODO: Refresh page to see if it is selected.
-        // await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         await page.select('select.form-select', 'legal');
+//         await saveAndWait();
+//         // TODO: Refresh page to see if it is selected.
+//         // await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        paperSize = await page.$('select.form-select');
-        selectedOption = await (await paperSize.getProperty('value')).jsonValue();
-        expect(selectedOption).toBe('legal');
-    });
-} );
+//         paperSize = await page.$('select.form-select');
+//         selectedOption = await (await paperSize.getProperty('value')).jsonValue();
+//         expect(selectedOption).toBe('legal');
+//     });
+// } );
 
 describe( 'Shipping label payment method', () => {
     afterEach(() => {
@@ -93,7 +93,7 @@ describe( 'Shipping label payment method', () => {
 
     it('should show "Add a credit card" button if Wordpress has no credit card', async () => {
         // Intercept API before making any HTTP request
-        await mockAccountSettingAPI(AccountWithOneCreditCard);
+        await mockAccountSettingAPI(AccountWithNoCreditCard);
 
         // No need to login again, refresh page
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
@@ -145,5 +145,46 @@ describe( 'Shipping label payment method', () => {
         expect(firstCardDefaultCheckbox).toBeFalsy();
         const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
         expect(secondCardDefaultCheckbox).toBeTruthy();
+    });
+
+    it('should have no default card checked if there are multiple cards in Wordpress.com', async () => {
+        await mockAccountSettingAPI(AccountWithTwoCreditCardAndNoDefault);
+
+        // Go to settings page after setting up interception.
+        await StoreOwnerFlow.login();
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+
+        // Verify "Add another credit card" is present after clicking 'Choose a different card'
+        await page.waitForSelector('.button.is-compact', { text: 'Add another credit card' } );
+
+        // The index is based on the order in the settings' API. Inside the payment_methods prop.
+        // This API end point is mocked, check fixtures/account_settings.js for ordering.
+        const VISA_CARD_INDEX = 0;
+        const MASTERCARD_INDEX = 1;
+
+        const cardNumbers = await page.$$('.label-settings__card-number');
+        const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardNumber).toEqual('VISA ****5959');
+        const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardNumber).toEqual('MasterCard ****2862');
+
+        const cardNames = await page.$$('.label-settings__card-name');
+        const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardName).toEqual('John Doe');
+        const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardName).toEqual('Jane Smith');
+
+        const cardExpiryDates = await page.$$('.label-settings__card-date');
+        const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
+        const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
+
+        // Verify that no default box is checked.
+        const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
+        const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
+        expect(firstCardDefaultCheckbox).toBeFalsy();
+        const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
+        expect(secondCardDefaultCheckbox).toBeFalsy();
     });
 });

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -257,6 +257,11 @@ describe( 'Packaging', () => {
         console.log('>> details name: ', detailValue);
 
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+        console.log('>> details name matched.');
+
+        const detailsDimension = await page.$$('.packages__packages-row .packages__packages-row-dimensions');
+        const detailsDimensionValue = await (await detailsDimension[1].getProperty('innerText')).jsonValue();
+        console.log('>> details dimension value: "' + detailsDimensionValue + '"');
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 cm" });
 
         // Save package

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -25,6 +25,8 @@ const waitForSelectorAndText = async (selector, text) => {
 };
 
 describe( 'Saving shipping label settings', () => {
+    console.log( "Running 'Saving shipping label settings'" );
+
 	it( 'Can toggle shipping labels' , async () => {
 		await StoreOwnerFlow.login();
 		await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
@@ -66,6 +68,8 @@ describe( 'Saving shipping label settings', () => {
 } );
 
 describe( 'Shipping label payment method', () => {
+    console.log( "Running 'Shipping label payment method'" );
+
     let response;
 
     const accountSettingsRequestListener = (request) => {
@@ -221,6 +225,8 @@ describe( 'Shipping label payment method', () => {
 });
 
 describe( 'Packaging', () => {
+    console.log("Running 'packaging'");
+
     it( 'Can add package' , async () => {
         const packageName = 'Package Box 5x5x5';
 

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -14,11 +14,11 @@ const saveAndWait = async () => {
 /**
  * This function will wait for a button with any CSS selector + text value.
  */
-const waitForButton = async (selector, buttonText) => {
+const waitForSelectorAndText = async (selector, text) => {
     return await page.waitForFunction(
-        (selector, buttonText) => Array.from(document.querySelectorAll(selector)).find(el => el.textContent === buttonText),
+        (selector, text) => Array.from(document.querySelectorAll(selector)).find(el => el.textContent === text),
         {},
-        selector, buttonText
+        selector, text
     );
 };
 
@@ -92,7 +92,7 @@ describe( 'Shipping label payment method', () => {
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
         // Test
-        await page.waitForSelector('.button.is-borderless', { text: 'Choose a different card' } );
+        await waitForSelectorAndText('.button.is-borderless', 'Choose a different card');
         await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
         await expect(page).toMatchElement('.label-settings__card-number', {
             text: 'VISA ****5959'
@@ -110,7 +110,7 @@ describe( 'Shipping label payment method', () => {
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
         // Test
-        await page.waitForSelector('.button.is-compact', { text: 'Add a credit card' } );
+        await waitForSelectorAndText('.button.is-compact', 'Add a credit card');
     });
 
     it('should show 2 credit cards with the right information if Wordpress.com has 2 credit cards', async () => {
@@ -121,11 +121,11 @@ describe( 'Shipping label payment method', () => {
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
         // Test
-        await page.waitForSelector('.button.is-borderless', { text: 'Choose a different card' } );
+        await waitForSelectorAndText('.button.is-borderless', 'Choose a different card' );
         await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
 
         // Verify "Add another credit card" is present after clicking 'Choose a different card'
-        await page.waitForSelector('.button.is-compact', { text: 'Add another credit card' } );
+        await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
 
         // The index is based on the order in the settings' API. Inside the payment_methods prop.
         // This API end point is mocked, check fixtures/account_settings.js for ordering.
@@ -161,12 +161,11 @@ describe( 'Shipping label payment method', () => {
     it('should have no default card checked if there are multiple cards in Wordpress.com', async () => {
         await mockAccountSettingAPI(AccountWithTwoCreditCardAndNoDefault);
 
-        // Go to settings page after setting up interception.
-        await StoreOwnerFlow.login();
+        // No need to login again, refresh page
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
         // Verify "Add another credit card" is present after clicking 'Choose a different card'
-        await page.waitForSelector('.button.is-compact', { text: 'Add another credit card' } );
+        await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
 
         // The index is based on the order in the settings' API. Inside the payment_methods prop.
         // This API end point is mocked, check fixtures/account_settings.js for ordering.
@@ -208,11 +207,11 @@ describe( 'Packaging', () => {
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
         // Wait for "Add package" to finish loading, click to pop up modal
-        await waitForButton('.button:not([disabled])', 'Add package');
+        await waitForSelectorAndText('.button:not([disabled])', 'Add package');
         await expect( page ).toClick( '.button', { text: 'Add package' } );
 
         // Create a new package
-        await page.waitForSelector( '.packages__add-edit-title.form-section-heading', { text: 'Add a package' } );
+        await waitForSelectorAndText( '.packages__add-edit-title.form-section-heading', 'Add a package' );
         await expect( page ).toFill( '.packages__properties-group #name', packageName );
         await expect( page ).toFill( '.form-text-input.form-dimensions-input__length', '5' );
         await expect( page ).toFill( '.form-text-input.form-dimensions-input__width', '5' );
@@ -231,7 +230,7 @@ describe( 'Packaging', () => {
 
         // Refresh page and make sure it is saved.
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
-        await waitForButton('.button:not([disabled])', 'Add package');
+        await waitForSelectorAndText('.button:not([disabled])', 'Add package');
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 cm" });
     });
@@ -242,11 +241,11 @@ describe( 'Packaging', () => {
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
         // Wait for "Add package" to finish loading, click "edit" once this session is loaded
-        await waitForButton('.button:not([disabled])', 'Add package');
+        await waitForSelectorAndText('.button:not([disabled])', 'Add package');
         await expect( page ).toClick( '.button.is-compact', { text: 'Edit' } );
 
         // Edit package
-        await page.waitForSelector( '.packages__add-edit-title.form-section-heading', { text: 'Add a package' } );
+        await waitForSelectorAndText( '.packages__add-edit-title.form-section-heading', 'Edit package' );
         await expect( page ).toFill( '.packages__properties-group #name', packageName );
         await expect( page ).toFill( '.form-text-input.form-dimensions-input__length', '10' );
         await expect( page ).toFill( '.form-text-input.form-dimensions-input__width', '10' );
@@ -264,7 +263,7 @@ describe( 'Packaging', () => {
 
         // Refresh page and make sure it is updated.
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
-        await waitForButton('.button:not([disabled])', 'Add package');
+        await waitForSelectorAndText('.button:not([disabled])', 'Add package');
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 cm" });
     });
@@ -275,11 +274,11 @@ describe( 'Packaging', () => {
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
         // Wait for "Add package" to finish loading, click "edit" once this session is loaded
-        await waitForButton('.button:not([disabled])', 'Add package');
+        await waitForSelectorAndText('.button:not([disabled])', 'Add package');
         await expect( page ).toClick( '.button.is-compact', { text: 'Edit' } );
 
         // Delete package
-        await page.waitForSelector( '.packages__add-edit-title.form-section-heading', { text: 'Add a package' } );
+        await page.waitForSelector( '.packages__add-edit-title.form-section-heading', { text: 'Edit package' } );
         await expect( page ).toClick( '.button.packages__delete.is-scary.is-borderless', { text: 'Delete this package' } )
 
         // Verify package is no longer in the list.

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -65,141 +65,141 @@ describe( 'Saving shipping label settings', () => {
     });
 } );
 
-describe( 'Shipping label payment method', () => {
-    afterEach(() => {
-        page.removeAllListeners('request');
-    });
+// describe( 'Shipping label payment method', () => {
+//     afterEach(() => {
+//         page.removeAllListeners('request');
+//     });
 
-    const mockAccountSettingAPI = async (response) => {
-        await page.setRequestInterception(true);
-        page.on('request', request => {
-            if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
-                request.respond({
-                    status: 200,
-                    contentType: 'application/json; charset=UTF-8',
-                    body: JSON.stringify(response)
-                });
-            } else {
-                request.continue();
-            }
-        });
-    };
+//     const mockAccountSettingAPI = async (response) => {
+//         await page.setRequestInterception(true);
+//         page.on('request', request => {
+//             if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
+//                 request.respond({
+//                     status: 200,
+//                     contentType: 'application/json; charset=UTF-8',
+//                     body: JSON.stringify(response)
+//                 });
+//             } else {
+//                 request.continue();
+//             }
+//         });
+//     };
 
-    it('should show "Add a credit card" button if Wordpress has no credit card', async () => {
-        // Intercept API before making any HTTP request
-        await mockAccountSettingAPI(AccountWithNoCreditCard);
+//     it('should show "Add a credit card" button if Wordpress has no credit card', async () => {
+//         // Intercept API before making any HTTP request
+//         await mockAccountSettingAPI(AccountWithNoCreditCard);
 
-        // Go to settings page after setting up interception.
-        await StoreOwnerFlow.login();
-        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         // Go to settings page after setting up interception.
+//         await StoreOwnerFlow.login();
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        // Test
-        await waitForSelectorAndText('.button.is-compact', 'Add a credit card');
-    });
+//         // Test
+//         await waitForSelectorAndText('.button.is-compact', 'Add a credit card');
+//     });
 
-    it('should show "Choose a different card" button if Wordpress.com has a credit card', async () => {
-        // Intercept API before making any HTTP request
-        await mockAccountSettingAPI(AccountWithOneCreditCard);
+//     it('should show "Choose a different card" button if Wordpress.com has a credit card', async () => {
+//         // Intercept API before making any HTTP request
+//         await mockAccountSettingAPI(AccountWithOneCreditCard);
 
-        // No need to login again, refresh page
-        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         // No need to login again, refresh page
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        // Test
-        await waitForSelectorAndText('.button.is-borderless', 'Choose a different card');
-        await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
-        await expect(page).toMatchElement('.label-settings__card-number', {
-            text: 'VISA ****5959'
-        });
-        await expect(page).toMatchElement('.label-settings__card-name', {
-            text: 'John Doe'
-        });
-    });
+//         // Test
+//         await waitForSelectorAndText('.button.is-borderless', 'Choose a different card');
+//         await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
+//         await expect(page).toMatchElement('.label-settings__card-number', {
+//             text: 'VISA ****5959'
+//         });
+//         await expect(page).toMatchElement('.label-settings__card-name', {
+//             text: 'John Doe'
+//         });
+//     });
 
-    it('should show 2 credit cards with the right information if Wordpress.com has 2 credit cards', async () => {
-        // Intercept API before making any HTTP request
-        await mockAccountSettingAPI(AccountWithTwoCreditCard);
+//     it('should show 2 credit cards with the right information if Wordpress.com has 2 credit cards', async () => {
+//         // Intercept API before making any HTTP request
+//         await mockAccountSettingAPI(AccountWithTwoCreditCard);
 
-        // No need to login again, refresh page
-        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         // No need to login again, refresh page
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        // Test
-        await waitForSelectorAndText('.button.is-borderless', 'Choose a different card' );
-        await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
+//         // Test
+//         await waitForSelectorAndText('.button.is-borderless', 'Choose a different card' );
+//         await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
 
-        // Verify "Add another credit card" is present after clicking 'Choose a different card'
-        await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
+//         // Verify "Add another credit card" is present after clicking 'Choose a different card'
+//         await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
 
-        // The index is based on the order in the settings' API. Inside the payment_methods prop.
-        // This API end point is mocked, check fixtures/account_settings.js for ordering.
-        const VISA_CARD_INDEX = 0;
-        const MASTERCARD_INDEX = 1;
+//         // The index is based on the order in the settings' API. Inside the payment_methods prop.
+//         // This API end point is mocked, check fixtures/account_settings.js for ordering.
+//         const VISA_CARD_INDEX = 0;
+//         const MASTERCARD_INDEX = 1;
 
-        const cardNumbers = await page.$$('.label-settings__card-number');
-        const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardNumber).toEqual('VISA ****5959');
-        const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardNumber).toEqual('MasterCard ****2862');
+//         const cardNumbers = await page.$$('.label-settings__card-number');
+//         const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardNumber).toEqual('VISA ****5959');
+//         const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardNumber).toEqual('MasterCard ****2862');
 
-        const cardNames = await page.$$('.label-settings__card-name');
-        const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardName).toEqual('John Doe');
-        const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardName).toEqual('Jane Smith');
+//         const cardNames = await page.$$('.label-settings__card-name');
+//         const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardName).toEqual('John Doe');
+//         const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardName).toEqual('Jane Smith');
 
-        const cardExpiryDates = await page.$$('.label-settings__card-date');
-        const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
-        const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
+//         const cardExpiryDates = await page.$$('.label-settings__card-date');
+//         const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
+//         const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
 
-        // Verify the default box is checked.
-        const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
-        const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
-        expect(firstCardDefaultCheckbox).toBeFalsy();
-        const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
-        expect(secondCardDefaultCheckbox).toBeTruthy();
-    });
+//         // Verify the default box is checked.
+//         const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
+//         const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
+//         expect(firstCardDefaultCheckbox).toBeFalsy();
+//         const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
+//         expect(secondCardDefaultCheckbox).toBeTruthy();
+//     });
 
-    it('should have no default card checked if there are multiple cards in Wordpress.com', async () => {
-        await mockAccountSettingAPI(AccountWithTwoCreditCardAndNoDefault);
+//     it('should have no default card checked if there are multiple cards in Wordpress.com', async () => {
+//         await mockAccountSettingAPI(AccountWithTwoCreditCardAndNoDefault);
 
-        // No need to login again, refresh page
-        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         // No need to login again, refresh page
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        // Verify "Add another credit card" is present after clicking 'Choose a different card'
-        await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
+//         // Verify "Add another credit card" is present after clicking 'Choose a different card'
+//         await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
 
-        // The index is based on the order in the settings' API. Inside the payment_methods prop.
-        // This API end point is mocked, check fixtures/account_settings.js for ordering.
-        const VISA_CARD_INDEX = 0;
-        const MASTERCARD_INDEX = 1;
+//         // The index is based on the order in the settings' API. Inside the payment_methods prop.
+//         // This API end point is mocked, check fixtures/account_settings.js for ordering.
+//         const VISA_CARD_INDEX = 0;
+//         const MASTERCARD_INDEX = 1;
 
-        const cardNumbers = await page.$$('.label-settings__card-number');
-        const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardNumber).toEqual('VISA ****5959');
-        const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardNumber).toEqual('MasterCard ****2862');
+//         const cardNumbers = await page.$$('.label-settings__card-number');
+//         const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardNumber).toEqual('VISA ****5959');
+//         const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardNumber).toEqual('MasterCard ****2862');
 
-        const cardNames = await page.$$('.label-settings__card-name');
-        const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardName).toEqual('John Doe');
-        const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardName).toEqual('Jane Smith');
+//         const cardNames = await page.$$('.label-settings__card-name');
+//         const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardName).toEqual('John Doe');
+//         const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardName).toEqual('Jane Smith');
 
-        const cardExpiryDates = await page.$$('.label-settings__card-date');
-        const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
-        const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
+//         const cardExpiryDates = await page.$$('.label-settings__card-date');
+//         const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
+//         const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
 
-        // Verify that no default box is checked.
-        const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
-        const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
-        expect(firstCardDefaultCheckbox).toBeFalsy();
-        const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
-        expect(secondCardDefaultCheckbox).toBeFalsy();
-    });
-});
+//         // Verify that no default box is checked.
+//         const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
+//         const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
+//         expect(firstCardDefaultCheckbox).toBeFalsy();
+//         const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
+//         expect(secondCardDefaultCheckbox).toBeFalsy();
+//     });
+// });
 
 describe( 'Packaging', () => {
     it( 'Can add package' , async () => {

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -102,7 +102,7 @@ describe( 'Shipping label payment method', () => {
         await page.waitForSelector('.button.is-compact', { text: 'Add a credit card' } );
     });
 
-    it('should show 2 credit cards with the right information f Wordpress.com has 2 credit cards', async () => {
+    it('should show 2 credit cards with the right information if Wordpress.com has 2 credit cards', async () => {
         // Intercept API before making any HTTP request
         await mockAccountSettingAPI(AccountWithTwoCreditCard);
 

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import { clickReactButton } from '../../utils/index';
+import { StoreOwnerFlow } from "../../utils/flows";
+
+describe( 'Shipping label settings', () => {
+
+	it( 'Can toggle to disable shipping labels' , async () => {
+		let slug = 'woocommerce-services';
+		await StoreOwnerFlow.login();
+		await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        await page.waitForSelector('.form-toggle__switch');
+        await expect(page).toClick('.form-toggle__switch');
+        await page.waitForSelector('.label-settings__cards-label form-label', {
+            hidden: true
+        });
+        await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
+        // Clicking save should persist the hidden state of the section.
+        await page.waitForSelector('.label-settings__cards-label form-label', {
+            hidden: true
+        });
+    });
+
+
+
+} );

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -231,14 +231,17 @@ describe( 'Packaging', () => {
         console.log("Started 'Can add package'");
         const packageName = 'Package Box 5x5x5';
 
+        console.log("Login");
 		await StoreOwnerFlow.login();
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
         // Wait for "Add package" to finish loading, click to pop up modal
+        console.log('Wait for "Add package" to finish loading, click to pop up modal');
         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
         await expect( page ).toClick( '.button', { text: 'Add package' } );
 
         // Create a new package
+        console.log('Create a new package');
         await waitForSelectorAndText( '.packages__add-edit-title.form-section-heading', 'Add a package' );
         await expect( page ).toFill( '.packages__properties-group #name', packageName );
         await expect( page ).toFill( '.form-text-input.form-dimensions-input__length', '5' );
@@ -248,15 +251,17 @@ describe( 'Packaging', () => {
         await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Add package' } )
 
         // Verify package shows up in list
-        // await waitForText('.packages__packages-row .packages__packages-row-details-dimensions', '5 x 5 x 5 cm');
+        console.log('Verify package shows up in list');
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 cm" });
 
         // Save package
+        console.log('Save package');
         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
         await saveAndWait();
 
         // Refresh page and make sure it is saved.
+        console.log('Refresh page and make sure it is saved.');
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -25,8 +25,6 @@ const waitForSelectorAndText = async (selector, text) => {
 };
 
 describe( 'Saving shipping label settings', () => {
-    console.log( "Running 'Saving shipping label settings'" );
-
 	it( 'Can toggle shipping labels' , async () => {
 		await StoreOwnerFlow.login();
 		await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
@@ -68,8 +66,6 @@ describe( 'Saving shipping label settings', () => {
 } );
 
 describe( 'Shipping label payment method', () => {
-    console.log( "Running 'Shipping label payment method'" );
-
     let response;
 
     const accountSettingsRequestListener = (request) => {
@@ -232,8 +228,6 @@ describe( 'Shipping label payment method', () => {
 describe( 'Packaging', () => {
     let metricSystemValue = ''; // either "in" or "cm".
 
-    console.log("Running 'packaging'");
-
     it( '> Can add package' , async () => {
         const packageName = 'Package Box 5x5x5';
 
@@ -241,12 +235,10 @@ describe( 'Packaging', () => {
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
         // Wait for "Add package" to finish loading, click to pop up modal
-        console.log('>> Wait for "Add package" to finish loading, click to pop up modal');
         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
         await expect( page ).toClick( '.button', { text: 'Add package' } );
 
         // Create a new package
-        console.log('>> Create a new package');
         await waitForSelectorAndText( '.packages__add-edit-title.form-section-heading', 'Add a package' );
         await expect( page ).toFill( '.packages__properties-group #name', packageName );
         await expect( page ).toFill( '.form-text-input.form-dimensions-input__length', '5' );
@@ -260,26 +252,21 @@ describe( 'Packaging', () => {
         metricSystemValue = await (await metricSystem[0].getProperty('innerText')).jsonValue();
 
         // Verify package shows up in list
-        console.log('>> Verify package shows up in list');
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 " + metricSystemValue });
 
         // Save package
-        console.log('>> Save package');
         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
         await saveAndWait();
 
         // Refresh page and make sure it is saved.
-        console.log('>> Refresh page and make sure it is saved.');
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 " + metricSystemValue });
-        console.log(">> Finished 'Can add package'");
     });
 
     it( '> Can edit package' , async () => {
-        console.log("Started 'Can edit package'");
         const packageName = 'Package Box 10x10x10';
 
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
@@ -298,12 +285,10 @@ describe( 'Packaging', () => {
         await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Done' } )
 
         // Verify package shows up in list
-        console.log('>> Verify package shows up in list');
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
 
         // Save package
-        console.log('>> Save package');
         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
         await saveAndWait();
 
@@ -312,11 +297,9 @@ describe( 'Packaging', () => {
         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
-        console.log("Started 'Finish edit package'");
     });
 
     it( '> Can delete package' , async () => {
-        console.log("Started 'Can delete package'");
         const packageName = 'Package Box 10x10x10';
 
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
@@ -330,12 +313,10 @@ describe( 'Packaging', () => {
         await expect( page ).toClick( '.button.packages__delete.is-scary.is-borderless', { text: 'Delete this package' } )
 
         // Verify package is no longer in the list.
-        console.log('>> Verify package shows up in list');
         await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
         await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
 
         // Save package
-        console.log('>> Save package');
         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
         await saveAndWait();
 
@@ -343,13 +324,10 @@ describe( 'Packaging', () => {
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
         await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
         await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
-        console.log("Started 'Finish delete package'");
     });
 
     it ( 'Can select and add service package', async () => {
         const packageName = 'Flat Rate Envelope'; // This is provided in services_data_mock_with_card.json
-
-        console.log("Started 'Can select and add service package'");
 
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
@@ -364,7 +342,6 @@ describe( 'Packaging', () => {
         await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Add package' } )
 
         // Verify the package was added to the list
-        console.log('>> Verify package shows up in list');
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "12.5 x 9.5 x 0.5 " + metricSystemValue });
     });

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -11,6 +11,17 @@ const saveAndWait = async () => {
     await page.waitForSelector('[class="button is-primary"]');
 };
 
+/**
+ * This function will wait for a button with any CSS selector + text value.
+ */
+const waitForButton = async (selector, buttonText) => {
+    return await page.waitForFunction(
+        (selector, buttonText) => Array.from(document.querySelectorAll(selector)).find(el => el.textContent === buttonText),
+        {},
+        selector, buttonText
+    );
+};
+
 // describe( 'Saving shipping label settings', () => {
 // 	it( 'Can toggle shipping labels' , async () => {
 // 		await StoreOwnerFlow.login();
@@ -52,139 +63,236 @@ const saveAndWait = async () => {
 //     });
 // } );
 
-describe( 'Shipping label payment method', () => {
-    afterEach(() => {
-        page.removeAllListeners('request');
-    });
+// describe( 'Shipping label payment method', () => {
+//     afterEach(() => {
+//         page.removeAllListeners('request');
+//     });
 
-    const mockAccountSettingAPI = async (response) => {
-        await page.setRequestInterception(true);
-        page.on('request', request => {
-            if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
-                request.respond({
-                    status: 200,
-                    contentType: 'application/json; charset=UTF-8',
-                    body: JSON.stringify(response)
-                });
-            } else {
-                request.continue();
-            }
-        });
-    };
+//     const mockAccountSettingAPI = async (response) => {
+//         await page.setRequestInterception(true);
+//         page.on('request', request => {
+//             if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
+//                 request.respond({
+//                     status: 200,
+//                     contentType: 'application/json; charset=UTF-8',
+//                     body: JSON.stringify(response)
+//                 });
+//             } else {
+//                 request.continue();
+//             }
+//         });
+//     };
 
-    it('should show "Choose a different card" button if Wordpress.com has a credit card', async () => {
-        // Intercept API before making any HTTP request
-        await mockAccountSettingAPI(AccountWithOneCreditCard);
+//     it('should show "Choose a different card" button if Wordpress.com has a credit card', async () => {
+//         // Intercept API before making any HTTP request
+//         await mockAccountSettingAPI(AccountWithOneCreditCard);
 
-        // Go to settings page after setting up interception.
-        await StoreOwnerFlow.login();
+//         // Go to settings page after setting up interception.
+//         await StoreOwnerFlow.login();
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+
+//         // Test
+//         await page.waitForSelector('.button.is-borderless', { text: 'Choose a different card' } );
+//         await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
+//         await expect(page).toMatchElement('.label-settings__card-number', {
+//             text: 'VISA ****5959'
+//         });
+//         await expect(page).toMatchElement('.label-settings__card-name', {
+//             text: 'John Doe'
+//         });
+//     });
+
+//     it('should show "Add a credit card" button if Wordpress has no credit card', async () => {
+//         // Intercept API before making any HTTP request
+//         await mockAccountSettingAPI(AccountWithNoCreditCard);
+
+//         // No need to login again, refresh page
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+
+//         // Test
+//         await page.waitForSelector('.button.is-compact', { text: 'Add a credit card' } );
+//     });
+
+//     it('should show 2 credit cards with the right information if Wordpress.com has 2 credit cards', async () => {
+//         // Intercept API before making any HTTP request
+//         await mockAccountSettingAPI(AccountWithTwoCreditCard);
+
+//         // No need to login again, refresh page
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+
+//         // Test
+//         await page.waitForSelector('.button.is-borderless', { text: 'Choose a different card' } );
+//         await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
+
+//         // Verify "Add another credit card" is present after clicking 'Choose a different card'
+//         await page.waitForSelector('.button.is-compact', { text: 'Add another credit card' } );
+
+//         // The index is based on the order in the settings' API. Inside the payment_methods prop.
+//         // This API end point is mocked, check fixtures/account_settings.js for ordering.
+//         const VISA_CARD_INDEX = 0;
+//         const MASTERCARD_INDEX = 1;
+
+//         const cardNumbers = await page.$$('.label-settings__card-number');
+//         const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardNumber).toEqual('VISA ****5959');
+//         const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardNumber).toEqual('MasterCard ****2862');
+
+//         const cardNames = await page.$$('.label-settings__card-name');
+//         const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardName).toEqual('John Doe');
+//         const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardName).toEqual('Jane Smith');
+
+//         const cardExpiryDates = await page.$$('.label-settings__card-date');
+//         const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
+//         const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
+
+//         // Verify the default box is checked.
+//         const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
+//         const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
+//         expect(firstCardDefaultCheckbox).toBeFalsy();
+//         const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
+//         expect(secondCardDefaultCheckbox).toBeTruthy();
+//     });
+
+//     it('should have no default card checked if there are multiple cards in Wordpress.com', async () => {
+//         await mockAccountSettingAPI(AccountWithTwoCreditCardAndNoDefault);
+
+//         // Go to settings page after setting up interception.
+//         await StoreOwnerFlow.login();
+//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+
+//         // Verify "Add another credit card" is present after clicking 'Choose a different card'
+//         await page.waitForSelector('.button.is-compact', { text: 'Add another credit card' } );
+
+//         // The index is based on the order in the settings' API. Inside the payment_methods prop.
+//         // This API end point is mocked, check fixtures/account_settings.js for ordering.
+//         const VISA_CARD_INDEX = 0;
+//         const MASTERCARD_INDEX = 1;
+
+//         const cardNumbers = await page.$$('.label-settings__card-number');
+//         const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardNumber).toEqual('VISA ****5959');
+//         const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardNumber).toEqual('MasterCard ****2862');
+
+//         const cardNames = await page.$$('.label-settings__card-name');
+//         const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardName).toEqual('John Doe');
+//         const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardName).toEqual('Jane Smith');
+
+//         const cardExpiryDates = await page.$$('.label-settings__card-date');
+//         const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
+//         const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+//         expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
+
+//         // Verify that no default box is checked.
+//         const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
+//         const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
+//         expect(firstCardDefaultCheckbox).toBeFalsy();
+//         const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
+//         expect(secondCardDefaultCheckbox).toBeFalsy();
+//     });
+// });
+
+describe( 'Packaging', () => {
+    it( 'Can add package' , async () => {
+        const packageName = 'Package Box 5x5x5';
+
+		await StoreOwnerFlow.login();
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        // Test
-        await page.waitForSelector('.button.is-borderless', { text: 'Choose a different card' } );
-        await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
-        await expect(page).toMatchElement('.label-settings__card-number', {
-            text: 'VISA ****5959'
-        });
-        await expect(page).toMatchElement('.label-settings__card-name', {
-            text: 'John Doe'
-        });
+        // Wait for "Add package" to finish loading, click to pop up modal
+        await waitForButton('.button:not([disabled])', 'Add package');
+        await expect( page ).toClick( '.button', { text: 'Add package' } );
+
+        // Create a new package
+        await page.waitForSelector( '.packages__add-edit-title.form-section-heading', { text: 'Add a package' } );
+        await expect( page ).toFill( '.packages__properties-group #name', packageName );
+        await expect( page ).toFill( '.form-text-input.form-dimensions-input__length', '5' );
+        await expect( page ).toFill( '.form-text-input.form-dimensions-input__width', '5' );
+        await expect( page ).toFill( '.form-text-input.form-dimensions-input__height', '5' );
+        await expect( page ).toFill( '.form-text-input-with-affixes #box_weight', '0.5' );
+        await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Add package' } )
+
+        // Verify package shows up in list
+        // await waitForText('.packages__packages-row .packages__packages-row-details-dimensions', '5 x 5 x 5 cm');
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 cm" });
+
+        // Save package
+        await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
+        await saveAndWait();
+
+        // Refresh page and make sure it is saved.
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        await waitForButton('.button:not([disabled])', 'Add package');
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 cm" });
     });
 
-    it('should show "Add a credit card" button if Wordpress has no credit card', async () => {
-        // Intercept API before making any HTTP request
-        await mockAccountSettingAPI(AccountWithNoCreditCard);
+    it( 'Can edit package' , async () => {
+        const packageName = 'Package Box 10x10x10';
 
-        // No need to login again, refresh page
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        // Test
-        await page.waitForSelector('.button.is-compact', { text: 'Add a credit card' } );
+        // Wait for "Add package" to finish loading, click "edit" once this session is loaded
+        await waitForButton('.button:not([disabled])', 'Add package');
+        await expect( page ).toClick( '.button.is-compact', { text: 'Edit' } );
+
+        // Edit package
+        await page.waitForSelector( '.packages__add-edit-title.form-section-heading', { text: 'Add a package' } );
+        await expect( page ).toFill( '.packages__properties-group #name', packageName );
+        await expect( page ).toFill( '.form-text-input.form-dimensions-input__length', '10' );
+        await expect( page ).toFill( '.form-text-input.form-dimensions-input__width', '10' );
+        await expect( page ).toFill( '.form-text-input.form-dimensions-input__height', '10' );
+        await expect( page ).toFill( '.form-text-input-with-affixes #box_weight', '0.8' );
+        await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Done' } )
+
+        // Verify package shows up in list
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 cm" });
+
+        // Save package
+        await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
+        await saveAndWait();
+
+        // Refresh page and make sure it is updated.
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        await waitForButton('.button:not([disabled])', 'Add package');
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 cm" });
     });
 
-    it('should show 2 credit cards with the right information if Wordpress.com has 2 credit cards', async () => {
-        // Intercept API before making any HTTP request
-        await mockAccountSettingAPI(AccountWithTwoCreditCard);
+    it( 'Can delete package' , async () => {
+        const packageName = 'Package Box 10x10x10';
 
-        // No need to login again, refresh page
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-        // Test
-        await page.waitForSelector('.button.is-borderless', { text: 'Choose a different card' } );
-        await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
+        // Wait for "Add package" to finish loading, click "edit" once this session is loaded
+        await waitForButton('.button:not([disabled])', 'Add package');
+        await expect( page ).toClick( '.button.is-compact', { text: 'Edit' } );
 
-        // Verify "Add another credit card" is present after clicking 'Choose a different card'
-        await page.waitForSelector('.button.is-compact', { text: 'Add another credit card' } );
+        // Delete package
+        await page.waitForSelector( '.packages__add-edit-title.form-section-heading', { text: 'Add a package' } );
+        await expect( page ).toClick( '.button.packages__delete.is-scary.is-borderless', { text: 'Delete this package' } )
 
-        // The index is based on the order in the settings' API. Inside the payment_methods prop.
-        // This API end point is mocked, check fixtures/account_settings.js for ordering.
-        const VISA_CARD_INDEX = 0;
-        const MASTERCARD_INDEX = 1;
+        // Verify package is no longer in the list.
+        await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+        await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 cm" });
 
-        const cardNumbers = await page.$$('.label-settings__card-number');
-        const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardNumber).toEqual('VISA ****5959');
-        const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardNumber).toEqual('MasterCard ****2862');
+        // Save package
+        await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
+        await saveAndWait();
 
-        const cardNames = await page.$$('.label-settings__card-name');
-        const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardName).toEqual('John Doe');
-        const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardName).toEqual('Jane Smith');
-
-        const cardExpiryDates = await page.$$('.label-settings__card-date');
-        const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
-        const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
-
-        // Verify the default box is checked.
-        const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
-        const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
-        expect(firstCardDefaultCheckbox).toBeFalsy();
-        const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
-        expect(secondCardDefaultCheckbox).toBeTruthy();
-    });
-
-    it('should have no default card checked if there are multiple cards in Wordpress.com', async () => {
-        await mockAccountSettingAPI(AccountWithTwoCreditCardAndNoDefault);
-
-        // Go to settings page after setting up interception.
-        await StoreOwnerFlow.login();
+        // Refresh page and make sure it is deleted.
         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
-
-        // Verify "Add another credit card" is present after clicking 'Choose a different card'
-        await page.waitForSelector('.button.is-compact', { text: 'Add another credit card' } );
-
-        // The index is based on the order in the settings' API. Inside the payment_methods prop.
-        // This API end point is mocked, check fixtures/account_settings.js for ordering.
-        const VISA_CARD_INDEX = 0;
-        const MASTERCARD_INDEX = 1;
-
-        const cardNumbers = await page.$$('.label-settings__card-number');
-        const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardNumber).toEqual('VISA ****5959');
-        const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardNumber).toEqual('MasterCard ****2862');
-
-        const cardNames = await page.$$('.label-settings__card-name');
-        const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardName).toEqual('John Doe');
-        const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardName).toEqual('Jane Smith');
-
-        const cardExpiryDates = await page.$$('.label-settings__card-date');
-        const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
-        const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-        expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
-
-        // Verify that no default box is checked.
-        const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
-        const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
-        expect(firstCardDefaultCheckbox).toBeFalsy();
-        const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
-        expect(secondCardDefaultCheckbox).toBeFalsy();
+        await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+        await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 cm" });
     });
 });

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -39,29 +39,30 @@ describe( 'Saving shipping label settings', () => {
             visible: false
         });
 
-        // Enable
+        // Toggle it back to enable so the following tests can run.
         await expect(page).toClick('.form-toggle__switch');
         await saveAndWait();
     });
 
     it ('Should be able to select a different paper size', async () => {
-        await page.select('select.form-select', 'label');
-        await saveAndWait();
-        // TODO: Refresh page to see if it is selected.
-        // await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
-
-        let paperSize = await page.$('select.form-select');
-        let selectedOption = await (await paperSize.getProperty('value')).jsonValue();
-        expect(selectedOption).toBe('label');
-
+        // Save it as legal
         await page.select('select.form-select', 'legal');
         await saveAndWait();
-        // TODO: Refresh page to see if it is selected.
-        // await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        await expect(page).toMatchElement('.notice.is-success .notice__text', { text: 'Your shipping settings have been saved.' });
 
         paperSize = await page.$('select.form-select');
         selectedOption = await (await paperSize.getProperty('value')).jsonValue();
         expect(selectedOption).toBe('legal');
+
+        // Save it back to label
+        await page.select('select.form-select', 'label');
+        await saveAndWait();
+        await expect(page).toMatchElement('.notice.is-success .notice__text', { text: 'Your shipping settings have been saved.' });
+
+        let paperSize = await page.$('select.form-select');
+        let selectedOption = await (await paperSize.getProperty('value')).jsonValue();
+            expect(selectedOption).toBe('label');
+
     });
 } );
 

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -51,7 +51,7 @@ describe( 'Saving shipping label settings', () => {
         await expect(page).toMatchElement('.notice.is-success .notice__text', { text: 'Your shipping settings have been saved.' });
 
         let paperSize = await page.$('select.form-select');
-        selectedOption = await (await paperSize.getProperty('value')).jsonValue();
+        let selectedOption = await (await paperSize.getProperty('value')).jsonValue();
         expect(selectedOption).toBe('legal');
 
         // Save it back to label
@@ -60,8 +60,8 @@ describe( 'Saving shipping label settings', () => {
         await expect(page).toMatchElement('.notice.is-success .notice__text', { text: 'Your shipping settings have been saved.' });
 
         paperSize = await page.$('select.form-select');
-        let selectedOption = await (await paperSize.getProperty('value')).jsonValue();
-            expect(selectedOption).toBe('label');
+        selectedOption = await (await paperSize.getProperty('value')).jsonValue();
+        expect(selectedOption).toBe('label');
     });
 } );
 

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -65,309 +65,307 @@ describe( 'Saving shipping label settings', () => {
         selectedOption = await (await paperSize.getProperty('value')).jsonValue();
         expect(selectedOption).toBe('label');
     });
-
-    it ('Should show the correct email receipts message', async () => {
-        const cardDesc = await page.$$('.label-settings__credit-card-description');
-        const cardDescValue = await (await cardDesc[2].getProperty('innerText')).jsonValue();
-        console.log(">>> email receipts", cardDescValue);
-        await expect(page).toMatchElement('.label-settings__credit-card-description', { text: /Email the label purchase receipts to \w+ \(\w+\) at .+\@.+/ });
-    });
 } );
 
-// describe( 'Shipping label payment method', () => {
-//     console.log( "Running 'Shipping label payment method'" );
+describe( 'Shipping label payment method', () => {
+    console.log( "Running 'Shipping label payment method'" );
 
-//     let response;
+    let response;
 
-//     const accountSettingsRequestListener = (request) => {
-//         if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
-//             request.respond({
-//                 status: 200,
-//                 contentType: 'application/json; charset=UTF-8',
-//                 body: JSON.stringify(response)
-//             });
-//         } else {
-//             request.continue();
-//         }
-//     };
+    const accountSettingsRequestListener = (request) => {
+        if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
+            request.respond({
+                status: 200,
+                contentType: 'application/json; charset=UTF-8',
+                body: JSON.stringify(response)
+            });
+        } else {
+            request.continue();
+        }
+    };
 
-//     const mockAccountSettingAPI = async (mockResponse) => {
-//         response = mockResponse;
-//         page.on('request', accountSettingsRequestListener);
-//     };
+    const mockAccountSettingAPI = async (mockResponse) => {
+        response = mockResponse;
+        page.on('request', accountSettingsRequestListener);
+    };
 
-//     afterEach(() => {
-//         response = '';
-//         page.removeListener('request', accountSettingsRequestListener);
-//     });
+    afterEach(() => {
+        response = '';
+        page.removeListener('request', accountSettingsRequestListener);
+    });
 
-//     /**
-//      * Not really a test case. But needed to run this once, prior to all test case in this describe.
-//      */
-//     it('should turn on request interception after all credit card test ran', async () => {
-//         await page.setRequestInterception(true);
-//     });
+    /**
+     * Not really a test case. But needed to run this once, prior to all test case in this describe.
+     */
+    it('should turn on request interception after all credit card test ran', async () => {
+        await page.setRequestInterception(true);
+    });
 
-//     it('should show "Add a credit card" button if Wordpress has no credit card', async () => {
-//         // Intercept API before making any HTTP request
-//         await mockAccountSettingAPI(AccountWithNoCreditCard);
+    it('should show "Add a credit card" button if Wordpress has no credit card', async () => {
+        // Intercept API before making any HTTP request
+        await mockAccountSettingAPI(AccountWithNoCreditCard);
 
-//         // Go to settings page after setting up interception.
-//         await StoreOwnerFlow.login();
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        // Go to settings page after setting up interception.
+        await StoreOwnerFlow.login();
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         // Test
-//         await waitForSelectorAndText('.button.is-compact', 'Add a credit card');
-//     });
+        // Test
+        await waitForSelectorAndText('.button.is-compact', 'Add a credit card');
+    });
 
-//     it('should show "Choose a different card" button if Wordpress.com has a credit card', async () => {
-//         // Intercept API before making any HTTP request
-//         await mockAccountSettingAPI(AccountWithOneCreditCard);
+    it('should show "Choose a different card" button if Wordpress.com has a credit card', async () => {
+        // Intercept API before making any HTTP request
+        await mockAccountSettingAPI(AccountWithOneCreditCard);
 
-//         // No need to login again, refresh page
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        // No need to login again, refresh page
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         // Test
-//         await waitForSelectorAndText('.button.is-borderless', 'Choose a different card');
-//         await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
-//         await expect(page).toMatchElement('.label-settings__card-number', {
-//             text: 'VISA ****5959'
-//         });
-//         await expect(page).toMatchElement('.label-settings__card-name', {
-//             text: 'John Doe'
-//         });
-//     });
+        // Test
+        await waitForSelectorAndText('.button.is-borderless', 'Choose a different card');
+        await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
+        await expect(page).toMatchElement('.label-settings__card-number', {
+            text: 'VISA ****5959'
+        });
+        await expect(page).toMatchElement('.label-settings__card-name', {
+            text: 'John Doe'
+        });
+    });
 
-//     it('should show 2 credit cards with the right information if Wordpress.com has 2 credit cards', async () => {
-//         // Intercept API before making any HTTP request
-//         await mockAccountSettingAPI(AccountWithTwoCreditCard);
+    it('should show 2 credit cards with the right information if Wordpress.com has 2 credit cards', async () => {
+        // Intercept API before making any HTTP request
+        await mockAccountSettingAPI(AccountWithTwoCreditCard);
 
-//         // No need to login again, refresh page
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        // No need to login again, refresh page
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         // Test
-//         await waitForSelectorAndText('.button.is-borderless', 'Choose a different card' );
-//         await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
+        // Test
+        await waitForSelectorAndText('.button.is-borderless', 'Choose a different card' );
+        await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
 
-//         // Verify "Add another credit card" is present after clicking 'Choose a different card'
-//         await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
+        // Verify "Add another credit card" is present after clicking 'Choose a different card'
+        await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
 
-//         // The index is based on the order in the settings' API. Inside the payment_methods prop.
-//         // This API end point is mocked, check fixtures/account_settings.js for ordering.
-//         const VISA_CARD_INDEX = 0;
-//         const MASTERCARD_INDEX = 1;
+        // The index is based on the order in the settings' API. Inside the payment_methods prop.
+        // This API end point is mocked, check fixtures/account_settings.js for ordering.
+        const VISA_CARD_INDEX = 0;
+        const MASTERCARD_INDEX = 1;
 
-//         const cardNumbers = await page.$$('.label-settings__card-number');
-//         const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardNumber).toEqual('VISA ****5959');
-//         const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardNumber).toEqual('MasterCard ****2862');
+        const cardNumbers = await page.$$('.label-settings__card-number');
+        const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardNumber).toEqual('VISA ****5959');
+        const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardNumber).toEqual('MasterCard ****2862');
 
-//         const cardNames = await page.$$('.label-settings__card-name');
-//         const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardName).toEqual('John Doe');
-//         const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardName).toEqual('Jane Smith');
+        const cardNames = await page.$$('.label-settings__card-name');
+        const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardName).toEqual('John Doe');
+        const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardName).toEqual('Jane Smith');
 
-//         const cardExpiryDates = await page.$$('.label-settings__card-date');
-//         const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
-//         const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
+        const cardExpiryDates = await page.$$('.label-settings__card-date');
+        const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
+        const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
 
-//         // Verify the default box is checked.
-//         const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
-//         const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
-//         expect(firstCardDefaultCheckbox).toBeFalsy();
-//         const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
-//         expect(secondCardDefaultCheckbox).toBeTruthy();
-//     });
+        // Verify the default box is checked.
+        const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
+        const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
+        expect(firstCardDefaultCheckbox).toBeFalsy();
+        const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
+        expect(secondCardDefaultCheckbox).toBeTruthy();
+    });
 
-//     it('should have no default card checked if there are multiple cards in Wordpress.com', async () => {
-//         await mockAccountSettingAPI(AccountWithTwoCreditCardAndNoDefault);
+    it('should have no default card checked if there are multiple cards in Wordpress.com', async () => {
+        await mockAccountSettingAPI(AccountWithTwoCreditCardAndNoDefault);
 
-//         // No need to login again, refresh page
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        // No need to login again, refresh page
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         // Verify "Add another credit card" is present after clicking 'Choose a different card'
-//         await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
+        // Verify "Add another credit card" is present after clicking 'Choose a different card'
+        await waitForSelectorAndText('.button.is-compact', 'Add another credit card' );
 
-//         // The index is based on the order in the settings' API. Inside the payment_methods prop.
-//         // This API end point is mocked, check fixtures/account_settings.js for ordering.
-//         const VISA_CARD_INDEX = 0;
-//         const MASTERCARD_INDEX = 1;
+        // The index is based on the order in the settings' API. Inside the payment_methods prop.
+        // This API end point is mocked, check fixtures/account_settings.js for ordering.
+        const VISA_CARD_INDEX = 0;
+        const MASTERCARD_INDEX = 1;
 
-//         const cardNumbers = await page.$$('.label-settings__card-number');
-//         const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardNumber).toEqual('VISA ****5959');
-//         const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardNumber).toEqual('MasterCard ****2862');
+        const cardNumbers = await page.$$('.label-settings__card-number');
+        const firstCardNumber = await (await cardNumbers[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardNumber).toEqual('VISA ****5959');
+        const secondCardNumber = await (await cardNumbers[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardNumber).toEqual('MasterCard ****2862');
 
-//         const cardNames = await page.$$('.label-settings__card-name');
-//         const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardName).toEqual('John Doe');
-//         const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardName).toEqual('Jane Smith');
+        const cardNames = await page.$$('.label-settings__card-name');
+        const firstCardName = await (await cardNames[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardName).toEqual('John Doe');
+        const secondCardName = await (await cardNames[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardName).toEqual('Jane Smith');
 
-//         const cardExpiryDates = await page.$$('.label-settings__card-date');
-//         const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
-//         const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
-//         expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
+        const cardExpiryDates = await page.$$('.label-settings__card-date');
+        const firstCardExpiryDate = await (await cardExpiryDates[VISA_CARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(firstCardExpiryDate).toEqual('Expires 2030-06-10');
+        const secondCardExpiryDate = await (await cardExpiryDates[MASTERCARD_INDEX].getProperty('innerText')).jsonValue();
+        expect(secondCardExpiryDate).toEqual('Expires 2025-12-31');
 
-//         // Verify that no default box is checked.
-//         const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
-//         const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
-//         expect(firstCardDefaultCheckbox).toBeFalsy();
-//         const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
-//         expect(secondCardDefaultCheckbox).toBeFalsy();
-//     });
+        // Verify that no default box is checked.
+        const cardDefaultCheckbox = await page.$$('.label-settings__card-checkbox.form-checkbox');
+        const firstCardDefaultCheckbox = await (await cardDefaultCheckbox[VISA_CARD_INDEX].getProperty('checked')).jsonValue();
+        expect(firstCardDefaultCheckbox).toBeFalsy();
+        const secondCardDefaultCheckbox = await (await cardDefaultCheckbox[MASTERCARD_INDEX].getProperty('checked')).jsonValue();
+        expect(secondCardDefaultCheckbox).toBeFalsy();
+    });
 
-//     /**
-//      * Not really a test case. But needed to run this once, after all test case ran in this describe.
-//      */
-//     it('should turn off request interception after all credit card test ran', async () => {
-//         await page.setRequestInterception(false);
-//     });
-// });
+    it ('Should show the correct email receipts message', async () => {
+        // This test continue to use the mocked account/settings from the above test, which relies on AccountWithTwoCreditCardAndNoDefault.
+        await expect(page).toMatchElement('.label-settings__credit-card-description', { text: "Email the label purchase receipts to johndoe (johndoe) at john.doe@automattic.com" });
+    });
 
-// describe( 'Packaging', () => {
-//     let metricSystemValue = ''; // either "in" or "cm".
+    /**
+     * Not really a test case. But needed to run this once, after all test case ran in this describe.
+     */
+    it('should turn off request interception after all credit card test ran', async () => {
+        await page.setRequestInterception(false);
+    });
+});
 
-//     console.log("Running 'packaging'");
+describe( 'Packaging', () => {
+    let metricSystemValue = ''; // either "in" or "cm".
 
-//     it( '> Can add package' , async () => {
-//         const packageName = 'Package Box 5x5x5';
+    console.log("Running 'packaging'");
 
-// 		await StoreOwnerFlow.login();
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+    it( '> Can add package' , async () => {
+        const packageName = 'Package Box 5x5x5';
 
-//         // Wait for "Add package" to finish loading, click to pop up modal
-//         console.log('>> Wait for "Add package" to finish loading, click to pop up modal');
-//         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
-//         await expect( page ).toClick( '.button', { text: 'Add package' } );
+		await StoreOwnerFlow.login();
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         // Create a new package
-//         console.log('>> Create a new package');
-//         await waitForSelectorAndText( '.packages__add-edit-title.form-section-heading', 'Add a package' );
-//         await expect( page ).toFill( '.packages__properties-group #name', packageName );
-//         await expect( page ).toFill( '.form-text-input.form-dimensions-input__length', '5' );
-//         await expect( page ).toFill( '.form-text-input.form-dimensions-input__width', '5' );
-//         await expect( page ).toFill( '.form-text-input.form-dimensions-input__height', '5' );
-//         await expect( page ).toFill( '.form-text-input-with-affixes #box_weight', '0.5' );
-//         await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Add package' } )
+        // Wait for "Add package" to finish loading, click to pop up modal
+        console.log('>> Wait for "Add package" to finish loading, click to pop up modal');
+        await waitForSelectorAndText('.button:not([disabled])', 'Add package');
+        await expect( page ).toClick( '.button', { text: 'Add package' } );
 
-//         // Set this once globally, all following test will use this metric
-//         const metricSystem = await page.$$('.form-text-input-with-affixes .form-text-input-with-affixes__suffix');
-//         metricSystemValue = await (await metricSystem[0].getProperty('innerText')).jsonValue();
+        // Create a new package
+        console.log('>> Create a new package');
+        await waitForSelectorAndText( '.packages__add-edit-title.form-section-heading', 'Add a package' );
+        await expect( page ).toFill( '.packages__properties-group #name', packageName );
+        await expect( page ).toFill( '.form-text-input.form-dimensions-input__length', '5' );
+        await expect( page ).toFill( '.form-text-input.form-dimensions-input__width', '5' );
+        await expect( page ).toFill( '.form-text-input.form-dimensions-input__height', '5' );
+        await expect( page ).toFill( '.form-text-input-with-affixes #box_weight', '0.5' );
+        await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Add package' } )
 
-//         // Verify package shows up in list
-//         console.log('>> Verify package shows up in list');
-//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 " + metricSystemValue });
+        // Set this once globally, all following test will use this metric
+        const metricSystem = await page.$$('.form-text-input-with-affixes .form-text-input-with-affixes__suffix');
+        metricSystemValue = await (await metricSystem[0].getProperty('innerText')).jsonValue();
 
-//         // Save package
-//         console.log('>> Save package');
-//         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
-//         await saveAndWait();
+        // Verify package shows up in list
+        console.log('>> Verify package shows up in list');
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 " + metricSystemValue });
 
-//         // Refresh page and make sure it is saved.
-//         console.log('>> Refresh page and make sure it is saved.');
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
-//         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
-//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 " + metricSystemValue });
-//         console.log(">> Finished 'Can add package'");
-//     });
+        // Save package
+        console.log('>> Save package');
+        await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
+        await saveAndWait();
 
-//     it( '> Can edit package' , async () => {
-//         console.log("Started 'Can edit package'");
-//         const packageName = 'Package Box 10x10x10';
+        // Refresh page and make sure it is saved.
+        console.log('>> Refresh page and make sure it is saved.');
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        await waitForSelectorAndText('.button:not([disabled])', 'Add package');
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "5 x 5 x 5 " + metricSystemValue });
+        console.log(">> Finished 'Can add package'");
+    });
 
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+    it( '> Can edit package' , async () => {
+        console.log("Started 'Can edit package'");
+        const packageName = 'Package Box 10x10x10';
 
-//         // Wait for "Add package" to finish loading, click "edit" once this session is loaded
-//         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
-//         await expect( page ).toClick( '.button.is-compact', { text: 'Edit' } );
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         // Edit package
-//         await waitForSelectorAndText( '.packages__add-edit-title.form-section-heading', 'Edit package' );
-//         await expect( page ).toFill( '.packages__properties-group #name', packageName );
-//         await expect( page ).toFill( '.form-text-input.form-dimensions-input__length', '10' );
-//         await expect( page ).toFill( '.form-text-input.form-dimensions-input__width', '10' );
-//         await expect( page ).toFill( '.form-text-input.form-dimensions-input__height', '10' );
-//         await expect( page ).toFill( '.form-text-input-with-affixes #box_weight', '0.8' );
-//         await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Done' } )
+        // Wait for "Add package" to finish loading, click "edit" once this session is loaded
+        await waitForSelectorAndText('.button:not([disabled])', 'Add package');
+        await expect( page ).toClick( '.button.is-compact', { text: 'Edit' } );
 
-//         // Verify package shows up in list
-//         console.log('>> Verify package shows up in list');
-//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
+        // Edit package
+        await waitForSelectorAndText( '.packages__add-edit-title.form-section-heading', 'Edit package' );
+        await expect( page ).toFill( '.packages__properties-group #name', packageName );
+        await expect( page ).toFill( '.form-text-input.form-dimensions-input__length', '10' );
+        await expect( page ).toFill( '.form-text-input.form-dimensions-input__width', '10' );
+        await expect( page ).toFill( '.form-text-input.form-dimensions-input__height', '10' );
+        await expect( page ).toFill( '.form-text-input-with-affixes #box_weight', '0.8' );
+        await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Done' } )
 
-//         // Save package
-//         console.log('>> Save package');
-//         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
-//         await saveAndWait();
+        // Verify package shows up in list
+        console.log('>> Verify package shows up in list');
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
 
-//         // Refresh page and make sure it is updated.
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
-//         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
-//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
-//         console.log("Started 'Finish edit package'");
-//     });
+        // Save package
+        console.log('>> Save package');
+        await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
+        await saveAndWait();
 
-//     it( '> Can delete package' , async () => {
-//         console.log("Started 'Can delete package'");
-//         const packageName = 'Package Box 10x10x10';
+        // Refresh page and make sure it is updated.
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        await waitForSelectorAndText('.button:not([disabled])', 'Add package');
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
+        console.log("Started 'Finish edit package'");
+    });
 
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+    it( '> Can delete package' , async () => {
+        console.log("Started 'Can delete package'");
+        const packageName = 'Package Box 10x10x10';
 
-//         // Wait for "Add package" to finish loading, click "edit" once this session is loaded
-//         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
-//         await expect( page ).toClick( '.button.is-compact', { text: 'Edit' } );
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         // Delete package
-//         await page.waitForSelector( '.packages__add-edit-title.form-section-heading', { text: 'Edit package' } );
-//         await expect( page ).toClick( '.button.packages__delete.is-scary.is-borderless', { text: 'Delete this package' } )
+        // Wait for "Add package" to finish loading, click "edit" once this session is loaded
+        await waitForSelectorAndText('.button:not([disabled])', 'Add package');
+        await expect( page ).toClick( '.button.is-compact', { text: 'Edit' } );
 
-//         // Verify package is no longer in the list.
-//         console.log('>> Verify package shows up in list');
-//         await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-//         await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
+        // Delete package
+        await page.waitForSelector( '.packages__add-edit-title.form-section-heading', { text: 'Edit package' } );
+        await expect( page ).toClick( '.button.packages__delete.is-scary.is-borderless', { text: 'Delete this package' } )
 
-//         // Save package
-//         console.log('>> Save package');
-//         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
-//         await saveAndWait();
+        // Verify package is no longer in the list.
+        console.log('>> Verify package shows up in list');
+        await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+        await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
 
-//         // Refresh page and make sure it is deleted.
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
-//         await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-//         await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
-//         console.log("Started 'Finish delete package'");
-//     });
+        // Save package
+        console.log('>> Save package');
+        await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
+        await saveAndWait();
 
-//     it ( 'Can select and add service package', async () => {
-//         const packageName = 'Flat Rate Envelope'; // This is provided in services_data_mock_with_card.json
+        // Refresh page and make sure it is deleted.
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+        await expect(page).not.toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "10 x 10 x 10 " + metricSystemValue });
+        console.log("Started 'Finish delete package'");
+    });
 
-//         console.log("Started 'Can select and add service package'");
+    it ( 'Can select and add service package', async () => {
+        const packageName = 'Flat Rate Envelope'; // This is provided in services_data_mock_with_card.json
 
-//         await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        console.log("Started 'Can select and add service package'");
 
-//         // Wait for "Add package" to finish loading, then click "Add package"
-//         await waitForSelectorAndText('.button:not([disabled])', 'Add package');
-//         await expect( page ).toClick( '.button', { text: 'Add package' } );
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
 
-//         // Click the "Service package" tab, pick and add a service package.
-//         await expect( page ).toClick( '.segmented-control__link.item-index-1' );
-//         await expect( page ).toClick( '.foldable-card__action.foldable-card__expand');
-//         await expect( page ).toClick( '.foldable-card__content :first-child .packages__packages-row-actions input');
-//         await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Add package' } )
+        // Wait for "Add package" to finish loading, then click "Add package"
+        await waitForSelectorAndText('.button:not([disabled])', 'Add package');
+        await expect( page ).toClick( '.button', { text: 'Add package' } );
 
-//         // Verify the package was added to the list
-//         console.log('>> Verify package shows up in list');
-//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
-//         await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "12.5 x 9.5 x 0.5 " + metricSystemValue });
-//     });
-// });
+        // Click the "Service package" tab, pick and add a service package.
+        await expect( page ).toClick( '.segmented-control__link.item-index-1' );
+        await expect( page ).toClick( '.foldable-card__action.foldable-card__expand');
+        await expect( page ).toClick( '.foldable-card__content :first-child .packages__packages-row-actions input');
+        await expect( page ).toClick( '.button.form-button.is-primary', { text: 'Add package' } )
+
+        // Verify the package was added to the list
+        console.log('>> Verify package shows up in list');
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-details-name', { text: packageName });
+        await expect(page).toMatchElement('.packages__packages-row .packages__packages-row-dimensions', { text: "12.5 x 9.5 x 0.5 " + metricSystemValue });
+    });
+});

--- a/tests/e2e-tests/specs/admin/shipping-settings.test.js
+++ b/tests/e2e-tests/specs/admin/shipping-settings.test.js
@@ -3,25 +3,100 @@
  */
 import { clickReactButton } from '../../utils/index';
 import { StoreOwnerFlow } from "../../utils/flows";
+import { AccountWithNoCreditCard, AccountWithOneCreditCard, AccountWithTwoCreditCard } from "../../fixtures/account_settings";
 
-describe( 'Shipping label settings', () => {
+// describe( 'Saving shipping label settings', () => {
+// 	it( 'Can toggle shipping labels' , async () => {
+// 		let slug = 'woocommerce-services';
+// 		await StoreOwnerFlow.login();
+// 		await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+//         await page.waitForSelector('.form-toggle__switch');
+//         await expect(page).toClick('.form-toggle__switch');
+//         await page.waitForSelector('.label-settings__cards-label form-label', {
+//             hidden: true
+//         });
+//         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
+//         // Clicking save should persist the hidden state of the section.
+//         await page.waitForSelector('.label-settings__cards-label form-label', {
+//             hidden: true
+//         });
 
-	it( 'Can toggle to disable shipping labels' , async () => {
-		let slug = 'woocommerce-services';
-		await StoreOwnerFlow.login();
-		await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
-        await page.waitForSelector('.form-toggle__switch');
-        await expect(page).toClick('.form-toggle__switch');
-        await page.waitForSelector('.label-settings__cards-label form-label', {
-            hidden: true
+//         // Enable
+//         await expect(page).toClick('.form-toggle__switch');
+//         await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
+//     });
+// } );
+
+describe( 'Shipping label payment method', () => {
+    // it('should show "Choose a different card" button if Wordpress.com has a credit card', async () => {
+    //     await page.setRequestInterception(true);
+    //     page.on('request', request => {
+    //         if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
+    //             request.respond({
+    //                 status: 200,
+    //                 contentType: 'application/json; charset=UTF-8',
+    //                 body: JSON.stringify(AccountWithOneCreditCard)
+    //             });
+    //         } else {
+    //             request.continue();
+    //         }
+    //     });
+
+    //     await StoreOwnerFlow.login();
+    //     await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+    //     await page.waitForSelector('.button.is-borderless', { text: 'Choose a different card' } );
+    //     await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
+    //     await expect(page).toMatchElement('.label-settings__card-number', {
+    //         text: 'VISA ****5959'
+    //     });
+    //     await expect(page).toMatchElement('.label-settings__card-name', {
+    //         text: 'John Doe'
+    //     });
+    // });
+
+    // it('should show "Add a credit card" button if Wordpress has no credit card', async () => {
+    //     await page.setRequestInterception(true);
+    //     page.on('request', request => {
+    //         if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
+    //             request.respond({
+    //                 status: 200,
+    //                 contentType: 'application/json; charset=UTF-8',
+    //                 body: JSON.stringify(AccountWithNoCreditCard)
+    //             });
+    //         } else {
+    //             request.continue();
+    //         }
+    //     });
+
+    //     await StoreOwnerFlow.login();
+    //     await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+    //     await page.waitForSelector('.button.is-compact', { text: 'Add a credit card' } );
+    // });
+
+    it('should show "Choose a different card" button if Wordpress.com has 2 credit cards', async () => {
+        console.log(AccountWithTwoCreditCard);
+        await page.setRequestInterception(true);
+        page.on('request', request => {
+            if (request.url().match('wp-json/wc/v1/connect/account/settings')) {
+                request.respond({
+                    status: 200,
+                    contentType: 'application/json; charset=UTF-8',
+                    body: JSON.stringify(AccountWithTwoCreditCard)
+                });
+            } else {
+                request.continue();
+            }
         });
-        await expect( page ).toClick( '.button.is-primary', { text: 'Save changes' } );
-        // Clicking save should persist the hidden state of the section.
-        await page.waitForSelector('.label-settings__cards-label form-label', {
-            hidden: true
+
+        await StoreOwnerFlow.login();
+        await StoreOwnerFlow.openSettings('shipping', 'woocommerce-services-settings');
+        await page.waitForSelector('.button.is-borderless', { text: 'Choose a different card' } );
+        await expect( page ).toClick( '.button.is-borderless', { text: 'Choose a different card' } );
+        await expect(page).toMatchElement('.label-settings__card-number', {
+            text: 'MasterCard ****2862'
+        });
+        await expect(page).toMatchElement('.label-settings__card-name', {
+            text: 'John Doe'
         });
     });
-
-
-
-} );
+});

--- a/tests/e2e-tests/utils/index.js
+++ b/tests/e2e-tests/utils/index.js
@@ -62,6 +62,20 @@ const clickReactButton = async( selector ) => {
     page.$eval( selector, elem => elem.click() );
 };
 
+/**
+ * This function will wait for a button with any CSS selector + text value.
+ *
+ * @param {string} selector CSS selector
+ * @param {string} text The text value of the element we want to search for. ie. button's value, div's innertext.
+ */
+const waitForSelectorAndText = async (selector, text) => {
+    return await page.waitForFunction(
+        (cssSelector, innerTextContent) => !!Array.from(document.querySelectorAll(cssSelector)).find(el => el.textContent.trim() === innerTextContent.trim()),
+        {},
+        selector, text
+    );
+};
+
 module.exports = {
 	...flows,
 	clickTab,
@@ -70,4 +84,5 @@ module.exports = {
 	uiUnblocked,
 	verifyCheckboxIsSet,
 	clickReactButton,
+	waitForSelectorAndText,
 };


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-services/issues/1916

## Goal
Not to cover everything using E2E tests but to cover critical user flows that would affect WCS experience inside the settings page.

## Tests include
### Settings
- Toggling, save change
- Changing paper size, save change
- Email Receipts, check box should display recipient name and email based on their `account/settings` info,  `Email the label purchase receipts to harris (harris) at harris@localhost.com save changes`

### Choose a different card
- Add a new card
- Remove card when there is 1 card
- 0 card

### Packaging
- Add new custom package
- Add new service package
- Edit package
- Delete package

