### PR TITLE
Lookup carrier name for email tracking URL

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.1 - 2020-XX-XX =
+* Fix   - Update carrier name in tracking notification email
+
 = 1.24.4 - 2020-XX-XX =
 * Fix   - UPS connect redirect prompt
 * Fix   - Allow UPS label purchase without payment method

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1040,7 +1040,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			// Generate a table row for each label
 			foreach ( $labels as $label ) {
 				$carrier = $label['carrier_id'];
-				$carrier_label = strtoupper( $carrier );
+				$carrier_service = $this->get_service_schemas_store()->get_service_schema_by_id( $carrier );
+				$carrier_label = ( ! empty( $carrier_service->carrier_name ) ) ? $carrier_service->carrier_name : strtoupper( $carrier );
 				$tracking = $label['tracking'];
 				$error = array_key_exists( 'error', $label );
 				$refunded = array_key_exists( 'refund', $label );

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1041,7 +1041,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			foreach ( $labels as $label ) {
 				$carrier = $label['carrier_id'];
 				$carrier_service = $this->get_service_schemas_store()->get_service_schema_by_id( $carrier );
-				$carrier_label = ( ! empty( $carrier_service->carrier_name ) ) ? $carrier_service->carrier_name : strtoupper( $carrier );
+				$carrier_label = ( ! $carrier_service || empty( $carrier_service->carrier_name ) ) ? strtoupper( $carrier ) : $carrier_service->carrier_name;
 				$tracking = $label['tracking'];
 				$error = array_key_exists( 'error', $label );
 				$refunded = array_key_exists( 'refund', $label );


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
The email notification to customers with the shipment tracking information was displaying DHLEXPRESS as one word instead of DHL EXPRESS. This was due to the fact that the carrier name was generated by making the carrier ID uppercase, but the `dhlexpress` carrier ID is all one word for other compatibility reasons. I chose to do a lookup for the service `carrier_name` instead of hardcoding the name to limit the number of places we'd have the carrier name hardcoded. This comes with a slight performance hit, but allows for much easier updates/additions to carrier names.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
Fixes #2218 

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
1. Start with a WC and WCS site set up with DHL Express enabled.
2. Place an order that DHL Express would be able to fulfill (international).
3. Go to the order and purchase the shipping label. Be sure to check the "Notify the customer with shipment details" checkbox.
4. Check the email notification for the Provider name in the tracking section of the email.
5. Confirm the provider name is displayed as DHL Express.

![NotificationEmail-Tracking](https://user-images.githubusercontent.com/68524302/95869784-c12a3d80-0d39-11eb-8784-8659dc76ba08.png)

### Checklist

<!-- All testable code should have tests. -->
- [ x ] unit tests

<!-- An entry in the changelog file is always required -->
- [ x ] `changelog.txt` entry added

