### PR TITLE
Transform order object to a presentable API object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,28 +13,6 @@ jobs:
    - php: 5.3
      env: WP_VERSION=4.5 WC_VERSION=3.2.6 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
      dist: precise
-   - php: 5.4
-     dist: trusty
-     env: WP_VERSION=4.6 WC_VERSION=3.1.2 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
-   - php: 5.5
-     dist: trusty
-     env: WP_VERSION=4.7 WC_VERSION=3.0.9 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
-   - php: 5.6
-     env: WP_VERSION=4.8 WC_VERSION=2.6.14 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
-   - php: 7.0
-     env: WP_VERSION=latest WC_VERSION=2.6.14 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
-     # By default, travis attempts PHPUnit 7.5.0 for PHP 7.0 - that version works on 7.1 and 7.2 only
-     # Install and use PHPUnit 6.4 instead (and because WP itself is not PHPUnit 7 ready)
-     script: curl -sSfL -o ~/.phpenv/versions/7.0/bin/phpunit https://phar.phpunit.de/phpunit-6.4.phar && phpunit
-   - php: 7.1
-     env: WP_VERSION=latest WC_VERSION=3.0.3 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
-     # By default, travis attempts PHPUnit 8.0.4 for PHP 7.1 - that version works on 7.2 and 7.3 only
-     # Install and use PHPUnit 6.4 instead (and because WP itself is not PHPUnit 7 ready)
-     script: curl -sSfL -o ~/.phpenv/versions/7.1/bin/phpunit https://phar.phpunit.de/phpunit-6.4.phar && phpunit
-   - php: 7.2
-     env: WP_VERSION=4.4 WC_VERSION=2.6.14 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
-     # Older versions of WP are not compatible with PHPUnit 6+. Manually install PHPUnit 5.
-     script: curl -sSfL -o ~/.phpenv/versions/7.2/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar && phpunit
    - php: 7.2
      env: WP_VERSION=latest WC_VERSION=3.3.3 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
      # Not even the latest WP version is compatible with PHPUnit 7. Manually install PHPUnit 6.

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix   - Carrier "disconnect modal" layout
 * Fix   - Primary button busy state updated to match color
 * Fix   - Remove padding from notice bar
+* Fix   - Add missing box in rate step for how much customer paid for shipping
 
 = 1.24.0 - 2020-07-30 =
 * Fix   - PHP 7.4 notice for taxes at checkout.

