### PR TITLE
fix(ShippingLabel): unsafe access to formSchema.custom

### DIFF
--- a/client/admin-pointers.js
+++ b/client/admin-pointers.js
@@ -37,15 +37,21 @@ import jQuery from 'jquery';
 
 				show_pointer( pointers, i + 1 );
 			},
+			open: function() {
+				if ( !pointer.dim ) {
+					return;
+				}
+
+				target.css( 'z-index', 9999 );
+				$( 'body' ).append( '<div id="wcs-pointer-page-dimmer" class="wcs-pointer-page-dimmer"></div>' );
+				$( '#wcs-pointer-page-dimmer' ).fadeIn( 500 ).one( 'click', function () {
+					target.pointer( 'close' );
+				} );
+			}
 		} );
 
 		function open() {
 			target.pointer( options ).pointer( 'open' );
-			if ( pointer.dim ) {
-				target.css( 'z-index', 9999 );
-				$( 'body' ).append( '<div id="wcs-pointer-page-dimmer" class="wcs-pointer-page-dimmer"></div>' );
-				$( '#wcs-pointer-page-dimmer' ).fadeIn( 500 );
-			}
 		}
 
 		/**

--- a/client/apps/shipping-label/index.js
+++ b/client/apps/shipping-label/index.js
@@ -36,7 +36,7 @@ export default ( { order, accountSettings, packagesSettings, shippingLabelData, 
 	const packages = packagesSettings.formData;
 	const dimensionUnit = packagesSettings.storeOptions.dimension_unit;
 	const weightUnit = packagesSettings.storeOptions.weight_unit;
-	const packageSchema = packagesSettings.formSchema.custom.items;
+	const packageSchema = packagesSettings.formSchema.custom ? packagesSettings.formSchema.custom.items : undefined;
 	const predefinedSchema = packagesSettings.formSchema.predefined;
 
 	return {


### PR DESCRIPTION
## Description
Looks like there's an unsafe access to `packagesSettings.formSchema.custom.items`.
In fact, it can happen that the `custom` property is `null`, causing JS to break.

I think it would be nice if [client/admin-pointers.js](https://github.com/Automattic/woocommerce-services/blob/develop/client/admin-pointers.js) was _Reactified_ , so that it could be tied to the React lifecycle, maybe?

It happens to be `null` on a new installation, in this scenario:
- `packageSettings` is generated: https://github.com/Automattic/woocommerce-services/blob/develop/classes/class-wc-connect-shipping-label.php#L422
- `packageSettings.custom` is generated: https://github.com/Automattic/woocommerce-services/blob/develop/classes/class-wc-connect-package-settings.php#L29
- `packageSettings.custom` is `null` at https://github.com/Automattic/woocommerce-services/blob/develop/classes/class-wc-connect-service-schemas-store.php#L235 , when the `services` option is empty

~I also considered changing https://github.com/Automattic/woocommerce-services/blob/develop/client/admin-pointers.js#L42-L49 to ensure that `#wcs-pointer-page-dimmer` is added only when the pointer is created (and so that an `onClick` listener can be added to the overlay), but I'm afraid that the PayPal integration might not work correctly, otherwise.~
I also changed `client/admin-pointers.js` to ensure that `#wcs-pointer-page-dimmer` is added only when the pointer is created (and so that an `onClick` listener can be added to the overlay).

## Fixes
Fixes https://github.com/Automattic/woocommerce-services/issues/2128

## Steps to reproduce
- Create an order in WC
- Install WCS **for the first time** (or delete _all_ its options)
- Ensure Jetpack is enabled
- Go to an order page
- Issue should no longer be present
