### PR TITLE
Use string validation for insurance

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@
 * Fix   - UPS connect redirect prompt
 * Fix   - Allow UPS label purchase without payment method
 * Fix   - PHP implode arguments order
-* Fix   - Validate insurance value as string instead of number
+* Fix   - Validate insurance value as both string and number
 
 = 1.24.3 - 2020-09-16 =
 * Fix   - Asset paths incompatible with some hosts.

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix   - UPS connect redirect prompt
 * Fix   - Allow UPS label purchase without payment method
 * Fix   - PHP implode arguments order
+* Fix   - Validate insurance value as string instead of number
 
 = 1.24.3 - 2020-09-16 =
 * Fix   - Asset paths incompatible with some hosts.

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
@@ -45,10 +45,10 @@ class ShippingRate extends Component {
 			}
 		}
 		if ( includedServices.insurance ) {
-			const numericInsurance = parseInt( includedServices.insurance );
+			const numericInsurance = Number( includedServices.insurance );
 			if ( isNaN( numericInsurance ) ) {
 				servicesToRender.push( translate( 'Insurance (%s)', { args: [ includedServices.insurance ] } ) );
-			} else if ( numericInsurance ) {
+			} else if ( numericInsurance > 0 ) {
 				servicesToRender.push( translate( 'Insurance (up to %s)', { args: [ formatCurrency( numericInsurance, 'USD') ] } ) );
 			}
 		}
