### PR TITLE
Fix UPS connect redirect prompt

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Services Changelog ***
 
+= 1.24.4 - 2020-XX-XX =
+* Fix   - UPS connect redirect prompt
+
 = 1.24.3 - 2020-XX-XX =
 * Tweak - Updating carrier logo and tracking links
 

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/settings.js
@@ -56,6 +56,7 @@ export const CarrierAccountSettings = ( props ) => {
 	if ( isConnectionSuccess ) {
 		const url = new URL( window.location.href );
 		url.searchParams.delete( 'carrier' );
+		window.onbeforeunload = null;
 		window.location.href = url.href;
 	}
 


### PR DESCRIPTION
**Summary**

When connecting a UPS account through WooCommerce Services, the browser would prompt the user with the "Leave site? Changes you made may not be saved." dialog. This is browser behavior that is bound to the `window.onbeforeunload` event when it thinks there were changes to a form that weren't saved. In this case the submission is done through AJAX and the form on the page isn't being used for submission so the browser thought there were unsaved changes. This fix unbinds the `window.onbeforeunload` event right before redirecting on a successful submission.

![Chrome-Dialog](https://user-images.githubusercontent.com/68524302/93353729-40475700-f80a-11ea-8f70-9cb56572606d.png)

**How to Test**

1. Start with WC and WCS set up for the site.
2. Enable UPS for the site.
3. From the WooCommerce > Settings > Shipping > WooCommerce Services click Connect next to the UPS Account in the Carrier Account table.
4. To confirm the event isn't unbound at the wrong time, fill in some information on the form, then click on any item in the Admin menu and confirm you are prompted with the "Leave site? Changes you made may not be saved." dialog.
5. Click Cancel on the dialog to stay on the page.
6. Fill in the relevant UPS account information and click Connect.
7. Confirm that there was no browser dialog about unsaved changes and that the browser properly refreshes the page and the UPS account is connected.

**Fixes**
Fixes #2178 

**Notes**

I was looking if there was a more elegant way to mark the form as submitted to avoid the browser dialog, but didn't see a clean way to make that happen. The most recommended solution to preventing the dialog was to unbind the event and since we had a narrowly scoped and clean place to do that I went with that option. I tested this on Chrome, Firefox, Safari, and Edge to confirm this update prevents that dialog.