### PR TITLE
Add ZIP code validation to UPS signup form.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,10 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 1.25.1 - 2020-XX-XX =
-* Tweak - DHL refund days copy adjustment
+* Tweak - DHL refund days copy adjustment.
+* Tweak - Add ZIP code validation to UPS(beta) signup form.
 * Tweak - Stop using deprecated Jetpack method is_development_mode().
-* Fix   - Update carrier name in tracking notification email
+* Fix   - Update carrier name in tracking notification email.
 * Add   - Add pre-commit and pre-push git hooks for linting and unit tests.
 * Add   - Disable refunds for USPS letters.
 

--- a/client/extensions/woocommerce/woocommerce-services/state/carrier-accounts/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/carrier-accounts/selectors.js
@@ -19,7 +19,7 @@ export const getCarrierAccountsState = ( state, siteId = getSelectedSiteId( stat
 };
 
 const emailRegex = /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/;
-
+const USPostalCodeRegex = /^\d{5}$/;
 const urlRegex = /^(?:(?:(?:https?|ftp):)?\/\/)*(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?$/i;
 
 export const getFormErrors = ( state, siteId, carrier ) => {
@@ -37,6 +37,10 @@ export const getFormErrors = ( state, siteId, carrier ) => {
 		} else {
 			delete fieldErrors[ field ];
 		}
+	}
+
+	if ( values.country === 'US' && values.postal_code && ! values.postal_code.match( USPostalCodeRegex ) ) {
+		fieldErrors.postal_code = translate( 'The ZIP/Postal code format is not valid.');
 	}
 
 	if ( values.email && ! values.email.match( emailRegex ) ) {


### PR DESCRIPTION
## Description
Provide some client-validation for the postal code field on the UPS signup form.

### Related issue(s)

Closes #2180 

### Steps to reproduce & screenshots/GIFs

GIF of it working in action:

![Screen Capture on 2020-10-23 at 14-53-27](https://user-images.githubusercontent.com/6723003/97010616-edb63480-1545-11eb-9769-2b5fd5e95a35.gif)

Verify also that it disables the Connect button when the ZIP/Postal code is incorrectly formatted(not a 5 digit number):
![Screen Shot 2020-10-23 at 14 58 47](https://user-images.githubusercontent.com/6723003/97010671-03c3f500-1546-11eb-9ac2-b38d4d8ea3e9.png)

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

Not yet - but a full e2e test will be a great idea when we know how this form will look in its final form(it may be abstracted to allow for additional carriers).

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

