### PR TITLE
Fix eslint errors and install missing packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "enzyme-adapter-react-16": "1.12.1",
     "enzyme-to-json": "3.3.5",
     "file-loader": "^4.3.0",
+    "glob": "^7.1.6",
     "globby": "^6.1.0",
+    "i18n-calypso-cli": "^1.0.0",
     "jest": "^24.9.0",
     "jest-puppeteer": "^4.4.0",
     "moment": "^2.25.3",
@@ -53,12 +55,12 @@
     "po2json": "^0.4.5",
     "postcss-safe-parser": "^4.0.2",
     "puppeteer": "^1.20.0",
+    "request": "^2.88.2",
     "shelljs": "^0.7.6",
     "sinon": "7.3.1",
     "sinon-chai": "3.3.0",
     "webpack-bundle-analyzer": "^3.6.1",
-    "xgettext-js": "^1.1.0",
-    "i18n-calypso-cli": "^1.0.0"
+    "xgettext-js": "^1.1.0"
   },
   "dependencies": {
     "@automattic/calypso-color-schemes": "^1.0.0-alpha.1",

--- a/tasks/i18n-download.js
+++ b/tasks/i18n-download.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console, import/no-nodejs-modules */
 const fs = require('fs');
 const request = require('request');
 

--- a/tasks/i18n.js
+++ b/tasks/i18n.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console, import/no-nodejs-modules */
 const i18nCli = require( 'i18n-calypso-cli' );
 const glob = require('glob');
 


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-services/issues/1973
Fix eslint errors so that pipeline can pass. Also added missing packages for tasks.