### PR TITLE
Fix PHP 7.4 notice for taxes at checkout.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Services Changelog ***
 
+= 1.24.0 - 2020-xx-xx =
+* Fix   - PHP 7.4 notice for taxes at checkout.
+
 = 1.23.2 - 2020-06-12 =
 * Fix   - Refund not possible on order page.
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -388,6 +388,11 @@ class WC_Connect_TaxJar_Integration {
 			'line_items' => $line_items,
 		) );
 
+		// Return if taxes could not be calculated.
+		if ( false === $taxes ) {
+			return;
+		}
+
 		$this->response_rate_ids = $taxes['rate_ids'];
 		$this->response_line_items = $taxes['line_items'];
 


### PR DESCRIPTION
Fixes #2060 

How to test:
The issue was a little challenging to get to reproduce because I had a customer address with a zip code already set. You'll want to make sure you can reproduce #2060 without this branch before testing it.

1. Use PHP 7.4 (a new Jurassic Ninja site defaults to this)
1. Enable automated taxes
1. Add a taxable product to cart
1. Go to checkout with no zip code set in address
1. Make sure no notices appear