### PR TITLE
Add/ups doc link

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/settings.js
@@ -146,7 +146,7 @@ export const CarrierAccountSettings = ( props ) => {
 					<p className="carrier-accounts__settings-subheader-description">
 						{ translate(
 							'Set up your own UPS carrier account to compare rates and print labels from multiple carriers in WooCommerce Services. Learn more about adding {{a}}carrier accounts{{/a}}.',
-							{ components: { a: <a href="https://link.to.carrier.accounts.com/" /> } }
+							{ components: { a: <a href="https://docs.woocommerce.com/document/using-your-own-ups-account-in-woocommerce-shipping/" /> } }
 						) }
 					</p>
 					<p className="carrier-accounts__settings-subheader-description">

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/settings.js
@@ -145,7 +145,8 @@ export const CarrierAccountSettings = ( props ) => {
 					</h4>
 					<p className="carrier-accounts__settings-subheader-description">
 						{ translate(
-							'Set up your own UPS carrier account to compare rates and print labels from multiple carriers in WooCommerce Services.'
+							'Set up your own UPS carrier account to compare rates and print labels from multiple carriers in WooCommerce Services. Learn more about adding {{a}}carrier accounts{{/a}}.',
+							{ components: { a: <a href="https://link.to.carrier.accounts.com/" /> } }
 						) }
 					</p>
 					<p className="carrier-accounts__settings-subheader-description">


### PR DESCRIPTION
Fixes #2065 

Adds link to carrier account docs. The link doesn't go anywhere _yet_. See: https://woodocsguild.wordpress.com/2020/07/23/new-doc-ups-for-woocommerce-services/#comment-294