### PR TITLE
Remove spinner from create shipping label button

### DIFF
--- a/classes/class-wc-connect-account-settings.php
+++ b/classes/class-wc-connect-account-settings.php
@@ -1,0 +1,58 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( class_exists( 'WC_Connect_Account_Settings' ) ) {
+	return;
+}
+
+class WC_Connect_Account_Settings {
+
+	/**
+	 * @var WC_Connect_Service_Settings_Store
+	 */
+	protected $settings_store;
+
+	public function __construct( 
+		WC_Connect_Service_Settings_Store $settings_store,
+		WC_Connect_Payment_Methods_Store $payment_methods_store
+	) {
+			$this->settings_store = $settings_store;
+			$this->payment_methods_store = $payment_methods_store;
+	}
+
+
+	public function get() {
+		$payment_methods_warning = false;
+		$payment_methods_success = $this->payment_methods_store->fetch_payment_methods_from_connect_server();
+
+		if ( ! $payment_methods_success ) {
+			$payment_methods_warning = __( 'There was a problem updating your saved credit cards.', 'woocommerce-services' );
+		}
+
+		$master_user = WC_Connect_Jetpack::get_master_user();
+		$connected_data = WC_Connect_Jetpack::get_connected_user_data( $master_user->ID );
+		$last_box_id = get_user_meta( get_current_user_id(), 'wc_connect_last_box_id', true );
+		$last_box_id = $last_box_id === "individual" ? "" : $last_box_id;
+
+		return array(
+			'storeOptions' => $this->settings_store->get_store_options(),
+			'formData' => $this->settings_store->get_account_settings(),
+			'formMeta' => array(
+				'can_manage_payments' => $this->settings_store->can_user_manage_payment_methods(),
+				'can_edit_settings' => true,
+				'master_user_name' => $master_user->display_name,
+				'master_user_login' => $master_user->user_login,
+				'master_user_wpcom_login' => $connected_data['login'],
+				'master_user_email' => $connected_data['email'],
+				'payment_methods' => $this->payment_methods_store->get_payment_methods(),
+				'warnings' => array( 'payment_methods' => $payment_methods_warning ),
+			),
+			'userMeta' => array(
+				'last_box_id' => $last_box_id,
+			),
+		);
+	}
+}

