### PR TITLE
Remove wp-admin dependency from banner

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1232,7 +1232,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 			wp_register_script( 'wc_services_admin_pointers', $this->wc_connect_base_url . 'woocommerce-services-admin-pointers-' . $plugin_version . '.js', array( 'wp-pointer', 'jquery' ), null );
 			wp_register_style( 'wc_connect_banner', $this->wc_connect_base_url . 'woocommerce-services-banner-' . $plugin_version . '.css', array(), null );
-			wp_register_script( 'wc_connect_banner', $this->wc_connect_base_url . 'woocommerce-services-banner-' . $plugin_version . '.js',  array( 'updates' ), null );
+			wp_register_script( 'wc_connect_banner', $this->wc_connect_base_url . 'woocommerce-services-banner-' . $plugin_version . '.js',  array(), null );
 
 			$i18n_json = $this->get_i18n_json();
 			/** @var array $i18nStrings defined in i18n/strings.php */


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-services/issues/2165

### Summary
Remove the `'updates'` dependency since WP has it inside script-loader by default. 

### Description 
The select-all feature checkbox stopped working when WCS's `wc_connect_banner` has a `updates.min.js` dependency in it. When we add `'updates'` as dependency in `wp_register_script()`, it seems like it moved `<script src='https://localhost/wp-admin/js/updates.min.js?ver=5.5.1' id='updates-js'></script>` to the `<head>`. When this happens, for some reason, the [event handler](https://github.com/WordPress/WordPress/blob/master/wp-admin/js/common.js#L1170 ) from WP's `common.js` is removed, as shown in [here](https://github.com/Automattic/woocommerce-services/issues/2165#issuecomment-690726954). By removing `'updates'` dependency, the `updates.min.js` no longer sits in the `<head>` and the event handler is back.

### Do we need the `updates` dependency?
I don't think we do anymore. This was added in https://github.com/Automattic/woocommerce-services/commit/a20273aac03ca23bdc0334a058730d11831eddbe#diff-57ae8afb227e356d71d37582f678a831R710, which was part of the work from here https://github.com/Automattic/woocommerce-services/commit/62a24300c8270aa949ada912d8e2a5d441e5d32a#diff-57ae8afb227e356d71d37582f678a831R858-R864. The purpose was to make sure `wp.updates.installPlugin( { slug: 'jetpack' } )` runs.

Given that WP's `script-loader.php` includes `updates` [by default](https://github.com/WordPress/WordPress/blob/master/wp-includes/script-loader.php#L1264), I don't think we need to load it ourselves anymore. It is also worth mentioning that in the code above, we can see that `updates` depends on `common`. Perhaps it is a problem when we use `wp_register_script()` with a dependency of `updates` without `common`?

### How to test
#### All "check-all" box should now work
1. Go to https://localhost/wp-admin/plugins.php
2. Click the "select-all" checkbox, all boxes should now show.
![image](https://user-images.githubusercontent.com/572862/92975444-85077280-f445-11ea-832f-34d76db7681b.png)

#### Regression, localhost, Jetpack still installs through banner
1. Pull this branch
2. Make sure Jetpack is deactivated/uninstalled. Then go to https://github.com/Automattic/woocommerce-services/blob/develop/classes/class-wc-connect-nux.php#L421-L426, add `$banner_to_display = 'before_jetpack_connection';` after `line 426` above to force the banner to show. 
Alternatively, you can disconnect Jetpack.
3. Click this
![image](https://user-images.githubusercontent.com/572862/92974893-6d7bba00-f444-11ea-998d-bcb945d5976b.png)
4. You should see Jetpack install and activate.

#### Regression, on a fresh live site (JN), Jetpack still installs through banner
1. Pull this branch, run `npm run build`
2. On your fresh live site, install latest WC
3. Upload `releases/woocommerce-services.zip` to your live's site plugin
4. You should see a similar banner, click Activate/Install/Connect
![image](https://user-images.githubusercontent.com/572862/92975199-027eb300-f445-11ea-99e6-5b841021c888.png)
5. Jetpack should installed and you should see a redirection, followed by a setup completed message.
![image](https://user-images.githubusercontent.com/572862/92975320-38bc3280-f445-11ea-84db-63e1091c740b.png)
![image](https://user-images.githubusercontent.com/572862/92975341-42de3100-f445-11ea-924a-ccf8cac557ce.png)
