### PR TITLE
Allow UPS Label Purchase with no payment method

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.24.4 - 2020-XX-XX =
 * Fix   - UPS connect redirect prompt
+* Fix   - Allow UPS label purchase without payment method
 
 = 1.24.3 - 2020-XX-XX =
 * Fix   - Asset paths incompatible with some hosts.

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -699,10 +699,11 @@ export const confirmCustoms = ( orderId, siteId ) => ( dispatch, getState ) => {
 	tryGetLabelRates( orderId, siteId, dispatch, getState );
 };
 
-export const updateRate = ( orderId, siteId, packageId, serviceId, signatureRequired ) => {
+export const updateRate = ( orderId, siteId, packageId, serviceId, carrierId, signatureRequired ) => {
 	return {
 		type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_UPDATE_RATE,
 		siteId,
+		carrierId,
 		orderId,
 		packageId,
 		serviceId,

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -1004,10 +1004,11 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SAVE_CUSTOMS ] = state => {
 	};
 };
 
-reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_UPDATE_RATE ] = ( state, { packageId, serviceId, signatureRequired } ) => {
+reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_UPDATE_RATE ] = ( state, { packageId, serviceId, carrierId, signatureRequired } ) => {
 	const newRates = { ...state.form.rates.values };
 	newRates[ packageId ] = {
 		serviceId,
+		carrierId,
 		signatureRequired,
 	};
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-section/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-section/index.js
@@ -4,7 +4,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { forEach } from 'lodash';
 
 /**
  * Internal dependencies
@@ -40,14 +39,9 @@ export const PurchaseSection = props => {
 	} = props;
 	const purchaseBusy = form.isSubmitting && ! form.needsPrintConfirmation;
 	const hasSelectedRate = hasSelectedRates( form.rates );
-	let labelRequiresPaymentMethod = false;
-	if( hasSelectedRate ) {
-		forEach( form.rates.values , ( label ) => {
-			if( 'ups' !== label.carrierId ) {
-				labelRequiresPaymentMethod = true;
-			}
-		});
-	}
+	const labelRequiresPaymentMethod = hasSelectedRate && Object.values( form.rates.values ).some( ( label ) => {
+		return 'ups' !== label.carrierId;
+	} );
 	const canPurchaseLabel = ( hasLabelsPaymentMethod && labelRequiresPaymentMethod ) || ! labelRequiresPaymentMethod;
 	
 	const addCardButtonDescription = ( onAddCard ) =>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-section/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-section/index.js
@@ -28,7 +28,7 @@ import {
  */
 import './style.scss';
 
-const PurchaseSection = props => {
+export const PurchaseSection = props => {
 	const {
 		orderId,
 		siteId,

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-section/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-section/index.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { forEach } from 'lodash';
 
 /**
  * Internal dependencies
@@ -39,6 +40,16 @@ const PurchaseSection = props => {
 	} = props;
 	const purchaseBusy = form.isSubmitting && ! form.needsPrintConfirmation;
 	const hasSelectedRate = hasSelectedRates( form.rates );
+	let labelRequiresPaymentMethod = false;
+	if( hasSelectedRate ) {
+		forEach( form.rates.values , ( label ) => {
+			if( 'ups' !== label.carrierId ) {
+				labelRequiresPaymentMethod = true;
+			}
+		});
+	}
+	const canPurchaseLabel = ( hasLabelsPaymentMethod && labelRequiresPaymentMethod ) || ! labelRequiresPaymentMethod;
+	
 	const addCardButtonDescription = ( onAddCard ) =>
 		/* eslint-disable jsx-a11y/anchor-is-valid */
 		translate( 'To print this shipping label, {{a}}add a credit card to your account{{/a}}.', {
@@ -55,7 +66,7 @@ const PurchaseSection = props => {
 	/* eslint-disable no-nested-ternary */
 	return (
 		<div className="purchase-section">
-			{ ( hasLabelsPaymentMethod || ! hasSelectedRate ) ? (
+			{ ( canPurchaseLabel || ! hasSelectedRate ) ? (
 				<PurchaseButton
 					siteId={ siteId }
 					orderId={ orderId }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-section/test/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-section/test/index.js
@@ -1,0 +1,124 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { configure, shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16'
+
+/**
+ * Internal dependencies
+ */
+import { PurchaseSection } from '../index.js';
+import PurchaseButton from '../purchase-button';
+import CreditCardButton from '../credit-card-button';
+
+configure({ adapter: new Adapter() });
+
+function createPurchaseSectionWrapper( initProps = {} ) {
+	const props = {
+		orderId: 1000,
+		siteId: 10,
+		translate: ( text ) => text,
+		errors: {},
+		form: { 
+			origin: { values: { country: 'US' } },
+			rates: {},
+		},
+		hasLabelsPaymentMethod: true,
+		paymentMethods: [ { card_digits: "4242", card_type: "visa", expiry: "2025-09-30", name: "Test", payment_method_id: 12345 } ],
+		disablePurchase: false,
+		...initProps,
+	};
+
+	const wrapper = shallow( <PurchaseSection { ...props } /> );
+
+	return {
+		wrapper,
+		props
+	}
+}
+
+describe( 'Purchase Section', () => {
+    describe( 'with payment method and no selected rate', () => {
+        const { wrapper } = createPurchaseSectionWrapper();
+        const renderedPurchaseButton = wrapper.find( PurchaseButton );
+
+		it( 'renders a PurchaseButton', function () {
+            expect( renderedPurchaseButton ).to.have.lengthOf( 1 );
+		} );
+    } );
+
+    describe( 'with payment method and has selected rate', () => {
+        const uspsFormRates = {
+			available: { default_box: { serviceId: 'Priority', carrierId: 'usps' } },
+			values: { default_box: { serviceId: 'Priority', carrierId: 'usps' } },
+        };
+        
+        const { wrapper } = createPurchaseSectionWrapper( { 
+            form: { 
+                origin: { values: { country: 'US' } },
+                rates: uspsFormRates,
+            },
+        } );
+        const renderedPurchaseButton = wrapper.find( PurchaseButton );
+
+		it( 'renders a PurchaseButton', function () {
+            expect( renderedPurchaseButton ).to.have.lengthOf( 1 );
+		} );
+    } );
+
+	describe( 'with no payment method and no selected rate', () => {
+        const { wrapper } = createPurchaseSectionWrapper( { hasLabelsPaymentMethod: false, paymentMethods: [] } );
+        const renderedPurchaseButton = wrapper.find( PurchaseButton );
+
+		it( 'renders a PurchaseButton', function () {
+            expect( renderedPurchaseButton ).to.have.lengthOf( 1 );
+		} );
+    } );
+
+    describe( 'with no payment method and has selected non-UPS rate', () => {
+        const uspsFormRates = {
+			available: { default_box: { serviceId: 'Priority', carrierId: 'usps' } },
+			values: { default_box: { serviceId: 'Priority', carrierId: 'usps' } },
+        };
+        
+        const { wrapper } = createPurchaseSectionWrapper( { 
+            form: { 
+                origin: { values: { country: 'US' } },
+                rates: uspsFormRates,
+            },
+            hasLabelsPaymentMethod: false, 
+            paymentMethods: [], 
+        } );
+        const renderedCreditCardButton = wrapper.find( CreditCardButton );
+
+		it( 'renders a CreditCardButton', function () {
+            expect( renderedCreditCardButton ).to.have.lengthOf( 1 );
+		} );
+    } );
+
+    describe( 'with no payment method and has selected UPS rate', () => {
+        const upsFormRates = {
+			available: { default_box: { serviceId: 'Ground', carrierId: 'ups' } },
+			values: { default_box: { serviceId: 'Ground', carrierId: 'ups' } },
+        };
+        
+        const { wrapper } = createPurchaseSectionWrapper( { 
+            form: { 
+                origin: { values: { country: 'US' } },
+                rates: upsFormRates,
+            },
+            hasLabelsPaymentMethod: false, 
+            paymentMethods: [], 
+        } );
+        const renderedPurchaseButton = wrapper.find( PurchaseButton );
+
+		it( 'renders a CreditCardButton', function () {
+            expect( renderedPurchaseButton ).to.have.lengthOf( 1 );
+		} );
+    } );
+} );
+

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
@@ -156,8 +156,8 @@ const RatesStep = props => {
 	} = props;
 	const summary = ratesSummary( values, available, ratesTotal, form.packages.saved, translate );
 	const toggleStepHandler = () => props.toggleStep( orderId, siteId, 'rates' );
-	const updateRateHandler = ( packageId, serviceId, signatureRequired ) =>
-		props.updateRate( orderId, siteId, packageId, serviceId, signatureRequired );
+	const updateRateHandler = ( packageId, serviceId, carrierId, signatureRequired ) =>
+		props.updateRate( orderId, siteId, packageId, serviceId, carrierId, signatureRequired );
 
 	// Preselect rates for packages that have only one rate available.
 	forEach( form.packages.selected, ( selectedRate, pckgId ) => {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
@@ -54,7 +54,7 @@ export const ShippingRates = ( {
 		// filter out duplicate error messages
 		const packageErrors = ( errors[ pckgId ] || [] ).filter( ( item, index ) => errors[ pckgId ].indexOf( item ) === index );
 
-		const onRateUpdate = ( serviceId, signatureRequired ) => updateRate( pckgId, serviceId, signatureRequired );
+		const onRateUpdate = ( serviceId, carrierId, signatureRequired ) => updateRate( pckgId, serviceId, carrierId, signatureRequired );
 		return (
 			<div key={ pckgId } className="rates-step__package-container">
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
@@ -123,7 +123,7 @@ class ShippingRate extends Component {
 					options={ [
 						{ label: '', value: service_id },
 					] }
-					onChange={ () => { updateValue( service_id, false ) } }
+					onChange={ () => { updateValue( service_id, carrier_id, false ) } }
 				/>
 				<div className="rates-step__shipping-rate-information">
 					<CarrierIcon carrier={ carrier_id } size={ 30 } />

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/sidebar.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/sidebar.js
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
 import { CheckboxControl } from '@wordpress/components';
-import { forEach } from 'lodash';
 
 /**
  * Internal dependencies
@@ -60,14 +59,9 @@ export const Sidebar = props => {
 	const onPaperSizeChange = value => props.updatePaperSize( orderId, siteId, value );
 
 	const hasSelectedRate = hasSelectedRates( form.rates );
-	let labelRequiresPaymentMethod = false;
-	if( hasSelectedRate ) {
-		forEach( form.rates.values , ( label ) => {
-			if( 'ups' !== label.carrierId ) {
-				labelRequiresPaymentMethod = true;
-			}
-		});
-	}
+	const labelRequiresPaymentMethod = hasSelectedRate && Object.values( form.rates.values ).some( ( label ) => {
+		return 'ups' !== label.carrierId;
+	} );
 	const canPurchaseLabel = ( hasLabelsPaymentMethod && labelRequiresPaymentMethod ) || ! labelRequiresPaymentMethod;
 
 	return (

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/sidebar.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/sidebar.js
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
 import { CheckboxControl } from '@wordpress/components';
+import { forEach } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,6 +30,7 @@ import {
 	getFormErrors,
 	shouldFulfillOrder,
 	shouldEmailDetails,
+	hasSelectedRates,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 import { getOrderWithEdits, isCurrentlyEditingOrder } from 'woocommerce/state/ui/orders/selectors';
 import { getOrder } from "woocommerce/state/sites/orders/selectors";
@@ -57,13 +59,24 @@ export const Sidebar = props => {
 	};
 	const onPaperSizeChange = value => props.updatePaperSize( orderId, siteId, value );
 
+	const hasSelectedRate = hasSelectedRates( form.rates );
+	let labelRequiresPaymentMethod = false;
+	if( hasSelectedRate ) {
+		forEach( form.rates.values , ( label ) => {
+			if( 'ups' !== label.carrierId ) {
+				labelRequiresPaymentMethod = true;
+			}
+		});
+	}
+	const canPurchaseLabel = ( hasLabelsPaymentMethod && labelRequiresPaymentMethod ) || ! labelRequiresPaymentMethod;
+
 	return (
 		<div className="label-purchase-modal__sidebar">
 			<ShippingSummary siteId={ siteId } orderId={ orderId } />
 			<PriceSummary siteId={ siteId } orderId={ orderId } />
 			<hr />
 			<div className="label-purchase-modal__purchase-container">
-				{ hasLabelsPaymentMethod ? <Dropdown
+				{ canPurchaseLabel ? <Dropdown
 					id={ 'paper_size' }
 					valuesMap={ getPaperSizes( form.origin.values.country ) }
 					title={ translate( 'Paper size' ) }


### PR DESCRIPTION
**Summary**

Since UPS labels are charged to the user's connected UPS account there is no need for them to have a payment method on file with WCS to purchase a UPS label. This update adds the `carrierId` to the selected rate data so that it can be checked if a label purchase is allowed with no payment method. Currently the only `carrierId` that does not require a payment method is UPS. 

**How to Test**

1. With WC and WCS set up on a site and UPS enabled.
2. Connect a UPS account.
3. Remove any payment method attached to the account.
4. Go to print a shipping label for an order that would provide UPS rates.
5. Select a USPS rate and see that the sidebar prompts to add a credit card.
6. Select a UPS rate and see that the label size dropdown and buy label button are present.
7. Click Buy Label for the UPS rate and confirm that the label was purchased.

Additional Test: Follow the above steps with an order shipment broken into multiple packages. Confirm that if UPS is selected for all packages, you are able to buy the labels. If a non-UPS carrier is selected for any of the packages it should prompt the user to add a credit card.
