### PR TITLE
Release 1.25.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Tweak - Add ZIP code validation to UPS(beta) signup form.
 * Fix   - Issue with printing labels in some iOS devices through Safari.
 * Fix   - Prevents warning when using PHP 5.5 or lesser
+* Add   - Add new API end point to retrieve carrier registration requirements.
 
 = 1.25.1 - 2020-10-28 =
 * Tweak - DHL refund days copy adjustment

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,8 @@
 * Fix   - Issue with printing labels in some iOS devices through Safari.
 * Fix   - Prevents warning when using PHP 5.5 or lesser
 * Add   - Add new API end point to retrieve carrier registration requirements.
+* Add   - Add composer command to run PHPUnit.
+* Tweak - Update readme with DHL information.
 
 = 1.25.1 - 2020-10-28 =
 * Tweak - DHL refund days copy adjustment

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.25.2 - 2020-XX-XX =
 * Tweak - Add ZIP code validation to UPS(beta) signup form.
 * Fix   - Issue with printing labels in some iOS devices through Safari.
+* Fix   - Prevents warning when using PHP 5.5 or lesser
 
 = 1.25.1 - 2020-10-28 =
 * Tweak - DHL refund days copy adjustment

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -312,6 +312,17 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		/**
+		 * Get all carriers we support for registration. This end point
+		 * returns a list of "fields" that we use to register the carrier
+		 * account.
+		 *
+		 * @return object|WP_Error
+		 */
+		public function get_carrier_types( ) {
+			return $this->request( 'GET', '/shipping/carrier-types' );
+		}
+
+		/**
 		 * Tests the connection to the WooCommerce Shipping & Tax Server
 		 *
 		 * @return true|WP_Error

--- a/classes/class-wc-rest-connect-shipping-carrier-types-controller.php
+++ b/classes/class-wc-rest-connect-shipping-carrier-types-controller.php
@@ -1,0 +1,42 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit();
+}
+
+if ( class_exists( 'WC_REST_Connect_Shipping_Carrier_Types_Controller' ) ) {
+	return;
+}
+
+/**
+ * Retrieve a list of carrier WooCommerce Shipping & Tax supports, along with the
+ * fields needed for each carrier in order to do carrier account registration.
+ */
+class WC_REST_Connect_Shipping_Carrier_Types_Controller extends WC_REST_Connect_Base_Controller {
+	/**
+	 * Carrier-types end point
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'connect/shipping/carrier-types';
+
+	/**
+	 * GET request
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get() {
+		$response = $this->api_client->get_carrier_types();
+		if ( is_wp_error( $response ) ) {
+			$this->logger->log( $response, __CLASS__ );
+			return $response;
+		}
+		return new WP_REST_Response(
+			[
+				'success'  => true,
+				'carriers' => $response->carriers,
+			]
+		);
+	}
+
+}

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,12 @@
 {
     "require-dev": {
-        "woocommerce/woocommerce-sniffs": "^0.1.0"
+        "woocommerce/woocommerce-sniffs": "^0.1.0",
+        "phpunit/phpunit": "^7"
     },
     "scripts": {
+		"test": [
+			"phpunit"
+		],
 		"phpcs": [
 			"phpcs -s -p"
 		],

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,16 @@
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	bootstrap="tests/php/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	verbose="true"
+	>
 	<testsuites>
-		<!-- Default test suite to run all tests -->
-		<testsuite>
-			<directory prefix="test_" suffix=".php">tests</directory>
+		<testsuite name="WooCommerce Services Test Suite">
+			<directory suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>
-	<filter>
-		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">tests</directory>
-			</exclude>
-		</whitelist>
-	</filter>
 </phpunit>
-

--- a/readme.txt
+++ b/readme.txt
@@ -86,6 +86,8 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 * Fix   - Issue with printing labels in some iOS devices through Safari.
 * Fix   - Prevents warning when using PHP 5.5 or lesser
 * Add   - Add new API end point to retrieve carrier registration requirements.
+* Add   - Add composer command to run PHPUnit.
+* Tweak - Update readme with DHL information.
 
 = 1.25.1 - 2020-10-28 =
 * Tweak - DHL refund days copy adjustment

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === WooCommerce Shipping & Tax ===
 Contributors: woocommerce, automattic, woothemes, allendav, kellychoffman, jkudish, jeffstieler, nabsul, robobot3000, danreylop, mikeyarce, shaunkuschel, orangesareorange, pauldechov, dappermountain, radogeorgiev, bor0, royho, cshultz88, bartoszbudzanowski, harriswong, ferdev, superdav42
-Tags: shipping, stamps, usps, woocommerce, taxes, payment, stripe
+Tags: shipping, stamps, usps, woocommerce, taxes, payment, stripe, dhl, labels
 Requires at least: 4.6
 Requires PHP: 5.3
 Tested up to: 5.5
@@ -19,8 +19,8 @@ To use the features, simply install this plugin and activate the ones you want d
 
 NOTE: This extensions was previously referred to as WooCommerce Services.
 
-= Print shipping labels for USPS at a discounted rate =
-Give customers lower rates on their shipping. Create ready-to-print shipping labels for USPS directly in WooCommerce and take advantage of our special discount rate.
+= Print USPS and DHL shipping labels and save up to 90% =
+Ship domestically and internationally right from your WooCommerce dashboard. Print USPS and DHL labels and instantly save up to 90%.
 
 = Collect accurate taxes at checkout =
 We've got taxes for you - no need to enter tax rates manually.
@@ -43,14 +43,14 @@ This section describes how to install the plugin and get it working.
 
 = What services are included? =
 
-* USPS label purchase/printing
+* USPS and DHL label purchase/printing
 * Automated tax calculation
 * Stripe account provisioning (through WooCommerce setup wizard)
 * PayPal Checkout payment authorization
 
 = Can I buy and print shipping labels for US domestic and international packages? =
 
-Yes! You can buy and print USPS shipping labels for domestic and international destinations.
+Yes! You can buy and print USPS shipping labels for domestic destinations and USPS and DHL shipping labels for international destinations. Shipments need to originate from the U.S.
 
 = This works with WooCommerce, right? =
 
@@ -68,9 +68,6 @@ Absolutely! You can read our Terms of Service [here](https://en.wordpress.com/to
 
 The source code is freely available [in GitHub](https://github.com/Automattic/woocommerce-services).
 
-= Can I show shipping rates at checkout? =
-
-As of the WooCommerce 3.5 release, WooCommerce Shipping & Tax no longer provides shipping rates for new stores. If you’re already using shipping rates in WooCommerce Shipping & Tax, they will continue to work.
 
 == Screenshots ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,12 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 1.25.2 - 2020-XX-XX =
+* Tweak - Add ZIP code validation to UPS(beta) signup form.
+* Fix   - Issue with printing labels in some iOS devices through Safari.
+* Fix   - Prevents warning when using PHP 5.5 or lesser
+* Add   - Add new API end point to retrieve carrier registration requirements.
+
 = 1.25.1 - 2020-10-28 =
 * Tweak - DHL refund days copy adjustment
 * Tweak - Stop using deprecated Jetpack method is_development_mode().
@@ -150,13 +156,3 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 * Add   - Link to carrier's schedule pickup page.
 * Add   - Improved shipping service feature descriptions.
 * Add   - Option to mark order complete when label is printed.
-
-= 1.22.5 - 2020-03-17 =
-* Add   - Admin asset API endpoint.
-* Fix   - GB support for WC 4.0.
-* Fix   - Jetpack staging check for PHP 5.3.
-* Tweak - Bump WP tested version to 5.4.
-
-= 1.22.4 - 2020-03-02 =
-* Fix   - Stop using deprecated method Jetpack::is_staging_site() when Jetpack
-8.1 is installed.

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -7,13 +7,15 @@
  * @package wordpress-plugin-tests
  */
 
-// Support for:
-// 1. `WC_DEVELOP_DIR` environment variable
-// 2. Tests checked out to /tmp
-if( false !== getenv( 'WC_DEVELOP_DIR' ) ) {
+/**
+ * Support for:
+ * 1. `WC_DEVELOP_DIR` environment variable.
+ * 2. Tests checked out to /tmp.
+ */
+if ( false !== getenv( 'WC_DEVELOP_DIR' ) ) {
 	$wc_root = getenv( 'WC_DEVELOP_DIR' );
-} else if ( file_exists( '/tmp/woocommerce/tests/bootstrap.php' ) ) {
-	$wc_root = '/tmp/woocommerce/tests';
+} elseif ( file_exists( '/tmp/woocommerce/tests/legacy/bootstrap.php' ) ) {
+	$wc_root = '/tmp/woocommerce';
 } else {
 	exit( 'Could not determine test root directory. Aborting.' );
 }
@@ -25,14 +27,18 @@ if ( ! $wp_tests_dir ) {
 }
 
 if ( ! file_exists( $wp_tests_dir . '/includes/functions.php' ) ) {
-	echo "Could not find $wp_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // WPCS: XSS ok.
+	echo "Could not find $wp_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	exit( 1 );
 }
 
-// load test function so tests_add_filter() is available
-require_once( $wp_tests_dir . '/includes/functions.php' );
+// load test function so tests_add_filter() is available.
+require_once $wp_tests_dir . '/includes/functions.php';
 
-// Activates this plugin in WordPress so it can be tested.
+/**
+ * Activates this plugin in WordPress so it can be tested.
+ *
+ * @return void
+ */
 function _manually_load_plugin() {
 	require dirname( __FILE__ ) . '/../../woocommerce-services.php';
 }
@@ -42,4 +48,4 @@ if ( ! defined( 'WC_UNIT_TESTING' ) ) {
 	define( 'WC_UNIT_TESTING', true );
 }
 
-require $wc_root . '/bootstrap.php';
+require $wc_root . '/tests/legacy/bootstrap.php';

--- a/tests/php/classes/test-class-wc-rest-connect-shipping-carrier-types-controller.php
+++ b/tests/php/classes/test-class-wc-rest-connect-shipping-carrier-types-controller.php
@@ -1,0 +1,90 @@
+<?php
+
+
+
+/**
+ * Unit test for WC_Connect_API_Client_Live
+ */
+class WP_Test_WC_REST_Connect_Shipping_Carrier_Types_Controller extends WC_Unit_Test_Case {
+
+	/** @var WC_Connect_API_Client_Live $api_client_mock */
+	protected $api_client_mock;
+
+	/** @var WC_Connect_Service_Settings_Store $setting_store_mock */
+	protected $setting_store_mock;
+
+	/** @var WC_Connect_Logger $connect_logger_mock */
+	protected $connect_logger_mock;
+
+	/**
+	 * @inherit
+	 */
+	public static function setupBeforeClass() {
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-api-client-live.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-service-settings-store.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-logger.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-rest-connect-base-controller.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-rest-connect-shipping-carrier-types-controller.php';
+	}
+
+	/**
+	 * Setup the test case.
+	 *
+	 * @see WC_Unit_Test_Case::setUp()
+	 */
+	public function setUp() {
+		// Creating a mock class and overide protected request method so that we can mock the API response.
+		$this->api_client_mock = $this->getMockBuilder( WC_Connect_API_Client_Live::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'request' ] )
+			->getMock();
+
+		$this->setting_store_mock  = $this->createMock( WC_Connect_Service_Settings_Store::class );
+		$this->connect_logger_mock = $this->createMock( WC_Connect_Logger::class );
+	}
+
+	/**
+	 * Test GET request on connect/shipping/carrier-types end point.
+	 */
+	public function test_get() {
+		$api_response        = '{"carriers":[{"type":"DhlExpressAccount","name":"DHL Express","fields":{"account_number":{"visibility":"visible","label":"DHL Account Number"},"country":{"visibility":"visible","label":"Account Country Code (2 Letter)"},"is_reseller":{"visibility":"checkbox","label":"Reseller Account? (check if yes)"}}},{"type":"UpsAccount","name":"UPS","fields":{}}]}';
+		$api_client_response = json_decode( $api_response ); // assumes api_client->request() successfully returns the JSON decoded response body.
+
+		$this->api_client_mock->expects( $this->once() )
+			->method( 'request' )
+			->with( 'GET', '/shipping/carrier-types' )
+			->willReturn( $api_client_response );
+
+		$wc_connect_shipping_carrier_types_controller = new WC_REST_Connect_Shipping_Carrier_Types_Controller( $this->api_client_mock, $this->setting_store_mock, $this->connect_logger_mock );
+		$actual                                       = $wc_connect_shipping_carrier_types_controller->get();
+		$expected                                     = [
+			'success'  => true,
+			'carriers' => $api_client_response->carriers,
+		];
+
+		$this->assertEquals( 200, $actual->status );
+		$this->assertEquals( $expected, $actual->data );
+	}
+
+	/**
+	 * Test error thrown during a GET request on connect/shipping/carrier-types end point.
+	 */
+	public function test_get_with_error() {
+		$api_response = new WP_Error( 'error_code_123', 'something is wrong' );
+
+		$this->api_client_mock->expects( $this->once() )
+			->method( 'request' )
+			->with( 'GET', '/shipping/carrier-types' )
+			->willReturn( $api_response );
+
+		$this->connect_logger_mock->expects( $this->once() )
+			->method( 'log' )
+			->with( $api_response, WC_REST_Connect_Shipping_Carrier_Types_Controller::class );
+
+		$wc_connect_shipping_carrier_types_controller = new WC_REST_Connect_Shipping_Carrier_Types_Controller( $this->api_client_mock, $this->setting_store_mock, $this->connect_logger_mock );
+		$actual                                       = $wc_connect_shipping_carrier_types_controller->get();
+
+		$this->assertInstanceOf( WP_Error::class, $actual );
+		$this->assertEquals( $api_response, $actual );
+	}
+}

--- a/tests/php/test-class-wc-connect-api-client.php
+++ b/tests/php/test-class-wc-connect-api-client.php
@@ -1,16 +1,29 @@
 <?php
 
+/**
+ * Unit test for WC_Connect_API_Client_Live
+ */
 class WP_Test_WC_Connect_API_Client extends WC_Unit_Test_Case {
 
+	/** @var WC_Connect_API_Client_Live $api_client */
 	protected $api_client;
+	/** @var WC_Product $product */
 	protected $product;
 
+	/**
+	 * Undocumented function
+	 */
 	public static function setupBeforeClass() {
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client-live.php' );
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client.php';
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client-live.php';
 
 	}
 
+	/**
+	 * Setup the test case.
+	 *
+	 * @see WC_Unit_Test_Case::setUp()
+	 */
 	public function setUp() {
 		$this->api_client = $this->getMockBuilder( 'WC_Connect_API_Client_Live' )
 			->disableOriginalConstructor()
@@ -18,20 +31,28 @@ class WP_Test_WC_Connect_API_Client extends WC_Unit_Test_Case {
 			->getMock();
 	}
 
+	/**
+	 * Clean up the test case.
+	 *
+	 * @see WC_Unit_Test_Case::tearDown()
+	 */
 	public function tearDown() {
-		// empty the test cart
+		// empty the test cart.
 		WC()->cart->empty_cart();
 
-		// release the test client instance
+		// release the test client instance.
 		unset( $this->api_client );
 
-		// delete test product
+		// delete test product.
 		WC_Helper_Product::delete_product( $this->product->get_id() );
 	}
 
+	/**
+	 * Test simple product but missing weight
+	 */
 	public function test_build_shipment_contents_simple_product_no_weight() {
 		$this->product = WC_Helper_Product::create_simple_product();
-		$product_id = $this->product->get_id();
+		$product_id    = $this->product->get_id();
 		update_post_meta( $product_id, '_weight', '' );
 
 		WC()->cart->add_to_cart( $product_id, 1 );
@@ -42,11 +63,14 @@ class WP_Test_WC_Connect_API_Client extends WC_Unit_Test_Case {
 		$this->assertEquals( 'product_missing_weight', $actual->get_error_code() );
 	}
 
+	/**
+	 * Test simple product
+	 */
 	public function test_build_shipment_contents_simple_product() {
 		$this->product = WC_Helper_Product::create_simple_product();
-		$product_id = $this->product->get_id();
+		$product_id    = $this->product->get_id();
 
-		// set base product dimensions
+		// set base product dimensions.
 		update_post_meta( $product_id, '_weight', '2' );
 		update_post_meta( $product_id, '_height', '5' );
 		update_post_meta( $product_id, '_width', '6' );
@@ -56,49 +80,56 @@ class WP_Test_WC_Connect_API_Client extends WC_Unit_Test_Case {
 
 		$actual = $this->api_client->build_shipment_contents( array( 'contents' => WC()->cart->get_cart() ) );
 
-		$expected = array( array(
-			'height'     => 5,
-			'product_id' => $product_id,
-			'length'     => 7,
-			'width'      => 6,
-			'quantity'   => 1,
-			'weight'     => 2,
-		) );
+		$expected = array(
+			array(
+				'height'     => 5,
+				'product_id' => $product_id,
+				'length'     => 7,
+				'width'      => 6,
+				'quantity'   => 1,
+				'weight'     => 2,
+			),
+		);
 
 		$this->assertEquals( $actual, $expected );
 	}
 
+	/**
+	 * Test variable product
+	 */
 	public function test_build_shipment_contents_variable_product() {
 		$this->product = WC_Helper_Product::create_variation_product();
 
 		$all_variations     = $this->product->get_available_variations();
-		$first_variation_id = $all_variations[ 0 ][ 'variation_id' ];
+		$first_variation_id = $all_variations[2]['variation_id'];
 		$product_id         = $this->product->get_id();
 
-		// set base product dimensions
+		// set base product dimensions.
 		update_post_meta( $product_id, '_weight', '2' );
 		update_post_meta( $product_id, '_height', '5' );
 		update_post_meta( $product_id, '_width', '6' );
 		update_post_meta( $product_id, '_length', '7' );
 
-		// set variation dimensions
+		// set variation dimensions.
 		update_post_meta( $first_variation_id, '_weight', '5' );
 		update_post_meta( $first_variation_id, '_height', '2' );
 		update_post_meta( $first_variation_id, '_width', '3' );
 		update_post_meta( $first_variation_id, '_length', '4' );
 
-		WC()->cart->add_to_cart( $first_variation_id, 1 );
+		WC()->cart->add_to_cart( $product_id, 1, $first_variation_id );
 
 		$actual = $this->api_client->build_shipment_contents( array( 'contents' => WC()->cart->get_cart() ) );
 
-		$expected = array( array(
-			'height'     => 2,
-			'product_id' => $first_variation_id,
-			'length'     => 4,
-			'width'      => 3,
-			'quantity'   => 1,
-			'weight'     => 5,
-		) );
+		$expected = array(
+			array(
+				'height'     => 2,
+				'product_id' => $first_variation_id,
+				'length'     => 4,
+				'width'      => 3,
+				'quantity'   => 1,
+				'weight'     => 5,
+			),
+		);
 
 		$this->assertEquals( $actual, $expected );
 	}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -149,6 +149,14 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		protected $rest_address_normalization_controller;
 
 		/**
+		 *
+		 * WC_REST_Connect_Shipping_Carrier_Types_Controller
+		 *
+		 * @var WC_REST_Connect_Shipping_Carrier_Types_Controller
+		 */
+		protected $rest_carrier_types_controller;
+
+		/**
 		 * @var WC_Connect_Service_Schemas_Validator
 		 */
 		protected $service_schemas_validator;
@@ -414,6 +422,14 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		public function set_rest_address_normalization_controller( WC_REST_Connect_Address_Normalization_Controller $rest_address_normalization_controller ) {
 			$this->rest_address_normalization_controller = $rest_address_normalization_controller;
+		}
+
+		public function set_carrier_types_controller( WC_REST_Connect_Shipping_Carrier_Types_Controller $rest_carrier_types_controller ) {
+			$this->rest_carrier_types_controller = $rest_carrier_types_controller;
+		}
+
+		public function get_carrier_types_controller() {
+			return $this->rest_carrier_types_controller;
 		}
 
 		public function get_service_schemas_validator() {
@@ -880,6 +896,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$rest_carrier_delete_controller = new WC_REST_Connect_Shipping_Carrier_Delete_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_carrier_delete_controller( $rest_carrier_delete_controller );
 			$rest_carrier_delete_controller->register_routes();
+
+			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-carrier-types-controller.php' ) );
+			$rest_carrier_types_controller = new WC_REST_Connect_Shipping_Carrier_Types_Controller( $this->api_client, $settings_store, $logger );
+			$this->set_carrier_types_controller( $rest_carrier_types_controller );
+			$rest_carrier_types_controller->register_routes();
 
 			if ( $this->stripe->is_stripe_plugin_enabled() ) {
 				require_once( plugin_basename( 'classes/class-wc-rest-connect-stripe-oauth-init-controller.php' ) );

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -52,7 +52,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 	}
 
 	// Check for CI environment variable to trigger test mode.
-	if ( false !== getenv( 'WOOCOMMERCE_SERVICES_CI_TEST_MODE', true ) ) {
+	if ( false !== getenv( 'WOOCOMMERCE_SERVICES_CI_TEST_MODE' ) ) {
 		if ( ! defined( 'WOOCOMMERCE_SERVICES_LOCAL_TEST_MODE' ) ) {
 			define( 'WOOCOMMERCE_SERVICES_LOCAL_TEST_MODE', true );
 		}


### PR DESCRIPTION
## Release PR for 1.25.2
### Changes in this release
#2216 Add composer command to run PHPUnit
#2229 Fallback to open PDF in new tab if Safari does not print natively
#2230 Add ZIP code validation to UPS Sign up form
#2239 Create new endpoint for carrier types
#2241 Remove second parameter from getenv

This release branch is branched from latest `develop` 

### Test notes

- Test label purchase flow
- Test live rates
- Test Store on WP.com
- Test ZIP code validation
- Test printing labels on iOS with Safari
- Test composer PHPUnit command
- Test in PHP 5.3 looking for getenv warnings

### Changelog
* Tweak - Add ZIP code validation to UPS(beta) signup form.
* Fix       - Issue with printing labels in some iOS devices through Safari.
* Fix       - Prevents warning when using PHP 5.5 or lesser
* Add     - Add new API end point to retrieve carrier registration requirements.
* Add     - Add composer command to run PHPUnit.
* Tweak - Update readme with DHL information.

## Build File
Built from this branch using `php woorelease.phar simulate --product_version=1.25.2 https://github.com/Automattic/woocommerce-services/tree/release/1.25.2`

[woocommerce-services.zip](https://github.com/Automattic/woocommerce-services/files/5502015/woocommerce-services.zip)