### PR TITLE
Create a new end point for carrier-types

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Tweak - Add ZIP code validation to UPS(beta) signup form.
 * Fix   - Issue with printing labels in some iOS devices through Safari.
 * Fix   - Prevents warning when using PHP 5.5 or lesser
+* Add   - Add new API end point to retrieve carrier registration requirements.
 
 = 1.25.1 - 2020-10-28 =
 * Tweak - DHL refund days copy adjustment

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -312,6 +312,17 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		/**
+		 * Get all carriers we support for registration. This end point
+		 * returns a list of "fields" that we use to register the carrier
+		 * account.
+		 *
+		 * @return object|WP_Error
+		 */
+		public function get_carrier_types( ) {
+			return $this->request( 'GET', '/shipping/carrier-types' );
+		}
+
+		/**
 		 * Tests the connection to the WooCommerce Shipping & Tax Server
 		 *
 		 * @return true|WP_Error

--- a/classes/class-wc-rest-connect-shipping-carrier-types-controller.php
+++ b/classes/class-wc-rest-connect-shipping-carrier-types-controller.php
@@ -31,7 +31,12 @@ class WC_REST_Connect_Shipping_Carrier_Types_Controller extends WC_REST_Connect_
 			$this->logger->log( $response, __CLASS__ );
 			return $response;
 		}
-		return new WP_REST_Response( $response );
+		return new WP_REST_Response(
+			[
+				'success' => true,
+				'fields'  => $response,
+			]
+		);
 	}
 
 }

--- a/classes/class-wc-rest-connect-shipping-carrier-types-controller.php
+++ b/classes/class-wc-rest-connect-shipping-carrier-types-controller.php
@@ -23,18 +23,13 @@ class WC_REST_Connect_Shipping_Carrier_Types_Controller extends WC_REST_Connect_
 	/**
 	 * GET request
 	 *
-	 * @return array
+	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get() {
 		$response = $this->api_client->get_carrier_types();
 		if ( is_wp_error( $response ) ) {
-			$error = new WP_Error(
-				$response->get_error_code(),
-				$response->get_error_message(),
-				array( 'message' => $response->get_error_message() )
-			);
-			$this->logger->log( $error, __CLASS__ );
-			return $error;
+			$this->logger->log( $response, __CLASS__ );
+			return $response;
 		}
 		return new WP_REST_Response( $response );
 	}

--- a/classes/class-wc-rest-connect-shipping-carrier-types-controller.php
+++ b/classes/class-wc-rest-connect-shipping-carrier-types-controller.php
@@ -23,10 +23,9 @@ class WC_REST_Connect_Shipping_Carrier_Types_Controller extends WC_REST_Connect_
 	/**
 	 * GET request
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
 	 * @return array
 	 */
-	public function get( $request ) {
+	public function get() {
 		$response = $this->api_client->get_carrier_types();
 		if ( is_wp_error( $response ) ) {
 			$error = new WP_Error(
@@ -37,8 +36,7 @@ class WC_REST_Connect_Shipping_Carrier_Types_Controller extends WC_REST_Connect_
 			$this->logger->log( $error, __CLASS__ );
 			return $error;
 		}
-
-		return array( 'success' => $response );
+		return new WP_REST_Response( $response );
 	}
 
 }

--- a/classes/class-wc-rest-connect-shipping-carrier-types-controller.php
+++ b/classes/class-wc-rest-connect-shipping-carrier-types-controller.php
@@ -1,0 +1,44 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit();
+}
+
+if ( class_exists( 'WC_REST_Connect_Shipping_Carrier_Types_Controller' ) ) {
+	return;
+}
+
+/**
+ * Retrieve a list of carrier WooCommerce Shipping & Tax supports, along with the
+ * fields needed for each carrier in order to do carrier account registration.
+ */
+class WC_REST_Connect_Shipping_Carrier_Types_Controller extends WC_REST_Connect_Base_Controller {
+	/**
+	 * Carrier-types end point
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'connect/shipping/carrier-types';
+
+	/**
+	 * GET request
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return array
+	 */
+	public function get( $request ) {
+		$response = $this->api_client->get_carrier_types();
+		if ( is_wp_error( $response ) ) {
+			$error = new WP_Error(
+				$response->get_error_code(),
+				$response->get_error_message(),
+				array( 'message' => $response->get_error_message() )
+			);
+			$this->logger->log( $error, __CLASS__ );
+			return $error;
+		}
+
+		return array( 'success' => $response );
+	}
+
+}

--- a/classes/class-wc-rest-connect-shipping-carrier-types-controller.php
+++ b/classes/class-wc-rest-connect-shipping-carrier-types-controller.php
@@ -33,8 +33,8 @@ class WC_REST_Connect_Shipping_Carrier_Types_Controller extends WC_REST_Connect_
 		}
 		return new WP_REST_Response(
 			[
-				'success' => true,
-				'fields'  => $response,
+				'success'  => true,
+				'carriers' => $response->carriers,
 			]
 		);
 	}

