### PR TITLE
Re-apply revert from PR-2047

### DIFF
--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -82,7 +82,7 @@ class WC_Connect_TaxJar_Integration {
 
 
 		// Scripts / Stylesheets
-		add_action( 'admin_enqueue_scripts', array( $this, 'load_taxjar_admin_order_assets' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'load_taxjar_admin_new_order_assets' ) );
 
 		$this->configure_tax_settings();
 
@@ -1191,30 +1191,19 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	/**
-	 * Checks if currently on the WooCommerce order page
+	 * Checks if currently on the WooCommerce new order page
 	 *
 	 * @return boolean
 	 */
 	public function on_order_page() {
 		global $pagenow;
-		global $post;
-		// On new order page.
-		if ( in_array( $pagenow, array( 'post-new.php', ) ) && isset( $_GET['post_type'] ) && 'shop_order' == $_GET['post_type'] ) {
-			return true;
-		}
-
-		// On order edit page.
-		if ( in_array( $pagenow, array( 'post.php', ) ) && 'shop_order' == $post->post_type ) {
-			return true;
-		}
-
-		return false;
+		return ( in_array( $pagenow, array( 'post-new.php' ) ) && isset( $_GET['post_type'] ) && 'shop_order' == $_GET['post_type'] );
 	}
 
 	/**
-	 * Admin Order Assets
+	 * Admin New Order Assets
 	 */
-	public function load_taxjar_admin_order_assets() {
+	public function load_taxjar_admin_new_order_assets() {
 		if ( ! $this->on_order_page() ) {
 			return;
 		}

--- a/client/new-order-taxjar.js
+++ b/client/new-order-taxjar.js
@@ -6,7 +6,7 @@ import jQuery from 'jquery';
 
 jQuery( document ).ready( function() {
 	/*
-	* JavaScript for WooCommerce order page
+	* JavaScript for WooCommerce new order page
 	*/
 	const TaxJarOrder = function( $ ){ // eslint-disable-line no-unused-vars
 		$( document ).ajaxSend( function( event, request, settings ) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,7 +53,7 @@ module.exports = {
 		'woocommerce-services': [ './client/main.js' ],
 		'woocommerce-services-banner': [ './client/banner.js' ],
 		'woocommerce-services-admin-pointers': [ './client/admin-pointers.js' ],
-		'woocommerce-services-admin-order-taxjar': [ './client/admin-order-taxjar.js' ],
+		'woocommerce-services-new-order-taxjar': [ './client/new-order-taxjar.js' ],
 	},
 	output: Object.assign(
 			{},


### PR DESCRIPTION
Closes #2072

How to test
1. Load an order page
2. Make sure there is no missing taxjar.js error
3. Make sure we can still do manual refund on order per https://github.com/Automattic/woocommerce-services/pull/2047.
4. `develop` should now contain changes from https://github.com/Automattic/woocommerce-services/pull/2047. 