### PR TITLE
Release 1.25.3

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.25.3 - 2020-**-** =
 * Add   - Initial code for WooCommerce.com subscriptions API.
+* Fix   - UI fix for input validation for package dimensions and weights.
 
 = 1.25.2 - 2020-11-10 =
 * Tweak - Add ZIP code validation to UPS(beta) signup form.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.25.3 - 2020-**-** =
 * Add   - Initial code for WooCommerce.com subscriptions API.
 * Fix   - UI fix for input validation for package dimensions and weights.
+* Add   - Dynamic carrier registration form.
 
 = 1.25.2 - 2020-11-10 =
 * Tweak - Add ZIP code validation to UPS(beta) signup form.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.25.3 - 2020-**-** =
 * Add   - Initial code for WooCommerce.com subscriptions API.
 * Add   - Dynamic carrier registration form.
+* Fix   - When adding "signature required" to some packages, prices were not updating.
 * Add   - DHL Schedule Pickup link within order notes.
 * Fix   - UI fix for input validation for package dimensions and weights.
 * Fix   - Correct validation for UPS fields in Carrier Account connect form.

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Add   - DHL Schedule Pickup link within order notes.
 * Fix   - UI fix for input validation for package dimensions and weights.
 * Fix   - Correct validation for UPS fields in Carrier Account connect form.
+* Tweak - Add message to explain automated tax requires tax-exclusive product pricing.
 
 = 1.25.2 - 2020-11-10 =
 * Tweak - Add ZIP code validation to UPS(beta) signup form.

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Add   - Initial code for WooCommerce.com subscriptions API.
 * Fix   - UI fix for input validation for package dimensions and weights.
 * Add   - Dynamic carrier registration form.
+* Fix   - Correct validation for UPS fields in Carrier Account connect form.
 
 = 1.25.2 - 2020-11-10 =
 * Tweak - Add ZIP code validation to UPS(beta) signup form.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,8 +2,9 @@
 
 = 1.25.3 - 2020-**-** =
 * Add   - Initial code for WooCommerce.com subscriptions API.
-* Fix   - UI fix for input validation for package dimensions and weights.
 * Add   - Dynamic carrier registration form.
+* Add   - DHL Schedule Pickup link within order notes.
+* Fix   - UI fix for input validation for package dimensions and weights.
 * Fix   - Correct validation for UPS fields in Carrier Account connect form.
 
 = 1.25.2 - 2020-11-10 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.3 - 2020-**-** =
+* Add   - Initial code for WooCommerce.com subscriptions API.
+
 = 1.25.2 - 2020-11-10 =
 * Tweak - Add ZIP code validation to UPS(beta) signup form.
 * Fix   - Issue with printing labels in some iOS devices through Safari.

--- a/classes/class-wc-connect-functions.php
+++ b/classes/class-wc-connect-functions.php
@@ -19,5 +19,25 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 				( isset( $_GET['rest_route'] ) && isset( $_GET['_for'] ) && ( 'jetpack' === $_GET['_for'] ) )
 			);
 		}
+
+		/**
+		 * Get the WC Helper authorization information to use with WC Connect Server requests( e.g. site ID, access token).
+		 *
+		 * @return array|WP_Error
+		 */
+		public static function get_wc_helper_auth_info() {
+			if ( class_exists( 'WC_Helper_Options' ) && is_callable( 'WC_Helper_Options::get' ) ) {
+				$helper_auth_data = WC_Helper_Options::get( 'auth' );
+			}
+
+			// It's possible for WC_Helper_Options::get() to return false, throw error if this is the case.
+			if ( ! $helper_auth_data ) {
+				return new WP_Error(
+					'missing_wccom_auth',
+					__( 'WooCommerce Helper auth is missing', 'woocommerce-services' )
+				);
+			}
+			return $helper_auth_data;
+		}
 	}
 }

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -98,6 +98,8 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 					case 'ups':
 						$translated_carrier_name = __( 'UPS', 'woocommerce-services' );
 						break;
