### PR TITLE
Fix button is-busy color to use pink

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -45,14 +45,15 @@
 		//wp-admin styles override the disabled button with !important, so need to do the same here
 		
 		&.is-busy {
+			background-size: 120px 100% !important;
 			background-image: linear-gradient(
 				-45deg,
 				var( --color-accent ) 28%,
 				var( --color-accent-600 ) 28%,
 				var( --color-accent-600 ) 72%,
 				var( --color-accent ) 72%
-			);
-			border-color: var( --color-accent-dark );
+			) !important;
+			border-color: var( --color-accent-dark ) !important;
 		}
 
 		&.is-borderless {

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -43,10 +43,16 @@
 			text-shadow: none !important;
 		}
 		//wp-admin styles override the disabled button with !important, so need to do the same here
+		
 		&.is-busy {
-			background-size: 120px 100% !important;
-			background-image: linear-gradient( -45deg, var( --color-primary ) 28%, var( --color-primary-400 ) 28%, var( --color-primary-400 ) 72%, var( --color-primary ) 72%) !important;
-			border-color: #0081a9 !important;
+			background-image: linear-gradient(
+				-45deg,
+				var( --color-accent ) 28%,
+				var( --color-accent-600 ) 28%,
+				var( --color-accent-600 ) 72%,
+				var( --color-accent ) 72%
+			);
+			border-color: var( --color-accent-dark );
 		}
 
 		&.is-borderless {

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.24.1 - 2020-xx-xx =
 * Fix   - Carrier "disconnect modal" layout
+* Fix   - Primary button busy state updated to match color
 
 = 1.24.0 - 2020-07-30 =
 * Fix   - PHP 7.4 notice for taxes at checkout.


### PR DESCRIPTION
**Description**

Changes the color of the is-busy state on the primary buttons to use the appropriate brand color.

**Issue**

Fixes number 3 in #1971.

**Testing**

You should be able to test this fix on any of the primary buttons in the WCS area. The issue called out the button on the Buy Shipping Label button in particular as this button will have typically have the is-busy state the longest.

1. With WC store and WCS set up to print shipping labels, go to an order that is shippable.
2. Click on the Create shipping label button.
3. Provide any necessary information for addresses, packages, and shipping rates to get the Buy shipping label button active.
4. Click on the Buy shipping label button and while the purchase is processed, the button should have the pink colors with animated slashes signifying the is-busy state.

Alternatively, you can inspect one of the WCS primary buttons (any pink button) from the browser Dev Tools and manually add the is-busy class to the button to confirm it uses the brand pink instead of default blue.

![Button-is-busy](https://user-images.githubusercontent.com/68524302/89945949-281f5f00-dbf0-11ea-8408-de1baf5fcbb9.png)
