### PR TITLE
Allows package dimension input to begin with zero, still validates positive values

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Add   - Add pre-commit and pre-push git hooks for linting and unit tests.
 * Add   - Disable refunds for USPS letters.
 * Fix   - Issue with printing labels in some iOS devices through Safari.
+* Fix   - UI fix for input validation for package dimensions and weights.
 
 = 1.25.0 - 2020-10-13 =
 * Fix   - UPS connect redirect prompt

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/input-filters.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/input-filters.js
@@ -41,7 +41,8 @@ const checkDimension = dimension => {
 		return '';
 	}
 
-	if ( 0 >= dimension ) {
+	// Allow users to type `0`, but not negative numbers
+	if ( 0 > dimension ) {
 		return '';
 	}
 
@@ -63,9 +64,16 @@ const parseDimensions = value => {
 	return { length, width, height };
 };
 
+// Final dimensions must all be positive numbers
+const validateDimensions = value => {
+	const { length, width, height } = parseDimensions( value );
+	return ( 0 < length ) && ( 0 < width ) && ( 0 < height );
+};
+
 export default {
 	string,
 	number,
 	dimensions,
 	parseDimensions,
+	validateDimensions,
 };

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/package-dialog.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/package-dialog.js
@@ -101,6 +101,10 @@ const PackageDialog = props => {
 		} );
 
 		const errors = checkInputs( filteredPackageData, boxNames, packageSchema );
+		if( ! inputFilters.validateDimensions( filteredPackageData.inner_dimensions ) ) {
+			errors.any = true;
+			errors.inner_dimensions = true;
+		}
 		if ( errors.any ) {
 			updatePackagesField( siteId, filteredPackageData );
 			setModalErrors( siteId, errors );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/package-info.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/package-info.js
@@ -122,6 +122,8 @@ const PackageInfo = props => {
 		props.updatePackageWeight( orderId, siteId, packageId, event.target.value );
 	};
 
+	const packageWeight = isNaN( pckg.weight ) ? '' : pckg.weight;
+
 	return (
 		<div className="packages-step__package">
 			<div>
@@ -154,7 +156,7 @@ const PackageInfo = props => {
 				<FormTextInputWithAffixes
 					id={ `weight_${ packageId }` }
 					placeholder={ translate( '0' ) }
-					value={ pckg.weight || '' }
+					value={ packageWeight }
 					onChange={ onWeightChange }
 					isError={ Boolean( pckgErrors.weight ) }
 					type="number"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Description
<!-- Explain the motivation for making this change -->
When adding a new package, the inputs for package dimensions will not allow you to start entering a number beginning with zero (e.g. decimals beginning with "0."). This is because there are `onChange` validation hooks on the inputs that clear out the field if the current value is non-positive (0 or negative). In addition, when submitting the form, the three dimension values are validated together as a string (`"{length} x {width} x {height}"`) against the regex `^(\\d+|(?:\\d*\\.\\d+)) x (\\d+|(?:\\d*\\.\\d+)) x (\\d+|(?:\\d*\\.\\d+))$`. This regex will match any non-negative values _including_ zero, so the validation relies on the hooks on the input field to prevent zero from being entered.

My solution is to loosen the validation in the `onChange` hooks, preventing negative values, but allowing zero. To maintain the correct validation on submission, we need to now validate on submission that the field values are non-zero (and non-negative). The regex appears to originate from some external package schema and besides, it didn't seem entirely appropriate to rely on string validation for a numeric value, so I simply added in one more function (`validateDimensions`) to double-check and confirm this validation before submitting.

This also occurs on the input field for _Total Weight (with package)_ on the create shipping label dialog, but this is because the input validation clears the field if the value is not truthy only allowing positive and non-zero values.

### Related issue(s)
Closes #2232 

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
Go to **WooCommerce -> Settings -> Shipping -> WooCommerce Shipping**.
Click **Add package** under **Packaging**.
Enter decimals with a leading zero into the dimensions fields.
Click **Add package** to submit the dialog and check validations.

![Add a package dialog](https://user-images.githubusercontent.com/6209518/97196441-b32ce180-1769-11eb-8fc1-88f31704c7ba.png)
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

Go to **WooCommerce -> Orders**.
Select an order.
Click **Create Shipping Label**/**Create new label** button.
Edit **Total Weight (with package)** field.

![Create shipping label dialog](https://user-images.githubusercontent.com/6209518/97196706-030ba880-176a-11eb-9d4e-dd0057bba65a.png)

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

