### PR TITLE
refactor: multi-carrier label orders note

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -784,34 +784,34 @@ const handlePrintFinished = ( orderId, siteId, dispatch, getState, hasError, lab
 		return;
 	}
 
-	if (shouldEmailDetails(getState(), orderId, siteId)) {
+	if ( shouldEmailDetails( getState(), orderId, siteId ) ) {
 		dispatch(
-			createNote(siteId, orderId, {
+			createNote( siteId, orderId, {
 				note: translate(
 					'Your order has been shipped. The tracking number is %(trackingNumbers)s.',
 					'Your order consisting of %(packageCount)d packages has been shipped. The tracking numbers are %(trackingNumbers)s.',
 					{
 						args: {
 							packageCount: labels.length,
-							trackingNumbers: labels.map(({tracking, carrier_id}) => {
+							trackingNumbers: labels.map( ( {tracking, carrier_id} ) => {
 								const carrierNamesMap = {
 									usps: "USPS",
 									ups: "UPS",
 								};
 								const carrierNameForLabel = carrierNamesMap[carrier_id || ''];
 
-								if (!carrierNameForLabel) {
+								if ( !carrierNameForLabel ) {
 									return tracking;
 								}
 
 								return `${tracking} (${carrierNameForLabel})`;
-							}).join(', '),
+							} ).join( ', ' ),
 						},
 						count: labels.length
 					}
 				),
 				customer_note: true,
-			})
+			} )
 		);
 	}
 

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -11,7 +11,6 @@ import {
 	fill,
 	filter,
 	find,
-	first,
 	flatten,
 	get,
 	includes,
@@ -785,54 +784,34 @@ const handlePrintFinished = ( orderId, siteId, dispatch, getState, hasError, lab
 		return;
 	}
 
-	if ( shouldEmailDetails( getState(), orderId, siteId ) ) {
-		const trackingNumbers = labels.map( label => label.tracking );
-		const carrierId = first( labels ).carrier_id;
-		let carrierIdReadable = '';
-		let note = '';
-		switch( carrierId ) {
-			case 'usps':
-				carrierIdReadable = 'USPS';
-				break;
-			case 'ups':
-				carrierIdReadable = 'UPS';
-				break;
-		}
-
-		if ( '' !== carrierIdReadable ) {
-			note = translate(
-				'Your order has been shipped with %(carrier)s. The tracking number is %(trackingNumbers)s.',
-				'Your order consisting of %(packageNum)d packages has been shipped with %(carrier)s. ' +
-					'The tracking numbers are %(trackingNumbers)s.',
-				{
-					args: {
-						packageNum: trackingNumbers.length,
-						trackingNumbers: trackingNumbers.join( ', ' ),
-						carrier: carrierIdReadable,
-					},
-					count: trackingNumbers.length,
-				}
-			);
-		} else {
-			note = translate(
-				'Your order has been shipped. The tracking number is %(trackingNumbers)s.',
-				'Your order consisting of %(packageNum)d packages has been shipped. ' +
-					'The tracking numbers are %(trackingNumbers)s.',
-				{
-					args: {
-						packageNum: trackingNumbers.length,
-						trackingNumbers: trackingNumbers.join( ', ' ),
-					},
-					count: trackingNumbers.length,
-				}
-			);
-
-		}
+	if (shouldEmailDetails(getState(), orderId, siteId)) {
 		dispatch(
-			createNote( siteId, orderId, {
-				note,
+			createNote(siteId, orderId, {
+				note: translate(
+					'Your order has been shipped. The tracking number is %(trackingNumbers)s.',
+					'Your order consisting of %(packageCount)d packages has been shipped. The tracking numbers are %(trackingNumbers)s.',
+					{
+						args: {
+							packageCount: labels.length,
+							trackingNumbers: labels.map(({tracking, carrier_id}) => {
+								const carrierNamesMap = {
+									usps: "USPS",
+									ups: "UPS",
+								};
+								const carrierNameForLabel = carrierNamesMap[carrier_id || ''];
+
+								if (!carrierNameForLabel) {
+									return tracking;
+								}
+
+								return `${tracking} (${carrierNameForLabel})`;
+							}).join(', '),
+						},
+						count: labels.length
+					}
+				),
 				customer_note: true,
-			} )
+			})
 		);
 	}
 


### PR DESCRIPTION
## Description

Changing the message on the created note when an order is shipped with multiple carriers.
This new messaging simplifies the logic a bit.

I didn't find existing unit tests for this logic in the codebase 👀 

![Screen Shot 2020-08-07 at 1 57 00 PM](https://user-images.githubusercontent.com/273592/89680086-e0c76480-d8b7-11ea-8bd5-978cfb3b1c58.png)


## Fixes

Fixes https://github.com/Automattic/woocommerce-services/issues/2113

## Steps to reproduce
- Create order with multiple items and packages
- Mark order as "Completed"
- Create the labels
- Choose USPS for one package and UPS for another
- Print label with this checked:
![image](https://user-images.githubusercontent.com/6209518/88956626-7b89c880-d252-11ea-8541-d1634dd8bdb6.png)
