### PR TITLE
Add composer command to run phpunit on WCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "require-dev": {
-        "woocommerce/woocommerce-sniffs": "^0.1.0"
+        "woocommerce/woocommerce-sniffs": "^0.1.0",
+        "phpunit/phpunit": "^9.4"
     },
     "scripts": {
 		"phpcs": [

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,12 @@
 {
     "require-dev": {
         "woocommerce/woocommerce-sniffs": "^0.1.0",
-        "phpunit/phpunit": "^9.4"
+        "phpunit/phpunit": "^7"
     },
     "scripts": {
+		"test": [
+			"phpunit"
+		],
 		"phpcs": [
 			"phpcs -s -p"
 		],

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -2,5 +2,4 @@ module.exports = {
 	'*.js': [
 		'npm run eslint:fix',
 	],
-	'*.php': [ 'php -d display_errors=1 -l', 'composer run-script phpcs' ],
 };

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -2,4 +2,5 @@ module.exports = {
 	'*.js': [
 		'npm run eslint:fix',
 	],
+	'*.php': [ 'php -d display_errors=1 -l', 'composer run-script phpcs' ],
 };

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,16 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	bootstrap="tests/php/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	verbose="true"
+	>
 	<testsuites>
-		<!-- Default test suite to run all tests -->
-		<testsuite>
-			<directory prefix="test_" suffix=".php">tests</directory>
+		<testsuite name="WooCommerce Services Test Suite">
+			<directory suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>
-	<filter>
-		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-			</exclude>
-		</whitelist>
-	</filter>
 </phpunit>
-

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -15,7 +15,7 @@
 if ( false !== getenv( 'WC_DEVELOP_DIR' ) ) {
 	$wc_root = getenv( 'WC_DEVELOP_DIR' );
 } elseif ( file_exists( '/tmp/woocommerce/tests/bootstrap.php' ) ) {
-	$wc_root = '/tmp/woocommerce/tests';
+	$wc_root = '/tmp/woocommerce';
 } else {
 	exit( 'Could not determine test root directory. Aborting.' );
 }

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -14,7 +14,7 @@
  */
 if ( false !== getenv( 'WC_DEVELOP_DIR' ) ) {
 	$wc_root = getenv( 'WC_DEVELOP_DIR' );
-} elseif ( file_exists( '/tmp/woocommerce/tests/bootstrap.php' ) ) {
+} elseif ( file_exists( '/tmp/woocommerce/tests/legacy/bootstrap.php' ) ) {
 	$wc_root = '/tmp/woocommerce';
 } else {
 	exit( 'Could not determine test root directory. Aborting.' );

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -7,12 +7,14 @@
  * @package wordpress-plugin-tests
  */
 
-// Support for:
-// 1. `WC_DEVELOP_DIR` environment variable
-// 2. Tests checked out to /tmp
-if( false !== getenv( 'WC_DEVELOP_DIR' ) ) {
+/**
+ * Support for:
+ * 1. `WC_DEVELOP_DIR` environment variable.
+ * 2. Tests checked out to /tmp.
+ */
+if ( false !== getenv( 'WC_DEVELOP_DIR' ) ) {
 	$wc_root = getenv( 'WC_DEVELOP_DIR' );
-} else if ( file_exists( '/tmp/woocommerce/tests/bootstrap.php' ) ) {
+} elseif ( file_exists( '/tmp/woocommerce/tests/bootstrap.php' ) ) {
 	$wc_root = '/tmp/woocommerce/tests';
 } else {
 	exit( 'Could not determine test root directory. Aborting.' );
@@ -25,14 +27,18 @@ if ( ! $wp_tests_dir ) {
 }
 
 if ( ! file_exists( $wp_tests_dir . '/includes/functions.php' ) ) {
-	echo "Could not find $wp_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // WPCS: XSS ok.
+	echo "Could not find $wp_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	exit( 1 );
 }
 
-// load test function so tests_add_filter() is available
-require_once( $wp_tests_dir . '/includes/functions.php' );
+// load test function so tests_add_filter() is available.
+require_once $wp_tests_dir . '/includes/functions.php';
 
-// Activates this plugin in WordPress so it can be tested.
+/**
+ * Activates this plugin in WordPress so it can be tested.
+ *
+ * @return void
+ */
 function _manually_load_plugin() {
 	require dirname( __FILE__ ) . '/../../woocommerce-services.php';
 }
@@ -42,4 +48,4 @@ if ( ! defined( 'WC_UNIT_TESTING' ) ) {
 	define( 'WC_UNIT_TESTING', true );
 }
 
-require $wc_root . '/bootstrap.php';
+require $wc_root . '/tests/legacy/bootstrap.php';

--- a/tests/php/test-class-wc-connect-api-client.php
+++ b/tests/php/test-class-wc-connect-api-client.php
@@ -1,16 +1,29 @@
 <?php
 
+/**
+ * Unit test for WC_Connect_API_Client_Live
+ */
 class WP_Test_WC_Connect_API_Client extends WC_Unit_Test_Case {
 
+	/** @var WC_Connect_API_Client_Live $api_client */
 	protected $api_client;
+	/** @var WC_Product $product */
 	protected $product;
 
+	/**
+	 * Undocumented function
+	 */
 	public static function setupBeforeClass() {
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client-live.php' );
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client.php';
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client-live.php';
 
 	}
 
+	/**
+	 * Setup the test case.
+	 *
+	 * @see WC_Unit_Test_Case::setUp()
+	 */
 	public function setUp() {
 		$this->api_client = $this->getMockBuilder( 'WC_Connect_API_Client_Live' )
 			->disableOriginalConstructor()
@@ -18,20 +31,28 @@ class WP_Test_WC_Connect_API_Client extends WC_Unit_Test_Case {
 			->getMock();
 	}
 
+	/**
+	 * Clean up the test case.
+	 *
+	 * @see WC_Unit_Test_Case::tearDown()
+	 */
 	public function tearDown() {
-		// empty the test cart
+		// empty the test cart.
 		WC()->cart->empty_cart();
 
-		// release the test client instance
+		// release the test client instance.
 		unset( $this->api_client );
 
-		// delete test product
+		// delete test product.
 		WC_Helper_Product::delete_product( $this->product->get_id() );
 	}
 
+	/**
+	 * Test simple product but missing weight
+	 */
 	public function test_build_shipment_contents_simple_product_no_weight() {
 		$this->product = WC_Helper_Product::create_simple_product();
-		$product_id = $this->product->get_id();
+		$product_id    = $this->product->get_id();
 		update_post_meta( $product_id, '_weight', '' );
 
 		WC()->cart->add_to_cart( $product_id, 1 );
@@ -42,11 +63,14 @@ class WP_Test_WC_Connect_API_Client extends WC_Unit_Test_Case {
 		$this->assertEquals( 'product_missing_weight', $actual->get_error_code() );
 	}
 
+	/**
+	 * Test simple product
+	 */
 	public function test_build_shipment_contents_simple_product() {
 		$this->product = WC_Helper_Product::create_simple_product();
-		$product_id = $this->product->get_id();
+		$product_id    = $this->product->get_id();
 
-		// set base product dimensions
+		// set base product dimensions.
 		update_post_meta( $product_id, '_weight', '2' );
 		update_post_meta( $product_id, '_height', '5' );
 		update_post_meta( $product_id, '_width', '6' );
@@ -56,32 +80,37 @@ class WP_Test_WC_Connect_API_Client extends WC_Unit_Test_Case {
 
 		$actual = $this->api_client->build_shipment_contents( array( 'contents' => WC()->cart->get_cart() ) );
 
-		$expected = array( array(
-			'height'     => 5,
-			'product_id' => $product_id,
-			'length'     => 7,
-			'width'      => 6,
-			'quantity'   => 1,
-			'weight'     => 2,
-		) );
+		$expected = array(
+			array(
+				'height'     => 5,
+				'product_id' => $product_id,
+				'length'     => 7,
+				'width'      => 6,
+				'quantity'   => 1,
+				'weight'     => 2,
+			),
+		);
 
 		$this->assertEquals( $actual, $expected );
 	}
 
+	/**
+	 * Test variable product
+	 */
 	public function test_build_shipment_contents_variable_product() {
 		$this->product = WC_Helper_Product::create_variation_product();
 
 		$all_variations     = $this->product->get_available_variations();
-		$first_variation_id = $all_variations[ 0 ][ 'variation_id' ];
+		$first_variation_id = $all_variations[0]['variation_id'];
 		$product_id         = $this->product->get_id();
 
-		// set base product dimensions
+		// set base product dimensions.
 		update_post_meta( $product_id, '_weight', '2' );
 		update_post_meta( $product_id, '_height', '5' );
 		update_post_meta( $product_id, '_width', '6' );
 		update_post_meta( $product_id, '_length', '7' );
 
-		// set variation dimensions
+		// set variation dimensions.
 		update_post_meta( $first_variation_id, '_weight', '5' );
 		update_post_meta( $first_variation_id, '_height', '2' );
 		update_post_meta( $first_variation_id, '_width', '3' );
@@ -91,14 +120,16 @@ class WP_Test_WC_Connect_API_Client extends WC_Unit_Test_Case {
 
 		$actual = $this->api_client->build_shipment_contents( array( 'contents' => WC()->cart->get_cart() ) );
 
-		$expected = array( array(
-			'height'     => 2,
-			'product_id' => $first_variation_id,
-			'length'     => 4,
-			'width'      => 3,
-			'quantity'   => 1,
-			'weight'     => 5,
-		) );
+		$expected = array(
+			array(
+				'height'     => 2,
+				'product_id' => $first_variation_id,
+				'length'     => 4,
+				'width'      => 3,
+				'quantity'   => 1,
+				'weight'     => 5,
+			),
+		);
 
 		$this->assertEquals( $actual, $expected );
 	}

--- a/tests/php/test-class-wc-connect-api-client.php
+++ b/tests/php/test-class-wc-connect-api-client.php
@@ -101,7 +101,7 @@ class WP_Test_WC_Connect_API_Client extends WC_Unit_Test_Case {
 		$this->product = WC_Helper_Product::create_variation_product();
 
 		$all_variations     = $this->product->get_available_variations();
-		$first_variation_id = $all_variations[0]['variation_id'];
+		$first_variation_id = $all_variations[2]['variation_id'];
 		$product_id         = $this->product->get_id();
 
 		// set base product dimensions.
@@ -116,7 +116,7 @@ class WP_Test_WC_Connect_API_Client extends WC_Unit_Test_Case {
 		update_post_meta( $first_variation_id, '_width', '3' );
 		update_post_meta( $first_variation_id, '_length', '4' );
 
-		WC()->cart->add_to_cart( $first_variation_id, 1 );
+		WC()->cart->add_to_cart( $product_id, 1, $first_variation_id );
 
 		$actual = $this->api_client->build_shipment_contents( array( 'contents' => WC()->cart->get_cart() ) );
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Add composer to run existing test suites inside WooCommerce Services. Update `phpunit.xml.dist` to use `legacy` WooCommerce Core test utils. 

### Notes
There is 1 failed test if we run against the latest WooCommerce Core. This will be fixed in another issue https://github.com/Automattic/woocommerce-services/issues/1631, where we will update our Travis pipeline to include a pipeline test to run against latest woo core.

### Related issue(s)
Closes https://github.com/Automattic/woocommerce-services/issues/2211

### Steps to reproduce & screenshots/GIFs
Do you already have WordPress PHPUnit database/test setup? If so, skip to step 7.

1. Install `composer` if you don't have it already. Install it [globally](https://getcomposer.org/doc/00-intro.md#globally) so you can use it in any repo.
2. Run `composer install`
3. Make sure you have `wp-cli` installed. If not, follow [this step](https://make.wordpress.org/cli/handbook/guides/installing/).
4. Now you need to setup a WordPress Test database. Follow instruction [here](https://make.wordpress.org/cli/handbook/misc/plugin-unit-tests/#running-tests-locally).
When running the `wp scaffold plugin-tests woocommerce-services` command, don’t overwrite existing files.
5. You will need a local copy of [WooCommerce core from GitHub](https://github.com/woocommerce/woocommerce). We need this because our tests use cores’ test utility.
6. Add an environmental variable to your `.bash_profile` file that points to your woocommerce core repo. Mine looks like:
`export WC_DEVELOP_DIR=/wordpress/wp-content/plugins/woocommerce-clone`. This allows WCS tests to look for WooCommerce core’s test utils.
7. Type `composer run test` and you should see
```shell
Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Installing WooCommerce...
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.3.11
/woocommerce-services/phpunit.xml.dist

................................................................. 65 / 98 ( 66%)
.................F...............                                 98 / 98 (100%)

Time: 22.8 seconds, Memory: 62.50 MB

There was 1 failure:

1) WP_Test_WC_Connect_Tracks_No_Jetpack::test_no_jetpack
Expectation failed for method name is equal to 'log' when invoked 1 time(s)
Parameter 0 for invocation WC_Connect_Logger::log('Tracked the following event: ...ed_out', '', false) does not match expected value.
Failed asserting that 'Tracked the following event: woocommerceconnect_opted_out' contains "error".

/woocommerce-services/classes/class-wc-connect-tracks.php:119
/woocommerce-services/classes/class-wc-connect-tracks.php:113
/woocommerce-services/classes/class-wc-connect-tracks.php:40
/woocommerce-services/tests/php/test_woocommerce-connect-tracks.php:32

FAILURES!
Tests: 98, Assertions: 196, Failures: 1.
Script phpunit handling the test event returned with error code 1
```

#### Troubleshooting
1. If you see the following error
```shell
> phpunit
Could not find /var/folders/mx/xyzxyzxyzxyz/T/wordpress-tests-lib/includes/functions.php, have you run bin/install-wp-tests.sh ?
Script phpunit handling the test event returned with error code 1
```
Then, remember to run `./bin/install-wp-tests.sh wordpress_test <username> <pwd> localhost latest` 
 
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

