### PR TITLE
Replace string 20 to number 18 to match gridicons requirements

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/package-select.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/package-select.js
@@ -109,7 +109,7 @@ const PackageSelect = props => {
 			</div>
 			{ 0 === totalPackagesCount ? (
 				<div className="packages-step__no-packages">
-					<Gridicon icon="product" size="20" />
+					<Gridicon icon="product" size={18} />
 					{ /* eslint-disable jsx-a11y/anchor-is-valid */ }
 					<a href="#" onClick={ () => props.addPackage( siteId ) }>
 						{ translate( 'Select a package type' ) }


### PR DESCRIPTION
Closes #2104

To test
1. You can setup WCS to have empty packages in your list. Or you can modify [this line](https://github.com/Automattic/woocommerce-services/blob/develop/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/package-select.js#L110) to `{ true || 0 === totalPackagesCount ? (` so that the `div` is forced to show.
2. Make sure no errors in console. 

