### PR TITLE
chore: merge `master` into `develop`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Services Changelog ***
 
-= 1.24.1 - 2020-xx-xx =
+= 1.24.1 - 2020-08-19 =
 * Tweak - Zip/Postcode/Postal code messaging consistency
 * Fix   - Services management CSS table layout
 * Fix   - Carrier "disconnect modal" layout

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Services Changelog ***
 
+= 1.24.2 - 2020-xx-xx =
+* Fix   - Remove duplicate rate errors
+
 = 1.24.1 - 2020-08-19 =
 * Tweak - Zip/Postcode/Postal code messaging consistency
 * Fix   - Services management CSS table layout
@@ -9,7 +12,6 @@
 * Fix   - Add missing box in rate step for how much customer paid for shipping
 * Tweak - Bump WP tested version to 5.5
 * Fix   - Issue with dismiss modal popup blocking access to edit order
-* Fix   - Remove duplicate rate errors
 
 = 1.24.0 - 2020-07-30 =
 * Fix   - PHP 7.4 notice for taxes at checkout.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-services",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "scripts": {
     "start": "cross-env NODE_ENV=development CALYPSO_CLIENT=true webpack-dev-server --hot --inline --watch --content-base dist --port 8085",
     "prepare": "cd wp-calypso && npm ci && cd ..",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: shipping, stamps, usps, woocommerce, taxes, payment, stripe
 Requires at least: 4.6
 Requires PHP: 5.3
 Tested up to: 5.5
-Stable tag: 1.24.0
+Stable tag: 1.24.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -83,7 +83,7 @@ As of the WooCommerce 3.5 release, WooCommerce Services no longer provides shipp
 
 == Changelog ==
 
-= 1.24.1 - 2020-xx-xx =
+= 1.24.1 - 2020-08-19 =
 * Tweak - Zip/Postcode/Postal code messaging consistency
 * Fix   - Services management CSS table layout
 * Fix   - Carrier "disconnect modal" layout

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -7,7 +7,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-services
  * Domain Path: /i18n/languages/
- * Version: 1.24.0
+ * Version: 1.24.1
  * WC requires at least: 3.0.0
  * WC tested up to: 4.2
  *


### PR DESCRIPTION
- Added new changelog version
- Fixed line from https://github.com/Automattic/woocommerce-services/pull/2135 to appear in the correct version