### PR TITLE
Add 'wc_connect_meta_box_payload' filter

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Fix   - Add missing box in rate step for how much customer paid for shipping
 * Tweak - Bump WP tested version to 5.5
 * Fix   - Issue with dismiss modal popup blocking access to edit order
+* Add   - Introduce 'wc_connect_meta_box_payload' filter for modifying order data
 
 = 1.24.0 - 2020-07-30 =
 * Fix   - PHP 7.4 notice for taxes at checkout.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.24.2 - 2020-xx-xx =
 * Fix   - Remove duplicate rate errors
+* Add   - Introduce 'wc_connect_meta_box_payload' filter for modifying order data
 
 = 1.24.1 - 2020-08-19 =
 * Tweak - Zip/Postcode/Postal code messaging consistency
@@ -12,7 +13,6 @@
 * Fix   - Add missing box in rate step for how much customer paid for shipping
 * Tweak - Bump WP tested version to 5.5
 * Fix   - Issue with dismiss modal popup blocking access to edit order
-* Add   - Introduce 'wc_connect_meta_box_payload' filter for modifying order data
 
 = 1.24.0 - 2020-07-30 =
 * Fix   - PHP 7.4 notice for taxes at checkout.

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -413,11 +413,13 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		public function meta_box( $post, $args ) {
 
 			$connect_order_presenter = new WC_Connect_Order_Presenter();
-			$order                   = wc_get_order( $post );
-			$order_id                = WC_Connect_Compatibility::instance()->get_order_id( $order );
-			$items                   = array_filter( $order->get_items(), array( $this, 'filter_items_needing_shipping' ) );
-			$items_count             = array_reduce( $items, array( $this, 'reducer_items_quantity' ), 0 );
-			$payload                 = apply_filters( 'wc_connect_meta_box_payload',
+
+ 			$order = wc_get_order( $post );
+ 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
+ 			$items = array_filter( $order->get_items(), array( $this, 'filter_items_needing_shipping' ) );
+ 			$items_count = array_reduce( $items, array( $this, 'reducer_items_quantity' ), 0 );
+
+			$payload = apply_filters( 'wc_connect_meta_box_payload',
 				array(
 					'order'             => $connect_order_presenter->get_order_for_api( $order ),
 					'accountSettings'   => $this->account_settings->get(),

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -394,7 +394,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		 * @param  array $item Item to check for shipping.
 		 * @return bool
 		 */
-		protected function filter_items_needing_shipping( $item ) {
+		public function filter_items_needing_shipping( $item ) {
 			$product = $item->get_product();
 			return $product && $product->needs_shipping();
 		}

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -413,13 +413,11 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		public function meta_box( $post, $args ) {
 
 			$connect_order_presenter = new WC_Connect_Order_Presenter();
-
- 			$order = wc_get_order( $post );
- 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
- 			$items = array_filter( $order->get_items(), array( $this, 'filter_items_needing_shipping' ) );
- 			$items_count = array_reduce( $items, array( $this, 'reducer_items_quantity' ), 0 );
-
-			$payload = apply_filters( 'wc_connect_meta_box_payload',
+			$order                   = wc_get_order( $post );
+			$order_id                = WC_Connect_Compatibility::instance()->get_order_id( $order );
+			$items                   = array_filter( $order->get_items(), array( $this, 'filter_items_needing_shipping' ) );
+			$items_count             = array_reduce( $items, array( $this, 'reducer_items_quantity' ), 0 );
+			$payload                 = apply_filters( 'wc_connect_meta_box_payload',
 				array(
 					'order'             => $connect_order_presenter->get_order_for_api( $order ),
 					'accountSettings'   => $this->account_settings->get(),
@@ -432,6 +430,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				$args,
 				$order,
 				$this
+			);
 
 			do_action( 'enqueue_wc_connect_script', 'wc-connect-create-shipping-label', $payload );
 		}

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -416,7 +416,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			$items       = array_filter( $order->get_items(), array( $this, 'filter_items_needing_shipping' ) );
 			$items_count = array_reduce( $items, array( $this, 'reducer_items_quantity' ), 0 );
 
-			$payload = add_filter( 'wc_connect_meta_box_payload',
+			$payload = apply_filters( 'wc_connect_meta_box_payload',
 				array(
 					'order'             => $order->get_data(),
 					'accountSettings'   => $this->account_settings->get(),

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -411,23 +411,26 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		}
 
 		public function meta_box( $post, $args ) {
-			$order = wc_get_order( $post );
-			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
-			$items = array_filter( $order->get_items(), array( $this, 'filter_items_needing_shipping' ) );
+			$order       = wc_get_order( $post );
+			$order_id    = WC_Connect_Compatibility::instance()->get_order_id( $order );
+			$items       = array_filter( $order->get_items(), array( $this, 'filter_items_needing_shipping' ) );
 			$items_count = array_reduce( $items, array( $this, 'reducer_items_quantity' ), 0 );
 
-			$payload = array(
-				'order'             => $order->get_data(),
-				'accountSettings'   => $this->account_settings->get(),
-				'packagesSettings'  => $this->package_settings->get(),
-				'shippingLabelData' => $this->get_label_payload( $order_id ),
-				'continents'        => $this->continents->get(),
-				'context'           => $args['args']['context'],
-				'items'             => $items_count,
+			$payload = add_filter( 'wc_connect_meta_box_payload',
+				array(
+					'order'             => $order->get_data(),
+					'accountSettings'   => $this->account_settings->get(),
+					'packagesSettings'  => $this->package_settings->get(),
+					'shippingLabelData' => $this->get_label_payload( $order_id ),
+					'continents'        => $this->continents->get(),
+					'context'           => $args['args']['context'],
+					'items'             => $items_count
+				),
+				$args,
+				$this
 			);
 
 			do_action( 'enqueue_wc_connect_script', 'wc-connect-create-shipping-label', $payload );
 		}
-
 	}
 }

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -427,6 +427,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 					'items'             => $items_count
 				),
 				$args,
+				$order,
 				$this
 			);
 

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -413,14 +413,13 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		public function meta_box( $post, $args ) {
 
 			$connect_order_presenter = new WC_Connect_Order_Presenter();
-
-			$order       = wc_get_order( $post );
-			$order_id    = WC_Connect_Compatibility::instance()->get_order_id( $order );
-			$items       = array_filter( $order->get_items(), array( $this, 'filter_items_needing_shipping' ) );
-			$items_count = array_reduce( $items, array( $this, 'reducer_items_quantity' ), 0 );
-			$payload     = apply_filters( 'wc_connect_meta_box_payload',
+			$order                   = wc_get_order( $post );
+			$order_id                = WC_Connect_Compatibility::instance()->get_order_id( $order );
+			$items                   = array_filter( $order->get_items(), array( $this, 'filter_items_needing_shipping' ) );
+			$items_count             = array_reduce( $items, array( $this, 'reducer_items_quantity' ), 0 );
+			$payload                 = apply_filters( 'wc_connect_meta_box_payload',
 				array(
-					'order'             => $order->get_data(),
+					'order'             => $connect_order_presenter->get_order_for_api( $order ),
 					'accountSettings'   => $this->account_settings->get(),
 					'packagesSettings'  => $this->package_settings->get(),
 					'shippingLabelData' => $this->get_label_payload( $order_id ),


### PR DESCRIPTION
### Description

Introduces a `wc_connect_meta_box_payload` filter that can be used to modify the order data used for label printing.

Restores compatibility with Product Bundles and Composite Products. See https://github.com/Automattic/woocommerce-services/issues/2133