### PR TITLE
Add DHL mappings for tracking URLs and shipping methods

### DIFF
--- a/client/extensions/woocommerce/state/sites/shipping-methods/selectors.js
+++ b/client/extensions/woocommerce/state/sites/shipping-methods/selectors.js
@@ -27,6 +27,7 @@ const METHOD_NAMES = {
 	wc_services_canada_post: translate( 'Canada Post' ),
 	wc_services_fedex: translate( 'FedEx' ),
 	wc_services_ups: translate( 'UPS' ),
+	wc_services_dhl: translate( 'DHL' ),
 };
 
 /**

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/reducer.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/reducer.js
@@ -37,6 +37,7 @@ export const builtInShippingMethods = {
 	wc_services_canada_post: wcsServiceSettings,
 	wc_services_fedex: wcsServiceSettings,
 	wc_services_ups: wcsServiceSettings,
+	wc_services_dhl: wcsServiceSettings,
 };
 
 export const initialState = {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/tracking-link.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/tracking-link.js
@@ -12,6 +12,7 @@ const TRACKING_URL_MAP = {
 	usps: tracking => `https://tools.usps.com/go/TrackConfirmAction.action?tLabels=${ tracking }`,
 	fedex: tracking => `https://www.fedex.com/apps/fedextrack/?action=track&tracknumbers=${ tracking }`,
 	ups: tracking => `https://www.ups.com/track?loc=en_US&tracknum=${ tracking }`,
+	dhl: tracking => `https://webtrack.dhlglobalmail.com/?trackingnumber=${ tracking }`,
 };
 
 const TrackingLink = ( { tracking, carrierId, translate } ) => {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1065,6 +1065,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					case 'ups':
 						$tracking_url = 'https://www.ups.com/track?tracknum=' . $tracking;
 						break;
+					case 'dhl':
+						$tracking_url = 'https://www.dhl.com/en/express/tracking.html?brand=DHL&AWB=' . $tracking;
+						break;
 
 				}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1066,7 +1066,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 						$tracking_url = 'https://www.ups.com/track?tracknum=' . $tracking;
 						break;
 					case 'dhl':
-						$tracking_url = 'https://www.dhl.com/en/express/tracking.html?brand=DHL&AWB=' . $tracking;
+						$tracking_url = 'https://webtrack.dhlglobalmail.com/?trackingnumber=' . $tracking;
 						break;
 
 				}


### PR DESCRIPTION
**Description**

Add DHL selectors for shipping methods and DHL tracking URLs.

**Fixes**

Closes #2142 

**Additional Notes**

I had found two possible tracking URLs:

https://www.dhl.com/en/express/tracking.html?AWB=55555555&brand=DHL
https://webtrack.dhlglobalmail.com/?trackingnumber=55555555

The first link is specifically for Express and I was using that at first. I took a look at an existing DHL for WooCommerce plugin and found they were using the 2nd link for tracking. I switched them out as the first link had the locale in the URL.

@aleftick I was wondering if you had any insight on the correct tracking URL to use? This would be an easy update once we get confirmation in the future so I didn't want to hold up this PR in the meantime. 