### PR TITLE
feat: adjusted messaging on label pointers

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix   - UPS connect redirect prompt
 * Fix   - Allow UPS label purchase without payment method
 * Fix   - PHP implode arguments order
+* Tweak - Adjusted messaging on label pointers
 
 = 1.24.3 - 2020-09-16 =
 * Fix   - Asset paths incompatible with some hosts.

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -155,7 +155,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				return $pointers;
 			}
 
-			$supported_carriers = [ 'USPS' ];
+			$supported_carriers = array( 'USPS' );
 			if ( $this->shipping_label->is_dhl_express_available() ) {
 				$supported_carriers[] = 'DHL';
 			}

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -71,6 +71,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 
 		private function init_pointers() {
 			add_filter( 'wc_services_pointer_post.php', array( $this, 'register_order_page_labels_pointer' ) );
+			add_filter( 'wc_services_pointer_post.php', array( $this, 'register_new_carrier_dhl_pointer' ) );
 		}
 
 		public function show_pointers( $hook ) {
@@ -163,6 +164,33 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					'dim' => true,
 				);
 			}
+
+			return $pointers;
+		}
+
+		public function register_new_carrier_dhl_pointer( $pointers ) {
+			// new user? no need to show this alert, `wc_services_labels_metabox` will take care of communicating about DHL
+			if ( $this->is_new_labels_user() ) {
+				return $pointers;
+			}
+
+			// existing user? figure out if the order supports DHL, then let them know DHL is a new carrier!
+			if ( ! $this->shipping_label->is_dhl_express_eligible() ) {
+				return $pointers;
+			}
+
+			$pointers[] = array(
+				'id' => 'wc_services_new_carrier_dhl',
+				'target' => '#woocommerce-order-label .button',
+				'options' => array(
+					'content' => sprintf( '<h3>%s</h3><p>%s</p>',
+						__( 'Discounted DHL Shipping Labels' ,'woocommerce-services' ),
+						__( "WooCommerce Shipping now supports DHL. Purchase and print discounted labels from DHL and USPS right here.", 'woocommerce-services' )
+					),
+					'position' => array( 'edge' => 'top', 'align' => 'left' ),
+				),
+				'dim' => true,
+			);
 
 			return $pointers;
 		}

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -147,23 +147,31 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			// If the user is not new to labels, we should just dismiss this pointer
 			if ( ! $this->is_new_labels_user() ) {
 				$this->dismiss_pointer( 'wc_services_labels_metabox' );
+
 				return $pointers;
 			}
 
-			if ( $this->shipping_label->should_show_meta_box() ) {
-				$pointers[] = array(
-					'id' => 'wc_services_labels_metabox',
-					'target' => '#woocommerce-order-label .button',
-					'options' => array(
-						'content' => sprintf( '<h3>%s</h3><p>%s</p>',
-							__( 'Discounted Shipping Labels' ,'woocommerce-services' ),
-							__( "When you're ready, purchase and print discounted labels from USPS right here.", 'woocommerce-services' )
-						),
-						'position' => array( 'edge' => 'top', 'align' => 'left' ),
-					),
-					'dim' => true,
-				);
+			if ( ! $this->shipping_label->should_show_meta_box() ) {
+				return $pointers;
 			}
+
+			$supported_carriers = [ 'USPS' ];
+			if ( $this->shipping_label->is_dhl_express_available() ) {
+				$supported_carriers[] = 'DHL';
+			}
+
+			$pointers[] = array(
+				'id' => 'wc_services_labels_metabox',
+				'target' => '#woocommerce-order-label .button',
+				'options' => array(
+					'content' => sprintf( '<h3>%s</h3><p>%s</p>',
+						__( 'Discounted Shipping Labels' ,'woocommerce-services' ),
+						sprintf( __( "When you're ready, purchase and print discounted labels from %s right here.", 'woocommerce-services' ), implode(' or ', $supported_carriers) )
+					),
+					'position' => array( 'edge' => 'top', 'align' => 'left' ),
+				),
+				'dim' => true,
+			);
 
 			return $pointers;
 		}
