### PR TITLE
Improve service listing readability

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/components/carrier-icon/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/components/carrier-icon/style.scss
@@ -1,9 +1,9 @@
 .carrier-icon {
 	text-align: center;
 	line-height: 30px;
+	display: flex;
 	& > .carrier-icon__logo {
-		max-width: 80%;
-		max-height: 80%;
+		max-width: 100%;
 		vertical-align: middle;
 	}
 }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
@@ -33,7 +33,9 @@
 .rates-step__shipping-rate-container {
 	display: flex;
 	align-items: stretch;
-	padding-top: 15px;
+	margin-top: 15px;
+	padding: 0 0 15px;
+	border-bottom: 1px solid #eee
 }
 
 .rates-step__carier-logo-image-usps {
@@ -44,16 +46,16 @@
 .rates-step__shipping-rate-information {
 	display: flex;
 	flex-grow: 1;
-	padding-left: 8px;
-	border-bottom: 1px solid #EDEFF0;
-	padding-bottom: 15px;
 	.carrier-icon {
-		padding-right: 10px;
+		display: flex;
+		height: 30px;
+		max-width: 30px;
+		margin: 15px 15px;
 	}
 }
 
 .rates-step__shipping-rate-radio-control {
-	padding: 8px 8px 0 0;
+	margin: 21px 0 0 0;
 	input[type='radio'] {
 		border: 2px solid gray;
 	}
@@ -69,6 +71,8 @@
 .rates-step__shipping-rate-description {
 	display: flex;
 	flex-direction: column;
+	width: 75%;
+	margin: 15px 0 0 0;
 }
 
 .rates-step__shipping-rate-description-title {
@@ -76,13 +80,16 @@
 }
 
 .rates-step__shipping-rate-description-details {
-	color: #646970;
+	color: #636d75;
 	font-size: 12px;
+	margin-bottom: 4px;
 	* label {
-		margin-left: 5px;
 	}
 	.components-base-control {
-		margin-bottom: 0px;
+		padding: 4px 0;
+	.components-base-control__field {
+		margin: 0;
+	}
 	}
 }
 
@@ -97,12 +104,14 @@
 .rates-step__shipping-rate-details {
 	display: flex;
 	flex-direction: column;
-	margin-left: auto;
+	margin: 15px auto;
+	width: 25%;
 }
 
 .rates-step__shipping-rate-delivery-date {
 	color: #646970;
 	font-size: 12px;
+	text-align: right;
 }
 
 .rates-step__shipping-rate-rate {


### PR DESCRIPTION
This is a style sheet-only fix to improve readability of the service listings in the shipping label modal, mainly tweaking the margins within the flex container. These changes will be especially noticable at smaller screen sizes. 
- Made the carrier logos consistent in size (they were decreasing in size with each row)
- Adjusted margins in the flex container for better readability (added some white space between the divs)
- Right aligned the detail text for time frame so it doesn't run into the services detail text

I tweaked a few things to get everything looking right so please have a look and let me know if this all makes sense!