### PR TITLE
Hide the carrier cards when no carriers enabled

### DIFF
--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -80,9 +80,10 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 				<?php
 			}
 
-			$carriers_response = $this->api_client->get_carrier_accounts();
-
-			$extra_args = array( 'carriers' => $carriers_response->carriers);
+			$extra_args = array();
+			if( $carriers_response = $this->api_client->get_carrier_accounts() ) {
+				$extra_args[ 'carriers' ] = $carriers_response->carriers;
+			}
 
 			if ( isset( $_GET['from_order'] ) ) {
 				$extra_args['order_id'] = $_GET['from_order'];

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/index.js
@@ -42,20 +42,17 @@ export class CarrierAccounts extends Component {
 	render() {
 		const { translate } = this.props;
 
-		let carriers = [ { id: null, carrier: 'UPS', account: null } ];
-		if ( ! isEmpty( this.props.carriers ) ) {
-			carriers = this.props.carriers;
-		}
+		const carriers = this.props.carriers || [];
 
+		if ( isEmpty( carriers ) ) {
+			return <div></div>;
+		}
 		return (
 			<div>
 				<ExtendedHeader
 					label={ translate( 'Carrier account' ) }
-					description={ translate(
-						'Set up your own carrier account by adding your credentials here'
-					) }
-				>
-				</ExtendedHeader>
+					description={ translate( 'Set up your own carrier account by adding your credentials here' ) }
+				></ExtendedHeader>
 				<Card className="carrier-accounts__list">
 					{ this.renderListHeader( carriers ) }
 					{ carriers.map( this.renderListItem ) }
@@ -69,8 +66,8 @@ CarrierAccounts.propTypes = {
 	siteId: PropTypes.number.isRequired,
 	carriers: PropTypes.arrayOf(
 		PropTypes.shape( {
-			id: PropTypes.string.isRequired,
-			carrier: PropTypes.string.isRequired,
+			id: PropTypes.string,
+			carrier: PropTypes.string,
 			account: PropTypes.string,
 		} )
 	),

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/index.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { configure, shallow } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16'
+import Adapter from 'enzyme-adapter-react-16';
 
 /**
  * Internal dependencies
@@ -16,26 +16,25 @@ import CarrierAccountListItem from '../list-item';
 import Card from 'components/card';
 import ExtendedHeader from 'woocommerce/components/extended-header';
 
-configure({ adapter: new Adapter() });
+configure( { adapter: new Adapter() } );
 
 function createCarrierAccountsWrapper( { carriers = [] } ) {
 	const props = {
 		siteId: 10,
-		translate: (text) => text,
-		carriers: carriers
+		translate: ( text ) => text,
+		carriers: carriers,
 	};
 
 	return shallow( <CarrierAccounts { ...props } /> );
-
 }
 
 describe( 'Carrier Accounts', () => {
 	describe( 'with a disconnected carrier', () => {
 		const carrier = {
-			carrierId: 'carrier',
-			name: 'carrier',
+			id: null,
+			account: 'carrier',
+			account: null,
 		};
-
 
 		const wrapper = createCarrierAccountsWrapper( { carriers: [ carrier ] } );
 		const renderedExtendedHeader = wrapper.find( ExtendedHeader );
@@ -46,7 +45,9 @@ describe( 'Carrier Accounts', () => {
 		it( 'renders a title with a description', function () {
 			expect( renderedExtendedHeader ).to.have.lengthOf( 1 );
 			expect( renderedExtendedHeader.props().label ).to.equal( 'Carrier account' );
-			expect( renderedExtendedHeader.props().description ).to.equal( 'Set up your own carrier account by adding your credentials here.' );
+			expect( renderedExtendedHeader.props().description ).to.equal(
+				'Set up your own carrier account by adding your credentials here.'
+			);
 		} );
 
 		it( 'renders a card', function () {
@@ -57,28 +58,38 @@ describe( 'Carrier Accounts', () => {
 			expect( renderedCarrierListItem ).to.have.lengthOf( 1 );
 		} );
 
-		it( "doesn't render the credentials column in the carriers list header", function() {
+		it( "doesn't render the credentials column in the carriers list header", function () {
 			expect( renderedCarrierListHeader.find( '.carrier-accounts__header-credentials' ) ).to.have.lengthOf( 0 );
 		} );
 
-		it( 'renders a name column in the carrier accounts list header', function() {
+		it( 'renders a name column in the carrier accounts list header', function () {
 			expect( renderedCarrierListHeader.find( '.carrier-accounts__header-name' ) ).to.have.lengthOf( 1 );
 		} );
 	} );
 	describe( 'with a connected carrier', () => {
 		const carrier = {
-			carrierId: 'carrier',
-			name: 'carrier',
-			credentials: 'carrier-credentials',
+			id: 'carrier',
+			carrier: 'carrier',
+			account: 'carrier-credentials',
 		};
-
 
 		const wrapper = createCarrierAccountsWrapper( { carriers: [ carrier ] } );
 		const renderedCarrierListHeader = wrapper.find( '.carrier-accounts__header' );
 
-		it( "renders the credentials column in the carriers list header", function() {
+		it( 'renders the credentials column in the carriers list header', function () {
 			expect( renderedCarrierListHeader.find( '.carrier-accounts__header-credentials' ) ).to.have.lengthOf( 1 );
 		} );
+	} );
+	describe( 'with no carriers', () => {
+		const wrapper = createCarrierAccountsWrapper( { carriers: [] } );
+		const renderedCarrierListHeader = wrapper.find( '.carrier-accounts__header' );
+		const renderedCard = wrapper.find( Card );
 
+		it( 'does not render the carriers header', function () {
+			expect( renderedCarrierListHeader ).to.have.lengthOf( 0 );
+		} );
+		it( 'does not render the carriers list', function () {
+			expect( renderedCard ).to.have.lengthOf( 0 );
+		} );
 	} );
 } );


### PR DESCRIPTION
Does not render the carriers card in WooCommerce Services settings
when there are no additional carriers enabled for that site.

Closes #2078 

### Testing instructions

1. To test this issue, this WooCommerce Connect Server PR's branch is needed: https://github.com/Automattic/woocommerce-connect-server/pull/1426

2. Enable UPS for the site under test.

3. The carriers card in WooCommerce Services settings at the bottom should be visible.

4. Disable UPS for the site under test.

5. The carriers card should be hidden now.