### PR TITLE
fix: carrier disconnect modal layout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@
 * Fix   - Fix localization issues
 * Tweak - Improve service listing readability
 * Add   - Support UPS as a carrier (beta)
+* Fix   - Carrier "disconnect modal" layout
 
 = 1.23.2 - 2020-06-12 =
 * Fix   - Refund not possible on order page.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Services Changelog ***
 
+= 1.24.1 - 2020-xx-xx =
+* Fix   - Carrier "disconnect modal" layout
+
 = 1.24.0 - 2020-xx-xx =
 * Fix   - PHP 7.4 notice for taxes at checkout.
 * Add   - Carrier logos next to rates.
@@ -14,7 +17,6 @@
 * Fix   - Fix localization issues
 * Tweak - Improve service listing readability
 * Add   - Support UPS as a carrier (beta)
-* Fix   - Carrier "disconnect modal" layout
 
 = 1.23.2 - 2020-06-12 =
 * Fix   - Refund not possible on order page.

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dialog-styles.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dialog-styles.scss
@@ -1,8 +1,8 @@
 .carrier-accounts__settings-cancel-dialog {
 	.dialog__content {
 		padding: 0;
-		width: 666px;
-		height: 200px;
+		max-width: 666px;
+		min-height: 200px;
 
 		.carrier-accounts__settings-cancel-dialog-header {
 			background-color: #fcfcfc;
@@ -11,9 +11,9 @@
 
 			.carrier-accounts__settings-cancel-dialog-title {
 				display: block;
-				margin: 0;
-				padding: 18px 28px;
+				margin: auto 28px;
 			}
+
 			.carrier-accounts__settings-cancel-dialog-close-button {
 				border: 0 none;
 				outline: 0 none;


### PR DESCRIPTION
## Description
Changing the "Disconnect Carrier" modal layout to fix the mobile behavior

## Issue

Fixes https://github.com/Automattic/woocommerce-services/issues/2112 (ticket also references grid layout - done separately in https://github.com/Automattic/woocommerce-services/issues/2122)

## Steps to reproduce
- Ensure you already connected "UPS"
- Go to **Settings > WooCommerce Services**
- Click  "Disconnect" on "UPS"
- Go to mobile viewport
- Modal layout behavior is fixed:
  - Text is wrapping
  - Title is centered
<img width="413" alt="Screenshot on 2020-08-06 at 15-11-37" src="https://user-images.githubusercontent.com/273592/89578141-561f3080-d7f7-11ea-820d-2867631327b3.png">
