### PR TITLE
Align carrier logo vertically in flex box

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
@@ -38,11 +38,6 @@
 	border-bottom: 1px solid #eee
 }
 
-.rates-step__carier-logo-image-usps {
-	width: 40px;
-	height: 40px;
-}
-
 .rates-step__shipping-rate-information {
 	display: flex;
 	flex-grow: 1;
@@ -51,6 +46,7 @@
 		height: 30px;
 		max-width: 30px;
 		margin: 15px 15px;
+		align-items: center;
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-services/issues/2170

### Summary 
Vertical align carrier logo in rate step.

### How to test
1. If you don't have DHL rates, then go to https://github.com/Automattic/woocommerce-services/blob/develop/client/extensions/woocommerce/woocommerce-services/components/carrier-icon/index.js#L18 and change `uspsLogo` to `dhlExpressLogo` to test.
2. Go through label purchasing, and you should see the label vertically aligned now.
3. Make sure UPS/USPS/DHL all show up properly.
![image](https://user-images.githubusercontent.com/572862/93115599-4f4acf80-f679-11ea-9487-3539f24d5aa5.png)
![image](https://user-images.githubusercontent.com/572862/93115610-5245c000-f679-11ea-9a99-3c3760a65de7.png)

