### PR TITLE
Change webpack chunks from [name] to [chunkhash]

### DIFF
--- a/client/apps/shipping-label/index.js
+++ b/client/apps/shipping-label/index.js
@@ -9,7 +9,7 @@ import React, {Suspense} from 'react';
 
 import ShippingLabelViewWrapper from './view-wrapper-label';
 // Lazy load ShipmentTrackingViewWrapper so shipping label will render faster.
-const ShipmentTrackingViewWrapper = React.lazy(() => import(/* webpackChunkName: "view-wrapper-tracking" */'./view-wrapper-tracking'));
+const ShipmentTrackingViewWrapper = React.lazy(() => import('./view-wrapper-tracking'));
 import reduxMiddleware from './redux-middleware';
 // from calypso
 import notices from 'state/notices/reducer';

--- a/client/apps/shipping-label/view-wrapper-label.js
+++ b/client/apps/shipping-label/view-wrapper-label.js
@@ -15,8 +15,8 @@ import { sumBy, differenceBy, filter, maxBy } from 'lodash';
  */
 // from calypso
 import Button from 'components/button';
-const LabelPurchaseModal = React.lazy(() => import(/* webpackChunkName: "shipping-label-modal" */'../../extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal'));
-const TrackingModal = React.lazy(() => import(/* webpackChunkName: "tracking-modal" */'../../extensions/woocommerce/woocommerce-services/views/shipping-label/tracking-modal'));
+const LabelPurchaseModal = React.lazy(() => import('../../extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal'));
+const TrackingModal = React.lazy(() => import('../../extensions/woocommerce/woocommerce-services/views/shipping-label/tracking-modal'));
 
 import {
 	openPrintingFlow,

--- a/client/main.js
+++ b/client/main.js
@@ -56,22 +56,22 @@ const getRouteClass = async ( className ) => {
 	let module = null;
 	switch ( className) {
 		case 'wc-connect-create-shipping-label':
-			module = await import(/* webpackChunkName: "shipping-label" */ './apps/shipping-label');
+			module = await import('./apps/shipping-label');
 			break;
 		case 'wc-connect-service-settings':
-			module = await import(/* webpackChunkName: "settings" */ './apps/settings');
+			module = await import('./apps/settings');
 			break;
 		case 'wc-connect-admin-status':
-			module = await import(/* webpackChunkName: "plugin-status" */ './apps/plugin-status');
+			module = await import('./apps/plugin-status');
 			break;
 		case 'wc-connect-shipping-settings':
-			module = await import(/* webpackChunkName: "shipping-settings" */ './apps/shipping-settings');
+			module = await import('./apps/shipping-settings');
 			break;
 		case 'wc-connect-admin-test-print':
-			module = await import(/* webpackChunkName: "print-test-label" */ './apps/print-test-label');
+			module = await import('./apps/print-test-label');
 			break;
 		case 'wc-connect-stripe-connect-account':
-			module = await import(/* webpackChunkName: "shipping-label" */ './apps/stripe-connect-account');
+			module = await import('./apps/stripe-connect-account');
 			break;
 		default:
 			return null;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -253,7 +253,7 @@ module.exports = {
 		} ),
 		! isDev && new MiniCssExtractPlugin( {
 			filename: '[name]-' + process.env.npm_package_version + '.css',
-			chunkFilename: './chunks/[chunkhash].css'
+			chunkFilename: 'chunks/[chunkhash].css'
 		} ),
 		new webpack.DefinePlugin( {
 			'process.env.NODE_ENV': isDev ? '"development"' : '"production"',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,7 +60,7 @@ module.exports = {
 			{
 			path: path.join( __dirname, 'dist' ),
 			filename: '[name]-' + process.env.npm_package_version + '.js',
-			chunkFilename: 'chunks/[name].[chunkhash].min.js',
+			chunkFilename: 'chunks/[chunkhash].min.js',
 			devtoolModuleFilenameTemplate: 'app:///[resource-path]',
 		},
 		isDev ? {
@@ -253,6 +253,7 @@ module.exports = {
 		} ),
 		! isDev && new MiniCssExtractPlugin( {
 			filename: '[name]-' + process.env.npm_package_version + '.css',
+			chunkFilename: './chunks/[chunkhash].css'
 		} ),
 		new webpack.DefinePlugin( {
 			'process.env.NODE_ENV': isDev ? '"development"' : '"production"',


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-services/issues/2141

### Summary
Updated chunks from `[name]` to `[chunkhash]` to address reduce filename size and to remove `~` in chunk filenames. I removed `id`, `name` form the `chunkFileName` since we don't really need that anymore. I kept `chunkhash` for cache busting purposes. I also added `chunkFileName` to the `MiniCssExtractPlugin` so that the chunks are now named with `chunkhash`, and placed properly in the `chunks` folder.
Before:
![image](https://user-images.githubusercontent.com/572862/92662982-4941a100-f2bd-11ea-8570-cca5b00cff2b.png)
After:
![image](https://user-images.githubusercontent.com/572862/92662984-4c3c9180-f2bd-11ea-84a9-7071fa550422.png)

### How to test
#### Local development
1. Pull this branch and run `npm run start`.
2. Open webpack dev server http://localhost:8085/chunks/ and you should see a bunch of `<hash>.css` and `<hash>.min.js`
3. Go to WooCommerce > Orders, and you should still be able to create a label.
4. You can also open up network tab and see all the chunks show up for `css` and `js`.

#### Production environment
1. Pull this branch and run `npm run build`
2. Go to `release/` folder and upload this `woocommerce-services.zip` to a production website (ie. JN).
3. You should be able to print a label without errors. Check WCS settings and the style, js should load fine (`wp-admin/admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings`)
4. You can also open up network tab and see all the chunks show up for `css` and `js`.
