### PR TITLE
Add phpcs with WooCommerce-Core rules to pre-commit hook

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "require-dev": {
+        "woocommerce/woocommerce-sniffs": "^0.1.0"
+    },
+    "scripts": {
+		"phpcs": [
+			"phpcs -s -p"
+		],
+		"phpcbf": [
+			"phpcbf -p"
+		]
+	}
+}

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -2,5 +2,4 @@ module.exports = {
 	'*.js': [
 		'npm run eslint:fix',
 	],
-	'*.php': [ 'php -d display_errors=1 -l', 'composer run-script phpcs' ],
 };

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -2,4 +2,5 @@ module.exports = {
 	'*.js': [
 		'npm run eslint:fix',
 	],
+	'*.php': [ 'php -d display_errors=1 -l', 'composer run-script phpcs' ],
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "analyze": "cross-env ANALYZE=true NODE_ENV=production DISABLE_FEATURES=wpcom-user-bootstrap CALYPSO_CLIENT=true webpack",
     "eslint": "eslint tasks/ client/",
     "eslint:fix": "eslint --fix tasks/ client/",
-    "test": "npm run test-client && npm run eslint",
+    "test": "npm run test-client",
     "test-client": "jest -c=tests/client/jest.config.js",
     "test-client:watch": "npm run -s test-client -- --watch",
     "prerelease": "npm run i18n && node tasks/i18n-download && npm run i18njson",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards">
+	<!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress-Core/ruleset.xml -->
+
+	<description>WooCommerce dev PHP_CodeSniffer ruleset.</description>
+
+	<!-- Exclude paths -->
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>bin/*</exclude-pattern>
+
+	<!-- Configs -->
+	<config name="minimum_supported_wp_version" value="4.7" />
+	<config name="testVersion" value="5.6-"/>
+
+	<!-- Rules -->
+	<rule ref="WooCommerce-Core" />
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array" value="woocommerce-admin" />
+		</properties>
+	</rule>
+
+	<rule ref="PHPCompatibility">
+		<exclude-pattern>tests/</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
+		<exclude-pattern>src/*</exclude-pattern>
+		<exclude-pattern>tests/*</exclude-pattern>
+		<exclude-pattern>woocommerce-admin.php</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
+		<exclude-pattern>src/*</exclude-pattern>
+	</rule>
+
+	<rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
+      <exclude-pattern>src/*</exclude-pattern>
+    </rule>
+
+	<rule ref="Generic.Commenting">
+		<exclude-pattern>tests/</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.FileComment.MissingPackageTag">
+		<exclude-pattern>src/</exclude-pattern>
+		<exclude-pattern>tests/</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.FileComment.Missing">
+		<exclude-pattern>src/</exclude-pattern>
+		<exclude-pattern>tests/</exclude-pattern>
+	</rule>
+</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -19,7 +19,7 @@
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" type="array" value="woocommerce-admin" />
+			<property name="text_domain" type="array" value="woocommerce-services" />
 		</properties>
 	</rule>
 
@@ -28,28 +28,27 @@
 	</rule>
 
 	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
-		<exclude-pattern>src/*</exclude-pattern>
 		<exclude-pattern>tests/*</exclude-pattern>
-		<exclude-pattern>woocommerce-admin.php</exclude-pattern>
+		<exclude-pattern>woocommerce-services.php</exclude-pattern>
 	</rule>
 
 	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
-		<exclude-pattern>src/*</exclude-pattern>
+		<exclude-pattern>classes/*</exclude-pattern>
 	</rule>
 
 	<rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
-      <exclude-pattern>src/*</exclude-pattern>
+      <exclude-pattern>classes/*</exclude-pattern>
     </rule>
 
 	<rule ref="Generic.Commenting">
 		<exclude-pattern>tests/</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.Commenting.FileComment.MissingPackageTag">
-		<exclude-pattern>src/</exclude-pattern>
+		<exclude-pattern>classes/</exclude-pattern>
 		<exclude-pattern>tests/</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.Commenting.FileComment.Missing">
-		<exclude-pattern>src/</exclude-pattern>
+		<exclude-pattern>classes/</exclude-pattern>
 		<exclude-pattern>tests/</exclude-pattern>
 	</rule>
 </ruleset>


### PR DESCRIPTION
### Description
Add phpcs with WooCommerce-Core rules to pre-commit hook. This only runs [WooCommerce-Core ](https://github.com/woocommerce/woocommerce-sniffs) on committed changes, not on all files. THis is similar to [how WooCommerce Admin is setup]( https://github.com/woocommerce/woocommerce-admin/blob/37f92a5cf142a8bd2b055e16b451307b2a2dd095/lint-staged.config.js#L8).

**Updated - Oct 16, 2020**
I [removed](https://github.com/Automattic/woocommerce-services/pull/2212/commits/c402222c1a5ccca3465fa3b0073a21859ee2fbf8) `phpcs` from pre-commit hooks. There were too many linting errors and it will slow down development. I have removed this for now until we addressed most of the linting errors. To run `phpcs`, you will have to do this manually with `composer run phpcs`.

### Related issue(s)
Closes https://github.com/Automattic/woocommerce-services/issues/2210

### Steps to reproduce & screenshots/GIFs
1. Pull this branch, run `composer install`. If you don't have `composer`, install it globally with [this instruction](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-macos).
2. Make changes to any `.php` file, (ie. `woocommerce-services.php`)
3. Run test manually. `composer run phpcs`.
4. The terminal runs and you should see linting errors preventing commit to go through
![image](https://user-images.githubusercontent.com/572862/95388589-c148ba00-08af-11eb-98fc-80868ef9f70a.png)


<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

