### PR TITLE
Fix signature required checkbox not updating prices for label requests.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.25.3 - 2020-**-** =
 * Add   - Initial code for WooCommerce.com subscriptions API.
 * Fix   - UI fix for input validation for package dimensions and weights.
+* Fix   - When adding "signature required" to some packages, prices were not updating.
 
 = 1.25.2 - 2020-11-10 =
 * Tweak - Add ZIP code validation to UPS(beta) signup form.

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
@@ -25,10 +25,10 @@ class ShippingRate extends Component {
 	}
 
 	onSignatureChecked = ( isChecked, i, signatureOption ) => {
-		const { rateObject: { service_id }, updateValue } = this.props;
+		const { rateObject: { service_id, carrier_id }, updateValue } = this.props;
 		const selectedSignature = isChecked ? { id: i, value: signatureOption.netCost } : null;
 		this.setState( { selectedSignature } );
-		updateValue( service_id, isChecked ? signatureOption.value : 0 );
+		updateValue( service_id, carrier_id, isChecked ? signatureOption.value : 0 );
 	}
 
 	renderServices( carrier_id, signatureOptions, includedServices ) {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
@@ -26,7 +26,7 @@ class ShippingRate extends Component {
 
 	onSignatureChecked = ( isChecked, i, signatureOption ) => {
 		const { rateObject: { service_id, carrier_id }, updateValue } = this.props;
-		const selectedSignature = isChecked ? { id: i, value: signatureOption.netCost } : null;
+		const selectedSignature = isChecked ? { id: i, value: signatureOption.value, netCost: signatureOption.netCost } : null;
 		this.setState( { selectedSignature } );
 		updateValue( service_id, carrier_id, isChecked ? signatureOption.value : 0 );
 	}
@@ -118,7 +118,7 @@ class ShippingRate extends Component {
 			} );
 		}
 
-		const ratePlusSignatureCost = selectedSignature ? rate + selectedSignature.value : rate;
+		const ratePlusSignatureCost = selectedSignature ? rate + selectedSignature.netCost : rate;
 
 		return(
 			<div className="rates-step__shipping-rate-container">
@@ -128,7 +128,7 @@ class ShippingRate extends Component {
 					options={ [
 						{ label: '', value: service_id },
 					] }
-					onChange={ () => { updateValue( service_id, carrier_id, false ) } }
+					onChange={ () => { updateValue( service_id, carrier_id, selectedSignature ? selectedSignature.value : false ) } }
 				/>
 				<div className="rates-step__shipping-rate-information">
 					<CarrierIcon carrier={ carrier_id } size={ 30 } />

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/test/shipping-rate.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/test/shipping-rate.js
@@ -197,10 +197,10 @@ describe( 'ShippingRate', () => {
 				it( 'behave as radio buttons', () => {
 					expect( activeShippingRateWrapper.state( 'selectedSignature' ) ).to.equal( undefined );
 					freeSignatureCheckbox.prop( 'onChange' )( true );
-					expect( activeShippingRateWrapper.state( 'selectedSignature' ) ).to.deep.equal( { id: 0, value: 0 } );
+					expect( activeShippingRateWrapper.state( 'selectedSignature' ) ).to.deep.equal( { id: 0, netCost: 0, value: "rate1" } );
 
 					adultSignatureCheckbox.prop( 'onChange' )( true );
-					expect ( activeShippingRateWrapper.state( 'selectedSignature' ) ).to.deep.equal( { id: 1, value: 3 } );
+					expect ( activeShippingRateWrapper.state( 'selectedSignature' ) ).to.deep.equal( { id: 1, netCost: 3, value: "rate2" } );
 				} );
 
 				it( "add its amount to the rate's total amount", () => {


### PR DESCRIPTION
## Description
Ensure that the correct number of arguments are passed to the parent ShippingRates component when checking "require signature" option when requesting a shipping label.

### Related issue(s)

Closes #2185 

### Steps to reproduce & screenshots/GIFs

See the screencast in the original issue:

https://github.com/Automattic/woocommerce-services/issues/2185#issue-702784563

With this branch checked out you should see the prices updating when adding a signature:

![Screen Capture on 2020-11-18 at 12-30-49](https://user-images.githubusercontent.com/6723003/99545663-eb64c000-29b5-11eb-9da8-3d59d87e5ff2.gif)


### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

