### PR TITLE
fix: services management table layout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@
 * Fix   - Fix localization issues
 * Tweak - Improve service listing readability
 * Add   - Support UPS as a carrier (beta)
+* Fix   - Services management CSS table layout
 
 = 1.23.2 - 2020-06-12 =
 * Fix   - Refund not possible on order page.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Services Changelog ***
 
+= 1.24.1 - 2020-xx-xx =
+* Fix   - Services management CSS table layout
+
 = 1.24.0 - 2020-xx-xx =
 * Fix   - PHP 7.4 notice for taxes at checkout.
 * Add   - Carrier logos next to rates.
@@ -14,7 +17,6 @@
 * Fix   - Fix localization issues
 * Tweak - Improve service listing readability
 * Add   - Support UPS as a carrier (beta)
-* Fix   - Services management CSS table layout
 
 = 1.23.2 - 2020-06-12 =
 * Fix   - Refund not possible on order page.

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/style.scss
@@ -8,7 +8,11 @@
 
 		.carrier-accounts__list-item-carrier-icon {
 			width: 48px;
-			padding-left: 24px;
+			padding-left: 16px;
+
+			@include breakpoint( '>480px' ) {
+				padding-left: 24px;
+			}
 		}
 
 		.carrier-accounts__list-item-name {
@@ -20,9 +24,13 @@
 		}
 
 		.carrier-accounts__list-item-actions {
-			padding-right: 24px;
 			width: 25%;
 			text-align: right;
+			padding-right: 16px;
+
+			@include breakpoint( '>480px' ) {
+				padding-right: 24px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Description
Changing the table layout on the **Settings > WooCommerce Services** page

## Issue

Fixes https://github.com/Automattic/woocommerce-services/issues/2112 (ticket also references modal layout - done separately in https://github.com/Automattic/woocommerce-services/issues/2121)

## Steps to reproduce
- Ensure you already connected "UPS"
- Go to **Settings > WooCommerce Services**
- Go to mobile viewport
- Layout behavior is fixed

![Screen Shot 2020-08-06 at 3 26 52 PM](https://user-images.githubusercontent.com/273592/89579801-02621680-d7fa-11ea-9500-e2bb6a34d2c5.png)
![Screen Shot 2020-08-06 at 3 27 05 PM](https://user-images.githubusercontent.com/273592/89579802-02faad00-d7fa-11ea-8ce2-809b3a64c5f9.png)
![Screen Shot 2020-08-06 at 3 27 51 PM](https://user-images.githubusercontent.com/273592/89579803-03934380-d7fa-11ea-9cc6-93ba7a64dc1c.png)
