### PR TITLE
Update changelog entries

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,9 @@
 *** WooCommerce Services Changelog ***
 
 = 1.24.3 - 2020-XX-XX =
+* Fix   - Asset paths incompatible with some hosts.
+* Fix   - Select all posts checkbox not working.
+* Fix   - Use of deprecated jQuery.load.
 * Tweak - Updating carrier logo and tracking links
 
 = 1.24.2 - 2020-09-03 =


### PR DESCRIPTION
Adding some missing changelog entries to prep for 1.24.3: https://github.com/Automattic/woocommerce-services/pull/2181

