### PR TITLE
Added array to get shipping labels API to include product ids associated with a shipping label

### DIFF
--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -106,8 +106,10 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 			}
 
 			$product_names = array();
+			$product_ids = array();
 			foreach ( $package[ 'products' ] as $product_id ) {
 				$product = wc_get_product( $product_id );
+				$product_ids[] = $product_id;
 
 				if ( $product ) {
 					$product_names[] = $product->get_title();
@@ -118,6 +120,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 			}
 
 			$label_meta[ 'product_names' ] = $product_names;
+			$label_meta[ 'product_ids' ] = $product_ids;
 
 			array_unshift( $purchased_labels_meta, $label_meta );
 		}


### PR DESCRIPTION
Fixes #2102 by including a new array to the GET shipping labels API. This array includes `product_ids` associated with a shipping label. 

#### To test
- Create a shipping label for an order with single or multiple SIMPLE products.
  - Verify that the GET shipping labels API returns the `product_ids` that are associated with the shipping label in the `product_ids` array.
- Create a shipping label for an order with single or multiple VARIABLE products.
  - Verify that the GET shipping labels API returns the `variable_ids` that are associated with the shipping label in the `product_ids` array.
- Smoke testing the API to ensure that existing functionality is not broken :) 

Note: I didn't find any unit tests to test this specific scenario but it's possible I missed something! Do let me know if I need to add unit tests to the PR before review 😄 