--- a/classes/class-wc-connect-order-presenter.php
+++ b/classes/class-wc-connect-order-presenter.php
@@ -4,7 +4,7 @@ if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
 
 	class WC_Connect_Order_Presenter {
 
-		public function get_order_for_api( $order ) {
+		public function get_order_for_api( WC_Order $order ) {
 			$dp = 2; //decimal point defaults
 			$order_data = array(
 				'id'                        => $order->get_id(),

--- a/classes/class-wc-connect-order-presenter.php
+++ b/classes/class-wc-connect-order-presenter.php
@@ -4,6 +4,13 @@ if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
 
 	class WC_Connect_Order_Presenter {
 
+		/**
+		 * This function transform the WC_Order object to a representational JSON form for the react app.
+		 * This is based on WooCommerce v3's get_order API woocommerce/includes/legacy/api/v3/class-wc-api-orders.php
+		 *
+		 * @param WC_Order $order
+		 * @return array
+		 */
 		public function get_order_for_api( WC_Order $order ) {
 			$dp = 2; //decimal point defaults
 			$order_data = array(

--- a/classes/class-wc-connect-order-presenter.php
+++ b/classes/class-wc-connect-order-presenter.php
@@ -91,14 +91,6 @@ if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
 					'meta'         => array_values( $item_meta ),
 				);
 
-				if ( in_array( 'products', $expand ) && is_object( $product ) ) {
-					$_product_data = WC()->api->WC_API_Products->get_product( $product->get_id() );
-
-					if ( isset( $_product_data['product'] ) ) {
-						$line_item['product_data'] = $_product_data['product'];
-					}
-				}
-
 				$order_data['line_items'][] = $line_item;
 			}
 
@@ -123,14 +115,6 @@ if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
 					'compound' => (bool) $tax->is_compound,
 				);
 
-				if ( in_array( 'taxes', $expand ) ) {
-					$_rate_data = WC()->api->WC_API_Taxes->get_tax( $tax->rate_id );
-
-					if ( isset( $_rate_data['tax'] ) ) {
-						$tax_line['rate_data'] = $_rate_data['tax'];
-					}
-				}
-
 				$order_data['tax_lines'][] = $tax_line;
 			}
 
@@ -152,14 +136,6 @@ if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
 					'code'   => $coupon_item->get_code(),
 					'amount' => wc_format_decimal( $coupon_item->get_discount(), $dp ),
 				);
-
-				if ( in_array( 'coupons', $expand ) ) {
-					$_coupon_data = WC()->api->WC_API_Coupons->get_coupon_by_code( $coupon_item->get_code() );
-
-					if ( ! is_wp_error( $_coupon_data ) && isset( $_coupon_data['coupon'] ) ) {
-						$coupon_line['coupon_data'] = $_coupon_data['coupon'];
-					}
-				}
 
 				$order_data['coupon_lines'][] = $coupon_line;
 			}

--- a/classes/class-wc-connect-order-presenter.php
+++ b/classes/class-wc-connect-order-presenter.php
@@ -12,7 +12,7 @@ if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
 		 * @return array
 		 */
 		public function get_order_for_api( WC_Order $order ) {
-			$dp = 2; //decimal point defaults
+			$decimal_point = 2;
 			$order_data = array(
 				'id'                        => $order->get_id(),
 				'order_number'              => $order->get_order_number(),
@@ -22,14 +22,14 @@ if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
 				'completed_at'              => wc_format_datetime( $order->get_date_completed() ? $order->get_date_completed()->getTimestamp() : 0 ),
 				'status'                    => $order->get_status(),
 				'currency'                  => $order->get_currency(),
-				'total'                     => wc_format_decimal( $order->get_total(), $dp ),
-				'subtotal'                  => wc_format_decimal( $order->get_subtotal(), $dp ),
+				'total'                     => wc_format_decimal( $order->get_total(), $decimal_point ),
+				'subtotal'                  => wc_format_decimal( $order->get_subtotal(), $decimal_point ),
 				'total_line_items_quantity' => $order->get_item_count(),
-				'total_tax'                 => wc_format_decimal( $order->get_total_tax(), $dp ),
-				'total_shipping'            => wc_format_decimal( $order->get_shipping_total(), $dp ),
-				'cart_tax'                  => wc_format_decimal( $order->get_cart_tax(), $dp ),
-				'shipping_tax'              => wc_format_decimal( $order->get_shipping_tax(), $dp ),
-				'total_discount'            => wc_format_decimal( $order->get_total_discount(), $dp ),
+				'total_tax'                 => wc_format_decimal( $order->get_total_tax(), $decimal_point ),
+				'total_shipping'            => wc_format_decimal( $order->get_shipping_total(), $decimal_point ),
+				'cart_tax'                  => wc_format_decimal( $order->get_cart_tax(), $decimal_point ),
+				'shipping_tax'              => wc_format_decimal( $order->get_shipping_tax(), $decimal_point ),
+				'total_discount'            => wc_format_decimal( $order->get_total_discount(), $decimal_point ),
 				'shipping_methods'          => $order->get_shipping_method(),
 				'payment_details' => array(
 					'method_id'    => $order->get_payment_method(),
@@ -85,11 +85,11 @@ if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
 
 				$line_item = array(
 					'id'           => $item_id,
-					'subtotal'     => wc_format_decimal( $order->get_line_subtotal( $item, false, false ), $dp ),
-					'subtotal_tax' => wc_format_decimal( $item->get_subtotal_tax(), $dp ),
-					'total'        => wc_format_decimal( $order->get_line_total( $item, false, false ), $dp ),
-					'total_tax'    => wc_format_decimal( $item->get_total_tax(), $dp ),
-					'price'        => wc_format_decimal( $order->get_item_total( $item, false, false ), $dp ),
+					'subtotal'     => wc_format_decimal( $order->get_line_subtotal( $item, false, false ), $decimal_point ),
+					'subtotal_tax' => wc_format_decimal( $item->get_subtotal_tax(), $decimal_point ),
+					'total'        => wc_format_decimal( $order->get_line_total( $item, false, false ), $decimal_point ),
+					'total_tax'    => wc_format_decimal( $item->get_total_tax(), $decimal_point ),
+					'price'        => wc_format_decimal( $order->get_item_total( $item, false, false ), $decimal_point ),
 					'quantity'     => $item->get_quantity(),
 					'tax_class'    => $item->get_tax_class(),
 					'name'         => $item->get_name(),
@@ -107,7 +107,7 @@ if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
 					'id'           => $shipping_item_id,
 					'method_id'    => $shipping_item->get_method_id(),
 					'method_title' => $shipping_item->get_name(),
-					'total'        => wc_format_decimal( $shipping_item->get_total(), $dp ),
+					'total'        => wc_format_decimal( $shipping_item->get_total(), $decimal_point ),
 				);
 			}
 
@@ -118,7 +118,7 @@ if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
 					'rate_id'  => $tax->rate_id,
 					'code'     => $tax_code,
 					'title'    => $tax->label,
-					'total'    => wc_format_decimal( $tax->amount, $dp ),
+					'total'    => wc_format_decimal( $tax->amount, $decimal_point ),
 					'compound' => (bool) $tax->is_compound,
 				);
 
@@ -131,8 +131,8 @@ if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
 					'id'        => $fee_item_id,
 					'title'     => $fee_item->get_name(),
 					'tax_class' => $fee_item->get_tax_class(),
-					'total'     => wc_format_decimal( $order->get_line_total( $fee_item ), $dp ),
-					'total_tax' => wc_format_decimal( $order->get_line_tax( $fee_item ), $dp ),
+					'total'     => wc_format_decimal( $order->get_line_total( $fee_item ), $decimal_point ),
+					'total_tax' => wc_format_decimal( $order->get_line_tax( $fee_item ), $decimal_point ),
 				);
 			}
 