+					case 'dhl':
+						$translated_carrier_name = __( 'DHL Express', 'woocommerce-services' );
 					default:
 						break;
 				}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -134,7 +134,7 @@ class WC_Connect_TaxJar_Integration {
 			'title'    => __( 'Automated taxes', 'woocommerce-services' ),
 			'id'       => self::OPTION_NAME, // TODO: save in `wc_connect_options`?
 			'desc_tip' => $this->get_tax_tooltip(),
-			'desc'     => $enabled ? '<p>' . __( 'Powered by WooCommerce Tax.', 'woocommerce-services' ) . '</p>' : '',
+			'desc'     => $enabled ? '<p>' . __( 'Powered by WooCommerce Tax. If automated taxes are enabled, you\'ll need to enter prices exclusive of tax.', 'woocommerce-services' ) . '</p>' : '',
 			'default'  => 'no',
 			'type'     => 'select',
 			'class'    => 'wc-enhanced-select',

--- a/client/apps/shipping-settings/view-wrapper.js
+++ b/client/apps/shipping-settings/view-wrapper.js
@@ -17,6 +17,7 @@ import notices from 'notices';
 import Packages from '../../extensions/woocommerce/woocommerce-services/views/packages';
 import CarrierAccounts from '../../extensions/woocommerce/woocommerce-services/views/carrier-accounts';
 import CarrierAccountSettings from '../../extensions/woocommerce/woocommerce-services/views/carrier-accounts/settings';
+import DynamicCarrierAccountSettings from '../../extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings';
 import { ProtectFormGuard } from 'lib/protect-form';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { createWcsShippingSaveActionList } from '../../extensions/woocommerce/woocommerce-services/state/actions';
@@ -69,7 +70,22 @@ class LabelSettingsWrapper extends Component {
 	render() {
 		const { carrier, carriers, isSaving, siteId, translate } = this.props;
 
-		if ( carrier ) {
+		if ( ! carrier ) {
+			return (
+				<div>
+					<GlobalNotices id="notices" notices={ notices.list } />
+					<LabelSettings onChange={ this.onChange } />
+					<Packages onChange={ this.onChange } />
+					<CarrierAccounts siteId={ siteId } carriers={ carriers } onChange={ this.onChange } />
+					<Button primary onClick={ this.onSaveChanges } busy={ isSaving } disabled={ isSaving }>
+						{ translate( 'Save changes' ) }
+					</Button>
+					<ProtectFormGuard isChanged={ ! this.state.pristine } />
+				</div>
+			);
+		}
+
+		if ( carrier.toLowerCase() === 'ups' ) {
 			return (
 				<div>
 					<GlobalNotices id="notices" notices={ notices.list } />
@@ -78,15 +94,12 @@ class LabelSettingsWrapper extends Component {
 				</div>
 			);
 		}
+
+		// Dynamically create registration form
 		return (
 			<div>
 				<GlobalNotices id="notices" notices={ notices.list } />
-				<LabelSettings onChange={ this.onChange } />
-				<Packages onChange={ this.onChange } />
-				<CarrierAccounts siteId={ siteId } carriers={ carriers } onChange={ this.onChange } />
-				<Button primary onClick={ this.onSaveChanges } busy={ isSaving } disabled={ isSaving }>
-					{ translate( 'Save changes' ) }
-				</Button>
+				<DynamicCarrierAccountSettings carrier={ carrier } />
 				<ProtectFormGuard isChanged={ ! this.state.pristine } />
 			</div>
 		);

--- a/client/extensions/woocommerce/woocommerce-services/api/url.js
+++ b/client/extensions/woocommerce/woocommerce-services/api/url.js
@@ -12,3 +12,4 @@ export const serviceSettings = ( methodId, instanceId = 0 ) => `connect/services
 export const shippingCarrier = () => 'connect/shipping/carrier';
 export const shippingCarriers = () => 'connect/shipping/carriers';
 export const shippingCarrierDelete = ( carrier ) => `connect/shipping/carrier/${ carrier }`;
+export const shippingCarrierTypes = () => 'connect/shipping/carrier-types';

--- a/client/extensions/woocommerce/woocommerce-services/state/carrier-accounts/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/carrier-accounts/selectors.js
@@ -20,6 +20,10 @@ export const getCarrierAccountsState = ( state, siteId = getSelectedSiteId( stat
 
 const emailRegex = /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/;
 const USPostalCodeRegex = /^\d{5}$/;
+const UPSAccountNumberRegex = /^[a-zA-Z0-9]{6}$/;
+const UPSInvoiceNumberRegex = /^(\d{9}|\d{13})$/;
+const phoneRegex = /^\d{10}$/;
+const dateRegex = /^(19|20)\d\d-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/;
 const urlRegex = /^(?:(?:(?:https?|ftp):)?\/\/)*(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?$/i;
 
 export const getFormErrors = ( state, siteId, carrier ) => {
@@ -39,15 +43,36 @@ export const getFormErrors = ( state, siteId, carrier ) => {
 		}
 	}
 
+	if ( values.account_number && ! values.account_number.match( UPSAccountNumberRegex ) ) {
+		fieldErrors.account_number = translate( 'The UPS account number needs to be 6 letters and digits in length' );
+	}
+
+	if ( values.phone && ! values.phone.match( phoneRegex ) ) {
+		fieldErrors.phone = translate( 'The phone number needs to be 10 digits in length' );
+	}
+
 	if ( values.country === 'US' && values.postal_code && ! values.postal_code.match( USPostalCodeRegex ) ) {
-		fieldErrors.postal_code = translate( 'The ZIP/Postal code format is not valid.');
+		fieldErrors.postal_code = translate( 'The ZIP/Postal code needs to be 5 digits in length' );
 	}
 
 	if ( values.email && ! values.email.match( emailRegex ) ) {
 		fieldErrors.email = translate( 'The email format is not valid' );
 	}
+
 	if ( values.website && ! values.website.match( urlRegex ) ) {
 		fieldErrors.website = translate( 'The company website format is not valid' );
+	}
+
+	if ( values.invoice_number && ! values.invoice_number.match( UPSInvoiceNumberRegex ) ) {
+		fieldErrors.invoice_number = translate( 'The invoice number needs to be 9 or 13 digits in length' );
+	} else {
+		delete fieldErrors.invoice_number;
+	}
+
+	if ( values.invoice_date && ! values.invoice_date.match( dateRegex ) ) {
+		fieldErrors.invoice_date = translate( 'The date must be a valid date in the format YYYY-MM-DD' );
+	} else {
+		delete fieldErrors.invoice_date;
 	}
 
 	if ( ignoreValidation ) {

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings-form.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings-form.js
@@ -1,0 +1,178 @@
+/**
+ * External dependencies
+ */
+import React, { useState, useCallback } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import CompactCard from 'components/card/compact';
+import Checkbox from 'woocommerce/woocommerce-services/components/checkbox';
+import TextField from 'woocommerce/woocommerce-services/components/text-field';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import * as api from 'woocommerce/woocommerce-services/api';
+import { errorNotice, successNotice } from 'state/notices/actions';
+
+const FormFieldFactory = ( { visibility, label, id, value, onChange } ) => {
+	const handleToggle = useCallback(() => {
+		onChange(id, !value);
+	}, [id, value, onChange]);
+
+	const handleTextChange = useCallback(( newValue ) => {
+		onChange(id, newValue);
+	}, [id, value, onChange]);
+
+	switch (visibility) {
+		case 'select':
+		case 'checkbox':
+			return (
+				<>
+					<Checkbox
+						id={ id }
+						onChange={ handleToggle }
+						checked={ value || false }
+					/>
+					<label htmlFor={ id }><span>{ label }</span></label>
+				</>
+			);
+
+		case 'invisible':
+		case 'masked':
+		case 'readonly':
+		// TODO: We will need to handle the above invisible/readonly fields separately. For now, use default.
+		case 'password':
+		// TODO: We will need to create a PasswordField component, for now, use default.
+		case 'visible':
+		default:
+			return (
+				<TextField
+					id={ id }
+					title={ label }
+					updateValue={ handleTextChange }
+					value={ value || '' }
+				/>
+			);
+	}
+}
+
+export const DynamicCarrierAccountSettingsForm = ( props ) => {
+	const {
+		translate,
+		siteId,
+		carrierType,
+		noticeActions,
+		carrierName,
+	} = props;
+
+	const [formValues, setFormValues] = useState({});
+	const [isSaving, setIsSaving] = useState(false);
+
+	const handleFormFieldChange = useCallback((id, newValue) => {
+		setFormValues((oldValues) => ({
+			...oldValues,
+			[id]: newValue,
+		}))
+	}, [setFormValues]);
+
+	const handleSubmit = useCallback( () => {
+		const submit = async () => {
+			setIsSaving(true);
+
+			try {
+				await api.post( siteId, api.url.shippingCarrier(), {
+					type: carrierType,
+					settings: formValues
+				} );
+			} catch (error) {
+				noticeActions.errorNotice(`Failed to register the carrier. ${ error }`);
+			}
+
+			setIsSaving(false);
+		}
+
+		submit();
+	}, [isSaving, setIsSaving, siteId, carrierType, formValues, noticeActions] );
+
+	const handleCancel = useCallback(() => {
+		history.back();
+	}, []);
+
+	return (
+		<div className="carrier-accounts__settings-container">
+			<div className="carrier-accounts__settings">
+				<div className="carrier-accounts__settings-info">
+					<h4 className="carrier-accounts__settings-subheader-above-description">
+						{ translate( 'Connect your %(carrierName)s account', {
+							args: {
+								carrierName,
+							}
+						} ) }
+					</h4>
+					<p className="carrier-accounts__settings-subheader-description">
+					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam et dolor quam.
+					</p>
+				</div>
+				<div className="carrier-accounts__settings-form">
+					<CompactCard>
+					<h4 className="carrier-accounts__settings-subheader">{ translate ( 'General Information' ) }</h4>
+						<p className="carrier-accounts__settings-subheader-description">
+						{ translate( 'This is the account number and address from your %(carrierName)s profile', {
+							args: {
+								carrierName,
+							}
+						} ) }
+						</p>
+					</CompactCard>
+
+					<CompactCard>
+						{props.registrationFields && Object.entries(props.registrationFields).map( ( [key, field] ) => (
+							<FormFieldFactory key={key} id={key} visibility={field.visibility} label={field.label} value={formValues[key]} onChange={handleFormFieldChange} />
+						))}
+					</CompactCard>
+
+					<CompactCard className="carrier-accounts__settings-actions">
+						<Button
+							compact
+							primary
+							onClick={ handleSubmit }
+							disabled={ isSaving }
+						>
+							{ translate( 'Connect' ) }
+						</Button>
+						<Button
+							compact
+							onClick={ handleCancel }
+						>
+							{ translate( 'Cancel' ) }
+						</Button>
+					</CompactCard>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+const mapStateToProps = ( state ) => {
+	return {
+		siteId: getSelectedSiteId( state ),
+	};
+};
+
+const mapDispatchToProps = ( dispatch ) => ({
+	noticeActions: bindActionCreators( { successNotice, errorNotice }, dispatch ),
+});
+
+DynamicCarrierAccountSettingsForm.propTypes = {
+	carrierType: PropTypes.string,
+	carrierName: PropTypes.string,
+	registrationFields: PropTypes.object,
+	siteId: PropTypes.number,
+	translate: PropTypes.func,
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( DynamicCarrierAccountSettingsForm ) );

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings.js
@@ -1,0 +1,73 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+
+/**
+ * Internal dependencies
+ */
+import * as api from 'woocommerce/woocommerce-services/api';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import DynamicCarrierAccountSettingsForm from './dynamic-settings-form';
+
+export const DynamicCarrierAccountSettings = ( props ) => {
+	const { translate } = props;
+	const [carrierRegistrationFields, setCarrierRegistrationFields] = useState([]);
+
+	useEffect(() => {
+		const fetchRegistrationFields = async () => {
+			const registrationFields = await api.get(props.siteId, api.url.shippingCarrierTypes());
+			setCarrierRegistrationFields(registrationFields.carriers);
+		}
+		fetchRegistrationFields();
+	}, [props.siteId]);
+
+	if ( ! carrierRegistrationFields || carrierRegistrationFields.length < 1) {
+		return (
+			<div>{ translate( 'Loading' ) }...</div>
+		);
+	}
+
+	const [ currentCarrierRegistrationField ] = carrierRegistrationFields.filter(carrier => carrier.type === props.carrier);
+
+	if (!currentCarrierRegistrationField) {
+		return (
+			<div>
+			{ translate( '%(carrierName)s not supported.', {
+				args: {
+					carrierName: props.carrier,
+				}
+			} ) }
+			</div>
+		);
+	}
+
+    return (
+		<div>
+			<DynamicCarrierAccountSettingsForm
+				carrierType={currentCarrierRegistrationField.type}
+				carrierName={currentCarrierRegistrationField.name}
+				registrationFields={currentCarrierRegistrationField.fields}
+			/>
+		</div>
+	);
+};
+
+const mapStateToProps = ( state ) => {
+	return {
+		siteId: getSelectedSiteId( state ),
+    };
+};
+
+DynamicCarrierAccountSettings.propTypes = {
+	carrier: PropTypes.string.isRequired,
+	siteId: PropTypes.number
+};
+
+export default connect( mapStateToProps )( localize( DynamicCarrierAccountSettings ) );

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings-form.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings-form.js
@@ -1,0 +1,121 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import CompactCard from 'components/card/compact';
+import TextField from 'woocommerce/woocommerce-services/components/text-field';
+import Checkbox from 'woocommerce/woocommerce-services/components/checkbox';
+import * as api from 'woocommerce/woocommerce-services/api';
+import { act } from 'react-dom/test-utils';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { DynamicCarrierAccountSettingsForm } from '../dynamic-settings-form.js';
+
+configure( { adapter: new Adapter() } );
+
+jest.mock('components/forms/form-text-input', () => {
+	return function DummyFormTextField(props) {
+		return (
+		<div>
+			<input className="test__dummy-form-text-field" onChange={props.onChange}/>
+		</div>
+		);
+	}
+});
+
+function createDynamicCarrierAccountSettingsFormWrapper() {
+	const props = {
+		siteId: 1234,
+		translate: translate,
+		carrierType: 'DhlExpressAccount',
+		carrierName: 'DHL Express',
+		registrationFields: {
+			"account_number": {
+				"visibility": "visible",
+				"label": "DHL Account Number"
+			},
+			"country": {
+				"visibility": "visible",
+				"label": "Account Country Code (2 Letter)"
+			},
+			"is_reseller": {
+				"visibility": "checkbox",
+				"label": "Reseller Account? (check if yes)"
+			}
+		}
+	};
+
+	return mount( <DynamicCarrierAccountSettingsForm { ...props } /> );
+}
+
+describe( 'Carrier Account Dynamic Registration Form', () => {
+	afterEach(() => {
+		jest.clearAllMocks();
+	  });
+
+	describe( 'with the correct sub-components', () => {
+		const wrapper = createDynamicCarrierAccountSettingsFormWrapper();
+		it( 'renders 3 fields from the provided props', function () {
+			expect(wrapper.find( CompactCard )).toHaveLength(3);
+		} );
+
+		it( 'renders 2 visible fields as TextField', function () {
+			expect(wrapper.find( TextField )).toHaveLength(2);
+		} );
+
+		it( 'renders 1 checkbox fields as Checkbox', function () {
+			expect(wrapper.find( Checkbox )).toHaveLength(1);
+		} );
+	} );
+
+	describe( 'when clicked registration button', () => {
+		it ('should submit the form when data are input into the fields', async () => {
+			let wrapper;
+
+			const apiSpy = jest.spyOn(api, "post").mockImplementation(() =>
+				Promise.resolve({})
+			);
+
+			await act(async () => {
+				wrapper = createDynamicCarrierAccountSettingsFormWrapper();
+			});
+
+			await act(async () => {
+				 wrapper.find( 'input.test__dummy-form-text-field' ).first().simulate('change', {target: {
+					value: 'A123456'
+				}});
+			});
+			await act(async () => {
+				wrapper.find( 'input.test__dummy-form-text-field' ).at(1).simulate('change', {target: {
+					value: 'US'
+				}});
+			});
+			await act(async () => {
+				wrapper.find( 'input#is_reseller' ).simulate('change', {target: {
+					checked: true
+				}});
+			});
+			await act(async () => {
+				// Click the register button
+				wrapper.find( 'button.is-primary' ).simulate('click');
+				expect(apiSpy).toHaveBeenCalledTimes(1);
+				expect(apiSpy).toHaveBeenCalledWith(1234, 'connect/shipping/carrier', {
+						type: 'DhlExpressAccount',
+						settings: {
+							account_number: 'A123456',
+							country: 'US',
+							is_reseller: true
+						}
+					}
+				);
+			});
+		});
+	} );
+} );

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings.js
@@ -1,0 +1,131 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import * as api from 'woocommerce/woocommerce-services/api';
+import { act } from 'react-dom/test-utils';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { DynamicCarrierAccountSettings } from '../dynamic-settings.js';
+
+configure( { adapter: new Adapter() } );
+
+const mockCarrierRegistrationFieldsState = [{
+	"type": "DhlExpressAccount",
+	"name": "Test DHL Express",
+	"fields": {
+		"account_number": {
+			"visibility": "visible",
+			"label": "DHL Account Number"
+		},
+		"country": {
+			"visibility": "visible",
+			"label": "Account Country Code (2 Letter)"
+		},
+		"is_reseller": {
+			"visibility": "checkbox",
+			"label": "Reseller Account? (check if yes)"
+		}
+	}
+}];
+
+jest.mock('../dynamic-settings-form', () => {
+	return function DummyDynamicSettingsForm(props) {
+		return (
+		<div>
+			{JSON.stringify(props)}
+		</div>
+		);
+	}
+});
+
+describe( 'Dynamic carrier registration settings', () => {
+	beforeEach(() => {
+		jest.spyOn(api, "get").mockImplementation(() =>
+			Promise.resolve({
+				carriers: mockCarrierRegistrationFieldsState
+			})
+		);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe( 'with supported carrier', () => {
+		const props = {
+			siteId: 1234,
+			carrier: 'DhlExpressAccount',
+			translate: translate
+		};
+
+
+		it( 'should render the Connect, Localized, and DynamicCarrierAccountSettingsForm sub components', async () => {
+			let wrapper;
+			await act(async () => {
+				wrapper = mount(<DynamicCarrierAccountSettings { ...props } />);
+			});
+
+			const actualDynamicCarrierAccountSettingsFormProps = JSON.parse(wrapper.text());
+			expect(actualDynamicCarrierAccountSettingsFormProps.carrierName).to.equal(mockCarrierRegistrationFieldsState[0].name);
+			expect(actualDynamicCarrierAccountSettingsFormProps.carrierType).to.equal(mockCarrierRegistrationFieldsState[0].type);
+			expect(actualDynamicCarrierAccountSettingsFormProps.registrationFields).to.deep.equal(mockCarrierRegistrationFieldsState[0].fields);
+		} );
+	} );
+
+	describe( 'with non-supported carrier', () => {
+		const props = {
+			siteId: 1234,
+			carrier: 'ASDASDASD',
+			translate: translate
+		};
+
+
+		it( 'should display not supported message', async () => {
+			let wrapper;
+			await act(async () => {
+				wrapper = mount(<DynamicCarrierAccountSettings { ...props } />);
+			});
+			expect(wrapper.text()).to.equal('ASDASDASD not supported.');
+		} );
+	} );
+} );
+
+describe( 'Dynamic carrier registration settings with pending promises', () => {
+	/**
+	 * Moved this into its own describe block to test pending promise
+	 * so that it doesn't change all the async-await promises in the above
+	 * test cases.
+	 */
+	beforeEach(() => {
+		jest.spyOn(api, "get").mockImplementation(() =>
+			Promise.resolve({})
+		);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	const props = {
+		siteId: 1234,
+		carrier: 'DhlExpressAccount',
+		translate: translate
+	};
+
+	it( 'should display a loading message', async () => {
+		let wrapper;
+		await act(async () => {
+			wrapper = mount(<DynamicCarrierAccountSettings { ...props } />);
+		});
+		expect(wrapper.text()).to.equal('Loading...');
+	} );
+} );

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/input-filters.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/input-filters.js
@@ -41,7 +41,8 @@ const checkDimension = dimension => {
 		return '';
 	}
 
-	if ( 0 >= dimension ) {
+	// Allow users to type `0`, but not negative numbers
+	if ( 0 > dimension ) {
 		return '';
 	}
 
@@ -63,9 +64,16 @@ const parseDimensions = value => {
 	return { length, width, height };
 };
 
+// Final dimensions must all be positive numbers
+const validateDimensions = value => {
+	const { length, width, height } = parseDimensions( value );
+	return ( 0 < length ) && ( 0 < width ) && ( 0 < height );
+};
+
 export default {
 	string,
 	number,
 	dimensions,
 	parseDimensions,
+	validateDimensions,
 };

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/package-dialog.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/package-dialog.js
@@ -101,6 +101,10 @@ const PackageDialog = props => {
 		} );
 
 		const errors = checkInputs( filteredPackageData, boxNames, packageSchema );
+		if( ! inputFilters.validateDimensions( filteredPackageData.inner_dimensions ) ) {
+			errors.any = true;
+			errors.inner_dimensions = true;
+		}
 		if ( errors.any ) {
 			updatePackagesField( siteId, filteredPackageData );
 			setModalErrors( siteId, errors );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -108,6 +108,7 @@ export class LabelItem extends Component {
 			'usps': 'https://tools.usps.com/schedule-pickup-steps.htm',
 			'fedex': 'https://www.fedex.com/en-us/shipping/schedule-manage-pickups.html',
 			'ups': 'https://wwwapps.ups.com/pickup/request',
+			'dhlexpress': 'https://mydhl.express.dhl/us/en/home.html#/schedulePickupTab',
 		};
 
 		if ( ! ( pickup_urls.hasOwnProperty( carrierId ) ) ) {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/package-info.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/package-info.js
@@ -122,6 +122,8 @@ const PackageInfo = props => {
 		props.updatePackageWeight( orderId, siteId, packageId, event.target.value );
 	};
 
+	const packageWeight = isNaN( pckg.weight ) ? '' : pckg.weight;
+
 	return (
 		<div className="packages-step__package">
 			<div>
@@ -154,7 +156,7 @@ const PackageInfo = props => {
 				<FormTextInputWithAffixes
 					id={ `weight_${ packageId }` }
 					placeholder={ translate( '0' ) }
-					value={ pckg.weight || '' }
+					value={ packageWeight }
 					onChange={ onWeightChange }
 					isError={ Boolean( pckgErrors.weight ) }
 					type="number"

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
@@ -25,10 +25,10 @@ class ShippingRate extends Component {
 	}
 
 	onSignatureChecked = ( isChecked, i, signatureOption ) => {
-		const { rateObject: { service_id }, updateValue } = this.props;
-		const selectedSignature = isChecked ? { id: i, value: signatureOption.netCost } : null;
+		const { rateObject: { service_id, carrier_id }, updateValue } = this.props;
+		const selectedSignature = isChecked ? { id: i, value: signatureOption.value, netCost: signatureOption.netCost } : null;
 		this.setState( { selectedSignature } );
-		updateValue( service_id, isChecked ? signatureOption.value : 0 );
+		updateValue( service_id, carrier_id, isChecked ? signatureOption.value : 0 );
 	}
 
 	renderServices( carrier_id, signatureOptions, includedServices ) {
@@ -118,7 +118,7 @@ class ShippingRate extends Component {
 			} );
 		}
 
-		const ratePlusSignatureCost = selectedSignature ? rate + selectedSignature.value : rate;
+		const ratePlusSignatureCost = selectedSignature ? rate + selectedSignature.netCost : rate;
 
 		return(
 			<div className="rates-step__shipping-rate-container">
@@ -128,7 +128,7 @@ class ShippingRate extends Component {
 					options={ [
 						{ label: '', value: service_id },
 					] }
-					onChange={ () => { updateValue( service_id, carrier_id, false ) } }
+					onChange={ () => { updateValue( service_id, carrier_id, selectedSignature ? selectedSignature.value : false ) } }
 				/>
 				<div className="rates-step__shipping-rate-information">
 					<CarrierIcon carrier={ carrier_id } size={ 30 } />

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/test/shipping-rate.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/test/shipping-rate.js
@@ -197,10 +197,10 @@ describe( 'ShippingRate', () => {
 				it( 'behave as radio buttons', () => {
 					expect( activeShippingRateWrapper.state( 'selectedSignature' ) ).to.equal( undefined );
 					freeSignatureCheckbox.prop( 'onChange' )( true );
-					expect( activeShippingRateWrapper.state( 'selectedSignature' ) ).to.deep.equal( { id: 0, value: 0 } );
+					expect( activeShippingRateWrapper.state( 'selectedSignature' ) ).to.deep.equal( { id: 0, netCost: 0, value: "rate1" } );
 
 					adultSignatureCheckbox.prop( 'onChange' )( true );
-					expect ( activeShippingRateWrapper.state( 'selectedSignature' ) ).to.deep.equal( { id: 1, value: 3 } );
+					expect ( activeShippingRateWrapper.state( 'selectedSignature' ) ).to.deep.equal( { id: 1, netCost: 3, value: "rate2" } );
 				} );
 
 				it( "add its amount to the rate's total amount", () => {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/test/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/test/label-item.js
@@ -119,6 +119,41 @@ describe( 'Label item', () => {
 		it( 'Request refund is not disabled', function () {
 			expect( requestRefundLink.length ).toBe( 1 );
 		} );
+
+		const requestShipmentLink = wrapper.findWhere( ( n ) => {
+			return n.is( PopoverMenuItem ) && 'Schedule a pickup' === n.children().text();
+		})
+
+		it( 'Request shipment pickup is available', function () {
+			expect( requestShipmentLink.length ).toBe( 1 );
+		} );
+
+	} );
+
+	describe( 'with DHL package', () => {
+		const props = {
+			label: {
+				isLetter: false,
+				carrierId: 'dhlexpress',
+			}
+		}
+		const wrapper = createLabelItemWrapper( props );
+		const requestRefundLink = wrapper.findWhere( ( n ) => {
+			return n.is( PopoverMenuItem ) && 'Request refund' === n.children().text();
+		}  );
+
+		it( 'Request refund is not disabled', function () {
+			expect( requestRefundLink.length ).toBe( 1 );
+		} );
+
+		const requestShipmentLink = wrapper.findWhere( ( n ) => {
+			return n.is( PopoverMenuItem ) && 'Schedule a pickup' === n.children().text();
+		})
+
+		it( 'Request shipment pickup is available', function () {
+			expect( requestShipmentLink.length ).toBe( 1 );
+		} );
+
 	} );
 
 	describe( 'with non usps carrier letter', () => {

--- a/readme.txt
+++ b/readme.txt
@@ -89,6 +89,7 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 * Fix   - UI fix for input validation for package dimensions and weights.
 * Fix   - Correct validation for UPS fields in Carrier Account connect form.
 * Tweak - Add message to explain automated tax requires tax-exclusive product pricing.
+* Fix   - Disable USPS refunds for untracked labels only.
 
 = 1.25.2 - 2020-11-10 =
 * Tweak - Add ZIP code validation to UPS(beta) signup form.

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,15 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 1.25.3 - 2020-**-** =
+* Add   - Initial code for WooCommerce.com subscriptions API.
+* Add   - Dynamic carrier registration form.
+* Fix   - When adding "signature required" to some packages, prices were not updating.
+* Add   - DHL Schedule Pickup link within order notes.
+* Fix   - UI fix for input validation for package dimensions and weights.
+* Fix   - Correct validation for UPS fields in Carrier Account connect form.
+* Tweak - Add message to explain automated tax requires tax-exclusive product pricing.
+
 = 1.25.2 - 2020-11-10 =
 * Tweak - Add ZIP code validation to UPS(beta) signup form.
 * Fix   - Issue with printing labels in some iOS devices through Safari.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: woocommerce, automattic, woothemes, allendav, kellychoffman, jkudi
 Tags: shipping, stamps, usps, woocommerce, taxes, payment, stripe, dhl, labels
 Requires at least: 4.6
 Requires PHP: 5.3
-Tested up to: 5.5
+Tested up to: 5.6
 Stable tag: 1.25.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === WooCommerce Shipping & Tax ===
 Contributors: woocommerce, automattic, woothemes, allendav, kellychoffman, jkudish, jeffstieler, nabsul, robobot3000, danreylop, mikeyarce, shaunkuschel, orangesareorange, pauldechov, dappermountain, radogeorgiev, bor0, royho, cshultz88, bartoszbudzanowski, harriswong, ferdev, superdav42
-Tags: shipping, stamps, usps, woocommerce, taxes, payment, stripe
+Tags: shipping, stamps, usps, woocommerce, taxes, payment, stripe, dhl, labels
 Requires at least: 4.6
 Requires PHP: 5.3
 Tested up to: 5.5
@@ -19,8 +19,8 @@ To use the features, simply install this plugin and activate the ones you want d
 
 NOTE: This extensions was previously referred to as WooCommerce Services.
 
-= Print shipping labels for USPS at a discounted rate =
-Give customers lower rates on their shipping. Create ready-to-print shipping labels for USPS directly in WooCommerce and take advantage of our special discount rate.
+= Print USPS and DHL shipping labels and save up to 90% =
+Ship domestically and internationally right from your WooCommerce dashboard. Print USPS and DHL labels and instantly save up to 90%.
 
 = Collect accurate taxes at checkout =
 We've got taxes for you - no need to enter tax rates manually.
@@ -43,14 +43,14 @@ This section describes how to install the plugin and get it working.
 
 = What services are included? =
 
-* USPS label purchase/printing
+* USPS and DHL label purchase/printing
 * Automated tax calculation
 * Stripe account provisioning (through WooCommerce setup wizard)
 * PayPal Checkout payment authorization
 
 = Can I buy and print shipping labels for US domestic and international packages? =
 
-Yes! You can buy and print USPS shipping labels for domestic and international destinations.
+Yes! You can buy and print USPS shipping labels for domestic destinations and USPS and DHL shipping labels for international destinations. Shipments need to originate from the U.S.
 
 = This works with WooCommerce, right? =
 
@@ -68,9 +68,6 @@ Absolutely! You can read our Terms of Service [here](https://en.wordpress.com/to
 
 The source code is freely available [in GitHub](https://github.com/Automattic/woocommerce-services).
 
-= Can I show shipping rates at checkout? =
-
-As of the WooCommerce 3.5 release, WooCommerce Shipping & Tax no longer provides shipping rates for new stores. If you’re already using shipping rates in WooCommerce Shipping & Tax, they will continue to work.
 
 == Screenshots ==
 


### PR DESCRIPTION
## Release PR for 1.25.3
### Changes in this release
#2245 Add WC Helper connection information to requests
#2238 Allows package dimension input to begin with zero
#2243 Add dynamic carrier account registration form
#2244 Adds more specific validation to UPS connect form
#2261 Add link to schedule pickup for DHL Express
#2259 Fix signature required checkbox not updating prices
#2233 Add message to explain exclusive tax is needed for automated tax service
#2266 Disable USPS refunds for labels without tracking id.

This release branch is branched from latest `develop` 

### Test notes

- Test label purchase flow
- Test live rates
- Test Store on WP.com
- Test all functionality with and without a connection to WooCommerce.com
- Test package dimensions starting with 0
- Test UPS connect form input validation
- Test DHL Express schedule pick up link
- Test signature required pricing updates
- Test automated taxes messaging for exclusive tax pricing
- Test USPS refunds are not available for labels with no tracking ID

### Changelog
* Add   - Initial code for WooCommerce.com subscriptions API.
* Add   - Dynamic carrier registration form.
* Fix     - When adding "signature required" to some packages, prices were not updating.
* Add   - DHL Schedule Pickup link within order notes.
* Fix     - UI fix for input validation for package dimensions and weights.
* Fix     - Correct validation for UPS fields in Carrier Account connect form.
* Tweak - Add message to explain automated tax requires tax-exclusive product pricing.
* Fix   - Disable USPS refunds for untracked labels only.

## Build File
Built from this branch using `php woorelease.phar simulate --product_version=1.25.3 https://github.com/Automattic/woocommerce-services/tree/release/1.25.3`

**Updated November 23rd**
[woocommerce-services.zip](https://github.com/Automattic/woocommerce-services/files/5583341/woocommerce-services.zip)