### PR TITLE
Update delivery_type to string since the API returns string

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
@@ -154,7 +154,7 @@ ShippingRate.propTypes = {
 		rate: PropTypes.number.isRequired,
 		delivery_days: PropTypes.number,
 		delivery_date_guaranteed: PropTypes.bool,
-		delivery_date: PropTypes.instanceOf( Date ),
+		delivery_date: PropTypes.string,
 		tracking: PropTypes.bool,
 		insurance: PropTypes.number,
 		free_pickup: PropTypes.bool,

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/test/shipping-rate.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/test/shipping-rate.js
@@ -54,7 +54,7 @@ function createShippingRateWrapper( {
 			rate: rateAmount || 10,
 			delivery_days: deliveryDays || 2,
 			delivery_date_guaranteed: deliveryDateGuaranteed || true,
-			delivery_date: deliveryDate || new Date(2020, 1, 1),
+			delivery_date: deliveryDate || "2020-01-01T23:59:00.000Z",
 			tracking: tracking || true,
 			insurance: insuranceAmount || 100,
 			free_pickup: freePickup || true,
@@ -94,7 +94,7 @@ describe( 'ShippingRate', () => {
 		} );
 
 		it( 'renders the delivery date', () => {
-			expect( shippingRateWrapper ).to.contain( <div className="rates-step__shipping-rate-delivery-date">February 1</div> ); // eslint-disable-line
+			expect( shippingRateWrapper ).to.contain( <div className="rates-step__shipping-rate-delivery-date">January 1</div> ); // eslint-disable-line
 		} );
 
 	} );


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-services/issues/1993

The data received for `delivery_date` is in the format of string. Updated type and updated test.

To test, open up console. Make sure label purchase process does not have this error anymore.