### PR TITLE
Add missing UPS tracking link to email

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1061,6 +1061,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					case 'usps':
 						$tracking_url = 'https://tools.usps.com/go/TrackConfirmAction.action?tLabels=' . $tracking;
 						break;
+					case 'ups':
+						$tracking_url = 'https://www.ups.com/track?tracknum=' . $tracking;
+						break;
+
 				}
 
 				$markup .= '<td class="td" scope="col">';


### PR DESCRIPTION
Closes #2090 

## How to test
1. Create an order
2. Click "notify customer" to complete order
![image](https://user-images.githubusercontent.com/572862/88946155-23e85e80-d24c-11ea-97fe-dc23e756a26e.png)
3. Go to mailcatcher to see the email
4. Verify the tracking link opens to a UPS tracking window.