@@ -171,16 +179,18 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		public function register_new_carrier_dhl_pointer( $pointers ) {
 			// new user? no need to show this alert, `wc_services_labels_metabox` will take care of communicating about DHL
 			if ( $this->is_new_labels_user() ) {
+				$this->dismiss_pointer( 'wc_services_new_carrier_dhl_express' );
+
 				return $pointers;
 			}
 
 			// existing user? figure out if the order supports DHL, then let them know DHL is a new carrier!
-			if ( ! $this->shipping_label->is_dhl_express_eligible() ) {
+			if ( ! $this->shipping_label->is_order_dhl_express_eligible() ) {
 				return $pointers;
 			}
 
 			$pointers[] = array(
-				'id' => 'wc_services_new_carrier_dhl',
+				'id' => 'wc_services_new_carrier_dhl_express',
 				'target' => '#woocommerce-order-label .button',
 				'options' => array(
 					'content' => sprintf( '<h3>%s</h3><p>%s</p>',

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -195,7 +195,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				'options' => array(
 					'content' => sprintf( '<h3>%s</h3><p>%s</p>',
 						__( 'Discounted DHL Shipping Labels' ,'woocommerce-services' ),
-						__( "WooCommerce Shipping now supports DHL. Purchase and print discounted labels from DHL and USPS right here.", 'woocommerce-services' )
+						__( "WooCommerce Shipping now supports DHL Express labels for international shipments. Purchase and print discounted labels from DHL and USPS right here.", 'woocommerce-services' )
 					),
 					'position' => array( 'edge' => 'top', 'align' => 'left' ),
 				),

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -195,7 +195,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				'options' => array(
 					'content' => sprintf( '<h3>%s</h3><p>%s</p>',
 						__( 'Discounted DHL Shipping Labels' ,'woocommerce-services' ),
-						__( "WooCommerce Shipping now supports DHL Express labels for international shipments. Purchase and print discounted labels from DHL and USPS right here.", 'woocommerce-services' )
+						__( "WooCommerce Shipping now supports DHL labels for international shipments. Purchase and print discounted labels from DHL and USPS right here.", 'woocommerce-services' )
 					),
 					'position' => array( 'edge' => 'top', 'align' => 'left' ),
 				),

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -320,12 +320,18 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return in_array( $currency_code, $this->supported_currencies );
 		}
 
-		public function is_dhl_express_eligible() {
-			$order = wc_get_order();
-			if ( ! $order ) return false;
-
+		public function is_dhl_express_available() {
 			$dhl_express = $this->service_schemas_store->get_service_schema_by_id( 'dhlexpress' );
 			if( ! $dhl_express ) return false;
+
+			return true;
+		}
+
+		public function is_order_dhl_express_eligible() {
+			if( ! $this-> is_dhl_express_available() ) return false;
+
+			$order = wc_get_order();
+			if ( ! $order ) return false;
 
 			$origin         = $this->get_origin_address();
 			$destination    = $this->get_destination_address( $order );

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -320,6 +320,19 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return in_array( $currency_code, $this->supported_currencies );
 		}
 
+		public function is_dhl_express_eligible() {
+			$order = wc_get_order();
+			if ( ! $order ) return false;
+
+			$dhl_express = $this->service_schemas_store->get_service_schema_by_id( 'dhlexpress' );
+			if( ! $dhl_express ) return false;
+
+			$origin         = $this->get_origin_address();
+			$destination    = $this->get_destination_address( $order );
+
+			return $origin['country'] !== $destination['country'];
+		}
+
 		public function should_show_meta_box() {
 			if ( null === $this->show_metabox ) {
 				$this->show_metabox = $this->calculate_should_show_meta_box();

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -322,9 +322,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 		public function is_dhl_express_available() {
 			$dhl_express = $this->service_schemas_store->get_service_schema_by_id( 'dhlexpress' );
-			if( ! $dhl_express ) return false;
 
-			return true;
+			return !! $dhl_express;
 		}
 
 		public function is_order_dhl_express_eligible() {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Adjustments on the admin "pointers"/"popovers" displayed on the orders page.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Closes https://github.com/Automattic/woocommerce-services/issues/2196

### Steps to reproduce & screenshots/GIFs

In order to see the "new user" pointer with adjusted messaging:
- PLEASE MAKE SURE IT IS A BRAND NEW SITE - there should be no previously created labels/no pointers displayed
- Create a new order
- Destination can be domestic or international
- See pointer in order management view
- Feel free to change the DHL flag(s), to ensure that the messaging is adjusted

In order to see the "print dhl labels now!" pointer:
- PLEASE MAKE SURE IT IS AN EXISTING SITE - labels should have been created and the updated version of the plugin should not have run
- Go to an existing order
- Make sure order destination is international (not domestic)
- Make sure site's DHL flag is enabled
- Make sure you have the most updated service data (or refresh it in **WooCommerce > Status > WooCommerce Services**)
- See pointer in order management view

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

New user, DHL is disabled: shoes "new user" popover with old messaging
![Screen Shot 2020-09-24 at 1 32 46 PM](https://user-images.githubusercontent.com/273592/94185250-ae26fa80-fe6a-11ea-81c9-7fea7f8da277.png)


New user, DHL is enabled: shows "new user" popover with adjusted messaging
**PLEASE NOTE**: I am not checking the order's destination, just whether the site has DHL enabled
![Screen Shot 2020-09-24 at 12 18 57 PM](https://user-images.githubusercontent.com/273592/94178258-7c109b00-fe60-11ea-8473-cd3b9258f67e.png)

Existing user, eligible order: shows new popover
![Screen Shot 2020-09-24 at 9 25 14 AM](https://user-images.githubusercontent.com/273592/94159097-ca19a480-fe48-11ea-8819-3810b93b699e.png)

Existing user, order is not eligible (because of domestic destination): do not show popover
**PLEASE NOTE**: message might also not be displayed because of the individual site flag
![Screen Shot 2020-09-24 at 9 39 10 AM](https://user-images.githubusercontent.com/273592/94160240-0b5e8400-fe4a-11ea-83f3-a8257b5e424b.png)


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests
I didn't see existing tests for pointers - any recommendations?

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
