### PR TITLE
Add message to explain exclusive tax is needed for automated tax service

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -28,11 +28,11 @@
 * Fix   - Allow UPS label purchase without payment method
 * Fix   - PHP implode arguments order
 * Fix   - Validate insurance value as both string and number
-* Tweak - Add new icons and banners with new plugin name
+* Tweak - Adjusted messaging on label pointers
 * Tweak - Update carrier logo
 * Tweak - Plugin rename
 * Add   - Link to print the customs form for all shipments that need it
-* Tweak - Inform users of products that should be entered exclusive of tax.
+* Tweak - Add new icons and banners with new plugin name
 
 = 1.24.3 - 2020-09-16 =
 * Fix   - Asset paths incompatible with some hosts.

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Add   - DHL Schedule Pickup link within order notes.
 * Fix   - UI fix for input validation for package dimensions and weights.
 * Fix   - Correct validation for UPS fields in Carrier Account connect form.
+* Tweak - Add message to explain automated tax requires tax-exclusive product pricing.
 
 = 1.25.2 - 2020-11-10 =
 * Tweak - Add ZIP code validation to UPS(beta) signup form.

--- a/changelog.txt
+++ b/changelog.txt
@@ -28,11 +28,11 @@
 * Fix   - Allow UPS label purchase without payment method
 * Fix   - PHP implode arguments order
 * Fix   - Validate insurance value as both string and number
-* Tweak - Adjusted messaging on label pointers
+* Tweak - Add new icons and banners with new plugin name
 * Tweak - Update carrier logo
 * Tweak - Plugin rename
 * Add   - Link to print the customs form for all shipments that need it
-* Tweak - Add new icons and banners with new plugin name
+* Tweak - Inform users of products that should be entered exclusive of tax.
 
 = 1.24.3 - 2020-09-16 =
 * Fix   - Asset paths incompatible with some hosts.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -134,7 +134,7 @@ class WC_Connect_TaxJar_Integration {
 			'title'    => __( 'Automated taxes', 'woocommerce-services' ),
 			'id'       => self::OPTION_NAME, // TODO: save in `wc_connect_options`?
 			'desc_tip' => $this->get_tax_tooltip(),
-			'desc'     => $enabled ? '<p>' . __( 'Powered by WooCommerce Tax.', 'woocommerce-services' ) . '</p>' : '',
+			'desc'     => $enabled ? '<p>' . __( 'Powered by WooCommerce Tax. Automated taxes are applied on top of the prices you entered. Please make sure these product prices were entered exclusive of tax.', 'woocommerce-services' ) . '</p>' : '',
 			'default'  => 'no',
 			'type'     => 'select',
 			'class'    => 'wc-enhanced-select',

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -134,7 +134,7 @@ class WC_Connect_TaxJar_Integration {
 			'title'    => __( 'Automated taxes', 'woocommerce-services' ),
 			'id'       => self::OPTION_NAME, // TODO: save in `wc_connect_options`?
 			'desc_tip' => $this->get_tax_tooltip(),
-			'desc'     => $enabled ? '<p>' . __( 'Powered by WooCommerce Tax. Automated taxes are applied on top of the prices you entered. Please make sure these product prices were entered exclusive of tax.', 'woocommerce-services' ) . '</p>' : '',
+			'desc'     => $enabled ? '<p>' . __( 'Powered by WooCommerce Tax. If automated taxes are enabled, you\'ll need to enter prices exclusive of tax.', 'woocommerce-services' ) . '</p>' : '',
 			'default'  => 'no',
 			'type'     => 'select',
 			'class'    => 'wc-enhanced-select',


### PR DESCRIPTION
## Description
If an user created product with tax inclusive, then installed WCS or enabled automated tax. The tax will be calculated twice. This problem can be reproduced with the steps [here](https://github.com/Automattic/woocommerce-services/issues/1367#issuecomment-716715892). 

### Related issue(s)
Closes https://github.com/Automattic/woocommerce-services/issues/1367

### Steps to reproduce & screenshots/GIFs
1. Go to WooCommerce Tax settings `wp-admin/admin.php?page=wc-settings&tab=tax`
2. Enable automated tax and make sure there is a message explaining why product's price needs to be exclusive of tax. 
![image](https://user-images.githubusercontent.com/572862/97223554-8c84a000-1795-11eb-8af7-8aedb9ea1545.png)

### Questions
1. Do we need to go through design for the location of this message?
2. This PR only adds a message to the user but does not address the duplicate tax problem - Products created with inclusive tax remains to be double taxed. [Automated tax + exclusive tax is by design](https://github.com/Automattic/woocommerce-services/issues/1367#issuecomment-379765928). Should we create another issue to check if the TaxJar API now allows inclusive/exclusive tax? 

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