--- a/tests/php/classes/test-class-wc-rest-connect-shipping-carrier-types-controller.php
+++ b/tests/php/classes/test-class-wc-rest-connect-shipping-carrier-types-controller.php
@@ -1,0 +1,64 @@
+<?php
+
+
+
+/**
+ * Unit test for WC_Connect_API_Client_Live
+ */
+class WP_Test_WC_REST_Connect_Shipping_Carrier_Types_Controller extends WC_Unit_Test_Case {
+
+	/** @var WC_Connect_API_Client_Live $api_client_mock */
+	protected $api_client_mock;
+
+	/** @var WC_Connect_Service_Settings_Store $setting_store_mock */
+	protected $setting_store_mock;
+
+	/** @var WC_Connect_Logger $connect_logger_mock */
+	protected $connect_logger_mock;
+
+	/**
+	 * @inherit
+	 */
+	public static function setupBeforeClass() {
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-api-client-live.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-service-settings-store.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-logger.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-rest-connect-base-controller.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-rest-connect-shipping-carrier-types-controller.php';
+	}
+
+	/**
+	 * Setup the test case.
+	 *
+	 * @see WC_Unit_Test_Case::setUp()
+	 */
+	public function setUp() {
+		// Creating a mock class and overide protected request method so that we can mock the API response.
+		$this->api_client_mock = $this->getMockBuilder( WC_Connect_API_Client_Live::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'request' ] )
+			->getMock();
+
+		$this->setting_store_mock  = $this->createMock( WC_Connect_Service_Settings_Store::class );
+		$this->connect_logger_mock = $this->createMock( WC_Connect_Logger::class );
+	}
+
+	/**
+	 * Test GET request on connect/shipping/carrier-types end point.
+	 */
+	public function test_get() {
+		$api_response        = '{"carriers":[{"type":"DhlExpressAccount","name":"DHL Express","fields":{"account_number":{"visibility":"visible","label":"DHL Account Number"},"country":{"visibility":"visible","label":"Account Country Code (2 Letter)"},"is_reseller":{"visibility":"checkbox","label":"Reseller Account? (check if yes)"}}},{"type":"UpsAccount","name":"UPS","fields":{}}]}';
+		$api_client_response = json_decode( $api_response ); // assumes api_client->request() successfully returns the JSON decoded response body.
+
+		$this->api_client_mock->expects( $this->once() )
+			->method( 'request' )
+			->with( 'GET', '/shipping/carrier-types' )
+			->willReturn( $api_client_response );
+
+		$wc_connect_shipping_carrier_types_controller = new WC_REST_Connect_Shipping_Carrier_Types_Controller( $this->api_client_mock, $this->setting_store_mock, $this->connect_logger_mock );
+		$actual                                       = $wc_connect_shipping_carrier_types_controller->get();
+
+		$this->assertEquals( 200, $actual->status );
+		$this->assertEquals( $api_client_response, $actual->data );
+	}
+}

--- a/tests/php/classes/test-class-wc-rest-connect-shipping-carrier-types-controller.php
+++ b/tests/php/classes/test-class-wc-rest-connect-shipping-carrier-types-controller.php
@@ -58,8 +58,8 @@ class WP_Test_WC_REST_Connect_Shipping_Carrier_Types_Controller extends WC_Unit_
 		$wc_connect_shipping_carrier_types_controller = new WC_REST_Connect_Shipping_Carrier_Types_Controller( $this->api_client_mock, $this->setting_store_mock, $this->connect_logger_mock );
 		$actual                                       = $wc_connect_shipping_carrier_types_controller->get();
 		$expected                                     = [
-			'success' => true,
-			'fields'  => $api_client_response,
+			'success'  => true,
+			'carriers' => $api_client_response->carriers,
 		];
 
 		$this->assertEquals( 200, $actual->status );

--- a/tests/php/classes/test-class-wc-rest-connect-shipping-carrier-types-controller.php
+++ b/tests/php/classes/test-class-wc-rest-connect-shipping-carrier-types-controller.php
@@ -57,9 +57,13 @@ class WP_Test_WC_REST_Connect_Shipping_Carrier_Types_Controller extends WC_Unit_
 
 		$wc_connect_shipping_carrier_types_controller = new WC_REST_Connect_Shipping_Carrier_Types_Controller( $this->api_client_mock, $this->setting_store_mock, $this->connect_logger_mock );
 		$actual                                       = $wc_connect_shipping_carrier_types_controller->get();
+		$expected                                     = [
+			'success' => true,
+			'fields'  => $api_client_response,
+		];
 
 		$this->assertEquals( 200, $actual->status );