@@ -141,7 +141,7 @@ if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
 				$coupon_line = array(
 					'id'     => $coupon_item_id,
 					'code'   => $coupon_item->get_code(),
-					'amount' => wc_format_decimal( $coupon_item->get_discount(), $dp ),
+					'amount' => wc_format_decimal( $coupon_item->get_discount(), $decimal_point ),
 				);
 
 				$order_data['coupon_lines'][] = $coupon_line;

--- a/classes/class-wc-connect-order-presenter.php
+++ b/classes/class-wc-connect-order-presenter.php
@@ -1,0 +1,170 @@
+<?php
+
+if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
+
+	class WC_Connect_Order_Presenter {
+
+		public function get_order_for_api( $order ) {
+			$dp = 2; //decimal point defaults
+			$order_data = array(
+				'id'                        => $order->get_id(),
+				'order_number'              => $order->get_order_number(),
+				'order_key'                 => $order->get_order_key(),
+				'created_at'                => $order->get_date_created()->getTimestamp(),
+				'updated_at'                => wc_format_datetime( $order->get_date_modified() ? $order->get_date_modified()->getTimestamp() : 0 ),
+				'completed_at'              => wc_format_datetime( $order->get_date_completed() ? $order->get_date_completed()->getTimestamp() : 0 ),
+				'status'                    => $order->get_status(),
+				'currency'                  => $order->get_currency(),
+				'total'                     => wc_format_decimal( $order->get_total(), $dp ),
+				'subtotal'                  => wc_format_decimal( $order->get_subtotal(), $dp ),
+				'total_line_items_quantity' => $order->get_item_count(),
+				'total_tax'                 => wc_format_decimal( $order->get_total_tax(), $dp ),
+				'total_shipping'            => wc_format_decimal( $order->get_shipping_total(), $dp ),
+				'cart_tax'                  => wc_format_decimal( $order->get_cart_tax(), $dp ),
+				'shipping_tax'              => wc_format_decimal( $order->get_shipping_tax(), $dp ),
+				'total_discount'            => wc_format_decimal( $order->get_total_discount(), $dp ),
+				'shipping_methods'          => $order->get_shipping_method(),
+				'payment_details' => array(
+					'method_id'    => $order->get_payment_method(),
+					'method_title' => $order->get_payment_method_title(),
+					'paid'         => ! is_null( $order->get_date_paid() ),
+				),
+				'billing_address' => array(
+					'first_name' => $order->get_billing_first_name(),
+					'last_name'  => $order->get_billing_last_name(),
+					'company'    => $order->get_billing_company(),
+					'address_1'  => $order->get_billing_address_1(),
+					'address_2'  => $order->get_billing_address_2(),
+					'city'       => $order->get_billing_city(),
+					'state'      => $order->get_billing_state(),
+					'postcode'   => $order->get_billing_postcode(),
+					'country'    => $order->get_billing_country(),
+					'email'      => $order->get_billing_email(),
+					'phone'      => $order->get_billing_phone(),
+				),
+				'shipping_address' => array(
+					'first_name' => $order->get_shipping_first_name(),
+					'last_name'  => $order->get_shipping_last_name(),
+					'company'    => $order->get_shipping_company(),
+					'address_1'  => $order->get_shipping_address_1(),
+					'address_2'  => $order->get_shipping_address_2(),
+					'city'       => $order->get_shipping_city(),
+					'state'      => $order->get_shipping_state(),
+					'postcode'   => $order->get_shipping_postcode(),
+					'country'    => $order->get_shipping_country(),
+				),
+				'note'                      => $order->get_customer_note(),
+				'customer_ip'               => $order->get_customer_ip_address(),
+				'customer_user_agent'       => $order->get_customer_user_agent(),
+				'customer_id'               => $order->get_user_id(),
+				'view_order_url'            => $order->get_view_order_url(),
+				'line_items'                => array(),
+				'shipping_lines'            => array(),
+				'tax_lines'                 => array(),
+				'fee_lines'                 => array(),
+				'coupon_lines'              => array(),
+			);
+
+			// Add line items.
+			foreach ( $order->get_items() as $item_id => $item ) {
+				$product    = $item->get_product();
+				$item_meta  = $item->get_formatted_meta_data();
+
+				foreach ( $item_meta as $key => $values ) {
+					$item_meta[ $key ]->label = $values->display_key;
+					unset( $item_meta[ $key ]->display_key );
+					unset( $item_meta[ $key ]->display_value );
+				}
+
+				$line_item = array(
+					'id'           => $item_id,
+					'subtotal'     => wc_format_decimal( $order->get_line_subtotal( $item, false, false ), $dp ),
+					'subtotal_tax' => wc_format_decimal( $item->get_subtotal_tax(), $dp ),
+					'total'        => wc_format_decimal( $order->get_line_total( $item, false, false ), $dp ),
+					'total_tax'    => wc_format_decimal( $item->get_total_tax(), $dp ),
+					'price'        => wc_format_decimal( $order->get_item_total( $item, false, false ), $dp ),
+					'quantity'     => $item->get_quantity(),
+					'tax_class'    => $item->get_tax_class(),
+					'name'         => $item->get_name(),
+					'product_id'   => $item->get_variation_id() ? $item->get_variation_id() : $item->get_product_id(),
+					'sku'          => is_object( $product ) ? $product->get_sku() : null,
+					'meta'         => array_values( $item_meta ),
+				);
+
+				if ( in_array( 'products', $expand ) && is_object( $product ) ) {
+					$_product_data = WC()->api->WC_API_Products->get_product( $product->get_id() );
+
+					if ( isset( $_product_data['product'] ) ) {
+						$line_item['product_data'] = $_product_data['product'];
+					}
+				}
+
+				$order_data['line_items'][] = $line_item;
+			}
+
+			// Add shipping.
+			foreach ( $order->get_shipping_methods() as $shipping_item_id => $shipping_item ) {
+				$order_data['shipping_lines'][] = array(
+					'id'           => $shipping_item_id,
+					'method_id'    => $shipping_item->get_method_id(),
+					'method_title' => $shipping_item->get_name(),
+					'total'        => wc_format_decimal( $shipping_item->get_total(), $dp ),
+				);
+			}
+
+			// Add taxes.
+			foreach ( $order->get_tax_totals() as $tax_code => $tax ) {
+				$tax_line = array(
+					'id'       => $tax->id,
+					'rate_id'  => $tax->rate_id,
+					'code'     => $tax_code,
+					'title'    => $tax->label,
+					'total'    => wc_format_decimal( $tax->amount, $dp ),
+					'compound' => (bool) $tax->is_compound,
+				);
+
+				if ( in_array( 'taxes', $expand ) ) {
+					$_rate_data = WC()->api->WC_API_Taxes->get_tax( $tax->rate_id );
+
+					if ( isset( $_rate_data['tax'] ) ) {
+						$tax_line['rate_data'] = $_rate_data['tax'];
+					}
+				}
+
+				$order_data['tax_lines'][] = $tax_line;
+			}
+
+			// Add fees.
+			foreach ( $order->get_fees() as $fee_item_id => $fee_item ) {
+				$order_data['fee_lines'][] = array(
+					'id'        => $fee_item_id,
+					'title'     => $fee_item->get_name(),
+					'tax_class' => $fee_item->get_tax_class(),
+					'total'     => wc_format_decimal( $order->get_line_total( $fee_item ), $dp ),
+					'total_tax' => wc_format_decimal( $order->get_line_tax( $fee_item ), $dp ),
+				);
+			}
+
+			// Add coupons.
+			foreach ( $order->get_items( 'coupon' ) as $coupon_item_id => $coupon_item ) {
+				$coupon_line = array(
+					'id'     => $coupon_item_id,
+					'code'   => $coupon_item->get_code(),
+					'amount' => wc_format_decimal( $coupon_item->get_discount(), $dp ),
+				);
+
+				if ( in_array( 'coupons', $expand ) ) {
+					$_coupon_data = WC()->api->WC_API_Coupons->get_coupon_by_code( $coupon_item->get_code() );
+
+					if ( ! is_wp_error( $_coupon_data ) && isset( $_coupon_data['coupon'] ) ) {
+						$coupon_line['coupon_data'] = $_coupon_data['coupon'];
+					}
+				}
+
+				$order_data['coupon_lines'][] = $coupon_line;
+			}
+
+			return $order_data;
+		}
+	}
+}

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -415,9 +415,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
 			$items = array_filter( $order->get_items(), array( $this, 'filter_items_needing_shipping' ) );
 			$items_count = array_reduce( $items, array( $this, 'reducer_items_quantity' ), 0 );
