### PR TITLE
Add link to schedule pickup for dhlexpress.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,8 +2,9 @@
 
 = 1.25.3 - 2020-**-** =
 * Add   - Initial code for WooCommerce.com subscriptions API.
-* Fix   - UI fix for input validation for package dimensions and weights.
 * Add   - Dynamic carrier registration form.
+* Add   - DHL Schedule Pickup link within order notes.
+* Fix   - UI fix for input validation for package dimensions and weights.
 * Fix   - Correct validation for UPS fields in Carrier Account connect form.
 
 = 1.25.2 - 2020-11-10 =

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -108,6 +108,7 @@ export class LabelItem extends Component {
 			'usps': 'https://tools.usps.com/schedule-pickup-steps.htm',
 			'fedex': 'https://www.fedex.com/en-us/shipping/schedule-manage-pickups.html',
 			'ups': 'https://wwwapps.ups.com/pickup/request',
+			'dhlexpress': 'https://mydhl.express.dhl/us/en/home.html#/schedulePickupTab',
 		};
 
 		if ( ! ( pickup_urls.hasOwnProperty( carrierId ) ) ) {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/test/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/test/label-item.js
@@ -119,6 +119,41 @@ describe( 'Label item', () => {
 		it( 'Request refund is not disabled', function () {
 			expect( requestRefundLink.length ).toBe( 1 );
 		} );
+
+		const requestShipmentLink = wrapper.findWhere( ( n ) => {
+			return n.is( PopoverMenuItem ) && 'Schedule a pickup' === n.children().text();
+		})
+
+		it( 'Request shipment pickup is available', function () {
+			expect( requestShipmentLink.length ).toBe( 1 );
+		} );
+
+	} );
+
+	describe( 'with DHL package', () => {
+		const props = {
+			label: {
+				isLetter: false,
+				carrierId: 'dhlexpress',
+			}
+		}
+		const wrapper = createLabelItemWrapper( props );
+		const requestRefundLink = wrapper.findWhere( ( n ) => {
+			return n.is( PopoverMenuItem ) && 'Request refund' === n.children().text();
+		}  );
+
+		it( 'Request refund is not disabled', function () {
+			expect( requestRefundLink.length ).toBe( 1 );
+		} );
+
+		const requestShipmentLink = wrapper.findWhere( ( n ) => {
+			return n.is( PopoverMenuItem ) && 'Schedule a pickup' === n.children().text();
+		})
+
+		it( 'Request shipment pickup is available', function () {
+			expect( requestShipmentLink.length ).toBe( 1 );
+		} );
+
 	} );
 
 	describe( 'with non usps carrier letter', () => {


### PR DESCRIPTION
## Description
Add a 'schedule pickup' link in the order notes for DHL Express labels.

### Steps to reproduce & screenshots/GIFs

Before:

<img width="402" alt="Screen Shot 2020-11-19 at 1 22 36 AM" src="https://user-images.githubusercontent.com/6723003/99658101-50c0bb80-2a5f-11eb-890b-e43f3d94f9dd.png">

After:

![Screen Capture on 2020-11-19 at 12-04-59](https://user-images.githubusercontent.com/6723003/99658306-95e4ed80-2a5f-11eb-81da-e550f4e59c56.gif)

They will end up here wherein they can schedule a pickup:

https://mydhl.express.dhl/us/en/home.html#/schedulePickupTab

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

