### PR TITLE
Fix  Invalid attempt to spread non-iterable instance warning

### DIFF
--- a/client/extensions/woocommerce/state/sites/orders/notes/reducer.js
+++ b/client/extensions/woocommerce/state/sites/orders/notes/reducer.js
@@ -99,7 +99,7 @@ export function orders( state = {}, action ) {
 		}
 		case WOOCOMMERCE_ORDER_NOTE_CREATE_SUCCESS: {
 			const { note, orderId } = action;
-			const idList = [ ...state[ orderId ], note.id ];
+			const idList = [ ... ( state[ orderId ] || [] ) , note.id ];
 			return Object.assign( {}, state, { [ orderId ]: idList } );
 		}
 		default:


### PR DESCRIPTION
After purchasing a label this error will show:
Uncaught (in promise) TypeError: Invalid attempt to spread non-iterable instance
If the notify customer option is checked.

Problem is `state[ orderId ]` can be undefined which would not work with the spread operator `...`