### PR TITLE
Load locale packages with lowercase file names

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-refund-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-refund-modal.js
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
 import formatCurrency from '@automattic/format-currency';
-// import 'moment/locale/ro';
 
 /**
  * Internal dependencies
@@ -37,7 +36,6 @@ const RefundDialog = props => {
 		translate,
 		moment,
 	} = props;
-	moment().locale('ro');
 
 	const getRefundableAmount = () => {
 		return formatCurrency( refundableAmount, currency );

--- a/client/main.js
+++ b/client/main.js
@@ -29,7 +29,7 @@ __webpack_public_path__ = global.wcsPluginData.assetPath;
 // First we try language code with region if it's different then fall back to language code only.
 if ( window.i18nLocale && window.i18nLocale.localeSlug !== 'en' ) {
 	const localeSlugParts = window.i18nLocale.localeSlug.split('-');
-	let localeFileSlug = window.i18nLocale.localeSlug;
+	let localeFileSlug = window.i18nLocale.localeSlug.toLowerCase();
 	if ( localeSlugParts[0] === localeSlugParts[1] ) {
 		localeFileSlug = localeSlugParts[0];
 	}


### PR DESCRIPTION
import `moment/locale/en-ca.js` instead of `moment/locale/en-CA.js` since moment locale files are in lowercase. https://github.com/moment/moment/tree/develop/locale

### How to test
1. Go to general settings and switch language to Spanish. https://localhost/wp-admin/options-general.php
2. Run `npm run i18n` to download translation files
3. Go to WCS order page and click refund popup modal
4. Verify the text are in Spanish.