-		$this->assertEquals( $api_client_response, $actual->data );
+		$this->assertEquals( $expected, $actual->data );
 	}
 
 	/**

--- a/tests/php/classes/test-class-wc-rest-connect-shipping-carrier-types-controller.php
+++ b/tests/php/classes/test-class-wc-rest-connect-shipping-carrier-types-controller.php
@@ -61,4 +61,26 @@ class WP_Test_WC_REST_Connect_Shipping_Carrier_Types_Controller extends WC_Unit_
 		$this->assertEquals( 200, $actual->status );
 		$this->assertEquals( $api_client_response, $actual->data );
 	}
+
+	/**
+	 * Test error thrown during a GET request on connect/shipping/carrier-types end point.
+	 */
+	public function test_get_with_error() {
+		$api_response = new WP_Error( 'error_code_123', 'something is wrong' );
+
+		$this->api_client_mock->expects( $this->once() )
+			->method( 'request' )
+			->with( 'GET', '/shipping/carrier-types' )
+			->willReturn( $api_response );
+
+		$this->connect_logger_mock->expects( $this->once() )
+			->method( 'log' )
+			->with( $api_response, WC_REST_Connect_Shipping_Carrier_Types_Controller::class );
+
+		$wc_connect_shipping_carrier_types_controller = new WC_REST_Connect_Shipping_Carrier_Types_Controller( $this->api_client_mock, $this->setting_store_mock, $this->connect_logger_mock );
+		$actual                                       = $wc_connect_shipping_carrier_types_controller->get();
+
+		$this->assertInstanceOf( WP_Error::class, $actual );
+		$this->assertEquals( $api_response, $actual );
+	}
 }

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -149,6 +149,14 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		protected $rest_address_normalization_controller;
 
 		/**
+		 *
+		 * WC_REST_Connect_Shipping_Carrier_Types_Controller
+		 *
+		 * @var WC_REST_Connect_Shipping_Carrier_Types_Controller
+		 */
+		protected $rest_carrier_types_controller;
+
+		/**
 		 * @var WC_Connect_Service_Schemas_Validator
 		 */
 		protected $service_schemas_validator;
@@ -414,6 +422,14 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		public function set_rest_address_normalization_controller( WC_REST_Connect_Address_Normalization_Controller $rest_address_normalization_controller ) {
 			$this->rest_address_normalization_controller = $rest_address_normalization_controller;
+		}
+
+		public function set_carrier_types_controller( WC_REST_Connect_Shipping_Carrier_Types_Controller $rest_carrier_types_controller ) {
+			$this->rest_carrier_types_controller = $rest_carrier_types_controller;
+		}
+
+		public function get_carrier_types_controller() {
+			return $this->rest_carrier_types_controller;
 		}
 
 		public function get_service_schemas_validator() {
@@ -880,6 +896,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$rest_carrier_delete_controller = new WC_REST_Connect_Shipping_Carrier_Delete_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_carrier_delete_controller( $rest_carrier_delete_controller );
 			$rest_carrier_delete_controller->register_routes();
+
+			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-carrier-types-controller.php' ) );
+			$rest_carrier_types_controller = new WC_REST_Connect_Shipping_Carrier_Types_Controller( $this->api_client, $settings_store, $logger );
+			$this->set_carrier_types_controller( $rest_carrier_types_controller );
+			$rest_carrier_types_controller->register_routes();
 
 			if ( $this->stripe->is_stripe_plugin_enabled() ) {
 				require_once( plugin_basename( 'classes/class-wc-rest-connect-stripe-oauth-init-controller.php' ) );


### PR DESCRIPTION
## Description
This address the first bullet in https://github.com/Automattic/woocommerce-services/issues/2234. 
> Creating an endpoint in the plugin that can be used by the React front-end to get the fields from the Connect Server

### Related issue(s)
https://github.com/Automattic/woocommerce-services/issues/2234

### Steps to reproduce & screenshots/GIFs
_If you can't make a request directly to your own localhost WC API. Refer to the "Steps to test with manual WooCommerce API Client"._
1. Assumes `shipping/carrier-types` end point is available from the server. You can use this [PR](https://github.com/Automattic/woocommerce-connect-server/pull/1597) if needed.
2. Make a GET request to your localhost's WooCommerce Services API `https://localhost/wp-json/wc/v1/connect/shipping/carrier-types` 
3. You should see a a similar response back after applying `json_decode()`:
```
stdClass Object
(
    [carriers] => Array
        (
            [0] => stdClass Object
                (
                    [type] => DhlExpressAccount
                    [name] => DHL Express
                    [fields] => stdClass Object
                        (
                            [account_number] => stdClass Object
                                (
                                    [visibility] => visible
                                    [label] => DHL Account Number
                                )
...
```

### Steps to test with manual WooCommerce API Client
1. We will be using this https://docs.woocommerce.com/document/woocommerce-rest-api/ to make a completely separate script to make API calls.
1. Create a new folder `mkdir woocommerce-api-test`
2. `composer install automattic/woocommerce` ([link](https://packagist.org/packages/automattic/woocommerce))
3. vim `index.php` 
4. paste this in there
```
<?php

require __DIR__ . '/vendor/autoload.php';

use Automattic\WooCommerce\Client;

$woocommerce = new Client(
    'http://localhost',
    'ck_***', // this needs to be your own key
    'cs_***', // this needs to be your own secrets
    [
        'version' => 'wc/v1',
    ]
);

print_r($woocommerce->get('connect/shipping/carrier-types'));
```

5. For the keys and secrets, follow the instructions [here](https://docs.woocommerce.com/document/woocommerce-rest-api/). 
6. run `php index.php` in your console.
7. You should see the results back.
### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

