### PR TITLE
Extern some more libs to save on js bundle size

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -130,13 +130,24 @@ module.exports = {
 		hot: true,
 		liveReload: false,
 	},
-	externals: {
-		'jquery': 'jQuery',
-		'cheerio': 'window',
-		'react/addons': true,
-		'react/lib/ExecutionEnvironment': true,
-		'react/lib/ReactContext': true,
-	},
+	externals: Object.assign(
+		{},
+		{
+			'jquery': 'jQuery',
+			'cheerio': 'window',
+			'react/addons': true,
+			'react/lib/ExecutionEnvironment': true,
+			'react/lib/ReactContext': true,
+			moment: 'moment',
+			lodash: 'lodash',
+			// WordPress components are too heavy to extern because we only use a few components.
+		},
+		! isDev ? {
+			// Dev mode cannot use external react-dom because HMR requires patched @hot-loader/react-dom
+			react: 'React',
+			'react-dom': 'ReactDOM',
+		} : undefined
+	),
 	module: {
 		rules: [
 			{


### PR DESCRIPTION
Split these changes from #1994 so we can make a better decision on how to handle WP < 5