### PR TITLE
Fix Refund option

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -27,7 +27,7 @@ import {
 import Gridicon from "gridicons";
 
 export class LabelItem extends Component {
-	renderRefund = ( label, expired ) => {
+	renderRefund = ( labelId, expired ) => {
 		const { orderId, siteId, translate } = this.props;
 
 		if ( expired ) {
@@ -42,7 +42,7 @@ export class LabelItem extends Component {
 		}
 
 		const openDialog = () => {
-			this.props.openRefundDialog( orderId, siteId, label.labelId );
+			this.props.openRefundDialog( orderId, siteId, labelId );
 		};
 
 		return (


### PR DESCRIPTION
I refactor the destructor of this.props to get all the vars without using the label object. I missed a spot.
Refund button works now.