### PR TITLE
Add carrier name to price summary and UPS carrier charge notice

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -156,6 +156,8 @@ export const getTotalPriceBreakdown = ( state, orderId, siteId = getSelectedSite
 				retailRate: foundRate.retail_rate,
 				rateWithDiscount: rateTotal,
 				addons: [],
+				carrierId: foundRate.carrier_id,
+				carrierTitle: foundRate.title.split( '-' )[0],
 			}
 			if ( null !== foundRateSignatureRequired ) {
 				price.addons = [ {

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -157,7 +157,7 @@ export const getTotalPriceBreakdown = ( state, orderId, siteId = getSelectedSite
 				rateWithDiscount: rateTotal,
 				addons: [],
 				carrierId: foundRate.carrier_id,
-				carrierTitle: foundRate.title.split( '-' )[0],
+				carrierTitle: foundRate.title.split( '-' )[0].trim(),
 			}
 			if ( null !== foundRateSignatureRequired ) {
 				price.addons = [ {

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/selectors.js
@@ -410,7 +410,7 @@ describe( 'Shipping label selectors', () => {
 			},
 		} );
 		const result = getTotalPriceBreakdown( state, orderId, siteId );
-		expect( result.prices ).to.eql( [ { title: 'USPS - Priority Mail', retailRate: 7.8, rateWithDiscount: 6.61, addons: [] } ] );
+		expect( result.prices ).to.eql( [ { title: 'USPS - Priority Mail', carrierId: 'usps', carrierTitle: 'USPS', retailRate: 7.8, rateWithDiscount: 6.61, addons: [] } ] );
 		expect( result.discount ).to.eql( 1.19 );
 		expect( result.total ).to.eql( 6.61 );
 	} );
@@ -459,7 +459,7 @@ describe( 'Shipping label selectors', () => {
 			},
 		} );
 		const result = getTotalPriceBreakdown( state, orderId, siteId );
-		expect( result.prices ).to.eql( [ { title: 'USPS - Priority Mail', retailRate: 7.8, rateWithDiscount: 6.61, addons: [] } ] );
+		expect( result.prices ).to.eql( [ { title: 'USPS - Priority Mail', carrierId: 'usps', carrierTitle: 'USPS', retailRate: 7.8, rateWithDiscount: 6.61, addons: [] } ] );
 		expect( result.discount ).to.eql( 1.19 );
 		expect( result.total ).to.eql( 6.61 );
 	} );
@@ -510,8 +510,8 @@ describe( 'Shipping label selectors', () => {
 		const result = getTotalPriceBreakdown( state, orderId, siteId );
 		expect( result.prices ).to.eql( [
 
-			{ title: 'USPS - Priority Mail', retailRate: 7.8, rateWithDiscount: 6.61, addons: [] },
-			{ title: 'USPS - Express Mail', retailRate: 23.85, rateWithDiscount: 21.18, addons: [] },
+			{ title: 'USPS - Priority Mail', carrierId: 'usps', carrierTitle: 'USPS', retailRate: 7.8, rateWithDiscount: 6.61, addons: [] },
+			{ title: 'USPS - Express Mail', carrierId: 'usps', carrierTitle: 'USPS', retailRate: 23.85, rateWithDiscount: 21.18, addons: [] },
 		] );
 		expect( result.discount ).to.eql( 3.86 );
 		expect( result.total ).to.eql( 27.79 );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
@@ -65,14 +65,16 @@ class PriceSummary extends Component {
 			<div className="label-purchase-modal__shipping-summary-section">
 				<hr />
 				{ prices.map( ( service, index ) => {
-					const title = translate( 'Package %(index)s', {
+					const title = translate( 'Package %(index)s – %(title)s', {
 						args: {
 							index: index + 1,
+							title: service.carrierTitle,
 						}
 					} );
 					return (
 						<Fragment key={ index }>
 							{ this.renderRow( title, service.rateWithDiscount, index ) }
+							{ service.carrierId === 'ups' ? <div className="label-purchase-modal__price-item-carrier-account-notice"> { translate( 'Your UPS account will be charged' ) }</div> : <div /> }
 							{ service.addons.map( ( addon, addonIndex ) =>
 								<div key={ 'addons-' + index } className="label-purchase-modal__price-item-addons">
 									{ this.renderRow( addon.title, addon.rate, 'addon-' + addonIndex ) }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -197,6 +197,11 @@
 	margin-left: 20px;
 }
 
+.label-purchase-modal__price-item-carrier-account-notice {
+	color: var( --color-neutral-400 );
+	margin-bottom: 8px;
+}
+
 .label-purchase-modal__price-item-help {
 	color: var( --color-neutral-200 );
 	cursor: help;


### PR DESCRIPTION
closes #2037
Adds a notice in sidebar that UPS account will be charged. Also adds carrier name next too each item in the price summary. 

Extracts Carrier name from title which includes both the carrier and service separated by a dash. I considered passing the carrier name in a field by itself but this would require changes to the connect server and changing the API versioning so it seemed better just to parse the existing title field. 