### PR TITLE
Remove padding from the notices bar

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -122,6 +122,7 @@
 
 		.notice {
 			max-width: 740px;
+			padding: 0;
 
 			@include breakpoint( '<660px' ) {
 				margin-left: 0;

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.24.1 - 2020-xx-xx =
 * Fix   - Carrier "disconnect modal" layout
+* Fix   - Remove padding from notice bar
 
 = 1.24.0 - 2020-07-30 =
 * Fix   - PHP 7.4 notice for taxes at checkout.


### PR DESCRIPTION
**Description**

Removes the padding from the notices bar so that there is no gap between the icon and the border.

**Issue**

Fixes number 1 in #1971.

**Testing**

You should be able to test this fix on any of the notice bars in the WCS area. The linked issue called out the notice bar after purchasing a label in particular.

1. With WC store and WCS set up to print shipping labels, go to an order that is shippable.
2. Click on the Create shipping label button.
3. Provide any necessary information for addresses, packages, and shipping rates to get the Buy shipping label button active.
4. Click on the Buy shipping label button.
5. Once the request is processed, there should now be a notification (success or fail) with the icon flush against the notification border.

This notice bar appears in different areas within WCS and can be tested in those cases as well as this fix addresses the notice bar globally in WCS.

![Notices-Padding](https://user-images.githubusercontent.com/68524302/89947336-4a19e100-dbf2-11ea-9cd0-2b0c0a714ccc.png)
