### PR TITLE
Update DHL Express names

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Services Changelog ***
 
+= 1.24.3 - 2020-XX-XX =
+* Tweak - Updating carrier logo and tracking links
+
 = 1.24.2 - 2020-09-03 =
 * Fix   - Optional preloading for wc-admin install compatibility
 * Fix   - Remove duplicate rate errors

--- a/client/extensions/woocommerce/state/sites/shipping-methods/selectors.js
+++ b/client/extensions/woocommerce/state/sites/shipping-methods/selectors.js
@@ -27,7 +27,7 @@ const METHOD_NAMES = {
 	wc_services_canada_post: translate( 'Canada Post' ),
 	wc_services_fedex: translate( 'FedEx' ),
 	wc_services_ups: translate( 'UPS' ),
-	wc_services_dhl: translate( 'DHL' ),
+	wc_services_dhlexpress: translate( 'DHL Express' ),
 };
 
 /**

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/reducer.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/reducer.js
@@ -37,7 +37,7 @@ export const builtInShippingMethods = {
 	wc_services_canada_post: wcsServiceSettings,
 	wc_services_fedex: wcsServiceSettings,
 	wc_services_ups: wcsServiceSettings,
-	wc_services_dhl: wcsServiceSettings,
+	wc_services_dhlexpress: wcsServiceSettings,
 };
 
 export const initialState = {

--- a/client/extensions/woocommerce/woocommerce-services/components/carrier-icon/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/carrier-icon/index.js
@@ -16,7 +16,7 @@ import dhlExpressLogo from './logos/dhlExpress.png';
 const carrierLogos = {
 	"ups": upsLogo,
 	"usps": uspsLogo,
-	"dhl_express": dhlExpressLogo,
+	"dhlexpress": dhlExpressLogo,
 };
 
 const sizeToPixels = ( size ) => {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/tracking-link.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/tracking-link.js
@@ -12,7 +12,7 @@ const TRACKING_URL_MAP = {
 	usps: tracking => `https://tools.usps.com/go/TrackConfirmAction.action?tLabels=${ tracking }`,
 	fedex: tracking => `https://www.fedex.com/apps/fedextrack/?action=track&tracknumbers=${ tracking }`,
 	ups: tracking => `https://www.ups.com/track?loc=en_US&tracknum=${ tracking }`,
-	dhl: tracking => `https://www.dhl.com/en/express/tracking.html?AWB=${ tracking }&brand=DHL`,
+	dhlexpress: tracking => `https://www.dhl.com/en/express/tracking.html?AWB=${ tracking }&brand=DHL`,
 };
 
 const TrackingLink = ( { tracking, carrierId, translate } ) => {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1069,7 +1069,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					case 'ups':
 						$tracking_url = 'https://www.ups.com/track?tracknum=' . $tracking;
 						break;
-					case 'dhl':
+					case 'dhlexpress':
 						$tracking_url = 'https://www.dhl.com/en/express/tracking.html?AWB=' . $tracking . '&brand=DHL';
 						break;
 


### PR DESCRIPTION
**Summary**

The logo, tracking links, and service names were using different IDs for DHL Express, this PR updates them all to be using the new ID of `dhlexpress`.

**How to Test**

1. Set up WC with WCS site.
2. Enable DHL Express for the site by setting the can_use_dhlexpress flag.
3. Place a non-domestic order on the site.
4. Go to create the shipping label for the order.
5. Confirm that the DHL logo is displayed in the Label Rates.
6. Purchase label and confirm that a tracking link is provided.

<img width="622" alt="DHL-With-Logo" src="https://user-images.githubusercontent.com/68524302/92940650-55dd0b00-f41d-11ea-8983-0b245a08a2d7.png">

<img width="411" alt="DHL-With-Tracking" src="https://user-images.githubusercontent.com/68524302/92940656-5a092880-f41d-11ea-8210-aef725770ad4.png">

**Fixes**
Fixes #2173 
