### PR TITLE
Dynamically generate carrier registration forms

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.25.3 - 2020-**-** =
 * Add   - Initial code for WooCommerce.com subscriptions API.
 * Fix   - UI fix for input validation for package dimensions and weights.
+* Add   - Dynamic carrier registration form.
 
 = 1.25.2 - 2020-11-10 =
 * Tweak - Add ZIP code validation to UPS(beta) signup form.

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -98,6 +98,8 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 					case 'ups':
 						$translated_carrier_name = __( 'UPS', 'woocommerce-services' );
 						break;
+					case 'dhl':
+						$translated_carrier_name = __( 'DHL Express', 'woocommerce-services' );
 					default:
 						break;
 				}

--- a/client/apps/shipping-settings/view-wrapper.js
+++ b/client/apps/shipping-settings/view-wrapper.js
@@ -70,36 +70,36 @@ class LabelSettingsWrapper extends Component {
 	render() {
 		const { carrier, carriers, isSaving, siteId, translate } = this.props;
 
-		if ( carrier ) {
-			if ( carrier.toLowerCase() === 'ups' ) {
-				return (
-					<div>
-						<GlobalNotices id="notices" notices={ notices.list } />
-						<CarrierAccountSettings carrier={ carrier } />
-						<ProtectFormGuard isChanged={ ! this.state.pristine } />
-					</div>
-				);
-			} 
-				// Dynamically create registration form
-				return (
-					<div>
-						<GlobalNotices id="notices" notices={ notices.list } />
-						<DynamicCarrierAccountSettings carrier={ carrier } />
-						<ProtectFormGuard isChanged={ ! this.state.pristine } />
-					</div>
-				);
-			
-
+		if (!carrier) {
+			return (
+				<div>
+					<GlobalNotices id="notices" notices={ notices.list } />
+					<LabelSettings onChange={ this.onChange } />
+					<Packages onChange={ this.onChange } />
+					<CarrierAccounts siteId={ siteId } carriers={ carriers } onChange={ this.onChange } />
+					<Button primary onClick={ this.onSaveChanges } busy={ isSaving } disabled={ isSaving }>
+						{ translate( 'Save changes' ) }
+					</Button>
+					<ProtectFormGuard isChanged={ ! this.state.pristine } />
+				</div>
+			);
 		}
+
+		if ( carrier.toLowerCase() === 'ups' ) {
+			return (
+				<div>
+					<GlobalNotices id="notices" notices={ notices.list } />
+					<CarrierAccountSettings carrier={ carrier } />
+					<ProtectFormGuard isChanged={ ! this.state.pristine } />
+				</div>
+			);
+		}
+
+		// Dynamically create registration form
 		return (
 			<div>
 				<GlobalNotices id="notices" notices={ notices.list } />
-				<LabelSettings onChange={ this.onChange } />
-				<Packages onChange={ this.onChange } />
-				<CarrierAccounts siteId={ siteId } carriers={ carriers } onChange={ this.onChange } />
-				<Button primary onClick={ this.onSaveChanges } busy={ isSaving } disabled={ isSaving }>
-					{ translate( 'Save changes' ) }
-				</Button>
+				<DynamicCarrierAccountSettings carrier={ carrier } />
 				<ProtectFormGuard isChanged={ ! this.state.pristine } />
 			</div>
 		);

--- a/client/apps/shipping-settings/view-wrapper.js
+++ b/client/apps/shipping-settings/view-wrapper.js
@@ -70,7 +70,7 @@ class LabelSettingsWrapper extends Component {
 	render() {
 		const { carrier, carriers, isSaving, siteId, translate } = this.props;
 
-		if (!carrier) {
+		if ( ! carrier ) {
 			return (
 				<div>
 					<GlobalNotices id="notices" notices={ notices.list } />

--- a/client/apps/shipping-settings/view-wrapper.js
+++ b/client/apps/shipping-settings/view-wrapper.js
@@ -17,6 +17,7 @@ import notices from 'notices';
 import Packages from '../../extensions/woocommerce/woocommerce-services/views/packages';
 import CarrierAccounts from '../../extensions/woocommerce/woocommerce-services/views/carrier-accounts';
 import CarrierAccountSettings from '../../extensions/woocommerce/woocommerce-services/views/carrier-accounts/settings';
+import DynamicCarrierAccountSettings from '../../extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings';
 import { ProtectFormGuard } from 'lib/protect-form';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { createWcsShippingSaveActionList } from '../../extensions/woocommerce/woocommerce-services/state/actions';
@@ -70,13 +71,25 @@ class LabelSettingsWrapper extends Component {
 		const { carrier, carriers, isSaving, siteId, translate } = this.props;
 
 		if ( carrier ) {
-			return (
-				<div>
-					<GlobalNotices id="notices" notices={ notices.list } />
-					<CarrierAccountSettings carrier={ carrier } />
-					<ProtectFormGuard isChanged={ ! this.state.pristine } />
-				</div>
-			);
+			if ( carrier.toLowerCase() === 'ups' ) {
+				return (
+					<div>
+						<GlobalNotices id="notices" notices={ notices.list } />
+						<CarrierAccountSettings carrier={ carrier } />
+						<ProtectFormGuard isChanged={ ! this.state.pristine } />
+					</div>
+				);
+			} 
+				// Dynamically create registration form
+				return (
+					<div>
+						<GlobalNotices id="notices" notices={ notices.list } />
+						<DynamicCarrierAccountSettings carrier={ carrier } />
+						<ProtectFormGuard isChanged={ ! this.state.pristine } />
+					</div>
+				);
+			
+
 		}
 		return (
 			<div>

--- a/client/extensions/woocommerce/woocommerce-services/api/url.js
+++ b/client/extensions/woocommerce/woocommerce-services/api/url.js
@@ -12,3 +12,4 @@ export const serviceSettings = ( methodId, instanceId = 0 ) => `connect/services
 export const shippingCarrier = () => 'connect/shipping/carrier';
 export const shippingCarriers = () => 'connect/shipping/carriers';
 export const shippingCarrierDelete = ( carrier ) => `connect/shipping/carrier/${ carrier }`;
+export const shippingCarrierTypes = () => 'connect/shipping/carrier-types';

--- a/client/extensions/woocommerce/woocommerce-services/state/carrier-accounts/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/carrier-accounts/actions.js
@@ -93,8 +93,3 @@ export const submitCarrierSettings = ( siteId, carrier, values ) => ( dispatch )
 			dispatch( errorNotice( translate( 'There was an error connecting to your UPS account. Please check that all of the information entered matches your UPS account and try to connect again.' ) ) );
 		} );
 };
-
-export const getCarrierRegistrationFields = ( siteId ) => () => {
-	return api.get(siteId, api.url.shippingCarrierTypes())
-	.then( carrierTypesResponse => carrierTypesResponse)
-};

--- a/client/extensions/woocommerce/woocommerce-services/state/carrier-accounts/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/carrier-accounts/actions.js
@@ -93,3 +93,8 @@ export const submitCarrierSettings = ( siteId, carrier, values ) => ( dispatch )
 			dispatch( errorNotice( translate( 'There was an error connecting to your UPS account. Please check that all of the information entered matches your UPS account and try to connect again.' ) ) );
 		} );
 };
+
+export const getCarrierRegistrationFields = ( siteId ) => () => {
+	return api.get(siteId, api.url.shippingCarrierTypes())
+	.then( carrierTypesResponse => carrierTypesResponse)
+};

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings-form.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings-form.js
@@ -62,22 +62,22 @@ const FormFieldFactory = ( { visibility, label, id, value, onChange } ) => {
 
 export const DynamicCarrierAccountSettingsForm = ( props ) => {
 	const {
-        translate,
+		translate,
 		siteId,
 		carrierType,
 		noticeActions,
 		carrierName,
-    } = props;
+	} = props;
 
-    const [formValues, setFormValues] = useState({});
-    const [isSaving, setIsSaving] = useState(false);
+	const [formValues, setFormValues] = useState({});
+	const [isSaving, setIsSaving] = useState(false);
 
-    const handleFormFieldChange = useCallback((id, newValue) => {
-    	setFormValues((oldValues) => ({
-    		...oldValues,
-		    [id]: newValue,
-	    }))
-    }, [setFormValues]);
+	const handleFormFieldChange = useCallback((id, newValue) => {
+		setFormValues((oldValues) => ({
+			...oldValues,
+			[id]: newValue,
+		}))
+	}, [setFormValues]);
 
 	const handleSubmit = useCallback( () => {
 		const submit = async () => {
@@ -98,69 +98,69 @@ export const DynamicCarrierAccountSettingsForm = ( props ) => {
 		submit();
 	}, [isSaving, setIsSaving, siteId, carrierType, formValues, noticeActions] );
 
-    const handleCancel = useCallback(() => {
-        history.back();
-    }, []);
+	const handleCancel = useCallback(() => {
+		history.back();
+	}, []);
 
-    return (
-        <div className="carrier-accounts__settings-container">
+	return (
+		<div className="carrier-accounts__settings-container">
 			<div className="carrier-accounts__settings">
 				<div className="carrier-accounts__settings-info">
 					<h4 className="carrier-accounts__settings-subheader-above-description">
 						{ translate( 'Connect your %(carrierName)s account', {
-                            args: {
-                                carrierName,
-                            }
-                        } ) }
+							args: {
+								carrierName,
+							}
+						} ) }
 					</h4>
 					<p className="carrier-accounts__settings-subheader-description">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam et dolor quam.
+					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam et dolor quam.
 					</p>
 				</div>
 				<div className="carrier-accounts__settings-form">
-                    <CompactCard>
-                        <h4 className="carrier-accounts__settings-subheader">General Information</h4>
-                        <p className="carrier-accounts__settings-subheader-description">
-                            { translate( 'This is the account number and address from your %(carrierName)s profile', {
-                            args: {
-                                carrierName,
-                            }
-                        } ) }
-                        </p>
-                    </CompactCard>
+					<CompactCard>
+					<h4 className="carrier-accounts__settings-subheader">{ translate ( 'General Information' ) }</h4>
+						<p className="carrier-accounts__settings-subheader-description">
+						{ translate( 'This is the account number and address from your %(carrierName)s profile', {
+							args: {
+								carrierName,
+							}
+						} ) }
+						</p>
+					</CompactCard>
 
-                    <CompactCard>
-                        {props.registrationFields && Object.entries(props.registrationFields).map( ( [key, field] ) => (
-                        	<FormFieldFactory key={key} id={key} visibility={field.visibility} label={field.label} value={formValues[key]} onChange={handleFormFieldChange} />
-                        ))}
-                    </CompactCard>
+					<CompactCard>
+						{props.registrationFields && Object.entries(props.registrationFields).map( ( [key, field] ) => (
+							<FormFieldFactory key={key} id={key} visibility={field.visibility} label={field.label} value={formValues[key]} onChange={handleFormFieldChange} />
+						))}
+					</CompactCard>
 
-                    <CompactCard className="carrier-accounts__settings-actions">
+					<CompactCard className="carrier-accounts__settings-actions">
 						<Button
 							compact
 							primary
-                            onClick={ handleSubmit }
-                            disabled={ isSaving }
-                        >
+							onClick={ handleSubmit }
+							disabled={ isSaving }
+						>
 							{ translate( 'Connect' ) }
 						</Button>
-                        <Button
-                            compact
-                            onClick={ handleCancel }
-                        >
+						<Button
+							compact
+							onClick={ handleCancel }
+						>
 							{ translate( 'Cancel' ) }
 						</Button>
 					</CompactCard>
-                </div>
-            </div>
-        </div>
+				</div>
+			</div>
+		</div>
 	);
 };
 
 const mapStateToProps = ( state ) => {
 	return {
 		siteId: getSelectedSiteId( state ),
-    };
+	};
 };
 
 const mapDispatchToProps = ( dispatch ) => ({
@@ -168,11 +168,11 @@ const mapDispatchToProps = ( dispatch ) => ({
 });
 
 DynamicCarrierAccountSettingsForm.propTypes = {
-    carrierType: PropTypes.string,
-    carrierName: PropTypes.string,
-    registrationFields: PropTypes.object,
-    siteId: PropTypes.number,
-    translate: PropTypes.func,
+	carrierType: PropTypes.string,
+	carrierName: PropTypes.string,
+	registrationFields: PropTypes.object,
+	siteId: PropTypes.number,
+	translate: PropTypes.func,
 };
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( DynamicCarrierAccountSettingsForm ) );

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings-form.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings-form.js
@@ -62,16 +62,6 @@ export const DynamicCarrierAccountSettingsForm = ( props ) => {
         let formComponent;
 
         switch (visibility) {
-            case 'password':
-                // TODO: We will need to create a PasswordField component
-                formComponent = <TextField
-                    id={ fieldKey }
-                    key={ fieldKey }
-                    title={ labelName }
-                    updateValue={ updateValue( fieldKey ) }
-                    value={formFields[fieldKey]||""}
-                />;
-                break;
             case 'select':
             case 'checkbox':
                 formComponent = <CheckboxFormFieldSet
@@ -86,7 +76,9 @@ export const DynamicCarrierAccountSettingsForm = ( props ) => {
             case 'invisible':
             case 'masked':
             case 'readonly':
-                // TODO: We will need to handle these invisible/readonly fields separately. For now, use default.
+                // TODO: We will need to handle the above invisible/readonly fields separately. For now, use default.
+            case 'password':
+                // TODO: We will need to create a PasswordField component, for now, use default.
             case 'visible':
             default:
                 formComponent = <TextField

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings-form.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings-form.js
@@ -1,0 +1,103 @@
+/** @format */
+/* eslint-disable */
+
+/**
+ * External dependencies
+ */
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import CompactCard from 'components/card/compact';
+import Dialog from 'components/dialog';
+import Dropdown from 'woocommerce/woocommerce-services/components/dropdown';
+import Checkbox from 'woocommerce/woocommerce-services/components/checkbox';
+import TextField from 'woocommerce/woocommerce-services/components/text-field';
+import {
+	getDestinationCountryNames,
+	getStateNames,
+} from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
+import {
+	getCarrierAccountsState,
+	getFormErrors,
+	getFormValidState,
+} from 'woocommerce/woocommerce-services/state/carrier-accounts/selectors';
+import {
+	getCarrierRegistrationFields
+} from 'woocommerce/woocommerce-services/state/carrier-accounts/actions';
+import { getCountryName } from 'woocommerce/state/sites/data/locations/selectors';
+import { decodeEntities } from 'lib/formatting';
+import * as api from 'woocommerce/woocommerce-services/api';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { forEach } from 'lodash';
+
+const FormFieldSet = ( props ) => {
+    return (
+        <div className="card carrier-accounts__settings-account-number is-compact">
+            <fieldset className="form-fieldset">
+                <label htmlFor={props.labelKey} className="form-label">{props.labelName}</label>
+                <input type={props.inputType} id={props.labelKey} name={props.labelKey} className="form-text-input" value="" />
+            </fieldset>
+        </div>
+    );
+};
+
+export const DynamicCarrierAccountSettingsForm = ( props ) => {
+	const {
+        carrierType,
+        carrierName,
+        registrationFields,
+		siteId,
+    } = props;
+
+    const listOfFormFieldSet = [];
+
+    console.log("re-render=>>>", props);
+    if (props.registrationFields) {
+        const listOfFields = Object.keys(props.registrationFields);
+        listOfFields.forEach( fieldKey => {
+            const inputType = props.registrationFields[fieldKey].visibility === 'visible' ? 'text' : 'password';
+            listOfFormFieldSet.push(
+                <FormFieldSet
+                    labelName={props.registrationFields[fieldKey].label}
+                    labelKey={fieldKey}
+                    inputType={inputType}
+                />
+            );
+        });
+    }
+
+    return (
+		<div className="carrier-accounts__settings-form">
+            <div className="card is-compact">
+                <h4 className="carrier-accounts__settings-subheader">General Information</h4>
+                <p className="carrier-accounts__settings-subheader-description">This is the account number and address from your UPS profile</p>
+            </div>
+
+            {listOfFormFieldSet}
+		</div>
+	);
+};
+
+const mapStateToProps = ( state ) => {
+	return {
+		siteId: getSelectedSiteId( state ),
+    };
+};
+
+const mapDispatchToProps = ( dispatch, {siteId} ) => ( {
+} );
+
+DynamicCarrierAccountSettingsForm.propTypes = {
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( DynamicCarrierAccountSettingsForm ) );
+
+/* eslint-enable */

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings-form.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings-form.js
@@ -38,51 +38,134 @@ import * as api from 'woocommerce/woocommerce-services/api';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { forEach } from 'lodash';
 
-const FormFieldSet = ( props ) => {
+const CheckboxFormFieldSet = ( props ) => {
+    const changeHandler = () => {
+    };
+
     return (
-        <div className="card carrier-accounts__settings-account-number is-compact">
-            <fieldset className="form-fieldset">
-                <label htmlFor={props.labelKey} className="form-label">{props.labelName}</label>
-                <input type={props.inputType} id={props.labelKey} name={props.labelKey} className="form-text-input" value="" />
-            </fieldset>
-        </div>
+        <>
+            <Checkbox
+                id={ props.labelKey }
+                onChange={changeHandler}
+                checked={false}
+            />
+            <span>{props.labelName}</span>
+        </>
     );
 };
+
 
 export const DynamicCarrierAccountSettingsForm = ( props ) => {
 	const {
         carrierType,
         carrierName,
         registrationFields,
-		siteId,
+        siteId,
+        translate,
     } = props;
 
     const listOfFormFieldSet = [];
+
+    const getInputComponent = (props, fieldKey) => {
+        const visibility = props.registrationFields[fieldKey].visibility;
+        const labelName = props.registrationFields[fieldKey].label;
+        const labelKey = fieldKey;
+
+        let formComponent;
+
+        switch (visibility) {
+            case 'password':
+                formComponent = <TextField
+                    id={ labelKey }
+                    title={ translate( labelName ) }
+                    value=""
+                />;
+                break;
+            case 'select':
+            case 'checkbox':
+                formComponent = <CheckboxFormFieldSet
+                    labelKey={ labelKey }
+                    labelName={ translate( labelName ) }
+                />
+
+                break;
+            case 'visible':
+            case 'invisible':
+            case 'masked':
+            case 'readonly':
+            default:
+                formComponent = <TextField
+                    id={ labelKey }
+                    title={ translate( labelName ) }
+                    value=""
+                />
+                break;
+        }
+        return formComponent;
+    };
+
+    const submitCarrierSettingsHandler = () => {
+        //TODO: Call register end point
+    }
+
+    const showCancelDialogHandler = () => {
+        //TODO: when clicked cancel
+    }
 
     console.log("re-render=>>>", props);
     if (props.registrationFields) {
         const listOfFields = Object.keys(props.registrationFields);
         listOfFields.forEach( fieldKey => {
-            const inputType = props.registrationFields[fieldKey].visibility === 'visible' ? 'text' : 'password';
-            listOfFormFieldSet.push(
-                <FormFieldSet
-                    labelName={props.registrationFields[fieldKey].label}
-                    labelKey={fieldKey}
-                    inputType={inputType}
-                />
-            );
+            const inputComponent = getInputComponent(props, fieldKey);
+            listOfFormFieldSet.push(inputComponent);
         });
     }
 
     return (
-		<div className="carrier-accounts__settings-form">
-            <div className="card is-compact">
-                <h4 className="carrier-accounts__settings-subheader">General Information</h4>
-                <p className="carrier-accounts__settings-subheader-description">This is the account number and address from your UPS profile</p>
-            </div>
+        <div className="carrier-accounts__settings-container">
+			<div className="carrier-accounts__settings">
+				<div className="carrier-accounts__settings-info">
+					<h4 className="carrier-accounts__settings-subheader-above-description">
+						{ translate( 'Connect your %(carrierName)s account', {
+                            args: {
+                                carrierName: props.carrierName
+                            }
+                        } ) }
+					</h4>
+					<p className="carrier-accounts__settings-subheader-description">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam et dolor quam.
+					</p>
+				</div>
+				<div className="carrier-accounts__settings-form">
+                    <CompactCard>
+                        <h4 className="carrier-accounts__settings-subheader">General Information</h4>
+                        <p className="carrier-accounts__settings-subheader-description">
+                            { translate( 'This is the account number and address from your %(carrierName)s profile', {
+                            args: {
+                                carrierName: props.carrierName
+                            }
+                        } ) }
+                        </p>
+                    </CompactCard>
 
-            {listOfFormFieldSet}
-		</div>
+                    <CompactCard>
+                        {listOfFormFieldSet}
+                    </CompactCard>
+
+                    <CompactCard className="carrier-accounts__settings-actions">
+						<Button
+							compact
+							primary
+							onClick={ submitCarrierSettingsHandler }>
+							{ translate( 'Connect' ) }
+						</Button>
+						<Button compact onClick={ showCancelDialogHandler }>
+							{ translate( 'Cancel' ) }
+						</Button>
+					</CompactCard>
+                </div>
+            </div>
+        </div>
 	);
 };
 

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings-form.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings-form.js
@@ -23,15 +23,12 @@ import * as api from 'woocommerce/woocommerce-services/api';
 import { errorNotice, successNotice } from 'state/notices/actions';
 
 const CheckboxFormFieldSet = ( props ) => {
-    const changeHandler = () => {
-    };
-
     return (
         <>
             <Checkbox
                 id={ props.labelKey }
-                onChange={changeHandler}
-                checked={false}
+                onChange={props.onChange}
+                checked={props.checked||false}
             />
             <span>{props.labelName}</span>
         </>
@@ -61,6 +58,12 @@ export const DynamicCarrierAccountSettingsForm = ( props ) => {
         setFormFields(formFieldsCopy);
     }
 
+    const toggleCheckbox = ( labelKey ) => () => {
+        const formFieldsCopy = {...formFields};
+        formFieldsCopy[labelKey] = !formFieldsCopy[labelKey];
+        setFormFields(formFieldsCopy);
+    };
+
     const getInputComponent = (props, fieldKey) => {
         const visibility = props.registrationFields[fieldKey].visibility;
         const labelName = props.registrationFields[fieldKey].label;
@@ -85,6 +88,8 @@ export const DynamicCarrierAccountSettingsForm = ( props ) => {
                     key={ labelKey }
                     labelKey={ labelKey }
                     labelName={ translate( labelName ) }
+                    onChange={toggleCheckbox(labelKey)}
+                    checked={formFields[labelKey]}
                 />
 
                 break;

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings-form.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings-form.js
@@ -1,15 +1,13 @@
 /** @format */
-/* eslint-disable */
 
 /**
  * External dependencies
  */
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -26,21 +24,17 @@ const CheckboxFormFieldSet = ( props ) => {
     return (
         <>
             <Checkbox
-                id={ props.labelKey }
+                id={ props.fieldKey }
                 onChange={props.onChange}
                 checked={props.checked||false}
             />
-            <span>{props.labelName}</span>
+            <label htmlFor={ props.fieldKey }><span>{props.labelName}</span></label>
         </>
     );
 };
 
 export const DynamicCarrierAccountSettingsForm = ( props ) => {
 	const {
-        carrierType,
-        carrierName,
-        registrationFields,
-        siteId,
         translate,
     } = props;
 
@@ -49,25 +43,21 @@ export const DynamicCarrierAccountSettingsForm = ( props ) => {
     const [formFields, setFormFields] = useState({});
     const [isSaving, setIsSaving] = useState(false);
 
-    /**
-     * Update the state for given form's fieldKey.
-     */
-    const updateValue = ( labelKey ) => ( newValue ) => {
+    const updateValue = ( fieldKey ) => ( newValue ) => {
         const formFieldsCopy = {...formFields};
-        formFieldsCopy[labelKey] = newValue;
+        formFieldsCopy[fieldKey] = newValue;
         setFormFields(formFieldsCopy);
     }
 
-    const toggleCheckbox = ( labelKey ) => () => {
+    const toggleCheckbox = ( fieldKey ) => () => {
         const formFieldsCopy = {...formFields};
-        formFieldsCopy[labelKey] = !formFieldsCopy[labelKey];
+        formFieldsCopy[fieldKey] = !formFieldsCopy[fieldKey];
         setFormFields(formFieldsCopy);
     };
 
-    const getInputComponent = (props, fieldKey) => {
+    const getInputComponent = (fieldKey) => {
         const visibility = props.registrationFields[fieldKey].visibility;
         const labelName = props.registrationFields[fieldKey].label;
-        const labelKey = fieldKey;
 
         let formComponent;
 
@@ -75,21 +65,21 @@ export const DynamicCarrierAccountSettingsForm = ( props ) => {
             case 'password':
                 // TODO: We will need to create a PasswordField component
                 formComponent = <TextField
-                    id={ labelKey }
-                    key={ labelKey }
-                    title={ translate( labelName ) }
-                    updateValue={ updateValue( labelKey ) }
-                    value={formFields[labelKey]||""}
+                    id={ fieldKey }
+                    key={ fieldKey }
+                    title={ labelName }
+                    updateValue={ updateValue( fieldKey ) }
+                    value={formFields[fieldKey]||""}
                 />;
                 break;
             case 'select':
             case 'checkbox':
                 formComponent = <CheckboxFormFieldSet
-                    key={ labelKey }
-                    labelKey={ labelKey }
-                    labelName={ translate( labelName ) }
-                    onChange={toggleCheckbox(labelKey)}
-                    checked={formFields[labelKey]}
+                    key={ fieldKey }
+                    fieldKey={ fieldKey }
+                    labelName={ labelName }
+                    onChange={toggleCheckbox(fieldKey)}
+                    checked={formFields[fieldKey]}
                 />
 
                 break;
@@ -100,11 +90,11 @@ export const DynamicCarrierAccountSettingsForm = ( props ) => {
             case 'visible':
             default:
                 formComponent = <TextField
-                    id={ labelKey }
-                    key={ labelKey }
-                    title={ translate( labelName ) }
-                    updateValue={ updateValue( labelKey ) }
-                    value={formFields[labelKey]||""}
+                    id={ fieldKey }
+                    key={ fieldKey }
+                    title={ labelName }
+                    updateValue={ updateValue( fieldKey ) }
+                    value={formFields[fieldKey]||""}
                 />
                 break;
         }
@@ -114,7 +104,7 @@ export const DynamicCarrierAccountSettingsForm = ( props ) => {
     const submitCarrierSettingsHandler = async () => {
         setIsSaving(true);
         try {
-            const apiPost = await api.post( props.siteId, api.url.shippingCarrier(), {
+            await api.post( props.siteId, api.url.shippingCarrier(), {
                 type: props.carrierType,
                 settings: formFields
             } );
@@ -131,7 +121,7 @@ export const DynamicCarrierAccountSettingsForm = ( props ) => {
     if (props.registrationFields) {
         const listOfFields = Object.keys(props.registrationFields);
         listOfFields.forEach( fieldKey => {
-            const inputComponent = getInputComponent(props, fieldKey);
+            const inputComponent = getInputComponent(fieldKey);
             listOfFormFieldSet.push(inputComponent);
         });
     }
@@ -199,9 +189,19 @@ const mapDispatchToProps = ( dispatch ) => ({
 	noticeActions: bindActionCreators( { successNotice, errorNotice }, dispatch ),
 });
 
+CheckboxFormFieldSet.propTypes = {
+    fieldKey: PropTypes.string,
+    labelName: PropTypes.string,
+    onChange: PropTypes.func,
+    checked: PropTypes.bool,
+};
+
 DynamicCarrierAccountSettingsForm.propTypes = {
+    carrierType: PropTypes.string,
+    carrierName: PropTypes.string,
+    registrationFields: PropTypes.object,
+    siteId: PropTypes.number,
+    translate: PropTypes.func,
 };
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( DynamicCarrierAccountSettingsForm ) );
-
-/* eslint-enable */

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings-form.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings-form.js
@@ -20,7 +20,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import * as api from 'woocommerce/woocommerce-services/api';
 import { errorNotice, successNotice } from 'state/notices/actions';
 
-const CheckboxFormFieldSet = ( props ) => {
+export const CheckboxFormFieldSet = ( props ) => {
     return (
         <>
             <Checkbox

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings-form.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings-form.js
@@ -25,10 +25,10 @@ export const CheckboxFormFieldSet = ( props ) => {
         <>
             <Checkbox
                 id={ props.fieldKey }
-                onChange={props.onChange}
-                checked={props.checked||false}
+                onChange={ props.onChange }
+                checked={ props.checked || false }
             />
-            <label htmlFor={ props.fieldKey }><span>{props.labelName}</span></label>
+            <label htmlFor={ props.fieldKey }><span>{ props.labelName }</span></label>
         </>
     );
 };

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
@@ -1,0 +1,75 @@
+/** @format */
+/* eslint-disable */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import CompactCard from 'components/card/compact';
+import Dialog from 'components/dialog';
+import Dropdown from 'woocommerce/woocommerce-services/components/dropdown';
+import Checkbox from 'woocommerce/woocommerce-services/components/checkbox';
+import TextField from 'woocommerce/woocommerce-services/components/text-field';
+import {
+	getDestinationCountryNames,
+	getStateNames,
+} from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
+import {
+	getCarrierAccountsState,
+	getFormErrors,
+	getFormValidState,
+} from 'woocommerce/woocommerce-services/state/carrier-accounts/selectors';
+import {
+	setVisibilityCancelConnectionDialog,
+	submitCarrierSettings,
+	updateCarrierSettings,
+	toggleShowUPSInvoiceFields,
+} from 'woocommerce/woocommerce-services/state/carrier-accounts/actions';
+import { getCountryName } from 'woocommerce/state/sites/data/locations/selectors';
+import { decodeEntities } from 'lib/formatting';
+
+export const DynamicCarrierAccountSettings = ( props ) => {
+	const {
+		carrier,
+		countryNames,
+		fieldErrors,
+		isConnectionSuccess,
+		isFormValid,
+		isSaving,
+		showCancelConnectionDialog,
+		showUPSInvoiceFields,
+		siteId,
+		stateNames,
+		translate,
+		values,
+	} = props;
+
+    return (
+		<div>
+            Hello world
+		</div>
+	);
+};
+
+const mapStateToProps = ( state ) => {
+	return {
+    };
+};
+
+DynamicCarrierAccountSettings.propTypes = {
+	carrier: PropTypes.string.isRequired,
+};
+
+export default connect( mapStateToProps )( localize( DynamicCarrierAccountSettings ) );
+
+/* eslint-enable */

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
@@ -41,7 +41,7 @@ export const DynamicCarrierAccountSettings = ( props ) => {
 
 	const apiResponseCarrierName = carrierNameMapper[props.carrier.toLowerCase()];
 
-	if (!apiResponseCarrierName && Object.keys(apiResponseCarrierName).length > 0) {
+	if (!apiResponseCarrierName) {
 		return (
 			<div>{props.carrier} not supported.</div>
 		);

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
@@ -20,15 +20,6 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import DynamicCarrierAccountSettingsForm from './dynamic-settings-form';
 
 export const DynamicCarrierAccountSettings = ( props ) => {
-	/**
-	 * This maps the URL querystring to the API response name for the carrier.
-	 * Keys are in lowercase.
-	 */
-	const carrierNameMapper = {
-		dhl: 'DhlExpressAccount',
-		ups: 'UpsAccount'
-	};
-
 	const [carrierRegistrationFields, setCarrierRegistrationFields] = useState([]);
 
 	useEffect(() => {
@@ -39,21 +30,21 @@ export const DynamicCarrierAccountSettings = ( props ) => {
 		fetchRegistrationFields();
 	}, [props.siteId]);
 
-	const apiResponseCarrierName = carrierNameMapper[props.carrier.toLowerCase()];
-
-	if (!apiResponseCarrierName) {
-		return (
-			<div>{props.carrier} not supported.</div>
-		);
-	}
-
 	if (!carrierRegistrationFields || carrierRegistrationFields.length < 1) {
 		return (
 			<div>Loading...</div>
 		);
 	}
 
-	const currentCarrierRegistrationField = carrierRegistrationFields.filter(carrier => carrier.type === apiResponseCarrierName)[0];
+	const supportedCarriers = carrierRegistrationFields.filter(carrier => carrier.type === props.carrier);
+
+	if (!supportedCarriers || supportedCarriers.length === 0) {
+		return (
+			<div>{props.carrier} not supported.</div>
+		);
+	}
+
+	const currentCarrierRegistrationField = supportedCarriers[0];
 
     return (
 		<div>

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
@@ -82,6 +82,7 @@ export const DynamicCarrierAccountSettings = ( props ) => {
     return (
 		<div>
 			<DynamicCarrierAccountSettingsForm
+				carrier={props.carrier}
 				carrierType={currentCarrierRegistrationField.type}
 				carrierName={currentCarrierRegistrationField.name}
 				registrationFields={currentCarrierRegistrationField.fields}

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
@@ -30,10 +30,7 @@ import {
 	getFormValidState,
 } from 'woocommerce/woocommerce-services/state/carrier-accounts/selectors';
 import {
-	setVisibilityCancelConnectionDialog,
-	submitCarrierSettings,
-	updateCarrierSettings,
-	toggleShowUPSInvoiceFields,
+	getCarrierRegistrationFields
 } from 'woocommerce/woocommerce-services/state/carrier-accounts/actions';
 import { getCountryName } from 'woocommerce/state/sites/data/locations/selectors';
 import { decodeEntities } from 'lib/formatting';
@@ -41,22 +38,18 @@ import { decodeEntities } from 'lib/formatting';
 export const DynamicCarrierAccountSettings = ( props ) => {
 	const {
 		carrier,
-		countryNames,
-		fieldErrors,
-		isConnectionSuccess,
-		isFormValid,
-		isSaving,
-		showCancelConnectionDialog,
-		showUPSInvoiceFields,
 		siteId,
-		stateNames,
-		translate,
-		values,
 	} = props;
 
     return (
 		<div>
             Hello world
+            <Button
+				onClick={ props.getCarrierRegistrationFields }
+				primary
+			>
+            Click to retrieve registration fields
+            </Button>
 		</div>
 	);
 };
@@ -66,10 +59,14 @@ const mapStateToProps = ( state ) => {
     };
 };
 
+const mapDispatchToProps = ( dispatch, {siteId} ) => ( {
+	getCarrierRegistrationFields: () => dispatch( getCarrierRegistrationFields( siteId ) ),
+} );
+
 DynamicCarrierAccountSettings.propTypes = {
 	carrier: PropTypes.string.isRequired,
 };
 
-export default connect( mapStateToProps )( localize( DynamicCarrierAccountSettings ) );
+export default connect( mapStateToProps, mapDispatchToProps )( localize( DynamicCarrierAccountSettings ) );
 
 /* eslint-enable */

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
@@ -17,6 +17,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import DynamicCarrierAccountSettingsForm from './dynamic-settings-form';
 
 export const DynamicCarrierAccountSettings = ( props ) => {
+	const { translate } = props;
 	const [carrierRegistrationFields, setCarrierRegistrationFields] = useState([]);
 
 	useEffect(() => {
@@ -27,9 +28,9 @@ export const DynamicCarrierAccountSettings = ( props ) => {
 		fetchRegistrationFields();
 	}, [props.siteId]);
 
-	if (!carrierRegistrationFields || carrierRegistrationFields.length < 1) {
+	if ( ! carrierRegistrationFields || carrierRegistrationFields.length < 1) {
 		return (
-			<div>Loading...</div>
+			<div>{ translate( 'Loading' ) }...</div>
 		);
 	}
 
@@ -37,7 +38,13 @@ export const DynamicCarrierAccountSettings = ( props ) => {
 
 	if (!currentCarrierRegistrationField) {
 		return (
-			<div>{props.carrier} not supported.</div>
+			<div>
+			{ translate( '%(carrierName)s not supported.', {
+				args: {
+					carrierName: props.carrier,
+				}
+			} ) }
+			</div>
 		);
 	}
 

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
@@ -12,9 +12,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import {
-	getCarrierRegistrationFields
-} from 'woocommerce/woocommerce-services/state/carrier-accounts/actions';
 import * as api from 'woocommerce/woocommerce-services/api';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import DynamicCarrierAccountSettingsForm from './dynamic-settings-form';
@@ -61,13 +58,9 @@ const mapStateToProps = ( state ) => {
     };
 };
 
-const mapDispatchToProps = ( dispatch, {siteId} ) => ( {
-	getCarrierRegistrationFields: () => dispatch( getCarrierRegistrationFields( siteId ) ),
-} );
-
 DynamicCarrierAccountSettings.propTypes = {
 	carrier: PropTypes.string.isRequired,
 	siteId: PropTypes.number
 };
 
-export default connect( mapStateToProps, mapDispatchToProps )( localize( DynamicCarrierAccountSettings ) );
+export default connect( mapStateToProps )( localize( DynamicCarrierAccountSettings ) );

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
@@ -1,5 +1,4 @@
 /** @format */
-/* eslint-disable */
 
 /**
  * External dependencies
@@ -7,43 +6,20 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+
 
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
-import CompactCard from 'components/card/compact';
-import Dialog from 'components/dialog';
-import Dropdown from 'woocommerce/woocommerce-services/components/dropdown';
-import Checkbox from 'woocommerce/woocommerce-services/components/checkbox';
-import TextField from 'woocommerce/woocommerce-services/components/text-field';
-import {
-	getDestinationCountryNames,
-	getStateNames,
-} from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
-import {
-	getCarrierAccountsState,
-	getFormErrors,
-	getFormValidState,
-} from 'woocommerce/woocommerce-services/state/carrier-accounts/selectors';
 import {
 	getCarrierRegistrationFields
 } from 'woocommerce/woocommerce-services/state/carrier-accounts/actions';
-import { getCountryName } from 'woocommerce/state/sites/data/locations/selectors';
-import { decodeEntities } from 'lib/formatting';
 import * as api from 'woocommerce/woocommerce-services/api';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import DynamicCarrierAccountSettingsForm from './dynamic-settings-form';
 
 export const DynamicCarrierAccountSettings = ( props ) => {
-	const {
-		carrier,
-		siteId,
-	} = props;
-
 	/**
 	 * This maps the URL querystring to the API response name for the carrier.
 	 * Keys are in lowercase.
@@ -103,8 +79,7 @@ const mapDispatchToProps = ( dispatch, {siteId} ) => ( {
 
 DynamicCarrierAccountSettings.propTypes = {
 	carrier: PropTypes.string.isRequired,
+	siteId: PropTypes.number
 };
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( DynamicCarrierAccountSettings ) );
-
-/* eslint-enable */

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
@@ -4,7 +4,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -34,12 +34,24 @@ import {
 } from 'woocommerce/woocommerce-services/state/carrier-accounts/actions';
 import { getCountryName } from 'woocommerce/state/sites/data/locations/selectors';
 import { decodeEntities } from 'lib/formatting';
+import * as api from 'woocommerce/woocommerce-services/api';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 export const DynamicCarrierAccountSettings = ( props ) => {
 	const {
 		carrier,
 		siteId,
 	} = props;
+
+	const [carrierRegistrationFields, setCarrierRegistrationFields] = useState({});
+
+	useEffect(() => {
+		const fetchRegistrationFields = async () => {
+			const registrationFields = await api.get(props.siteId, api.url.shippingCarrierTypes());
+			setCarrierRegistrationFields(registrationFields);
+		}
+		fetchRegistrationFields();
+	}, [props.siteId]);
 
     return (
 		<div>
@@ -56,6 +68,7 @@ export const DynamicCarrierAccountSettings = ( props ) => {
 
 const mapStateToProps = ( state ) => {
 	return {
+		siteId: getSelectedSiteId( state ),
     };
 };
 

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
@@ -58,7 +58,6 @@ export const DynamicCarrierAccountSettings = ( props ) => {
     return (
 		<div>
 			<DynamicCarrierAccountSettingsForm
-				carrier={props.carrier}
 				carrierType={currentCarrierRegistrationField.type}
 				carrierName={currentCarrierRegistrationField.name}
 				registrationFields={currentCarrierRegistrationField.fields}

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
@@ -36,15 +36,13 @@ export const DynamicCarrierAccountSettings = ( props ) => {
 		);
 	}
 
-	const supportedCarriers = carrierRegistrationFields.filter(carrier => carrier.type === props.carrier);
+	const [ currentCarrierRegistrationField ] = carrierRegistrationFields.filter(carrier => carrier.type === props.carrier);
 
-	if (!supportedCarriers || supportedCarriers.length === 0) {
+	if (!currentCarrierRegistrationField) {
 		return (
 			<div>{props.carrier} not supported.</div>
 		);
 	}
-
-	const currentCarrierRegistrationField = supportedCarriers[0];
 
     return (
 		<div>

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings-form.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings-form.js
@@ -1,0 +1,104 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { configure, shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import CompactCard from 'components/card/compact';
+import TextField from 'woocommerce/woocommerce-services/components/text-field';
+import * as api from 'woocommerce/woocommerce-services/api';
+import { spy } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { DynamicCarrierAccountSettingsForm, CheckboxFormFieldSet } from '../dynamic-settings-form.js';
+
+configure( { adapter: new Adapter() } );
+
+function createCarrierAccountsWrapper() {
+	const props = {
+		siteId: 1234,
+		translate: ( text ) => text,
+        carrierType: 'DhlExpressAccount',
+        carrierName: 'DHL Express',
+        registrationFields: {
+            "account_number": {
+                "visibility": "visible",
+                "label": "DHL Account Number"
+            },
+            "country": {
+                "visibility": "visible",
+                "label": "Account Country Code (2 Letter)"
+            },
+            "is_reseller": {
+                "visibility": "checkbox",
+                "label": "Reseller Account? (check if yes)"
+            }
+        }
+	};
+
+	return shallow( <DynamicCarrierAccountSettingsForm { ...props } /> );
+}
+
+describe( 'Carrier Account Dynamic Registration Form', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+      });
+
+	describe( 'with the correct sub-components', () => {
+        const wrapper = createCarrierAccountsWrapper();
+		it( 'renders 3 fields from the provided props', function () {
+			expect(wrapper.find( CompactCard )).to.have.lengthOf(3);
+        } );
+
+        it( 'renders 2 visible fields as TextField', function () {
+			expect(wrapper.find( TextField )).to.have.lengthOf(2);
+        } );
+
+        it( 'renders 1 checkbox fields as Checkbox', function () {
+			expect(wrapper.find( CheckboxFormFieldSet )).to.have.lengthOf(1);
+		} );
+    } );
+
+    describe( 'should submit the form when data are input into the fields', () => {
+        const wrapper = createCarrierAccountsWrapper();
+        const apiPostSpy = spy(api, 'post');
+
+        /**
+         * Note. We uses ShallowMount and we are not able to simulate text typing into <TextField>
+         * because it doesn't listen to "change" event, nor any React's SyntheticEvent.
+         * We could not use Enzyme.mount either because <TextField> uses Calypso's FormTextInput, which
+         * uses the deprecated "refs" in function component. As a reuslt, Enzyme fails to mount and can
+         * only do shallow mount here.
+         *
+         * ref: woocommerce-services/wp-calypso/client/components/forms/form-text-input/index.jsx
+         */
+        // wrapper.find( '#account_number' ).simulate('change', {target: {
+        //     value: 'A123456'
+        // }});
+        // wrapper.find( '#country' ).simulate('change', {target: {
+        //     value: 'US'
+        // }});
+        wrapper.find( CheckboxFormFieldSet ).simulate('change', {target: {
+            checked: true
+        }});
+
+        // Click the register button
+        wrapper.find( '.carrier-accounts__settings-actions' ).children().first().simulate('click');
+
+        // Expect API to be called
+        expect(apiPostSpy.called).to.be.true;
+        expect(apiPostSpy).to.have.been.calledWith(1234, 'connect/shipping/carrier', {
+            type: 'DhlExpressAccount',
+            settings: {
+                // account_number: 'A123456',
+                // country: 'US',
+                is_reseller: true
+            }
+        });
+    } );
+} );

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings-form.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings-form.js
@@ -8,13 +8,14 @@ import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import CompactCard from 'components/card/compact';
 import TextField from 'woocommerce/woocommerce-services/components/text-field';
+import Checkbox from 'woocommerce/woocommerce-services/components/checkbox';
 import * as api from 'woocommerce/woocommerce-services/api';
 import { act } from 'react-dom/test-utils';
 
 /**
  * Internal dependencies
  */
-import { DynamicCarrierAccountSettingsForm, CheckboxFormFieldSet } from '../dynamic-settings-form.js';
+import { DynamicCarrierAccountSettingsForm } from '../dynamic-settings-form.js';
 
 configure( { adapter: new Adapter() } );
 
@@ -69,7 +70,7 @@ describe( 'Carrier Account Dynamic Registration Form', () => {
         } );
 
         it( 'renders 1 checkbox fields as Checkbox', function () {
-			expect(wrapper.find( CheckboxFormFieldSet )).toHaveLength(1);
+			expect(wrapper.find( Checkbox )).toHaveLength(1);
         } );
     } );
 

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings-form.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings-form.js
@@ -20,101 +20,101 @@ import { DynamicCarrierAccountSettingsForm } from '../dynamic-settings-form.js';
 configure( { adapter: new Adapter() } );
 
 jest.mock('components/forms/form-text-input', () => {
-    return function DummyFormTextField(props) {
-        return (
-        <div>
-            <input className="test__dummy-form-text-field" onChange={props.onChange}/>
-        </div>
-        );
-    }
+	return function DummyFormTextField(props) {
+		return (
+		<div>
+			<input className="test__dummy-form-text-field" onChange={props.onChange}/>
+		</div>
+		);
+	}
 });
 
 function createDynamicCarrierAccountSettingsFormWrapper() {
 	const props = {
 		siteId: 1234,
 		translate: ( text ) => text,
-        carrierType: 'DhlExpressAccount',
-        carrierName: 'DHL Express',
-        registrationFields: {
-            "account_number": {
-                "visibility": "visible",
-                "label": "DHL Account Number"
-            },
-            "country": {
-                "visibility": "visible",
-                "label": "Account Country Code (2 Letter)"
-            },
-            "is_reseller": {
-                "visibility": "checkbox",
-                "label": "Reseller Account? (check if yes)"
-            }
-        }
+		carrierType: 'DhlExpressAccount',
+		carrierName: 'DHL Express',
+		registrationFields: {
+			"account_number": {
+				"visibility": "visible",
+				"label": "DHL Account Number"
+			},
+			"country": {
+				"visibility": "visible",
+				"label": "Account Country Code (2 Letter)"
+			},
+			"is_reseller": {
+				"visibility": "checkbox",
+				"label": "Reseller Account? (check if yes)"
+			}
+		}
 	};
 
 	return mount( <DynamicCarrierAccountSettingsForm { ...props } /> );
 }
 
 describe( 'Carrier Account Dynamic Registration Form', () => {
-    afterEach(() => {
-        jest.clearAllMocks();
-      });
+	afterEach(() => {
+		jest.clearAllMocks();
+	  });
 
 	describe( 'with the correct sub-components', () => {
-        const wrapper = createDynamicCarrierAccountSettingsFormWrapper();
+		const wrapper = createDynamicCarrierAccountSettingsFormWrapper();
 		it( 'renders 3 fields from the provided props', function () {
 			expect(wrapper.find( CompactCard )).toHaveLength(3);
-        } );
+		} );
 
-        it( 'renders 2 visible fields as TextField', function () {
+		it( 'renders 2 visible fields as TextField', function () {
 			expect(wrapper.find( TextField )).toHaveLength(2);
-        } );
+		} );
 
-        it( 'renders 1 checkbox fields as Checkbox', function () {
+		it( 'renders 1 checkbox fields as Checkbox', function () {
 			expect(wrapper.find( Checkbox )).toHaveLength(1);
-        } );
-    } );
+		} );
+	} );
 
-    describe( 'when clicked registration button', () => {
-        it ('should submit the form when data are input into the fields', async () => {
-            let wrapper;
+	describe( 'when clicked registration button', () => {
+		it ('should submit the form when data are input into the fields', async () => {
+			let wrapper;
 
-            const apiSpy = jest.spyOn(api, "post").mockImplementation(() =>
-                Promise.resolve({})
-            );
+			const apiSpy = jest.spyOn(api, "post").mockImplementation(() =>
+				Promise.resolve({})
+			);
 
-            await act(async () => {
-                wrapper = createDynamicCarrierAccountSettingsFormWrapper();
-            });
+			await act(async () => {
+				wrapper = createDynamicCarrierAccountSettingsFormWrapper();
+			});
 
-            await act(async () => {
-                 wrapper.find( 'input.test__dummy-form-text-field' ).first().simulate('change', {target: {
-                    value: 'A123456'
-                }});
-            });
-            await act(async () => {
-                wrapper.find( 'input.test__dummy-form-text-field' ).at(1).simulate('change', {target: {
-                    value: 'US'
-                }});
-            });
-            await act(async () => {
-                wrapper.find( 'input#is_reseller' ).simulate('change', {target: {
-                    checked: true
-                }});
-            });
-            await act(async () => {
-                // Click the register button
-                wrapper.find( 'button.is-primary' ).simulate('click');
-                expect(apiSpy).toHaveBeenCalledTimes(1);
-                expect(apiSpy).toHaveBeenCalledWith(1234, 'connect/shipping/carrier', {
-                        type: 'DhlExpressAccount',
-                        settings: {
-                            account_number: 'A123456',
-                            country: 'US',
-                            is_reseller: true
-                        }
-                    }
-                );
-            });
-        });
-    } );
+			await act(async () => {
+				 wrapper.find( 'input.test__dummy-form-text-field' ).first().simulate('change', {target: {
+					value: 'A123456'
+				}});
+			});
+			await act(async () => {
+				wrapper.find( 'input.test__dummy-form-text-field' ).at(1).simulate('change', {target: {
+					value: 'US'
+				}});
+			});
+			await act(async () => {
+				wrapper.find( 'input#is_reseller' ).simulate('change', {target: {
+					checked: true
+				}});
+			});
+			await act(async () => {
+				// Click the register button
+				wrapper.find( 'button.is-primary' ).simulate('click');
+				expect(apiSpy).toHaveBeenCalledTimes(1);
+				expect(apiSpy).toHaveBeenCalledWith(1234, 'connect/shipping/carrier', {
+						type: 'DhlExpressAccount',
+						settings: {
+							account_number: 'A123456',
+							country: 'US',
+							is_reseller: true
+						}
+					}
+				);
+			});
+		});
+	} );
 } );

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings-form.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings-form.js
@@ -11,6 +11,7 @@ import TextField from 'woocommerce/woocommerce-services/components/text-field';
 import Checkbox from 'woocommerce/woocommerce-services/components/checkbox';
 import * as api from 'woocommerce/woocommerce-services/api';
 import { act } from 'react-dom/test-utils';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -32,7 +33,7 @@ jest.mock('components/forms/form-text-input', () => {
 function createDynamicCarrierAccountSettingsFormWrapper() {
 	const props = {
 		siteId: 1234,
-		translate: ( text ) => text,
+		translate: translate,
 		carrierType: 'DhlExpressAccount',
 		carrierName: 'DHL Express',
 		registrationFields: {

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings-form.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings-form.js
@@ -19,7 +19,7 @@ import { DynamicCarrierAccountSettingsForm, CheckboxFormFieldSet } from '../dyna
 
 configure( { adapter: new Adapter() } );
 
-function createCarrierAccountsWrapper() {
+function createDynamicCarrierAccountSettingsFormWrapper() {
 	const props = {
 		siteId: 1234,
 		translate: ( text ) => text,
@@ -50,7 +50,7 @@ describe( 'Carrier Account Dynamic Registration Form', () => {
       });
 
 	describe( 'with the correct sub-components', () => {
-        const wrapper = createCarrierAccountsWrapper();
+        const wrapper = createDynamicCarrierAccountSettingsFormWrapper();
 		it( 'renders 3 fields from the provided props', function () {
 			expect(wrapper.find( CompactCard )).to.have.lengthOf(3);
         } );
@@ -65,7 +65,7 @@ describe( 'Carrier Account Dynamic Registration Form', () => {
     } );
 
     describe( 'should submit the form when data are input into the fields', () => {
-        const wrapper = createCarrierAccountsWrapper();
+        const wrapper = createDynamicCarrierAccountSettingsFormWrapper();
         const apiPostSpy = spy(api, 'post');
 
         /**

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings.js
@@ -50,7 +50,7 @@ describe( 'Dynamic carrier registration settings', () => {
 	describe( 'with supported carrier', () => {
         const props = {
             siteId: 1234,
-            carrier: 'DHL'
+            carrier: 'DhlExpressAccount'
         };
 		it( 'should render the Connect, Localized, and DynamicCarrierAccountSettingsForm sub components', function () {
             const wrapper = shallow( <DynamicCarrierAccountSettings { ...props } /> );

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings.js
@@ -5,8 +5,11 @@
  */
 import React from 'react';
 import { expect } from 'chai';
-import { configure, shallow } from 'enzyme';
+import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import * as api from 'woocommerce/woocommerce-services/api';
+import { act } from 'react-dom/test-utils';
+
 /**
  * Internal dependencies
  */
@@ -16,7 +19,7 @@ configure( { adapter: new Adapter() } );
 
 const mockCarrierRegistrationFieldsState = [{
     "type": "DhlExpressAccount",
-    "name": "DHL Express",
+    "name": "Test DHL Express",
     "fields": {
         "account_number": {
             "visibility": "visible",
@@ -33,16 +36,25 @@ const mockCarrierRegistrationFieldsState = [{
     }
 }];
 
-/**
- * useEffect not called when shallow mount. Refer to bug https://github.com/enzymejs/enzyme/issues/2086
- * Here, we try to start the component with a pre-defined state.
- */
-jest.mock('react', () => ({
-    ...jest.requireActual('react'),
-    useState: () => ([mockCarrierRegistrationFieldsState]),
-}));
+jest.mock('../dynamic-settings-form', () => {
+    return function DummyDynamicSettingsForm(props) {
+        return (
+        <div>
+            {JSON.stringify(props)}
+        </div>
+        );
+    }
+});
 
 describe( 'Dynamic carrier registration settings', () => {
+    beforeEach(() => {
+        jest.spyOn(api, "get").mockImplementation(() =>
+            Promise.resolve({
+                carriers: mockCarrierRegistrationFieldsState
+            })
+        );
+    });
+
     afterEach(() => {
         jest.clearAllMocks();
     });
@@ -52,9 +64,18 @@ describe( 'Dynamic carrier registration settings', () => {
             siteId: 1234,
             carrier: 'DhlExpressAccount'
         };
-		it( 'should render the Connect, Localized, and DynamicCarrierAccountSettingsForm sub components', function () {
-            const wrapper = shallow( <DynamicCarrierAccountSettings { ...props } /> );
-			expect(wrapper.text()).to.match(/Connect\(Localized\(DynamicCarrierAccountSettingsForm/);
+
+
+		it( 'should render the Connect, Localized, and DynamicCarrierAccountSettingsForm sub components', async () => {
+            let wrapper;
+            await act(async () => {
+                wrapper = mount(<DynamicCarrierAccountSettings { ...props } />);
+            });
+
+            const actualDynamicCarrierAccountSettingsFormProps = JSON.parse(wrapper.text());
+            expect(actualDynamicCarrierAccountSettingsFormProps.carrierName).to.equal(mockCarrierRegistrationFieldsState[0].name);
+            expect(actualDynamicCarrierAccountSettingsFormProps.carrierType).to.equal(mockCarrierRegistrationFieldsState[0].type);
+            expect(actualDynamicCarrierAccountSettingsFormProps.registrationFields).to.deep.equal(mockCarrierRegistrationFieldsState[0].fields);
         } );
     } );
 
@@ -63,9 +84,44 @@ describe( 'Dynamic carrier registration settings', () => {
             siteId: 1234,
             carrier: 'ASDASDASD'
         };
-		it( 'should render the Connect, Localized, and DynamicCarrierAccountSettingsForm sub components', function () {
-            const wrapper = shallow( <DynamicCarrierAccountSettings { ...props } /> );
+
+
+		it( 'should display not supported message', async () => {
+            let wrapper;
+            await act(async () => {
+                wrapper = mount(<DynamicCarrierAccountSettings { ...props } />);
+            });
             expect(wrapper.text()).to.equal('ASDASDASD not supported.');
         } );
+    } );
+} );
+
+describe( 'Dynamic carrier registration settings with pending promises', () => {
+    /**
+     * Moved this into its own describe block to test pending promise
+     * so that it doesn't change all the async-await promises in the above
+     * test cases.
+     */
+    beforeEach(() => {
+        jest.spyOn(api, "get").mockImplementation(() =>
+            Promise.resolve({})
+        );
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const props = {
+        siteId: 1234,
+        carrier: 'DhlExpressAccount'
+    };
+
+    it( 'should display a loading message', async () => {
+        let wrapper;
+        await act(async () => {
+            wrapper = mount(<DynamicCarrierAccountSettings { ...props } />);
+        });
+        expect(wrapper.text()).to.equal('Loading...');
     } );
 } );

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings.js
@@ -18,110 +18,110 @@ import { DynamicCarrierAccountSettings } from '../dynamic-settings.js';
 configure( { adapter: new Adapter() } );
 
 const mockCarrierRegistrationFieldsState = [{
-    "type": "DhlExpressAccount",
-    "name": "Test DHL Express",
-    "fields": {
-        "account_number": {
-            "visibility": "visible",
-            "label": "DHL Account Number"
-        },
-        "country": {
-            "visibility": "visible",
-            "label": "Account Country Code (2 Letter)"
-        },
-        "is_reseller": {
-            "visibility": "checkbox",
-            "label": "Reseller Account? (check if yes)"
-        }
-    }
+	"type": "DhlExpressAccount",
+	"name": "Test DHL Express",
+	"fields": {
+		"account_number": {
+			"visibility": "visible",
+			"label": "DHL Account Number"
+		},
+		"country": {
+			"visibility": "visible",
+			"label": "Account Country Code (2 Letter)"
+		},
+		"is_reseller": {
+			"visibility": "checkbox",
+			"label": "Reseller Account? (check if yes)"
+		}
+	}
 }];
 
 jest.mock('../dynamic-settings-form', () => {
-    return function DummyDynamicSettingsForm(props) {
-        return (
-        <div>
-            {JSON.stringify(props)}
-        </div>
-        );
-    }
+	return function DummyDynamicSettingsForm(props) {
+		return (
+		<div>
+			{JSON.stringify(props)}
+		</div>
+		);
+	}
 });
 
 describe( 'Dynamic carrier registration settings', () => {
-    beforeEach(() => {
-        jest.spyOn(api, "get").mockImplementation(() =>
-            Promise.resolve({
-                carriers: mockCarrierRegistrationFieldsState
-            })
-        );
-    });
+	beforeEach(() => {
+		jest.spyOn(api, "get").mockImplementation(() =>
+			Promise.resolve({
+				carriers: mockCarrierRegistrationFieldsState
+			})
+		);
+	});
 
-    afterEach(() => {
-        jest.clearAllMocks();
-    });
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
 
 	describe( 'with supported carrier', () => {
-        const props = {
-            siteId: 1234,
-            carrier: 'DhlExpressAccount'
-        };
+		const props = {
+			siteId: 1234,
+			carrier: 'DhlExpressAccount'
+		};
 
 
 		it( 'should render the Connect, Localized, and DynamicCarrierAccountSettingsForm sub components', async () => {
-            let wrapper;
-            await act(async () => {
-                wrapper = mount(<DynamicCarrierAccountSettings { ...props } />);
-            });
+			let wrapper;
+			await act(async () => {
+				wrapper = mount(<DynamicCarrierAccountSettings { ...props } />);
+			});
 
-            const actualDynamicCarrierAccountSettingsFormProps = JSON.parse(wrapper.text());
-            expect(actualDynamicCarrierAccountSettingsFormProps.carrierName).to.equal(mockCarrierRegistrationFieldsState[0].name);
-            expect(actualDynamicCarrierAccountSettingsFormProps.carrierType).to.equal(mockCarrierRegistrationFieldsState[0].type);
-            expect(actualDynamicCarrierAccountSettingsFormProps.registrationFields).to.deep.equal(mockCarrierRegistrationFieldsState[0].fields);
-        } );
-    } );
+			const actualDynamicCarrierAccountSettingsFormProps = JSON.parse(wrapper.text());
+			expect(actualDynamicCarrierAccountSettingsFormProps.carrierName).to.equal(mockCarrierRegistrationFieldsState[0].name);
+			expect(actualDynamicCarrierAccountSettingsFormProps.carrierType).to.equal(mockCarrierRegistrationFieldsState[0].type);
+			expect(actualDynamicCarrierAccountSettingsFormProps.registrationFields).to.deep.equal(mockCarrierRegistrationFieldsState[0].fields);
+		} );
+	} );
 
-    describe( 'with non-supported carrier', () => {
-        const props = {
-            siteId: 1234,
-            carrier: 'ASDASDASD'
-        };
+	describe( 'with non-supported carrier', () => {
+		const props = {
+			siteId: 1234,
+			carrier: 'ASDASDASD'
+		};
 
 
 		it( 'should display not supported message', async () => {
-            let wrapper;
-            await act(async () => {
-                wrapper = mount(<DynamicCarrierAccountSettings { ...props } />);
-            });
-            expect(wrapper.text()).to.equal('ASDASDASD not supported.');
-        } );
-    } );
+			let wrapper;
+			await act(async () => {
+				wrapper = mount(<DynamicCarrierAccountSettings { ...props } />);
+			});
+			expect(wrapper.text()).to.equal('ASDASDASD not supported.');
+		} );
+	} );
 } );
 
 describe( 'Dynamic carrier registration settings with pending promises', () => {
-    /**
-     * Moved this into its own describe block to test pending promise
-     * so that it doesn't change all the async-await promises in the above
-     * test cases.
-     */
-    beforeEach(() => {
-        jest.spyOn(api, "get").mockImplementation(() =>
-            Promise.resolve({})
-        );
-    });
+	/**
+	 * Moved this into its own describe block to test pending promise
+	 * so that it doesn't change all the async-await promises in the above
+	 * test cases.
+	 */
+	beforeEach(() => {
+		jest.spyOn(api, "get").mockImplementation(() =>
+			Promise.resolve({})
+		);
+	});
 
-    afterEach(() => {
-        jest.clearAllMocks();
-    });
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
 
-    const props = {
-        siteId: 1234,
-        carrier: 'DhlExpressAccount'
-    };
+	const props = {
+		siteId: 1234,
+		carrier: 'DhlExpressAccount'
+	};
 
-    it( 'should display a loading message', async () => {
-        let wrapper;
-        await act(async () => {
-            wrapper = mount(<DynamicCarrierAccountSettings { ...props } />);
-        });
-        expect(wrapper.text()).to.equal('Loading...');
-    } );
+	it( 'should display a loading message', async () => {
+		let wrapper;
+		await act(async () => {
+			wrapper = mount(<DynamicCarrierAccountSettings { ...props } />);
+		});
+		expect(wrapper.text()).to.equal('Loading...');
+	} );
 } );

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings.js
@@ -9,6 +9,7 @@ import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import * as api from 'woocommerce/woocommerce-services/api';
 import { act } from 'react-dom/test-utils';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -62,7 +63,8 @@ describe( 'Dynamic carrier registration settings', () => {
 	describe( 'with supported carrier', () => {
 		const props = {
 			siteId: 1234,
-			carrier: 'DhlExpressAccount'
+			carrier: 'DhlExpressAccount',
+			translate: translate
 		};
 
 
@@ -82,7 +84,8 @@ describe( 'Dynamic carrier registration settings', () => {
 	describe( 'with non-supported carrier', () => {
 		const props = {
 			siteId: 1234,
-			carrier: 'ASDASDASD'
+			carrier: 'ASDASDASD',
+			translate: translate
 		};
 
 
@@ -114,7 +117,8 @@ describe( 'Dynamic carrier registration settings with pending promises', () => {
 
 	const props = {
 		siteId: 1234,
-		carrier: 'DhlExpressAccount'
+		carrier: 'DhlExpressAccount',
+		translate: translate
 	};
 
 	it( 'should display a loading message', async () => {

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings.js
@@ -1,0 +1,71 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { configure, shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+/**
+ * Internal dependencies
+ */
+import { DynamicCarrierAccountSettings } from '../dynamic-settings.js';
+
+configure( { adapter: new Adapter() } );
+
+const mockCarrierRegistrationFieldsState = [{
+    "type": "DhlExpressAccount",
+    "name": "DHL Express",
+    "fields": {
+        "account_number": {
+            "visibility": "visible",
+            "label": "DHL Account Number"
+        },
+        "country": {
+            "visibility": "visible",
+            "label": "Account Country Code (2 Letter)"
+        },
+        "is_reseller": {
+            "visibility": "checkbox",
+            "label": "Reseller Account? (check if yes)"
+        }
+    }
+}];
+
+/**
+ * useEffect not called when shallow mount. Refer to bug https://github.com/enzymejs/enzyme/issues/2086
+ * Here, we try to start the component with a pre-defined state.
+ */
+jest.mock('react', () => ({
+    ...jest.requireActual('react'),
+    useState: () => ([mockCarrierRegistrationFieldsState]),
+}));
+
+describe( 'Dynamic carrier registration settings', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+	describe( 'with supported carrier', () => {
+        const props = {
+            siteId: 1234,
+            carrier: 'DHL'
+        };
+		it( 'should render the Connect, Localized, and DynamicCarrierAccountSettingsForm sub components', function () {
+            const wrapper = shallow( <DynamicCarrierAccountSettings { ...props } /> );
+			expect(wrapper.text()).to.match(/Connect\(Localized\(DynamicCarrierAccountSettingsForm/);
+        } );
+    } );
+
+    describe( 'with non-supported carrier', () => {
+        const props = {
+            siteId: 1234,
+            carrier: 'ASDASDASD'
+        };
+		it( 'should render the Connect, Localized, and DynamicCarrierAccountSettingsForm sub components', function () {
+            const wrapper = shallow( <DynamicCarrierAccountSettings { ...props } /> );
+            expect(wrapper.text()).to.equal('ASDASDASD not supported.');
+        } );
+    } );
+} );


### PR DESCRIPTION
## Description
This PR address bullet 2 on https://github.com/Automattic/woocommerce-services/issues/2234
> Building a registration form that is dynamically built based on the list of fields for each carrier (the UPS account registration form at /wp-admin/admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings&carrier=UPS should be used as a design reference)

### Notes
- No form validation on this page. Every carrier will be different and we are not supplied with their individual validation rules.
- Carrier description is in `Lorem ipsum` placeholder text.

### Related issue(s)
Closes https://github.com/Automattic/woocommerce-services/issues/2234

### Steps to reproduce & screenshots/GIFs
1. Pull this branch, go to https://localhost/wp-admin/admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings&carrier=DhlExpressAccount
2. You should see something like this:
https://localhost/wp-admin/admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings&carrier=DhlExpressAccount
![image](https://user-images.githubusercontent.com/572862/98575441-7509e480-2276-11eb-9562-db24d7cefcfd.png)
3. Enter values into the form and press "Connect"
4. In the network tab, you should see the request sent with the form values you entered:
![image](https://user-images.githubusercontent.com/572862/98575737-c9ad5f80-2276-11eb-85c3-fb8abe2eba70.png)
Error is expected because the end point does not support this registration yet.
5. Click "Cancel" and it should bring you back to the previous page.

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