@@ -178,7 +178,10 @@ ShippingRate.propTypes = {
 		delivery_date_guaranteed: PropTypes.bool,
 		delivery_date: PropTypes.string,
 		tracking: PropTypes.bool,
-		insurance: PropTypes.string,
+		insurance: PropTypes.oneOfType([
+			PropTypes.string,
+			PropTypes.number
+		]),
 		free_pickup: PropTypes.bool,
 	}).isRequired,
 	signatureRates: PropTypes.object.isRequired,

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
@@ -45,7 +45,12 @@ class ShippingRate extends Component {
 			}
 		}
 		if ( includedServices.insurance ) {
-			servicesToRender.push( translate( 'Insurance (up to %s)', { args: [ formatCurrency( includedServices.insurance, 'USD') ] } ) );
+			const numericInsurance = parseInt(includedServices.insurance);
+			if (isNaN(numericInsurance)) {
+				servicesToRender.push( translate( 'Insurance (%s)', { args: [ includedServices.insurance ] } ) );
+			} else {
+				servicesToRender.push( translate( 'Insurance (up to %s)', { args: [ formatCurrency( numericInsurance, 'USD') ] } ) );
+			}
 		}
 		if ( signatureOptions.filter( signatureOption => 0 === signatureOption.netCost ).length > 0 ) {
 			servicesToRender.push( translate( 'Signature required' ) );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
@@ -45,10 +45,10 @@ class ShippingRate extends Component {
 			}
 		}
 		if ( includedServices.insurance ) {
-			const numericInsurance = parseInt(includedServices.insurance);
-			if (isNaN(numericInsurance)) {
+			const numericInsurance = parseInt( includedServices.insurance );
+			if ( isNaN( numericInsurance ) ) {
 				servicesToRender.push( translate( 'Insurance (%s)', { args: [ includedServices.insurance ] } ) );
-			} else if (numericInsurance) {
+			} else if ( numericInsurance ) {
 				servicesToRender.push( translate( 'Insurance (up to %s)', { args: [ formatCurrency( numericInsurance, 'USD') ] } ) );
 			}
 		}

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
@@ -178,7 +178,7 @@ ShippingRate.propTypes = {
 		delivery_date_guaranteed: PropTypes.bool,
 		delivery_date: PropTypes.string,
 		tracking: PropTypes.bool,
-		insurance: PropTypes.number,
+		insurance: PropTypes.string,
 		free_pickup: PropTypes.bool,
 	}).isRequired,
 	signatureRates: PropTypes.object.isRequired,

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
@@ -48,7 +48,7 @@ class ShippingRate extends Component {
 			const numericInsurance = parseInt(includedServices.insurance);
 			if (isNaN(numericInsurance)) {
 				servicesToRender.push( translate( 'Insurance (%s)', { args: [ includedServices.insurance ] } ) );
-			} else {
+			} else if (numericInsurance) {
 				servicesToRender.push( translate( 'Insurance (up to %s)', { args: [ formatCurrency( numericInsurance, 'USD') ] } ) );
 			}
 		}

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/test/shipping-rate.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/test/shipping-rate.js
@@ -56,7 +56,7 @@ function createShippingRateWrapper( {
 			delivery_date_guaranteed: deliveryDateGuaranteed || true,
 			delivery_date: deliveryDate || "2020-01-01T23:59:00.000Z",
 			tracking: tracking || true,
-			insurance: insuranceAmount || '100',
+			insurance: insuranceAmount === undefined ? 100 : insuranceAmount,
 			free_pickup: freePickup || true,
 		},
 		signatureRates: signatureRates || {
@@ -136,22 +136,36 @@ describe( 'ShippingRate', () => {
 	} );
 
 	describe( 'for rates with insurance', () => {
-		it( 'renders the string without additional dollar sign in front ', () => {
+		it( 'renders the string without additional dollar sign in front', () => {
 			const shippingRateWrapper = createShippingRateWrapper( { insuranceAmount: 'limited', signatureRates: { rate1: signatureRequiredRate } } );
 			const listOfServices = /Includes tracking, Insurance \(limited\), Signature required, Eligible for free pickup/;
 
 			expect( shippingRateWrapper.find( '.rates-step__shipping-rate-description-details' ).text() ).to.match( listOfServices );
 		} );
 
-		it( 'renders the number with additional dollar sign in front ', () => {
+		it( 'renders the number with additional dollar sign in front if insurance is a number-string', () => {
 			const shippingRateWrapper = createShippingRateWrapper( { insuranceAmount: '100', signatureRates: { rate1: signatureRequiredRate } } );
 			const listOfServices = /Includes tracking, Insurance \(up to \$100.00\), Signature required, Eligible for free pickup/;
 
 			expect( shippingRateWrapper.find( '.rates-step__shipping-rate-description-details' ).text() ).to.match( listOfServices );
 		} );
 
-		it( 'should not include insurance if it is 0 ', () => {
+		it( 'renders the number with additional dollar sign in front if insurance is a number', () => {
+			const shippingRateWrapper = createShippingRateWrapper( { insuranceAmount: 234.99, signatureRates: { rate1: signatureRequiredRate } } );
+			const listOfServices = /Includes tracking, Insurance \(up to \$234.99\), Signature required, Eligible for free pickup/;
+
+			expect( shippingRateWrapper.find( '.rates-step__shipping-rate-description-details' ).text() ).to.match( listOfServices );
+		} );
+
+		it( 'should not include insurance if it is "0"', () => {
 			const shippingRateWrapper = createShippingRateWrapper( { insuranceAmount: '0', signatureRates: { rate1: signatureRequiredRate } } );
+			const listOfServices = /Includes tracking, Signature required, Eligible for free pickup/;
+
+			expect( shippingRateWrapper.find( '.rates-step__shipping-rate-description-details' ).text() ).to.match( listOfServices );
+		} );
+
+		it( 'should not include insurance if it is 0', () => {
+			const shippingRateWrapper = createShippingRateWrapper( { insuranceAmount: 0, signatureRates: { rate1: signatureRequiredRate } } );
 			const listOfServices = /Includes tracking, Signature required, Eligible for free pickup/;
 
 			expect( shippingRateWrapper.find( '.rates-step__shipping-rate-description-details' ).text() ).to.match( listOfServices );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/test/shipping-rate.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/test/shipping-rate.js
@@ -56,7 +56,7 @@ function createShippingRateWrapper( {
 			delivery_date_guaranteed: deliveryDateGuaranteed || true,
 			delivery_date: deliveryDate || "2020-01-01T23:59:00.000Z",
 			tracking: tracking || true,
-			insurance: insuranceAmount || 100,
+			insurance: insuranceAmount || '100',
 			free_pickup: freePickup || true,
 		},
 		signatureRates: signatureRates || {
@@ -129,6 +129,18 @@ describe( 'ShippingRate', () => {
 
 		it( 'renders an abreviated list of services, including "Signature required"', () => {
 			const listOfServices = /Includes tracking, Insurance \(up to \$100.00\), Signature required, Eligible for free pickup/;
+
+			expect( shippingRateWrapper.find( '.rates-step__shipping-rate-description-details' ).text() ).to.match( listOfServices );
+		} );
+
+	} );
+
+	describe( 'for rates with insurance in string format', () => {
+
+		const shippingRateWrapper = createShippingRateWrapper( { insuranceAmount: 'limited', signatureRates: { rate1: signatureRequiredRate } } );
+
+		it( 'renders an abreviated list of services, including "Signature required"', () => {
+			const listOfServices = /Includes tracking, Insurance \(limited\), Signature required, Eligible for free pickup/;
 
 			expect( shippingRateWrapper.find( '.rates-step__shipping-rate-description-details' ).text() ).to.match( listOfServices );
 		} );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/test/shipping-rate.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/test/shipping-rate.js
@@ -135,12 +135,24 @@ describe( 'ShippingRate', () => {
 
 	} );
 
-	describe( 'for rates with insurance in string format', () => {
-
-		const shippingRateWrapper = createShippingRateWrapper( { insuranceAmount: 'limited', signatureRates: { rate1: signatureRequiredRate } } );
-
-		it( 'renders an abreviated list of services, including "Signature required"', () => {
+	describe( 'for rates with insurance', () => {
+		it( 'renders the string without additional dollar sign in front ', () => {
+			const shippingRateWrapper = createShippingRateWrapper( { insuranceAmount: 'limited', signatureRates: { rate1: signatureRequiredRate } } );
 			const listOfServices = /Includes tracking, Insurance \(limited\), Signature required, Eligible for free pickup/;
+
+			expect( shippingRateWrapper.find( '.rates-step__shipping-rate-description-details' ).text() ).to.match( listOfServices );
+		} );
+
+		it( 'renders the number with additional dollar sign in front ', () => {
+			const shippingRateWrapper = createShippingRateWrapper( { insuranceAmount: '100', signatureRates: { rate1: signatureRequiredRate } } );
+			const listOfServices = /Includes tracking, Insurance \(up to \$100.00\), Signature required, Eligible for free pickup/;
+
+			expect( shippingRateWrapper.find( '.rates-step__shipping-rate-description-details' ).text() ).to.match( listOfServices );
+		} );
+
+		it( 'should not include insurance if it is 0 ', () => {
+			const shippingRateWrapper = createShippingRateWrapper( { insuranceAmount: '0', signatureRates: { rate1: signatureRequiredRate } } );
+			const listOfServices = /Includes tracking, Signature required, Eligible for free pickup/;
 
 			expect( shippingRateWrapper.find( '.rates-step__shipping-rate-description-details' ).text() ).to.match( listOfServices );
 		} );


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-services/issues/2193

### Summary
Render `Insurance ($100)...` if `insurance` is a number. Render `Insurance (<some-text>)...` if `insurance` is a string.

### How to test
1. Pull this branch
2. Create a label
3. The insurance amount should continue to show if and only if the amount is > 0. 
![image](https://user-images.githubusercontent.com/572862/93800006-2ee0bf00-fbfd-11ea-98d9-704ae9975427.png)
