### PR TITLE
PHP8: The glue must be the first parameter to implode().

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.24.4 - 2020-XX-XX =
 * Fix   - UPS connect redirect prompt
+* Fix   - PHP implode arguments order
 
 = 1.24.3 - 2020-09-16 =
 * Fix   - Asset paths incompatible with some hosts.

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -611,7 +611,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				) );
 
 				if ( ! is_wp_error( $method_classes ) && ! empty( $method_classes ) ) {
-					$class_names = implode( wp_list_pluck( $method_classes, 'name' ), ', ' );
+					$class_names = implode( ', ', wp_list_pluck( $method_classes, 'name' ) );
 				} else {
 					$class_names = 'No shipping classes found';
 				}


### PR DESCRIPTION
PHP8: The glue must be the first parameter to implode().

Detected via PHPCompatibility:
```
FILE: ...oocommerce-services/classes/class-wc-connect-shipping-method.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 614 | ERROR | Passing the $glue and $pieces parameters in reverse
     |       | order to implode has been deprecated since PHP 7.4 and
     |       | is removed since PHP 8.0; $glue should be the first
     |       | parameter and $pieces the second
     |       | (PHPCompatibility.ParameterValues.RemovedImplodeFlexibleParamOrder.Removed)
----------------------------------------------------------------------
```