### PR TITLE
feat(DHL): adjust refund days copy

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.24.4 - 2020-XX-XX =
 * Fix   - UPS connect redirect prompt
+* Tweak - DHL refund days copy adjustment
 * Fix   - Allow UPS label purchase without payment method
 * Fix   - PHP implode arguments order
 * Fix   - Validate insurance value as both string and number

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 1.24.4 - 2020-XX-XX =
-* Fix   - UPS connect redirect prompt
 * Tweak - DHL refund days copy adjustment
+* Fix   - UPS connect redirect prompt
 * Fix   - Allow UPS label purchase without payment method
 * Fix   - PHP implode arguments order
 * Fix   - Validate insurance value as both string and number

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -87,7 +87,7 @@ export const getLabels = ( state, orderId, siteId = getSelectedSiteId( state ) )
 export const getLabelById = ( state, orderId, siteId, labelId ) => {
 	const labels = getLabels( state, orderId, siteId );
 
-	return labels.find( ({label_id}) => label_id === labelId );
+	return labels.find( ( { label_id } ) => label_id === labelId );
 };
 
 export const shouldFulfillOrder = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -84,6 +84,12 @@ export const getLabels = ( state, orderId, siteId = getSelectedSiteId( state ) )
 	return shippingLabel && shippingLabel.loaded ? shippingLabel.labels : [];
 };
 
+export const getLabelById = ( state, orderId, siteId, labelId ) => {
+	const labels = getLabels( state, orderId, siteId );
+
+	return labels.find( ({label_id}) => label_id === labelId );
+};
+
 export const shouldFulfillOrder = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
 	const shippingLabel = getShippingLabel( state, orderId, siteId );
 	return shippingLabel && shippingLabel.fulfillOrder;

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-refund-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-refund-modal.js
@@ -22,6 +22,7 @@ import {
 import {
 	isLoaded,
 	getShippingLabel,
+	getLabelById,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 
 const RefundDialog = props => {
@@ -35,6 +36,7 @@ const RefundDialog = props => {
 		labelId,
 		translate,
 		moment,
+		label,
 	} = props;
 
 	const getRefundableAmount = () => {
@@ -66,8 +68,8 @@ const RefundDialog = props => {
 			<FormSectionHeading>{ translate( 'Request a refund' ) }</FormSectionHeading>
 			<p>
 				{ translate(
-					'You can request a refund for a shipping label that has not been used to ship a package. ' +
-						'It will take at least 14 days to process.'
+					'You can request a refund for a shipping label that has not been used to ship a package. It will take at least %(days)s days to process.',
+					{ args: { days: label.carrier_id === 'dhlexpress' ? '31' : '14' } }
 				) }
 			</p>
 			<dl>
@@ -93,11 +95,12 @@ RefundDialog.propTypes = {
 	confirmRefund: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = ( state, { orderId, siteId } ) => {
+const mapStateToProps = ( state, { orderId, siteId, labelId } ) => {
 	const loaded = isLoaded( state, orderId, siteId );
 	const shippingLabel = getShippingLabel( state, orderId, siteId );
 	return {
 		refundDialog: loaded ? shippingLabel.refundDialog : {},
+		label: getLabelById(state, orderId, siteId, labelId),
 	};
 };
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-refund-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-refund-modal.js
@@ -36,7 +36,7 @@ const RefundDialog = props => {
 		labelId,
 		translate,
 		moment,
-		label,
+		label = {},
 	} = props;
 
 	const getRefundableAmount = () => {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Adjusting the refund copy for DHL Express labels.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Closes https://github.com/Automattic/woocommerce-services/issues/2217

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

- Purchase a DHL Express label
- Request refund
- Refund days should be 31

![Screen Shot 2020-10-13 at 9 22 44 AM](https://user-images.githubusercontent.com/273592/95873596-b1a8f580-0d35-11eb-9fae-5c97eade5ca6.png)

---

- Purchase another label (e.g.: USPS)
- Request refund
- Refund days should be 14

![Screen Shot 2020-10-13 at 9 21 42 AM](https://user-images.githubusercontent.com/273592/95873607-b4a3e600-0d35-11eb-913b-e03aac6935f4.png)


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

