### PR TITLE
Remove second parameter from getenv for php5.3 compatability

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,7 +11,6 @@
 * Fix   - Update carrier name in tracking notification email.
 * Add   - Add pre-commit and pre-push git hooks for linting and unit tests.
 * Add   - Disable refunds for USPS letters.
-* Fix   - Issue with printing labels in some iOS devices through Safari.
 
 = 1.25.0 - 2020-10-13 =
 * Fix   - UPS connect redirect prompt

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Add   - Add pre-commit and pre-push git hooks for linting and unit tests.
 * Add   - Disable refunds for USPS letters.
 * Fix   - Issue with printing labels in some iOS devices through Safari.
+* Fix   - Prevents warning when using PHP 5.5 or lesser
 
 = 1.25.0 - 2020-10-13 =
 * Fix   - UPS connect redirect prompt

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -52,7 +52,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 	}
 
 	// Check for CI environment variable to trigger test mode.
-	if ( false !== getenv( 'WOOCOMMERCE_SERVICES_CI_TEST_MODE', true ) ) {
+	if ( false !== getenv( 'WOOCOMMERCE_SERVICES_CI_TEST_MODE' ) ) {
 		if ( ! defined( 'WOOCOMMERCE_SERVICES_LOCAL_TEST_MODE' ) ) {
 			define( 'WOOCOMMERCE_SERVICES_LOCAL_TEST_MODE', true );
 		}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
Our extension supports a minimum version of PHP 5.3; in versions of PHP less than 5.5 the function `getenv` only supports a single parameter: there is one instance of `getenv` with two parameters in our extension and this will cause a warning. 

`Warning: getenv() expects exactly 1 parameter, 2 given in woocommerce-services/woocommerce-services.php on line 55`

This fix removes that second parameter!

### Related issue(s)
Closes #2025 
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
As of WordPress 5.2, WordPress requires PHP 5.6 or greater, so you will need a version older than this to see this warning.

As of WooCommerce 3.8, WooCommerce also requires PHP 5.6 or greater, so you will need to use an older version of this extension.

As of Jetpack 8.4, Jetpack requires WordPress 5.3 or greater, so you will need to use an older version of this extension too.

If you can find the sweet spot for all of these deprecated tools to work together, you will be able to test to confirm that this warning no longer appears!

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

