### PR TITLE
Adds more specific regex validation to UPS connect form

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.25.2 - 2020-XX-XX =
 * Tweak - Add ZIP code validation to UPS(beta) signup form.
 * Fix   - Issue with printing labels in some iOS devices through Safari.
+* Fix   - Correct validation for UPS fields in Carrier Account connect form.
 
 = 1.25.1 - 2020-10-28 =
 * Tweak - DHL refund days copy adjustment

--- a/client/extensions/woocommerce/woocommerce-services/state/carrier-accounts/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/carrier-accounts/selectors.js
@@ -20,7 +20,7 @@ export const getCarrierAccountsState = ( state, siteId = getSelectedSiteId( stat
 
 const emailRegex = /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/;
 const USPostalCodeRegex = /^\d{5}$/;
-const UPSAccountNumberRegex = /^\d{6}$/;
+const UPSAccountNumberRegex = /^[a-zA-Z0-9]{6}$/;
 const UPSInvoiceNumberRegex = /^(\d{9}|\d{13})$/;
 const phoneRegex = /^\d{10}$/;
 const dateRegex = /^(19|20)\d\d-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/;
@@ -44,7 +44,7 @@ export const getFormErrors = ( state, siteId, carrier ) => {
 	}
 
 	if ( values.account_number && ! values.account_number.match( UPSAccountNumberRegex ) ) {
-		fieldErrors.account_number = translate( 'The UPS account number needs to be 6 digits in length' );
+		fieldErrors.account_number = translate( 'The UPS account number needs to be 6 letters and digits in length' );
 	}
 
 	if ( values.phone && ! values.phone.match( phoneRegex ) ) {

--- a/client/extensions/woocommerce/woocommerce-services/state/carrier-accounts/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/carrier-accounts/selectors.js
@@ -20,6 +20,10 @@ export const getCarrierAccountsState = ( state, siteId = getSelectedSiteId( stat
 
 const emailRegex = /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/;
 const USPostalCodeRegex = /^\d{5}$/;
+const UPSAccountNumberRegex = /^\d{6}$/;
+const UPSInvoiceNumberRegex = /^(\d{9}|\d{13})$/;
+const phoneRegex = /^\d{10}$/;
+const dateRegex = /^(19|20)\d\d-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/;
 const urlRegex = /^(?:(?:(?:https?|ftp):)?\/\/)*(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?$/i;
 
 export const getFormErrors = ( state, siteId, carrier ) => {
@@ -39,15 +43,36 @@ export const getFormErrors = ( state, siteId, carrier ) => {
 		}
 	}
 
+	if ( values.account_number && ! values.account_number.match( UPSAccountNumberRegex ) ) {
+		fieldErrors.account_number = translate( 'The UPS account number needs to be 6 digits in length' );
+	}
+
+	if ( values.phone && ! values.phone.match( phoneRegex ) ) {
+		fieldErrors.phone = translate( 'The phone number needs to be 10 digits in length' );
+	}
+
 	if ( values.country === 'US' && values.postal_code && ! values.postal_code.match( USPostalCodeRegex ) ) {
-		fieldErrors.postal_code = translate( 'The ZIP/Postal code format is not valid.');
+		fieldErrors.postal_code = translate( 'The ZIP/Postal code needs to be 5 digits in length');
 	}
 
 	if ( values.email && ! values.email.match( emailRegex ) ) {
 		fieldErrors.email = translate( 'The email format is not valid' );
 	}
+	
 	if ( values.website && ! values.website.match( urlRegex ) ) {
 		fieldErrors.website = translate( 'The company website format is not valid' );
+	}
+
+	if ( values.invoice_number && ! values.invoice_number.match( UPSInvoiceNumberRegex ) ) {
+		fieldErrors.invoice_number = translate( 'The invoice number needs to be 9 or 13 digits in length' );
+	} else {
+		delete fieldErrors.invoice_number;
+	}
+
+	if ( values.invoice_date && ! values.invoice_date.match( dateRegex ) ) {
+		fieldErrors.invoice_date = translate( 'The date must be a valid date in the format YYYY-MM-DD' );
+	} else {
+		delete fieldErrors.invoice_date;
 	}
 
 	if ( ignoreValidation ) {

--- a/client/extensions/woocommerce/woocommerce-services/state/carrier-accounts/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/carrier-accounts/selectors.js
@@ -52,13 +52,13 @@ export const getFormErrors = ( state, siteId, carrier ) => {
 	}
 
 	if ( values.country === 'US' && values.postal_code && ! values.postal_code.match( USPostalCodeRegex ) ) {
-		fieldErrors.postal_code = translate( 'The ZIP/Postal code needs to be 5 digits in length');
+		fieldErrors.postal_code = translate( 'The ZIP/Postal code needs to be 5 digits in length' );
 	}
 
 	if ( values.email && ! values.email.match( emailRegex ) ) {
 		fieldErrors.email = translate( 'The email format is not valid' );
 	}
-	
+
 	if ( values.website && ! values.website.match( urlRegex ) ) {
 		fieldErrors.website = translate( 'The company website format is not valid' );
 	}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
The current form field validations when a user is connecting their UPS account don't always provide enough information to inform a user on how to correct them: in a few cases, the only validation present was checking non-empty values for required fields and in others the error lacked specificity. 

This PR adds the following validations for fields in this form.

- **UPS account number**: `The UPS account number needs to be 6 digits in length`
- **Phone number**: `The phone number needs to be 10 digits in length`
- **ZIP/Postal Code** (US only): `The ZIP/Postal code needs to be 5 digits in length`
- **UPS Invoice Number**: If present, `The invoice number needs to be 9 or 13 digits in length`
- **UPS Invoice Date**: If present, `The date must be a valid date in the format YYYY-MM-DD`

### Related issue(s)
Closes #2136 
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
Enable UPS for your site, by adding a row to `wcc_site_flags` with `flag_name` as `can_use_ups` and your site's ID for `siteid`. Refresh the WCS plugin from **WooCommerce > Status > WooCommerce Shipping & Tax** to complete the enablement.
![Enable UPS beta](https://cdn-std.droplr.net/files/acc_1104206/p8jI4Z)

Go to **WooCommerce > Settings > Shipping > WooCommerce Shipping** and from the Carrier Account section at the bottom of the page, select "Connect" next to UPS.
![Connect UPS account](https://cdn-std.droplr.net/files/acc_1104206/SL2Lh8)

Enter values into the fields mentioned above and check the validation.
![UPS account form field](https://cdn-std.droplr.net/files/acc_1104206/vzhXCm)

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

