### PR TITLE
Fix order status changing after purchasing label

### DIFF
--- a/client/apps/shipping-label/view-wrapper-label.js
+++ b/client/apps/shipping-label/view-wrapper-label.js
@@ -27,7 +27,6 @@ import {
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	areLabelsFullyLoaded,
-	shouldUpdateOrderDetailPage,
 } from '../../extensions/woocommerce/woocommerce-services/state/shipping-label/selectors';
 import {
 	areLabelsEnabled,
@@ -163,16 +162,6 @@ export class ShippingLabelViewWrapper extends Component {
 		this.props.openTrackingFlow( orderId, siteId );
 	};
 
-	updateOrderDetailScreen = () => {
-		if ( window.jQuery ) {
-			window.jQuery.get( window.location.href, function( result ) {
-				const parsedResult = window.jQuery( result );
-				const updatedOrderNotes = parsedResult.find( '#woocommerce-order-notes' );
-				window.jQuery( '#woocommerce-order-notes' ).html( updatedOrderNotes.html() );
-				window.jQuery('#order_status').val('wc-completed').trigger('change');
-			} );
-		}
-	}
 	render() {
 		const {
 			siteId,
@@ -183,7 +172,6 @@ export class ShippingLabelViewWrapper extends Component {
 			translate,
 			events,
 			moment,
-			updateOrderDetailPage,
 		} = this.props;
 
 		const shouldRenderButton = ! loaded || labelsEnabled;
@@ -201,10 +189,6 @@ export class ShippingLabelViewWrapper extends Component {
 			const latestLabel = maxBy( activeLabels, 'createdDate' );
 			const createdMoment = moment( latestLabel.createdDate );
 			createdDate = createdMoment.format( 'll' );
-		}
-
-		if ( updateOrderDetailPage ) {
-			this.updateOrderDetailScreen();
 		}
 
 		return (
@@ -262,7 +246,6 @@ export default connect(
 		const events = getActivityLogEvents( state, orderId );
 		const orderLoading = isOrderLoading( state, orderId, siteId );
 		const orderLoaded = isOrderLoaded( state, orderId, siteId );
-		const updateOrderDetailPage = shouldUpdateOrderDetailPage( state, orderId, siteId );
 
 		return {
 			siteId,
@@ -271,7 +254,6 @@ export default connect(
 			orderLoading,
 			orderLoaded,
 			labelsEnabled: areLabelsEnabled( state, siteId ),
-			updateOrderDetailPage,
 		};
 	},
 	( dispatch ) => ( {

--- a/client/extensions/woocommerce/state/sites/orders/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/actions.js
@@ -12,6 +12,7 @@ import {
 	getNormalizedOrdersQuery,
 	removeTemporaryIds,
 	transformOrderForApi,
+	updateOrderDetailScreen,
 } from './utils';
 import { getOrderStatusGroup } from 'woocommerce/lib/order-status';
 import {
@@ -150,6 +151,7 @@ export const saveOrderSuccess = ( siteId, orderId, order = {} ) => {
 	if ( 'undefined' === typeof order.id ) {
 		return saveOrderError( siteId, orderId, order );
 	}
+	updateOrderDetailScreen();
 	return {
 		type: WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
 		siteId,

--- a/client/extensions/woocommerce/state/sites/orders/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/actions.js
@@ -151,7 +151,7 @@ export const saveOrderSuccess = ( siteId, orderId, order = {} ) => {
 	if ( 'undefined' === typeof order.id ) {
 		return saveOrderError( siteId, orderId, order );
 	}
-	updateOrderDetailScreen();
+	updateOrderDetailScreen( order );
 	return {
 		type: WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
 		siteId,

--- a/client/extensions/woocommerce/state/sites/orders/notes/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/notes/actions.js
@@ -11,6 +11,7 @@ import {
 	WOOCOMMERCE_ORDER_NOTES_REQUEST_FAILURE,
 	WOOCOMMERCE_ORDER_NOTES_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
+import { updateOrderDetailScreen } from '../utils';
 
 export const createNote = ( siteId, orderId, note, onSuccess = false, onFailure = false ) => {
 	return {
@@ -33,6 +34,7 @@ export const createNoteFailure = ( siteId, orderId, error = {} ) => {
 };
 
 export const createNoteSuccess = ( siteId, orderId, note ) => {
+	updateOrderDetailScreen({});
 	return {
 		type: WOOCOMMERCE_ORDER_NOTE_CREATE_SUCCESS,
 		siteId,

--- a/client/extensions/woocommerce/state/sites/orders/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/test/actions.js
@@ -145,7 +145,7 @@ describe( 'actions', () => {
 		test( 'should update order detail screen on order save', () => {
 			utils.updateOrderDetailScreen = spy();
 			saveOrderSuccess( siteId, 40, updatedOrder );
-			expect( utils.updateOrderDetailScreen ).to.have.been.called;
+			expect( utils.updateOrderDetailScreen ).to.have.been.called();
 		} );
 
 		test( 'should dispatch a failure action with the error when a the request fails', () => {

--- a/client/extensions/woocommerce/state/sites/orders/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/test/actions.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import { spy } from 'sinon';
 import { noop } from 'lodash';
 
 /**
@@ -33,6 +34,9 @@ import {
 	WOOCOMMERCE_ORDERS_REQUEST_FAILURE,
 	WOOCOMMERCE_ORDERS_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
+
+jest.unmock( '../utils' );
+import * as utils from '../utils';
 
 describe( 'actions', () => {
 	describe( '#fetchOrders()', () => {
@@ -129,12 +133,19 @@ describe( 'actions', () => {
 
 		test( 'should dispatch a success action with the order when request completes', () => {
 			const action = saveOrderSuccess( siteId, 40, updatedOrder );
+
 			expect( action ).to.eql( {
 				type: WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
 				siteId: 123,
 				orderId: 40,
 				order: { id: 40, status: 'completed' },
 			} );
+		} );
+
+		test( 'should update order detail screen on order save', () => {
+			utils.updateOrderDetailScreen = spy();
+			saveOrderSuccess( siteId, 40, updatedOrder );
+			expect( utils.updateOrderDetailScreen ).to.have.been.called;
 		} );
 
 		test( 'should dispatch a failure action with the error when a the request fails', () => {

--- a/client/extensions/woocommerce/state/sites/orders/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/test/actions.js
@@ -145,7 +145,7 @@ describe( 'actions', () => {
 		test( 'should update order detail screen on order save', () => {
 			utils.updateOrderDetailScreen = spy();
 			saveOrderSuccess( siteId, 40, updatedOrder );
-			expect( utils.updateOrderDetailScreen ).to.have.been.called();
+			expect( utils.updateOrderDetailScreen ).to.have.been.called;
 		} );
 
 		test( 'should dispatch a failure action with the error when a the request fails', () => {

--- a/client/extensions/woocommerce/state/sites/orders/utils.js
+++ b/client/extensions/woocommerce/state/sites/orders/utils.js
@@ -166,3 +166,17 @@ export function transformOrderForApi( order ) {
 
 	return order;
 }
+
+/**
+ * Directly update the order details screen with latest data.
+ */
+export function updateOrderDetailScreen() {
+	if ( window.jQuery ) {
+		window.jQuery.get( window.location.href, function( result ) {
+			const parsedResult = window.jQuery( result );
+			const updatedOrderNotes = parsedResult.find( '#woocommerce-order-notes' );
+			window.jQuery( '#woocommerce-order-notes' ).html( updatedOrderNotes.html() );
+			window.jQuery('#order_status').val('wc-completed').trigger('change');
+		} );
+	}
+}

--- a/client/extensions/woocommerce/state/sites/orders/utils.js
+++ b/client/extensions/woocommerce/state/sites/orders/utils.js
@@ -170,13 +170,20 @@ export function transformOrderForApi( order ) {
 /**
  * Directly update the order details screen with latest data.
  */
-export function updateOrderDetailScreen() {
+export function updateOrderDetailScreen( { status = '' } ) {
 	if ( window.jQuery ) {
-		window.jQuery.get( window.location.href, function( result ) {
-			const parsedResult = window.jQuery( result );
-			const updatedOrderNotes = parsedResult.find( '#woocommerce-order-notes' );
-			window.jQuery( '#woocommerce-order-notes' ).html( updatedOrderNotes.html() );
-			window.jQuery('#order_status').val('wc-completed').trigger('change');
-		} );
+
+		if ( status ) {
+			window.jQuery('#order_status').val( 'wc-' + status ).trigger('change');
+		}
+
+		const notesBox = window.jQuery( '#woocommerce-order-notes' );
+		if ( notesBox.length ) {
+			window.jQuery.get( window.location.href, function( result ) {
+				const parsedResult = window.jQuery( result );
+				const updatedOrderNotes = parsedResult.find( '#woocommerce-order-notes' );
+				window.jQuery( '#woocommerce-order-notes' ).html( updatedOrderNotes.html() );
+			} );
+		}
 	}
 }

--- a/client/extensions/woocommerce/woocommerce-services/lib/initialize-labels-state/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/initialize-labels-state/index.js
@@ -31,11 +31,12 @@ export default data => {
 			loaded: false,
 			isFetching: false,
 			error: false,
+			fulfillOrder: false,
+			emailDetails: false,
 		};
 	}
 
 	const { formData, labelsData, paperSize, storeOptions, canChangeCountries } = data;
-
 	//old WCS required a phone number and detected normalization status based on the existence of the phone field
 	//newer versions send the normalized flag
 	const originNormalized = Boolean( formData.origin_normalized || formData.origin.phone );
@@ -77,8 +78,6 @@ export default data => {
 		labels: labelsData || [],
 		paperSize,
 		storeOptions,
-		fulfillOrder: true,
-		emailDetails: true,
 		form: {
 			orderId: formData.order_id,
 			origin: {
@@ -136,6 +135,5 @@ export default data => {
 			rateOptions: {},
 		},
 		openedPackageId: Object.keys( formData.selected_packages )[ 0 ] || '',
-		shouldUpdateOrderDetailPage: false,
 	};
 };

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -92,9 +92,10 @@ import {
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_CUSTOMS_ITEM_ORIGIN_COUNTRY,
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SAVE_CUSTOMS,
 } from '../action-types';
-import { WOOCOMMERCE_ORDER_UPDATE_SUCCESS } from 'woocommerce/state/action-types';
+import { WOOCOMMERCE_ORDER_REQUEST_SUCCESS } from 'woocommerce/state/action-types';
 import getBoxDimensions from 'woocommerce/woocommerce-services/lib/utils/get-box-dimensions';
 import initializeLabelsState from 'woocommerce/woocommerce-services/lib/initialize-labels-state';
+import { isOrderFinished } from 'woocommerce/lib/order-status';
 
 const generateUniqueBoxId = ( keyBase, boxIds ) => {
 	for ( let i = 0; i <= boxIds.length; i++ ) {
@@ -1346,15 +1347,12 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_CLOSE_DETAILS_DIALOG ] = state => 
 	};
 };
 
-// Reset the state when the order changes
-reducers[ WOOCOMMERCE_ORDER_UPDATE_SUCCESS ] = ( { fulfillOrder }, { order: { status } } ) => {
-	const initialState = initializeLabelsState();
-
-	if ( fulfillOrder && "completed" === status ) {
-		initialState.shouldUpdateOrderDetailPage = true;
+reducers[ WOOCOMMERCE_ORDER_REQUEST_SUCCESS ] = ( state, { order: { status } } ) => {
+	return {
+		... state,
+		fulfillOrder: ! isOrderFinished( status ),
+		emailDetails: isOrderFinished( status ),
 	}
-
-	return initialState;
 };
 
 export default keyedReducer( 'orderId', ( state = initializeLabelsState(), action ) => {

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -685,8 +685,3 @@ export const isLabelDataFetchError = ( state, orderId, siteId = getSelectedSiteI
 		areLocationsErrored( state, siteId )
 	);
 };
-
-export const shouldUpdateOrderDetailPage = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
-	const shippingLabel = getShippingLabel( state, orderId, siteId );
-	return shippingLabel && shippingLabel.shouldUpdateOrderDetailPage;
-};


### PR DESCRIPTION
Closes #1987

Test:
Change order status to 'failed'
Purchase a new label.
Order status should not be changed to 'completed'
Also notes should be updated without a refresh.