### PR TITLE
Hide customer note from shipment tracking metabox.

### DIFF
--- a/client/extensions/woocommerce/state/sites/orders/activity-log/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/activity-log/selectors.js
@@ -119,9 +119,13 @@ export const isActivityLogLoading = ( state, orderId, siteId = getSelectedSiteId
  */
 export const getActivityLogEvents = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
 	const order = getOrder( state, orderId, siteId );
-	const events = getOrderNotes( state, orderId, siteId ).map( note => ( {
+
+	// There's no current need to display a note about customer emails, so just filter it out.
+	const orderNotes = getOrderNotes( state, orderId, siteId ).filter( o => false === o.customer_note );
+
+	const events = orderNotes.map( note => ( {
 		key: note.id,
-		type: note.customer_note ? EVENT_TYPES.CUSTOMER_NOTE : EVENT_TYPES.INTERNAL_NOTE,
+		type: EVENT_TYPES.INTERNAL_NOTE,
 		timestamp: new Date( note.date_created_gmt + 'Z' ).getTime(),
 		content: note.note,
 	} ) );

--- a/client/extensions/woocommerce/state/sites/orders/activity-log/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/activity-log/test/selectors.js
@@ -370,12 +370,6 @@ describe( 'selectors', () => {
 					timestamp: 1505727471000,
 					content: 'Something internal',
 				},
-				{
-					key: 2,
-					type: 'CUSTOMER_NOTE',
-					timestamp: 1505731071000,
-					content: 'Something customer-facing',
-				},
 			] );
 		} );
 
@@ -386,12 +380,6 @@ describe( 'selectors', () => {
 					type: 'INTERNAL_NOTE',
 					timestamp: 1505727471000,
 					content: 'Something internal',
-				},
-				{
-					key: 2,
-					type: 'CUSTOMER_NOTE',
-					timestamp: 1505731071000,
-					content: 'Something customer-facing',
 				},
 				{
 					key: 4,


### PR DESCRIPTION
Fixes #1984 

To test:
- Create new order (order cannot have any existing labels)
- Purchase label and print
- Close shipping modal
- Check Shipment Tracking metabox

Confirm that no invalid date notes appear. Should look like:
<img width="160" alt="image" src="https://user-images.githubusercontent.com/6209518/78167354-31f3b300-7403-11ea-93df-2306d3909f29.png">
