### PR TITLE
Revert "Fix tax recalculation on admin order screen missing street address."

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,5 @@
 *** WooCommerce Services Changelog ***
 
-= 1.23.1 - 2020-xx-xx =
-* Fix   - Tax recalculation on admin order screen missing street address.
-
 = 1.23.0 - 2020-04-08 =
 * Fix   - Hide paper selection until valid payment method is selected.
 * Tweak - Shipping banner wording improvements.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -76,7 +76,7 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		// Scripts / Stylesheets
-		add_action( 'admin_enqueue_scripts', array( $this, 'load_taxjar_admin_order_assets' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'load_taxjar_admin_new_order_assets' ) );
 
 		$this->configure_tax_settings();
 
@@ -1136,34 +1136,23 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	/**
-	 * Checks if currently on the WooCommerce order page
+	 * Checks if currently on the WooCommerce new order page
 	 *
 	 * @return boolean
 	 */
 	public function on_order_page() {
 		global $pagenow;
-		global $post;
-		// On new order page.
-		if ( in_array( $pagenow, array( 'post-new.php', ) ) && isset( $_GET['post_type'] ) && 'shop_order' == $_GET['post_type'] ) {
-			return true;
-		}
-
-		// On order edit page.
-		if ( in_array( $pagenow, array( 'post.php', ) ) && 'shop_order' == $post->post_type ) {
-			return true;
-		}
-
-		return false;
+		return ( in_array( $pagenow, array( 'post-new.php' ) ) && isset( $_GET['post_type'] ) && 'shop_order' == $_GET['post_type'] );
 	}
 
 	/**
-	 * Admin Order Assets
+	 * Admin New Order Assets
 	 */
-	public function load_taxjar_admin_order_assets() {
+	public function load_taxjar_admin_new_order_assets() {
 		if ( ! $this->on_order_page() ) {
 			return;
 		}
-		// Load Javascript for WooCommerce order page
-		wp_enqueue_script( 'wc-taxjar-admin-order', $this->wc_connect_base_url . 'woocommerce-services-admin-order-taxjar-' . WC_Connect_Loader::get_wcs_version() . '.js', array( 'jquery' ), null, true );
+		// Load Javascript for WooCommerce new order page
+		wp_enqueue_script( 'wc-taxjar-order', $this->wc_connect_base_url . 'woocommerce-services-new-order-taxjar-' . WC_Connect_Loader::get_wcs_version() . '.js', array( 'jquery' ), null, true );
 	}
 }

--- a/client/new-order-taxjar.js
+++ b/client/new-order-taxjar.js
@@ -6,7 +6,7 @@ import jQuery from 'jquery';
 
 jQuery( document ).ready( function() {
 	/*
-	* JavaScript for WooCommerce order page
+	* JavaScript for WooCommerce new order page
 	*/
 	const TaxJarOrder = function( $ ){ // eslint-disable-line no-unused-vars
 		$( document ).ajaxSend( function( event, request, settings ) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,7 +53,7 @@ module.exports = {
 		'woocommerce-services': [ './client/main.js' ],
 		'woocommerce-services-banner': [ './client/banner.js' ],
 		'woocommerce-services-admin-pointers': [ './client/admin-pointers.js' ],
-		'woocommerce-services-admin-order-taxjar': [ './client/admin-order-taxjar.js' ],
+		'woocommerce-services-new-order-taxjar': [ './client/new-order-taxjar.js' ],
 	},
 	output: Object.assign(
 			{},


### PR DESCRIPTION
Reverts Automattic/woocommerce-services#2041

Created a very critical bug that disabled order refunds: #2044. This is already reverted from `master` on #2047