### PR TITLE
Remove the slice on the rates errors array

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.24.1 - 2020-xx-xx =
 * Fix   - Services management CSS table layout
 * Fix   - Carrier "disconnect modal" layout
+* Fix   - Remove rates error array slice
 
 = 1.24.0 - 2020-07-30 =
 * Fix   - PHP 7.4 notice for taxes at checkout.

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
@@ -75,7 +75,7 @@ export const ShippingRates = ( {
 						/>
 					} ) )
 				) }
-				{ packageErrors.slice( 1 ).map( ( error, index ) => {
+				{ packageErrors.map( ( error, index ) => {
 					// Print the rest of the errors (if any) below the dropdown
 					return <FieldError type="server-error" key={ index } text={ error } />;
 				} ) }


### PR DESCRIPTION
**Description**

There was a JavaScript  array slice on the packageErrors array on the Label Purchase Modal, Rate Step that would remove the first error in the array. This was originally done to remove duplicate errors since errors would be duplicated for each carrier. With a fix for the duplicate errors coming, this slice is no longer needed.

**Steps to Reproduce**

1. Start with a WC store with WCS set up.
2. Go into a shippable order and click Create Shipping Label.
3. Go through the Address verification and package selection.
4. Will need to force an error from the rates request. Which can be challenging given the error handling from the previous steps. 
5. Once the duplicate errors issue is addressed the response will look like this:

![Rates-Error-No-Dups](https://user-images.githubusercontent.com/68524302/90144346-b577c600-dd4c-11ea-89ca-5e735c31b100.png)

This will cause there to be no errors displayed as the single error is sliced out.

**Fixes**

Fixes #2048 

**Additional Notes**

This PR should be coordinated with the duplicate errors issue on the server. 87-GH-woocommerce-shipping-issues


