### PR TITLE
CSS tweaks to fix UPS logo dimensions.

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/components/carrier-icon/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/carrier-icon/index.js
@@ -34,7 +34,7 @@ const CarrierIcon = ( { carrier, size } ) => {
 		return <span/>;
 	}
 	const pixels = `${sizeToPixels( size )}px`;
-	return <div style={{ height: pixels, width: pixels }} className="carrier-icon">
+	return <div style={{ width: pixels }} className="carrier-icon">
 			<img src={ carrierLogos[ carrier.toLowerCase() ] } alt={ carrier } className="carrier-icon__logo" />
 	</div>;
 };

--- a/client/extensions/woocommerce/woocommerce-services/components/carrier-icon/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/components/carrier-icon/style.scss
@@ -1,9 +1,10 @@
 .carrier-icon {
 	text-align: center;
 	line-height: 30px;
+	width: 100%;
 	display: flex;
+	align-items: flex-start;
 	& > .carrier-icon__logo {
-		max-width: 100%;
 		vertical-align: middle;
 	}
 }


### PR DESCRIPTION
Fixes #2087 
Fixes UPS logo dimensions on rates:
![image](https://user-images.githubusercontent.com/6209518/88841504-ebd11500-d192-11ea-95b5-59a1320aefd3.png)
 
And settings:
<img width="395" alt="image" src="https://user-images.githubusercontent.com/6209518/88841623-0d320100-d193-11ea-9586-9523154863e2.png">
