### PR TITLE
chore: ZIP/postcode/postal code messaging consistency

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@
 * Fix   - Fix localization issues
 * Tweak - Improve service listing readability
 * Add   - Support UPS as a carrier (beta)
+* Tweak - Zip/Postcode/Postal code messaging consistency
 
 = 1.23.2 - 2020-06-12 =
 * Fix   - Refund not possible on order page.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Services Changelog ***
 
+= 1.24.1 - 2020-xx-xx =
+* Tweak - Zip/Postcode/Postal code messaging consistency
+
 = 1.24.0 - 2020-xx-xx =
 * Fix   - PHP 7.4 notice for taxes at checkout.
 * Add   - Carrier logos next to rates.
@@ -14,7 +17,6 @@
 * Fix   - Fix localization issues
 * Tweak - Improve service listing readability
 * Add   - Support UPS as a carrier (beta)
-* Tweak - Zip/Postcode/Postal code messaging consistency
 
 = 1.23.2 - 2020-06-12 =
 * Fix   - Refund not possible on order page.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -315,15 +315,15 @@ class WC_Connect_TaxJar_Integration {
 		$invalid_postcode = false !== strpos( $formatted_message, 'isn\'t a valid postal code for' );
 		if ( ! is_admin() && ( $state_zip_mismatch || $invalid_postcode ) ) {
 			$fields = WC()->countries->get_address_fields();
-			$postcode_field_name = __( 'Postcode / ZIP', 'woocommerce-services' );
+			$postcode_field_name = __( 'ZIP / Postal code', 'woocommerce-services' );
 			if ( isset( $fields['billing_postcode'] ) && isset( $fields['billing_postcode']['label'] ) ) {
 				$postcode_field_name = $fields['billing_postcode']['label'];
 			}
 
 			if ( $state_zip_mismatch ) {
-				$message = sprintf( _x( '%s does not match the selected state.', '%s - Postcode/Zip checkout field label', 'woocommerce-services' ), $postcode_field_name );
+				$message = sprintf( _x( '%s does not match the selected state.', '%s - ZIP/Postal code checkout field label', 'woocommerce-services' ), $postcode_field_name );
 			} else {
-				$message = sprintf( _x( 'Invalid %s entered.', '%s - Postcode/Zip checkout field label', 'woocommerce-services' ), $postcode_field_name );
+				$message = sprintf( _x( 'Invalid %s entered.', '%s - ZIP/Postal code checkout field label', 'woocommerce-services' ), $postcode_field_name );
 			}
 
 			if ( ! wc_has_notice( $message, 'error' ) ) {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -315,7 +315,7 @@ class WC_Connect_TaxJar_Integration {
 		$invalid_postcode = false !== strpos( $formatted_message, 'isn\'t a valid postal code for' );
 		if ( ! is_admin() && ( $state_zip_mismatch || $invalid_postcode ) ) {
 			$fields = WC()->countries->get_address_fields();
-			$postcode_field_name = __( 'ZIP / Postal code', 'woocommerce-services' );
+			$postcode_field_name = __( 'ZIP/Postal code', 'woocommerce-services' );
 			if ( isset( $fields['billing_postcode'] ) && isset( $fields['billing_postcode']['label'] ) ) {
 				$postcode_field_name = $fields['billing_postcode']['label'];
 			}

--- a/client/extensions/woocommerce/components/address-view/index.js
+++ b/client/extensions/woocommerce/components/address-view/index.js
@@ -162,7 +162,7 @@ class AddressView extends Component {
 					</FormFieldSet>
 					{ this.renderEditableState() }
 					<FormFieldSet>
-						<FormLabel>{ translate( 'Postal code' ) }</FormLabel>
+						<FormLabel>{ translate( 'ZIP/Postal code' ) }</FormLabel>
 						<FormTextInput
 							autoComplete="postal-code"
 							name="postcode"

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -235,7 +235,7 @@ const getRawAddressErrors = ( appState, addressData, siteId, shouldValidatePhone
 		includes( ACCEPTED_USPS_ORIGIN_COUNTRIES, country ) &&
 		! /^\d{5}(?:-\d{4})?$/.test( postcode )
 	) {
-		errors.postcode = translate( 'Invalid ZIP code format' );
+		errors.postcode = translate( 'Invalid ZIP/Postal code format' );
 	}
 
 	if ( ! state && hasStates( appState, country, siteId ) ) {

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/settings.js
@@ -236,7 +236,7 @@ export const CarrierAccountSettings = ( props ) => {
 						<div className="carrier-accounts__settings-two-columns">
 							<TextField
 								id={ 'postal_code' }
-								title={ translate( 'Postal code / Zip' ) }
+								title={ translate( 'ZIP/Postal code' ) }
 								value={ getValue( 'postal_code' ) }
 								updateValue={ updateValue( 'postal_code' ) }
 								error={ fieldErrors.postal_code }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/fields.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/fields.js
@@ -189,7 +189,7 @@ const AddressFields = props => {
 				) }
 				<TextField
 					id={ getId( 'postcode' ) }
-					title={ translate( 'Postal code' ) }
+					title={ translate( 'ZIP/Postal code' ) }
 					value={ getValue( 'postcode' ) }
 					updateValue={ updateValue( 'postcode' ) }
 					className="address-step__postal-code"


### PR DESCRIPTION
## Description

Bringing more consistency on the "ZIP code"/"Postal Code" messaging

## Fixes

Fixes https://github.com/Automattic/woocommerce-services/issues/2091

## Steps to reproduce

Carrier connection:
<img width="823" alt="Screenshot on 2020-08-06 at 16-04-45" src="https://user-images.githubusercontent.com/273592/89584777-3f320b80-d802-11ea-8287-788ef7101088.png">

Address selection (destination/source):
<img width="1259" alt="Annotation on 2020-08-06 at 16-31-52" src="https://user-images.githubusercontent.com/273592/89584844-5f61ca80-d802-11ea-889a-adbbc73bd686.png">
