### PR TITLE
Update error message for connecting carrier error

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.24.2 - 2020-xx-xx =
 * Fix   - Remove duplicate rate errors
 * Add   - Introduce 'wc_connect_meta_box_payload' filter for modifying order data
+* Tweak - Update UPS failed connection error message
 
 = 1.24.1 - 2020-08-19 =
 * Tweak - Zip/Postcode/Postal code messaging consistency

--- a/client/extensions/woocommerce/woocommerce-services/state/carrier-accounts/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/carrier-accounts/actions.js
@@ -90,6 +90,6 @@ export const submitCarrierSettings = ( siteId, carrier, values ) => ( dispatch )
 		} )
 		.catch( () => {
 			dispatch( toggleSettingsIsSaving( siteId, carrier ) );
-			dispatch( errorNotice( translate( 'There was an error trying to connect your carrier account' ) ) );
+			dispatch( errorNotice( translate( 'There was an error connecting to your UPS account. Please check that all of the information entered matches your UPS account and try to connect again.' ) ) );
 		} );
 };


### PR DESCRIPTION
**Description**

The error message presented when connecting a UPS account fails was too generic. This error message has been updated to give the user more direction on how to address the problem.

> There was an error connecting to your UPS account. Please check that all of the information entered matches your UPS account and try to connect again.

**How to Test**

1. Start with a WCS site with UPS enabled, but not connected.
2. Go to the WCS Settings page and click Connect for UPS.
3. Enter the relevant information, but with a bad phone number (5555555555, 10-digits).
4. Click Connect and confirm the above error message is displayed.


![UPS-Connect-Better-Error](https://user-images.githubusercontent.com/68524302/91185247-91f13b80-e6bb-11ea-96ef-c3a1a7eb0a47.png)

**Fixes**

Closes #2149 