### PR TITLE
Fallback to open PDF in new tab if Safari does not print natively

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix   - Update carrier name in tracking notification email
 * Add   - Add pre-commit and pre-push git hooks for linting and unit tests.
 * Add   - Disable refunds for USPS letters.
+* Fix   - Issue with printing labels in some iOS devices through Safari.
 
 = 1.25.0 - 2020-10-13 =
 * Fix   - UPS connect redirect prompt

--- a/client/extensions/woocommerce/woocommerce-services/lib/utils/pdf-support.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/utils/pdf-support.js
@@ -35,6 +35,13 @@ export default memoize( () => {
 		return 'native';
 	}
 
+	if ( includes( navigator.userAgent, 'Safari' ) ) {
+		// In some version of iPads, the navigator.userAgent stopped including the device name.
+		// If this Safari does not support native, then given that iOS doesn't support a print
+		// dialog, this serves as a catch-all to load the pdf in a new tab.
+		return 'addon';
+	}
+
 	const getActiveXObject = name => {
 		try {
 			return new ActiveXObject( name ); /*eslint no-undef: 0 */


### PR DESCRIPTION
### Description
On some iPad devices, `navigator.userAgent` stopped including `iPad` in the string. This causes our logic to fallback on using `print()`, resurfacing [this problem](https://github.com/Automattic/woocommerce-services/issues/1166). 

### Related issue(s)
Closes https://github.com/Automattic/woocommerce-services/issues/1166

### Steps to reproduce & screenshots/GIFs
1. Use an iPad with Safari. Use the iPad (7th generation) if possible. 
![image](https://user-images.githubusercontent.com/572862/96932977-eecf5f00-147c-11eb-9872-754249b8d25a.png)
1a. Alternatively, use browserstack and choose these iPad:
![image](https://user-images.githubusercontent.com/572862/96931832-2b9a5680-147b-11eb-9bab-5ef3a8c87fdc.png)
2. Go to your store and click re-print label in the "Shipment Tracking" block
![image](https://user-images.githubusercontent.com/572862/96934053-ccd6dc00-147e-11eb-860c-ca60961b89f7.png)
3. The label should open in a new tab instead of closing the modal itself. 


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

