### PR TITLE
Disable refund button for USPS letters.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.25.1 - 2020-XX-XX =
 * Fix   - Update carrier name in tracking notification email
 * Add   - Add pre-commit and pre-push git hooks for linting and unit tests.
+* Add   - Disable refunds for USPS letters.
 
 = 1.25.0 - 2020-10-13 =
 * Fix   - UPS connect redirect prompt

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -106,6 +106,8 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 				$label_meta[ 'package_name' ] = __( 'Unknown package', 'woocommerce-services' );
 			}
 
+			$label_meta['is_letter'] = $package['is_letter'];
+
 			$product_names = array();
 			$product_ids = array();
 			foreach ( $package[ 'products' ] as $product_id ) {

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -106,7 +106,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 				$label_meta[ 'package_name' ] = __( 'Unknown package', 'woocommerce-services' );
 			}
 
-			$label_meta['is_letter'] = $package['is_letter'];
+			$label_meta[ 'is_letter' ] = isset( $package[ 'is_letter' ] ) ? $package[ 'is_letter' ] : false;
 
 			$product_names = array();
 			$product_ids = array();

--- a/client/extensions/woocommerce/state/sites/orders/activity-log/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/activity-log/selectors.js
@@ -209,6 +209,7 @@ export const getActivityLogEvents = ( state, orderId, siteId = getSelectedSiteId
 				// TODO: Currently we only store the names of the items & packages, we need to store more data to show dimensions etc
 				productNames: label.product_names,
 				packageName: label.package_name,
+				isLetter: label.is_letter,
 				receiptId: label.main_receipt_id,
 				serviceName: label.service_name,
 				tracking: label.tracking,

--- a/client/extensions/woocommerce/state/sites/orders/activity-log/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/activity-log/test/selectors.js
@@ -103,6 +103,7 @@ const labelsLoadedSubtree = {
 			product_names: [ 'poutine' ],
 			package_name: 'box',
 			tracking: '12345',
+			is_letter: false,
 			carrier_id: 'canada_post',
 			service_name: 'Xpress',
 			main_receipt_id: 12345,
@@ -124,6 +125,7 @@ const labelsLoadedSubtree = {
 			product_names: [ 'Autograph' ],
 			package_name: 'Small Envelope',
 			tracking: '12345',
+			is_letter: true,
 			carrier_id: 'usps',
 			service_name: 'First Class',
 			main_receipt_id: 12345,
@@ -395,7 +397,7 @@ describe( 'selectors', () => {
 					createdDate: 4000000,
 					usedDate: null,
 					expiryDate: 4500000,
-					isLetter: undefined,
+					isLetter: false,
 					showDetails: true, // Refund rejected, user can refund/reprint again
 					labelId: 4,
 					labelIndex: 4,
@@ -427,7 +429,7 @@ describe( 'selectors', () => {
 					createdDate: 3000000,
 					usedDate: null,
 					expiryDate: null,
-					isLetter: undefined,
+					isLetter: true,
 					showDetails: false, // Already requested refund
 					labelId: 3,
 					labelIndex: 3,

--- a/client/extensions/woocommerce/state/sites/orders/activity-log/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/activity-log/test/selectors.js
@@ -395,6 +395,7 @@ describe( 'selectors', () => {
 					createdDate: 4000000,
 					usedDate: null,
 					expiryDate: 4500000,
+					isLetter: undefined,
 					showDetails: true, // Refund rejected, user can refund/reprint again
 					labelId: 4,
 					labelIndex: 4,
@@ -426,6 +427,7 @@ describe( 'selectors', () => {
 					createdDate: 3000000,
 					usedDate: null,
 					expiryDate: null,
+					isLetter: undefined,
 					showDetails: false, // Already requested refund
 					labelId: 3,
 					labelIndex: 3,
@@ -457,6 +459,7 @@ describe( 'selectors', () => {
 					createdDate: 2000000,
 					usedDate: null,
 					expiryDate: 2500000,
+					isLetter: undefined,
 					showDetails: false, // Already requested refund
 					labelId: 2,
 					labelIndex: 2,
@@ -479,6 +482,7 @@ describe( 'selectors', () => {
 					createdDate: 1000000,
 					usedDate: 1100000,
 					expiryDate: 1500000,
+					isLetter: undefined,
 					showDetails: true,
 					labelId: 1,
 					labelIndex: 1,

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -27,12 +27,23 @@ import {
 import Gridicon from "gridicons";
 
 export class LabelItem extends Component {
-	renderRefund = ( labelId, expired ) => {
+	renderRefund = ( labelId, expired, isLetter, carrierId ) => {
 		const { orderId, siteId, translate } = this.props;
+		let toolTipMessage = '';
+		let disabled = false;
 
 		if ( expired ) {
+			toolTipMessage = translate( 'Labels older than 30 days cannot be refunded.' );
+			disabled       = true;
+		} 
+		else if ( isLetter && 'usps' === carrierId ) {
+			toolTipMessage = translate( 'USPS letters are not eligible for refund.' );
+			disabled       = true
+		}
+
+		if ( disabled ) {
 			return (
-				<Tooltip position="top left" text={ translate('Labels older than 30 days cannot be refunded.') }>
+				<Tooltip position="top left" text={ toolTipMessage }>
 					<button className="popover__menu-item shipping-label__item-menu-reprint-expired" role="menuitem" tabIndex="-1">
 						<Gridicon icon="refund" size={ 18 }/>
 						<span> { translate( 'Request refund' ) } </span>
@@ -138,6 +149,7 @@ export class LabelItem extends Component {
 				labelIndex,
 				serviceName,
 				packageName,
+				isLetter,
 				productNames,
 				receiptId,
 				labelId,
@@ -193,7 +205,7 @@ export class LabelItem extends Component {
 								<EllipsisMenu position="bottom left">
 									{ this.renderLabelDetails( labelId ) }
 									{ this.renderPickup( carrierId ) }
-									{ this.renderRefund( labelId, refundExpired ) }
+									{ this.renderRefund( labelId, refundExpired, isLetter, carrierId ) }
 									{ this.renderReprint( labelId, expired ) }
 									{ this.renderCommercialInvoiceLink( commercialInvoiceUrl ) }
 								</EllipsisMenu>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -262,7 +262,7 @@ LabelItem.propTypes = {
 		anonymized: PropTypes.bool.isRequired,
 		usedDate: PropTypes.string.isRequired,
 		tracking: PropTypes.string.isRequired,
-		carrierId: PropTypes.number.isRequired,
+		carrierId: PropTypes.string.isRequired,
 		commercialInvoiceUrl: PropTypes.string,
 	}).isRequired,
 	isModal: PropTypes.bool.isRequired,

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/test/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/test/label-item.js
@@ -13,6 +13,7 @@ import { translate } from 'i18n-calypso';
  */
 import { LabelItem } from '../label-item.js';
 import PopoverMenuItem from 'components/popover/menu-item';
+import { Tooltip } from '@wordpress/components';
 
 function createLabelItemWrapper( props = {} ) {
 	const defaults = {
@@ -33,7 +34,7 @@ function createLabelItemWrapper( props = {} ) {
 			anonymized: false,
 			usedDate: "",
 			tracking: "tracking code 01",
-			carrierId: 1,
+			carrierId: "",
 		},
 		isModal: false,
 		openRefundDialog: () => {},
@@ -73,8 +74,66 @@ describe( 'Label item', () => {
 			return n.is( PopoverMenuItem ) && 'Print customs form' === n.children().text();
 		}  );
 
-		it( 'doest not render a link to print it', function () {
+		it( 'does not render a link to print it', function () {
 			expect( renderedPrintCustomsFormLink.length ).toBe( 0 );
+		} );
+	} );
+
+	describe( 'with usps letter', () => {
+		const props = {
+			label: {
+				isLetter: true,
+				carrierId: 'usps',
+			}
+		}
+		const wrapper = createLabelItemWrapper( props );
+		const requestRefundLink = wrapper.findWhere( ( n ) => {
+			return n.is( PopoverMenuItem ) && 'Request refund' === n.children().text();
+		}  );
+
+		it( 'Request refund is disabled', function () {
+			expect( requestRefundLink.length ).toBe( 0 );
+		} );
+		const tooltip = wrapper.findWhere( ( n ) => {
+			return n.is( Tooltip );
+		}  );
+		it( 'Tooltip message is displayed', function () {
+			expect( tooltip.props().text ).toEqual('USPS letters are not eligible for refund.');
+		} );
+	} );
+
+	describe( 'with usps package', () => {
+		const props = {
+			label: {
+				isLetter: false,
+				carrierId: 'usps',
+			}
+		}
+		const wrapper = createLabelItemWrapper( props );
+		const requestRefundLink = wrapper.findWhere( ( n ) => {
+			return n.is( PopoverMenuItem ) && 'Request refund' === n.children().text();
+		}  );
+
+		it( 'Request refund is not disabled', function () {
+			expect( requestRefundLink.length ).toBe( 1 );
+		} );
+
+	} );
+
+	describe( 'with non usps carrier letter', () => {
+		const props = {
+			label: {
+				isLetter: true,
+				carrierId: 'canada_post',
+			}
+		}
+		const wrapper = createLabelItemWrapper( props );
+		const requestRefundLink = wrapper.findWhere( ( n ) => {
+			return n.is( PopoverMenuItem ) && 'Request refund' === n.children().text();
+		}  );
+
+		it( 'Request refund is not disabled', function () {
+			expect( requestRefundLink.length ).toBe( 1 );
 		} );
 
 	} );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/test/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/test/label-item.js
@@ -94,9 +94,11 @@ describe( 'Label item', () => {
 		it( 'Request refund is disabled', function () {
 			expect( requestRefundLink.length ).toBe( 0 );
 		} );
+
 		const tooltip = wrapper.findWhere( ( n ) => {
 			return n.is( Tooltip );
 		}  );
+
 		it( 'Tooltip message is displayed', function () {
 			expect( tooltip.props().text ).toEqual('USPS letters are not eligible for refund.');
 		} );
@@ -117,7 +119,6 @@ describe( 'Label item', () => {
 		it( 'Request refund is not disabled', function () {
 			expect( requestRefundLink.length ).toBe( 1 );
 		} );
-
 	} );
 
 	describe( 'with non usps carrier letter', () => {
@@ -135,6 +136,5 @@ describe( 'Label item', () => {
 		it( 'Request refund is not disabled', function () {
 			expect( requestRefundLink.length ).toBe( 1 );
 		} );
-
 	} );
 } );


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
USPS letters are not eligible for refunds as they are untracked.

This PR disables the `Request a Refund` button for USPS labels when the package has the value `is_letter = true` and shows a tooltip message `USPS letters are not eligible for refund`.

This PR adds `is_letter` to label metadata when a label is purchased. Labels purchased before this PR will not have that information and thus the button will not be disabled. As labels are only refundable for a certain amount of time, overtime the difference will disappear.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

closes #2120 

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

1. With WooCommerce Shipping and Tax ready to purchase labels, place an order on your store.
2. Edit the order, click on Purchase a Label, verify the addresses and select a package that is a USPS envelope.
![USPSEnvelopes](https://user-images.githubusercontent.com/8002881/96184385-0ac38580-0efe-11eb-9003-2bb61c4e1e6c.png)
3. Select one of USPS services and finish purchasing the label
![USPSCarrier](https://user-images.githubusercontent.com/8002881/96184621-59711f80-0efe-11eb-97e1-1b9657e951fd.png)

4. On the order notes, click on the ellipsis for the label you just purchased and verify the "Request a Refund" button is disabled.
![DisabledRefund](https://user-images.githubusercontent.com/8002881/96184894-b371e500-0efe-11eb-9612-f8b9a14a6545.png)

5. Hover over `Request a Refund`, verify there is a tooltip message: `USPS letters are not eligible for refund`
![Tooltip](https://user-images.githubusercontent.com/8002881/96185658-d9e45000-0eff-11eb-85b6-38fd9c001a74.png)

6. Purchase a label for another carrier, like DHL Express, using an envelope package. Verify the button is not disabled.
![RequestRefund](https://user-images.githubusercontent.com/8002881/96186478-1b292f80-0f01-11eb-9b89-775700e1e7ac.png)


### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests
<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

