### PR TITLE
Add placeholder for the invoice date field in carrier settings form

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/settings.js
@@ -95,6 +95,7 @@ export const CarrierAccountSettings = ( props ) => {
 						value={ getValue( 'invoice_date' ) }
 						updateValue={ updateValue( 'invoice_date' ) }
 						error={ fieldErrors.invoice_date }
+						placeholder={ 'YYYY-MM-DD' }
 					/>
 				</div>
 				<div className="carrier-accounts__settings-two-columns">


### PR DESCRIPTION
Adds date placeholder in ups date field in carrier settings, which was lost in a merge commit.