### PR TITLE
Open customs forms in new browser tabs

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -920,6 +920,17 @@ function downloadAndPrint( orderId, siteId, dispatch, getState, labels ) {
 
 	let hasError = false;
 
+	const customsForms = labels.map( ( label ) => label.commercial_invoice_url ).filter( ( url ) => url );
+	if ( customsForms && 0 < customsForms.length) {
+		dispatch(
+			NoticeActions.infoNotice( translate( "Note: A customs form will open in a new tab and must be printed and included on this international shipment." ), {
+			} )
+		);
+		for (const customsFormsUrl of customsForms) {
+			window.open( customsFormsUrl );
+		}
+	}
+
 	api
 		.get( siteId, printUrl )
 		.then( fileData => {


### PR DESCRIPTION
After a shipping label is purchased, if it needs a customs form to be printed, this patch creates an info
note for the user, and opens the customs form in a new browser tab.

### Test instructions.

1. Patch WooCommerce Connect Server to make it always include a commercial invoice:

``` javascript
1 file changed, 2 insertions(+), 1 deletion(-)
lib/shipping/easypost-client/index.js | 3 ++-

modified   lib/shipping/easypost-client/index.js
@@ -352,7 +352,8 @@ const buyShipment = ( shipment, rateToBuy ) => {
 const extractCommercialInvoiceFromShipment = ( shipment ) => {
 	if ( shipment.forms ) {
 		for ( const form of shipment.forms ) {
-			if ( FORM_TYPE_COMMERCIAL_INVOICE === form.form_type && ! form.submitted_electronically ) {
+			// if ( FORM_TYPE_COMMERCIAL_INVOICE === form.form_type && ! form.submitted_electronically ) {
+			if ( FORM_TYPE_COMMERCIAL_INVOICE === form.form_type ) {
 				return form.form_url;
 			}
 		}
```

2. Create an international order.
3. Purchase a new shipping label for the order created in step 2.
4. The customs form pdf should be open on a new tab and a notice should be displayed.

----

Related issue https://github.com/Automattic/woocommerce-services/issues/2157