### PR TITLE
Use is_offline_mode instead of deprecated is_development_mode.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.25.1 - 2020-XX-XX =
 * Tweak - DHL refund days copy adjustment
+* Tweak - Stop using deprecated Jetpack method is_development_mode().
 * Fix   - Update carrier name in tracking notification email
 * Add   - Add pre-commit and pre-push git hooks for linting and unit tests.
 * Add   - Disable refunds for USPS letters.

--- a/classes/class-wc-connect-jetpack.php
+++ b/classes/class-wc-connect-jetpack.php
@@ -7,8 +7,9 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 		 * @return bool
 		 */
 		public static function is_development_mode() {
-			if ( method_exists( 'Jetpack', 'is_development_mode' ) ) {
-				return Jetpack::is_development_mode();
+			if ( method_exists( '\\Automattic\\Jetpack\\Status', 'is_offline_mode' ) ) {
+				$status = new \Automattic\Jetpack\Status();
+				return $status->is_offline_mode();
 			}
 
 			return false;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
This PR uses the method [is_offline_mode](https://github.com/Automattic/jetpack/blob/d6dfd9c34b18c5e378b9ed2a2674bc2212b289df/vendor/automattic/jetpack-status/src/class-status.php#L37) instead of the deprecated (since Jetpack 8.0) [is_development_mode](https://github.com/Automattic/jetpack/blob/e940e90c3f26a6f24f8e7fccd72a1dd6360be2b5/class.jetpack.php#L1676).

Note: [There was no deprecation notice](https://github.com/Automattic/jetpack/blob/e940e90c3f26a6f24f8e7fccd72a1dd6360be2b5/class.jetpack.php#L1669).

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
closes: #2202 
### Steps to reproduce & screenshots/GIFs

Turn on Jetpack Offline mode [with any of these methods](https://jetpack.com/support/development-mode/).
On your site, go to WP-Admin > WooCommerce > Settings > Shipping > WooCommerce Shipping
Verify that you get the following message:
<img width="1132" alt="JetpackOfflineMode" src="https://user-images.githubusercontent.com/8002881/96904354-9be5af80-145c-11eb-9a87-ffce1b5b48a9.png">


If Jetpack was connected, the message will be:
`Note: Jetpack is connected, but development mode is also enabled on this site. Please disable development mode.`

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

