### PR TITLE
Improve padding between service choices

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
@@ -33,7 +33,7 @@
 .rates-step__shipping-rate-container {
 	display: flex;
 	align-items: stretch;
-	height: 100px;
+	padding-top: 15px;
 }
 
 .rates-step__carier-logo-image-usps {
@@ -46,7 +46,7 @@
 	flex-grow: 1;
 	padding-left: 8px;
 	border-bottom: 1px solid #EDEFF0;
-	margin-bottom: 12px;
+	padding-bottom: 15px;
 }
 
 .rates-step__shipping-rate-radio-control {
@@ -77,6 +77,9 @@
 	font-size: 12px;
 	* label {
 		margin-left: 5px;
+	}
+	.components-base-control {
+		margin-bottom: 0px;
 	}
 }
 


### PR DESCRIPTION
Fixes #1989

Removes the fixed height for service options and replaces it with padding to improve desktop view and make the mobile view more usable.

Desktop view:
![image](https://user-images.githubusercontent.com/6209518/78291549-6f773f80-74da-11ea-93ff-d10eec7dade7.png)

Mobile view:
![image](https://user-images.githubusercontent.com/6209518/78291575-7c942e80-74da-11ea-869d-b8dafc4dd134.png)


The mobile view is not perfect but it's much more usable.
