### PR TITLE
Use shipment_id from rate object instead

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -1047,7 +1047,7 @@ export const purchaseLabel = ( orderId, siteId ) => ( dispatch, getState ) => {
 					const rate = find( form.rates.available[ pckgId ][ rateType ].rates, r => serviceId === r.service_id );
 					const packageData = {
 						...packageFields,
-						shipment_id: form.rates.available[ pckgId ][ rateType ].shipment_id,
+						shipment_id: rate.shipment_id,
 						rate_id: rate.rate_id,
 						service_id: serviceId,
 						carrier_id: rate.carrier_id,

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -48,7 +48,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 	define( 'WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH', 32 );
 
 	if ( ! defined( 'WOOCOMMERCE_CONNECT_SERVER_API_VERSION ' ) ) {
-		define( 'WOOCOMMERCE_CONNECT_SERVER_API_VERSION', '2');
+		define( 'WOOCOMMERCE_CONNECT_SERVER_API_VERSION', '3');
 	}
 
 	// Check for CI environment variable to trigger test mode.


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-services/issues/2045

Update our code to retrieve `shipment_id` using WCS server API v3. In v3, the `shipment_id` no longer comes from `form.rates.available[ pckgId ][ rateType ]` but `rate` object itself. 

### Release notes
- This requires WCS server API v3 to be in place. If not, we can't release this.

### Testing steps
1. Pull this branch
2. checkout an item 
3. Purchase a label
4. Rates should continue to show