-
 			$payload = array(
-				'order'             => $order->get_data(),
+				'order'             => $this->get_order_for_api($order),
 				'accountSettings'   => $this->account_settings->get(),
 				'packagesSettings'  => $this->package_settings->get(),
 				'shippingLabelData' => $this->get_label_payload( $order_id ),
@@ -427,6 +426,169 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			);
 
 			do_action( 'enqueue_wc_connect_script', 'wc-connect-create-shipping-label', $payload );
+		}
+
+		private function get_order_for_api( $order ) {
+			$dp = 2;
+			$order_data = array(
+				'id'                        => $order->get_id(),
+				'order_number'              => $order->get_order_number(),
+				'order_key'                 => $order->get_order_key(),
+				'created_at'                => $order->get_date_created()->getTimestamp(),
+				'updated_at'                => wc_format_datetime( $order->get_date_modified() ? $order->get_date_modified()->getTimestamp() : 0 ),
+				'completed_at'              => wc_format_datetime( $order->get_date_completed() ? $order->get_date_completed()->getTimestamp() : 0 ),
+				'status'                    => $order->get_status(),
+				'currency'                  => $order->get_currency(),
+				'total'                     => wc_format_decimal( $order->get_total(), $dp ),
+				'subtotal'                  => wc_format_decimal( $order->get_subtotal(), $dp ),
+				'total_line_items_quantity' => $order->get_item_count(),
+				'total_tax'                 => wc_format_decimal( $order->get_total_tax(), $dp ),
+				'total_shipping'            => wc_format_decimal( $order->get_shipping_total(), $dp ),
+				'cart_tax'                  => wc_format_decimal( $order->get_cart_tax(), $dp ),
+				'shipping_tax'              => wc_format_decimal( $order->get_shipping_tax(), $dp ),
+				'total_discount'            => wc_format_decimal( $order->get_total_discount(), $dp ),
+				'shipping_methods'          => $order->get_shipping_method(),
+				'payment_details' => array(
+					'method_id'    => $order->get_payment_method(),
+					'method_title' => $order->get_payment_method_title(),
+					'paid'         => ! is_null( $order->get_date_paid() ),
+				),
+				'billing_address' => array(
+					'first_name' => $order->get_billing_first_name(),
+					'last_name'  => $order->get_billing_last_name(),
+					'company'    => $order->get_billing_company(),
+					'address_1'  => $order->get_billing_address_1(),
+					'address_2'  => $order->get_billing_address_2(),
+					'city'       => $order->get_billing_city(),
+					'state'      => $order->get_billing_state(),
+					'postcode'   => $order->get_billing_postcode(),
+					'country'    => $order->get_billing_country(),
+					'email'      => $order->get_billing_email(),
+					'phone'      => $order->get_billing_phone(),
+				),
+				'shipping_address' => array(
+					'first_name' => $order->get_shipping_first_name(),
+					'last_name'  => $order->get_shipping_last_name(),
+					'company'    => $order->get_shipping_company(),
+					'address_1'  => $order->get_shipping_address_1(),
+					'address_2'  => $order->get_shipping_address_2(),
+					'city'       => $order->get_shipping_city(),
+					'state'      => $order->get_shipping_state(),
+					'postcode'   => $order->get_shipping_postcode(),
+					'country'    => $order->get_shipping_country(),
+				),
+				'note'                      => $order->get_customer_note(),
+				'customer_ip'               => $order->get_customer_ip_address(),
+				'customer_user_agent'       => $order->get_customer_user_agent(),
+				'customer_id'               => $order->get_user_id(),
+				'view_order_url'            => $order->get_view_order_url(),
+				'line_items'                => array(),
+				'shipping_lines'            => array(),
+				'tax_lines'                 => array(),
+				'fee_lines'                 => array(),
+				'coupon_lines'              => array(),
+			);
+
+			// Add line items.
+			foreach ( $order->get_items() as $item_id => $item ) {
+				$product    = $item->get_product();
+				$item_meta  = $item->get_formatted_meta_data();
+
+				foreach ( $item_meta as $key => $values ) {
+					$item_meta[ $key ]->label = $values->display_key;
+					unset( $item_meta[ $key ]->display_key );
+					unset( $item_meta[ $key ]->display_value );
+				}
+
+				$line_item = array(
+					'id'           => $item_id,
+					'subtotal'     => wc_format_decimal( $order->get_line_subtotal( $item, false, false ), $dp ),
+					'subtotal_tax' => wc_format_decimal( $item->get_subtotal_tax(), $dp ),
+					'total'        => wc_format_decimal( $order->get_line_total( $item, false, false ), $dp ),
+					'total_tax'    => wc_format_decimal( $item->get_total_tax(), $dp ),
+					'price'        => wc_format_decimal( $order->get_item_total( $item, false, false ), $dp ),
+					'quantity'     => $item->get_quantity(),
+					'tax_class'    => $item->get_tax_class(),
+					'name'         => $item->get_name(),
+					'product_id'   => $item->get_variation_id() ? $item->get_variation_id() : $item->get_product_id(),
+					'sku'          => is_object( $product ) ? $product->get_sku() : null,
+					'meta'         => array_values( $item_meta ),
+				);
+
+				if ( in_array( 'products', $expand ) && is_object( $product ) ) {
+					$_product_data = WC()->api->WC_API_Products->get_product( $product->get_id() );
+
+					if ( isset( $_product_data['product'] ) ) {
+						$line_item['product_data'] = $_product_data['product'];
+					}
+				}
+
+				$order_data['line_items'][] = $line_item;
+			}
+
+			// Add shipping.
+			foreach ( $order->get_shipping_methods() as $shipping_item_id => $shipping_item ) {
+				$order_data['shipping_lines'][] = array(
+					'id'           => $shipping_item_id,
+					'method_id'    => $shipping_item->get_method_id(),
+					'method_title' => $shipping_item->get_name(),
+					'total'        => wc_format_decimal( $shipping_item->get_total(), $dp ),
+				);
+			}
+
+			// Add taxes.
+			foreach ( $order->get_tax_totals() as $tax_code => $tax ) {
+				$tax_line = array(
+					'id'       => $tax->id,
+					'rate_id'  => $tax->rate_id,
+					'code'     => $tax_code,
+					'title'    => $tax->label,
+					'total'    => wc_format_decimal( $tax->amount, $dp ),
+					'compound' => (bool) $tax->is_compound,
+				);
+
+				if ( in_array( 'taxes', $expand ) ) {
+					$_rate_data = WC()->api->WC_API_Taxes->get_tax( $tax->rate_id );
+
+					if ( isset( $_rate_data['tax'] ) ) {
+						$tax_line['rate_data'] = $_rate_data['tax'];
+					}
+				}
+
+				$order_data['tax_lines'][] = $tax_line;
+			}
+
+			// Add fees.
+			foreach ( $order->get_fees() as $fee_item_id => $fee_item ) {
+				$order_data['fee_lines'][] = array(
+					'id'        => $fee_item_id,
+					'title'     => $fee_item->get_name(),
+					'tax_class' => $fee_item->get_tax_class(),
+					'total'     => wc_format_decimal( $order->get_line_total( $fee_item ), $dp ),
+					'total_tax' => wc_format_decimal( $order->get_line_tax( $fee_item ), $dp ),
+				);
+			}
+
+			// Add coupons.
+			foreach ( $order->get_items( 'coupon' ) as $coupon_item_id => $coupon_item ) {
+				$coupon_line = array(
+					'id'     => $coupon_item_id,
+					'code'   => $coupon_item->get_code(),
+					'amount' => wc_format_decimal( $coupon_item->get_discount(), $dp ),
+				);
+
+				if ( in_array( 'coupons', $expand ) ) {
+					$_coupon_data = WC()->api->WC_API_Coupons->get_coupon_by_code( $coupon_item->get_code() );
+
+					if ( ! is_wp_error( $_coupon_data ) && isset( $_coupon_data['coupon'] ) ) {
+						$coupon_line['coupon_data'] = $_coupon_data['coupon'];
+					}
+				}
+
+				$order_data['coupon_lines'][] = $coupon_line;
+			}
+
+			return $order_data;
 		}
 
 	}

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -411,15 +411,14 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		}
 
 		public function meta_box( $post, $args ) {
-			$connectOrderPresenter = new WC_Connect_Order_Presenter();
+			$connect_order_presenter = new WC_Connect_Order_Presenter();
 
 			$order = wc_get_order( $post );
-			print_r($connectOrderPresenter->get_order_for_api($order));exit;
 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
 			$items = array_filter( $order->get_items(), array( $this, 'filter_items_needing_shipping' ) );
 			$items_count = array_reduce( $items, array( $this, 'reducer_items_quantity' ), 0 );
 			$payload = array(
-				'order'             => $connectOrderPresenter->get_order_for_api($order),
+				'order'             => $connect_order_presenter->get_order_for_api( $order ),
 				'accountSettings'   => $this->account_settings->get(),
 				'packagesSettings'  => $this->package_settings->get(),
 				'shippingLabelData' => $this->get_label_payload( $order_id ),

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -42,4 +42,4 @@ if ( ! defined( 'WC_UNIT_TESTING' ) ) {
 	define( 'WC_UNIT_TESTING', true );
 }
 
-require $wc_root . '/tests/legacy/bootstrap.php';
+require $wc_root . '/bootstrap.php';

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -18,7 +18,16 @@ if( false !== getenv( 'WC_DEVELOP_DIR' ) ) {
 	exit( 'Could not determine test root directory. Aborting.' );
 }
 
-$wp_tests_dir = getenv( 'WP_TESTS_DIR' ) ? getenv( 'WP_TESTS_DIR' ) : '/tmp/wordpress-tests-lib';
+$wp_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( ! $wp_tests_dir ) {
+	$wp_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+}
+
+if ( ! file_exists( $wp_tests_dir . '/includes/functions.php' ) ) {
+	echo "Could not find $wp_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // WPCS: XSS ok.
+	exit( 1 );
+}
 
 // load test function so tests_add_filter() is available
 require_once( $wp_tests_dir . '/includes/functions.php' );
@@ -33,4 +42,4 @@ if ( ! defined( 'WC_UNIT_TESTING' ) ) {
 	define( 'WC_UNIT_TESTING', true );
 }
 
-require $wc_root . '/bootstrap.php';
+require $wc_root . '/tests/legacy/bootstrap.php';

--- a/tests/php/test_class-wc-connect-order-presenter.php
+++ b/tests/php/test_class-wc-connect-order-presenter.php
@@ -1,0 +1,52 @@
+<?php
+
+class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
+	public static function setupBeforeClass() {
+		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-compatibility.php' );
+		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-shipping-label.php' );
+		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-service-settings-store.php' );
+		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client.php' );
+		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client-live.php' );
+		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-service-schemas-store.php' );
+		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-payment-methods-store.php' );
+		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-account-settings.php' );
+		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-package-settings.php' );
+		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-continents.php' );
+
+		WC_Connect_Compatibility::set_version( '3.0.0' );
+	}
+
+	public function get_order_for_api() {
+		$mock_order_item_shipping = $this->createMock( WC_Order_Item_Shipping::class );
+		$mock_order_item_shipping->expects( $this->once() )
+			->method('get_method_id')
+			->willReturn('flat_rate');
+		$mock_order_item_shipping->expects( $this->once() )
+			->method('get_name')
+			->willReturn('Flat rate');
+		$mock_order_item_shipping->expects( $this->once() )
+			->method('get_total')
+			->willReturn(7);
+
+		$mock_order = $this->getMockBuilder( WC_Order::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$mock_order->expects( $this->once() )->method( 'get_shipping_methods' )->willReturn(
+			array(
+				131 => $mock_order_item_shipping
+			)
+		);
+
+		$expected = array(
+			'id' => 131,
+			'method_id' => 'flat_rate',
+			'method_title' => 'Flat Rate',
+			'total' => 7.00
+		);
+
+		$connect_order_presenter = new WC_Connect_Order_Presenter();
+		$actual = $connect_order_presenter->get_order_for_api($mock_order);
+
+		$this->assertEquals( $expected, $actual['shipping_lines'] );
+	}
+}

--- a/tests/php/test_class-wc-connect-order-presenter.php
+++ b/tests/php/test_class-wc-connect-order-presenter.php
@@ -1,52 +1,87 @@
 <?php
 
-class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
+class WP_Test_WC_Connect_Order_Presenter extends WC_Unit_Test_Case {
 	public static function setupBeforeClass() {
 		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-compatibility.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-shipping-label.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-service-settings-store.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client-live.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-service-schemas-store.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-payment-methods-store.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-account-settings.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-package-settings.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-continents.php' );
+		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-order-presenter.php' );
 
 		WC_Connect_Compatibility::set_version( '3.0.0' );
 	}
 
-	public function get_order_for_api() {
-		$mock_order_item_shipping = $this->createMock( WC_Order_Item_Shipping::class );
-		$mock_order_item_shipping->expects( $this->once() )
-			->method('get_method_id')
-			->willReturn('flat_rate');
-		$mock_order_item_shipping->expects( $this->once() )
-			->method('get_name')
-			->willReturn('Flat rate');
-		$mock_order_item_shipping->expects( $this->once() )
-			->method('get_total')
-			->willReturn(7);
-
-		$mock_order = $this->getMockBuilder( WC_Order::class )
-			->disableOriginalConstructor()
-			->getMock();
-		$mock_order->expects( $this->once() )->method( 'get_shipping_methods' )->willReturn(
-			array(
-				131 => $mock_order_item_shipping
-			)
-		);
-
-		$expected = array(
-			'id' => 131,
-			'method_id' => 'flat_rate',
-			'method_title' => 'Flat Rate',
-			'total' => 7.00
-		);
+	public function test_get_order_for_api_order_data() {
+		// Setup order
+		$order = WC_Helper_Order::create_order();
+		$order->save();
 
 		$connect_order_presenter = new WC_Connect_Order_Presenter();
-		$actual = $connect_order_presenter->get_order_for_api($mock_order);
+		$actual = $connect_order_presenter->get_order_for_api($order);
 
-		$this->assertEquals( $expected, $actual['shipping_lines'] );
+		// Refer to WC_Helper_Order::create_order()
+		$this->assertEquals( 'pending', $actual['status']);
+		$this->assertEquals( 1, $actual['customer_id']);
+		$this->assertEquals( '50.00', $actual['total']);
+		$this->assertEquals( '40.00', $actual['subtotal']);
+		$this->assertEquals( '10.00', $actual['total_shipping']);
+	}
+
+	public function test_get_order_for_api_shipping_lines() {
+		// Setup order
+		$order = WC_Helper_Order::create_order();
+		$order->save();
+
+		$connect_order_presenter = new WC_Connect_Order_Presenter();
+		$actual = $connect_order_presenter->get_order_for_api($order);
+
+		$this->assertEquals( 'flat_rate_shipping', $actual['shipping_lines'][0]['method_id'] );
+		$this->assertEquals( 'Flat rate shipping', $actual['shipping_lines'][0]['method_title'] );
+		$this->assertEquals( '10.00', $actual['shipping_lines'][0]['total'] );
+	}
+
+	public function test_get_order_for_api_line_items() {
+		// Setup order
+		$order = WC_Helper_Order::create_order();
+		$order->save();
+
+		$connect_order_presenter = new WC_Connect_Order_Presenter();
+		$actual = $connect_order_presenter->get_order_for_api($order);
+
+		$this->assertEquals( '40.00', $actual['line_items'][0]['subtotal'] );
+		$this->assertEquals( '40.00', $actual['line_items'][0]['total'] );
+		$this->assertEquals( 4, $actual['line_items'][0]['quantity'] );
+		$this->assertEquals( 'DUMMY SKU', $actual['line_items'][0]['sku'] );
+		$this->assertEquals( 'Dummy Product', $actual['line_items'][0]['name'] );
+	}
+
+	public function test_get_order_for_api_fees_lines() {
+		$feeItem = new WC_Order_item_Fee();
+		$feeItem->set_total( '15.01' );
+		$feeItem->set_total_tax( '5.01' );
+
+		// Setup order
+		$order = WC_Helper_Order::create_order();
+		$order->add_item($feeItem);
+		$order->save();
+
+		$connect_order_presenter = new WC_Connect_Order_Presenter();
+		$actual = $connect_order_presenter->get_order_for_api($order);
+
+		$this->assertEquals( '15.01', $actual['fee_lines'][0]['total'] );
+		$this->assertEquals( '5.01', $actual['fee_lines'][0]['total_tax'] );
+	}
+
+	public function test_get_order_for_api_coupon_lines() {
+		$coupon = WC_Helper_Coupon::create_coupon( 'coupon_1' );
+
+		// Setup order
+		$order = WC_Helper_Order::create_order();
+		$order->apply_coupon($coupon);
+		$order->save();
+
+		$connect_order_presenter = new WC_Connect_Order_Presenter();
+		$actual = $connect_order_presenter->get_order_for_api($order);
+
+		// Refer to WC_Helper_Coupon::create_coupon()
+		$this->assertEquals( 'coupon_1', $actual['coupon_lines'][0]['code'] );
+		$this->assertEquals( '1.00', $actual['coupon_lines'][0]['amount'] );
 	}
 }

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -637,6 +637,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			require_once( plugin_basename( 'classes/class-wc-connect-account-settings.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-package-settings.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-continents.php' ) );
+			require_once( plugin_basename( 'classes/class-wc-connect-order-presenter.php' ) );
 
 			$core_logger           = new WC_Logger();
 			$logger                = new WC_Connect_Logger( $core_logger );


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-services/issues/2116

### Description
WCS 1.24.0 [initializes order](https://github.com/Automattic/woocommerce-services/blob/d7f915ed13cb53dea0118325da0d912e93b8d501/classes/class-wc-connect-shipping-label.php#L420) as the initial states of the react app. 

Currently, `$order->get_data()` returns a PHP object of the order. This object is not suitable to output as `json_encode()`, some of its protected fields are not generated, resulting a `{}` at the end. 

We should transform this order object to something that can be represented as a JSON object. This can be done similar to [Woo core's API](https://github.com/woocommerce/woocommerce/blob/cbfe4bd59587aadb4b6c6e95a5787bebe3925310/includes/legacy/api/v3/class-wc-api-orders.php#L142-L320). 

### To test
1. Go to an order page, and click to the step where you can see rates.
2. Verify the "Customer paid..." box shows
![image](https://user-images.githubusercontent.com/572862/89829471-e28f6300-db17-11ea-8aea-841dbbc15454.png)