--- a/classes/class-wc-connect-account-settings.php
+++ b/classes/class-wc-connect-account-settings.php
@@ -4,10 +4,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( class_exists( 'WC_Connect_Account_Settings' ) ) {
-	return;
-}
-
 class WC_Connect_Account_Settings {
 
 	/**
@@ -15,7 +11,7 @@ class WC_Connect_Account_Settings {
 	 */
 	protected $settings_store;
 
-	public function __construct( 
+	public function __construct(
 		WC_Connect_Service_Settings_Store $settings_store,
 		WC_Connect_Payment_Methods_Store $payment_methods_store
 	) {

--- a/classes/class-wc-connect-continents.php
+++ b/classes/class-wc-connect-continents.php
@@ -1,4 +1,3 @@
-
 <?php
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/classes/class-wc-connect-continents.php
+++ b/classes/class-wc-connect-continents.php
@@ -1,0 +1,106 @@
+
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( class_exists( 'WC_Connect_Continents' ) ) {
+	return;
+}
+
+class WC_Connect_Continents {
+
+	/**
+	 * Return the list of countries and states for a given continent.
+	 *
+	 * @since  3.1.0
+	 * @param  string          $continent_code
+	 * @return array|mixed Response data, ready for insertion into collection data.
+	 */
+	public function get_continent( $continent_code = false ) {
+		$continents  = WC()->countries->get_continents();
+		$countries   = WC()->countries->get_countries();
+		$states      = WC()->countries->get_states();
+		$locale_info = include WC()->plugin_path() . '/i18n/locale-info.php';
+		$data        = array();
+
+		if ( ! array_key_exists( $continent_code, $continents ) ) {
+			return false;
+		}
+
+		$continent_list = $continents[ $continent_code ];
+
+		$continent = array(
+			'code' => $continent_code,
+			'name' => $continent_list['name'],
+		);
+
+		$local_countries = array();
+		foreach ( $continent_list['countries'] as $country_code ) {
+			if ( isset( $countries[ $country_code ] ) ) {
+				$country = array(
+					'code' => $country_code,
+					'name' => $countries[ $country_code ],
+				);
+
+				// If we have detailed locale information include that in the response
+				if ( array_key_exists( $country_code, $locale_info ) ) {
+					// Defensive programming against unexpected changes in locale-info.php
+					$country_data = wp_parse_args( $locale_info[ $country_code ], array(
+						'currency_code'  => 'USD',
+						'currency_pos'   => 'left',
+						'decimal_sep'    => '.',
+						'dimension_unit' => 'in',
+						'num_decimals'   => 2,
+						'thousand_sep'   => ',',
+						'weight_unit'    => 'lbs',
+					) );
+
+					$country = array_merge( $country, $country_data );
+				}
+
+				$local_states = array();
+				if ( isset( $states[ $country_code ] ) ) {
+					foreach ( $states[ $country_code ] as $state_code => $state_name ) {
+						$local_states[] = array(
+							'code' => $state_code,
+							'name' => $state_name,
+						);
+					}
+				}
+				$country['states'] = $local_states;
+
+				// Allow only desired keys (e.g. filter out tax rates)
+				$allowed = array(
+					'code',
+					'currency_code',
+					'currency_pos',
+					'decimal_sep',
+					'dimension_unit',
+					'name',
+					'num_decimals',
+					'states',
+					'thousand_sep',
+					'weight_unit',
+				);
+				$country = array_intersect_key( $country, array_flip( $allowed ) );
+
+				$local_countries[] = $country;
+			}
+		}
+
+		$continent['countries'] = $local_countries;
+		return $continent;
+	}
+
+
+	public function get() {
+		$continents = array();
+		foreach ( array_keys( WC()->countries->get_continents() ) as $continent_code ) {
+			$continents[] = $this->get_continent( $continent_code, null );
+		}
+
+		return $continents;
+	}
+}

--- a/classes/class-wc-connect-jetpack.php
+++ b/classes/class-wc-connect-jetpack.php
@@ -19,6 +19,9 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 		 * @return bool
 		 */
 		public static function is_active() {
+			if ( defined( 'WOOCOMMERCE_SERVICES_LOCAL_TEST_MODE') && WOOCOMMERCE_SERVICES_LOCAL_TEST_MODE ) {
+				return true;
+			}
 			if ( method_exists( 'Jetpack', 'is_active' ) ) {
 				return Jetpack::is_active();
 			}
@@ -77,6 +80,7 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 			}
 
 			return false;
+
 		}
 
 		/**

--- a/classes/class-wc-connect-package-settings.php
+++ b/classes/class-wc-connect-package-settings.php
@@ -4,10 +4,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( class_exists( 'WC_Connect_Package_Settings' ) ) {
-	return;
-}
-
 class WC_Connect_Package_Settings {
 	/**
 	 * @var WC_Connect_Service_Settings_Store
@@ -19,7 +15,7 @@ class WC_Connect_Package_Settings {
 	 */
 	protected $service_schemas_store;
 
-	public function __construct(			
+	public function __construct(
 		WC_Connect_Service_Settings_Store $settings_store,
 		WC_Connect_Service_Schemas_Store $service_schemas_store
 	) {

--- a/classes/class-wc-connect-package-settings.php
+++ b/classes/class-wc-connect-package-settings.php
@@ -1,0 +1,42 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( class_exists( 'WC_Connect_Package_Settings' ) ) {
+	return;
+}
+
+class WC_Connect_Package_Settings {
+	/**
+	 * @var WC_Connect_Service_Settings_Store
+	 */
+	protected $settings_store;
+
+	/**
+	 * @var WC_Connect_Service_Schemas_Store
+	 */
+	protected $service_schemas_store;
+
+	public function __construct(			
+		WC_Connect_Service_Settings_Store $settings_store,
+		WC_Connect_Service_Schemas_Store $service_schemas_store
+	) {
+		$this->settings_store = $settings_store;
+		$this->service_schemas_store = $service_schemas_store;
+	}
+	public function get() {
+		return array(
+			'storeOptions' => $this->settings_store->get_store_options(),
+			'formSchema'   => array(
+				'custom' => $this->service_schemas_store->get_packages_schema(),
+				'predefined' => $this->service_schemas_store->get_predefined_packages_schema()
+			),
+			'formData'     => array(
+				'custom' => $this->settings_store->get_packages(),
+				'predefined' => $this->settings_store->get_predefined_packages()
+			)
+		);
+	}
+}

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -20,11 +20,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		protected $service_schemas_store;
 
 		/**
-		 * @var WC_Connect_Payment_Methods_Store
-		 */
-		protected $payment_methods_store;
-
-		/**
 		 * @var WC_Connect_Account_Settings
 		 */
 		protected $account_settings;
@@ -60,7 +55,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			$this->api_client = $api_client;
 			$this->settings_store = $settings_store;
 			$this->service_schemas_store = $service_schemas_store;
-			$this->payment_methods_store = $payment_methods_store;
 			$this->account_settings = new WC_Connect_Account_Settings(
 					$settings_store,
 					$payment_methods_store

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -25,6 +25,21 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		protected $payment_methods_store;
 
 		/**
+		 * @var WC_Connect_Account_Settings
+		 */
+		protected $account_settings;
+
+		/**
+		 * @var WC_Connect_Package_Settings
+		 */
+		protected $package_settings;
+
+		/**
+		 * @var WC_Connect_Continents
+		 */
+		protected $continents;
+
+		/**
 		 * @var array Supported countries by USPS, see: https://webpmt.usps.gov/pmt010.cfm
 		 */
 		private $supported_countries = array( 'US', 'AS', 'PR', 'VI', 'GU', 'MP', 'UM', 'FM', 'MH' );
@@ -39,11 +54,22 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		public function __construct(
 			WC_Connect_API_Client $api_client,
 			WC_Connect_Service_Settings_Store $settings_store,
-			WC_Connect_Service_Schemas_Store $service_schemas_store
+			WC_Connect_Service_Schemas_Store $service_schemas_store,
+			WC_Connect_Payment_Methods_Store $payment_methods_store
 		) {
 			$this->api_client = $api_client;
 			$this->settings_store = $settings_store;
 			$this->service_schemas_store = $service_schemas_store;
+			$this->payment_methods_store = $payment_methods_store;
+			$this->account_settings = new WC_Connect_Account_Settings(
+					$settings_store,
+					$payment_methods_store
+			);
+			$this->package_settings = new WC_Connect_Package_Settings(
+					$settings_store,
+					$service_schemas_store
+			);
+			$this->continents = new WC_Connect_Continents();
 		}
 
 		public function get_item_data( WC_Order $order, $item ) {
@@ -395,10 +421,15 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
 			$items = array_filter( $order->get_items(), array( $this, 'filter_items_needing_shipping' ) );
 			$items_count = array_reduce( $items, array( $this, 'reducer_items_quantity' ), 0 );
+
 			$payload = array(
-				'orderId' => $order_id,
-				'context' => $args['args']['context'],
-				'items'   => $items_count,
+				'order'             => $order->get_data(),
+				'accountSettings'   => $this->account_settings->get(),
+				'packagesSettings'  => $this->package_settings->get(),
+				'shippingLabelData' => $this->get_label_payload( $order_id ),
+				'continents'        => $this->continents->get(),
+				'context'           => $args['args']['context'],
+				'items'             => $items_count,
 			);
 
 			do_action( 'enqueue_wc_connect_script', 'wc-connect-create-shipping-label', $payload );

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -17,57 +17,22 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 	 */
 	protected $payment_methods_store;
 
+	/**
+	 * @var WC_Connect_Account_Settings
+	 */
+	protected $account_settings;
+
 	public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Service_Settings_Store $settings_store, WC_Connect_Logger $logger, WC_Connect_Payment_Methods_Store $payment_methods_store ) {
 		parent::__construct( $api_client, $settings_store, $logger );
 		$this->payment_methods_store = $payment_methods_store;
+
+		$this->account_settings = new WC_Connect_Account_Settings(
+					$settings_store,
+					$payment_methods_store );
 	}
 
 	public function get() {
-		// Always get a fresh list of payment methods when hitting this endpoint
-		$payment_methods_warning = false;
-		$payment_methods_success = $this->payment_methods_store->fetch_payment_methods_from_connect_server();
-
-		if ( ! $payment_methods_success ) {
-			$payment_methods_warning = __( 'There was a problem updating your saved credit cards.', 'woocommerce-services' );
-		}
-
-		$master_user = WC_Connect_Jetpack::get_master_user();
-		if ( is_a( $master_user, 'WP_User' ) ) {
-			$master_user_name = $master_user->display_name;
-			$master_user_login = $master_user->user_login;
-
-			$connected_data = WC_Connect_Jetpack::get_connected_user_data( $master_user->ID );
-			$master_user_email = $connected_data['email'];
-			$master_user_wpcom_login = $connected_data['login'];
-		} else {
-			$master_user_name = '';
-			$master_user_login = '';
-
-			$master_user_email = '';
-			$master_user_wpcom_login = '';
-		}
-
-		$last_box_id = get_user_meta( get_current_user_id(), 'wc_connect_last_box_id', true );
-		$last_box_id = $last_box_id === "individual" ? "" : $last_box_id;
-
-		return new WP_REST_Response( array(
-			'success'  => true,
-			'storeOptions' => $this->settings_store->get_store_options(),
-			'formData' => $this->settings_store->get_account_settings(),
-			'formMeta' => array(
-				'can_manage_payments' => $this->settings_store->can_user_manage_payment_methods(),
-				'can_edit_settings' => true,
-				'master_user_name' => $master_user_name,
-				'master_user_login' => $master_user_login,
-				'master_user_wpcom_login' => $master_user_wpcom_login,
-				'master_user_email' => $master_user_email,
-				'payment_methods' => $this->payment_methods_store->get_payment_methods(),
-				'warnings' => array( 'payment_methods' => $payment_methods_warning ),
-			),
-			'userMeta' => array(
-				'last_box_id' => $last_box_id,
-			),
-		), 200 );
+		return new WP_REST_Response( $this->account_settings->get(), 200 );
 	}
 
 	public function post( $request ) {

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -32,7 +32,10 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 	}
 
 	public function get() {
-		return new WP_REST_Response( $this->account_settings->get(), 200 );
+		return new WP_REST_Response( array_merge(
+			array( 'success' => true ),
+			$this->account_settings->get()
+		), 200);
 	}
 
 	public function post( $request ) {

--- a/classes/class-wc-rest-connect-packages-controller.php
+++ b/classes/class-wc-rest-connect-packages-controller.php
@@ -24,7 +24,10 @@ class WC_REST_Connect_Packages_Controller extends WC_REST_Connect_Base_Controlle
 	}
 
 	public function get() {
-		return new WP_REST_Response( $this->package_settings->get(), 200 );
+		return new WP_REST_Response( array_merge(
+			array( 'success' => true ),
+			$this->package_settings->get()
+		), 200 );
 	}
 
 	public function post( $request ) {

--- a/classes/class-wc-rest-connect-packages-controller.php
+++ b/classes/class-wc-rest-connect-packages-controller.php
@@ -12,28 +12,19 @@ class WC_REST_Connect_Packages_Controller extends WC_REST_Connect_Base_Controlle
 	protected $rest_base = 'connect/packages';
 
 	/*
-	 * @var WC_Connect_Service_Schemas_Store
+	 * @var WC_Connect_Package_Settings
 	 */
-	protected $service_schemas_store;
+	protected $package_settings;
 
 	public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Service_Settings_Store $settings_store, WC_Connect_Logger $logger, WC_Connect_Service_Schemas_Store $service_schemas_store ) {
 		parent::__construct( $api_client, $settings_store, $logger );
-		$this->service_schemas_store = $service_schemas_store;
+		$this->package_settings = new WC_Connect_Package_Settings(
+			$settings_store, $service_schemas_store
+		);
 	}
 
 	public function get() {
-		return new WP_REST_Response( array(
-			'success'  => true,
-			'storeOptions' => $this->settings_store->get_store_options(),
-			'formSchema'   => array(
-				'custom' => $this->service_schemas_store->get_packages_schema(),
-				'predefined' => $this->service_schemas_store->get_predefined_packages_schema()
-			),
-			'formData'     => array(
-				'custom' => $this->settings_store->get_packages(),
-				'predefined' => $this->settings_store->get_predefined_packages()
-			)
-		), 200 );
+		return new WP_REST_Response( $this->package_settings->get(), 200 );
 	}
 
 	public function post( $request ) {

--- a/classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php
+++ b/classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php
@@ -32,11 +32,21 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 	protected $namespace = 'wc/v3';
 
 	/**
+	 * @var WC_Connect_Continents
+	 */
+	protected $continents;
+
+	/**
 	 * Route base.
 	 *
 	 * @var string
 	 */
 	protected $rest_base = 'data/continents';
+
+	public function __construct() {
+		parent::__construct();
+		$this->continents = new WC_Connect_Continents();
+	}
 
 	/**
 	 * Register routes.
@@ -69,90 +79,6 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 	}
 
 	/**
-	 * Return the list of countries and states for a given continent.
-	 *
-	 * @since  3.1.0
-	 * @param  string          $continent_code
-	 * @param  WP_REST_Request $request
-	 * @return array|mixed Response data, ready for insertion into collection data.
-	 */
-	public function get_continent( $continent_code = false, $request ) {
-		$continents  = WC()->countries->get_continents();
-		$countries   = WC()->countries->get_countries();
-		$states      = WC()->countries->get_states();
-		$locale_info = include WC()->plugin_path() . '/i18n/locale-info.php';
-		$data        = array();
-
-		if ( ! array_key_exists( $continent_code, $continents ) ) {
-			return false;
-		}
-
-		$continent_list = $continents[ $continent_code ];
-
-		$continent = array(
-			'code' => $continent_code,
-			'name' => $continent_list['name'],
-		);
-
-		$local_countries = array();
-		foreach ( $continent_list['countries'] as $country_code ) {
-			if ( isset( $countries[ $country_code ] ) ) {
-				$country = array(
-					'code' => $country_code,
-					'name' => $countries[ $country_code ],
-				);
-
-				// If we have detailed locale information include that in the response
-				if ( array_key_exists( $country_code, $locale_info ) ) {
-					// Defensive programming against unexpected changes in locale-info.php
-					$country_data = wp_parse_args( $locale_info[ $country_code ], array(
-						'currency_code'  => 'USD',
-						'currency_pos'   => 'left',
-						'decimal_sep'    => '.',
-						'dimension_unit' => 'in',
-						'num_decimals'   => 2,
-						'thousand_sep'   => ',',
-						'weight_unit'    => 'lbs',
-					) );
-
-					$country = array_merge( $country, $country_data );
-				}
-
-				$local_states = array();
-				if ( isset( $states[ $country_code ] ) ) {
-					foreach ( $states[ $country_code ] as $state_code => $state_name ) {
-						$local_states[] = array(
-							'code' => $state_code,
-							'name' => $state_name,
-						);
-					}
-				}
-				$country['states'] = $local_states;
-
-				// Allow only desired keys (e.g. filter out tax rates)
-				$allowed = array(
-					'code',
-					'currency_code',
-					'currency_pos',
-					'decimal_sep',
-					'dimension_unit',
-					'name',
-					'num_decimals',
-					'states',
-					'thousand_sep',
-					'weight_unit',
-				);
-				$country = array_intersect_key( $country, array_flip( $allowed ) );
-
-				$local_countries[] = $country;
-			}
-		}
-
-		$continent['countries'] = $local_countries;
-		return $continent;
-	}
-
-	/**
 	 * Return the list of states for all continents.
 	 *
 	 * @since  3.1.0
@@ -164,7 +90,7 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 		$data       = array();
 
 		foreach ( array_keys( $continents ) as $continent_code ) {
-			$continent = $this->get_continent( $continent_code, $request );
+			$continent = $this->continents->get_continent( $continent_code, $request );
 			$response  = $this->prepare_item_for_response( $continent, $request );
 			$data[]    = $this->prepare_response_for_collection( $response );
 		}
@@ -180,7 +106,7 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_item( $request ) {
-		$data = $this->get_continent( strtoupper( $request['location'] ), $request );
+		$data = $this->continents->get_continent( strtoupper( $request['location'] ), $request );
 		if ( empty( $data ) ) {
 			return new WP_Error( 'woocommerce_rest_data_invalid_location', __( 'There are no locations matching these parameters.', 'woocommerce' ), array( 'status' => 404 ) );
 		}

--- a/client/apps/shipping-label/index.js
+++ b/client/apps/shipping-label/index.js
@@ -107,6 +107,8 @@ export default ( { order, accountSettings, packagesSettings, shippingLabelData, 
 									},
 								},
 								packages: {
+									modalErrors: {},
+									pristine: true,
 									packages,
 									dimensionUnit,
 									weightUnit,

--- a/client/extensions/woocommerce/woocommerce-services/lib/initialize-labels-state/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/initialize-labels-state/index.js
@@ -74,6 +74,8 @@ export default data => {
 		loaded: true,
 		isFetching: false,
 		error: false,
+		fulfillOrder: false,
+		emailDetails: false,
 		refreshedLabelStatus: false,
 		labels: labelsData || [],
 		paperSize,

--- a/tests/php/test_class-wc-connect-shipping-label.php
+++ b/tests/php/test_class-wc-connect-shipping-label.php
@@ -156,6 +156,9 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client-live.php' );
 		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-service-schemas-store.php' );
 		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-payment-methods-store.php' );
+		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-account-settings.php' );
+		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-package-settings.php' );
+		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-continents.php' );
 
 		WC_Connect_Compatibility::set_version( '3.0.0' );
 	}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -675,6 +675,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			require_once( plugin_basename( 'classes/class-wc-connect-paypal-ec.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-label-reports.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-privacy.php' ) );
+			require_once( plugin_basename( 'classes/class-wc-connect-account-settings.php' ) );
+			require_once( plugin_basename( 'classes/class-wc-connect-package-settings.php' ) );
+			require_once( plugin_basename( 'classes/class-wc-connect-continents.php' ) );
 
 			$core_logger           = new WC_Logger();
 			$logger                = new WC_Connect_Logger( $core_logger );
@@ -693,7 +696,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$settings_store        = new WC_Connect_Service_Settings_Store( $schemas_store, $api_client, $logger );
 			$payment_methods_store = new WC_Connect_Payment_Methods_Store( $settings_store, $api_client, $logger );
 			$tracks                = new WC_Connect_Tracks( $logger, __FILE__ );
-			$shipping_label        = new WC_Connect_Shipping_Label( $api_client, $settings_store, $schemas_store );
+			$shipping_label        = new WC_Connect_Shipping_Label( $api_client, $settings_store, $schemas_store, $payment_methods_store );
 			$nux                   = new WC_Connect_Nux( $tracks, $shipping_label );
 			$taxjar                = new WC_Connect_TaxJar_Integration( $api_client, $taxes_logger, $this->wc_connect_base_url );
 			$options               = new WC_Connect_Options();


### PR DESCRIPTION
Removes the preloading step in the create shipping label component and provides it with all the that it needs from the PHP side.