### PR TITLE
Show which nexus automatted taxes will work with and link to doc

### DIFF
--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -124,11 +124,16 @@ class WC_Connect_TaxJar_Integration {
 	public function add_tax_settings( $tax_settings ) {
 		$enabled = $this->is_enabled();
 
+		$store_settings = $this->get_store_settings();
+		$all_states = WC()->countries->get_states( $store_settings['country'] );
+		$full_state = $all_states[ $store_settings['state'] ];
+
 		$automated_taxes = array(
 			'title'    => __( 'Automated taxes', 'woocommerce-services' ),
 			'id'       => self::OPTION_NAME, // TODO: save in `wc_connect_options`?
-			'desc_tip' => __( 'Automate your sales tax calculations with WooCommerce Services, powered by Jetpack.', 'woocommerce-services' ),
-			'desc'     => $enabled ? '<p>' . __( 'Powered by WooCommerce Services ― Your tax rates and settings are automatically configured.', 'woocommerce-services' ) . '</p>' : '',
+			/* translators: 1: Full state name */
+			'desc_tip' => sprintf( __( 'Your tax rates and settings will be automatically configured for %1$s. <a href="https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-12">Learn more about setting up tax rates for additional nexuses</a>', 'woocommerce-services' ), $full_state ),
+			'desc'     => $enabled ? '<p>' . __( 'Powered by WooCommerce Services.', 'woocommerce-services' ) . '</p>' : '',
 			'default'  => 'no',
 			'type'     => 'select',
 			'class'    => 'wc-enhanced-select',


### PR DESCRIPTION
closes #2019

Looks like ![image](https://user-images.githubusercontent.com/1534605/82251676-de81e980-990a-11ea-8ecf-7e0fe7285c6b.png)

There may be an issue with adding links in the tooltips as it's impossible for me to hover over the tooltip and click on the link. I the problem may be limited to me and my browser/OS combination so I'd like to know if others can click on the link.