### PR TITLE
Show subscriptions usage in admin

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.5 - 2020-**-** =
+* Add	- Display subscriptions usage.
+
 = 1.25.4 - 2020-12-08 =
 * Tweak - Remove Stripe connect functionality.
 * Tweak - Remove unused method in shipping settings view.

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -317,7 +317,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 * @param object|WP_Error
 		 */
 		public function get_wccom_subscriptions() {
-			return $this->request( 'POST', '/subscriptions', array() );
+			return $this->request( 'POST', '/subscriptions' );
 		}
 
 		/**

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -316,8 +316,8 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 * @param $body
 		 * @param object|WP_Error
 		 */
-		public function get_wccom_subscriptions( $body ) {
-			return $this->request( 'POST', '/subscriptions', $body );
+		public function get_wccom_subscriptions() {
+			return $this->request( 'POST', '/subscriptions', array() );
 		}
 
 		/**

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -86,6 +86,11 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 				$extra_args[ 'carriers' ] = $carriers_response->carriers;
 			}
 
+			$subscriptions_usage_response = $this->api_client->get_wccom_subscriptions();
+			if ( ! is_wp_error( $subscriptions_usage_response ) && $subscriptions_usage_response ) {
+				$extra_args[ 'subscriptions' ] = $subscriptions_usage_response->subscriptions;
+			}
+
 			if ( isset( $_GET['from_order'] ) ) {
 				$extra_args['order_id'] = $_GET['from_order'];
 				$extra_args['order_href'] = get_edit_post_link( $_GET['from_order'] );

--- a/classes/class-wc-rest-connect-subscriptions-controller.php
+++ b/classes/class-wc-rest-connect-subscriptions-controller.php
@@ -11,7 +11,7 @@ if ( class_exists( 'WC_REST_Connect_Subscriptions_Controller' ) ) {
 class WC_REST_Connect_Subscriptions_Controller extends WC_REST_Connect_Base_Controller {
 	protected $rest_base = 'connect/subscriptions';
 
-	public function get() {
+	public function post() {
 		$response = $this->api_client->get_wccom_subscriptions();
 		if ( is_wp_error( $response ) ) {
 			$this->logger->log( $response, __CLASS__ );

--- a/classes/class-wc-rest-connect-subscriptions-controller.php
+++ b/classes/class-wc-rest-connect-subscriptions-controller.php
@@ -9,20 +9,20 @@ if ( class_exists( 'WC_REST_Connect_Subscriptions_Controller' ) ) {
 }
 
 class WC_REST_Connect_Subscriptions_Controller extends WC_REST_Connect_Base_Controller {
-	protected $rest_base = 'connect/shipping/subscriptions';
+	protected $rest_base = 'connect/subscriptions';
 
 	public function get() {
 		$response = $this->api_client->get_wccom_subscriptions();
 		if ( is_wp_error( $response ) ) {
-			$error = new WP_Error(
-				$response->get_error_code(),
-				$response->get_error_message(),
-				array( 'message' => $response->get_error_message() )
-			);
-			$this->logger->log( $error, __CLASS__ );
-			return $error;
+			$this->logger->log( $response, __CLASS__ );
+			return $response;
 		}
 
-		return $response;
+		return new WP_REST_Response(
+			array(
+				'success'  => true,
+				'subscriptions' => $response->subscriptions,
+			)
+		);
 	}
 }

--- a/classes/class-wc-rest-connect-subscriptions-controller.php
+++ b/classes/class-wc-rest-connect-subscriptions-controller.php
@@ -1,0 +1,28 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit();
+}
+
+if ( class_exists( 'WC_REST_Connect_Subscriptions_Controller' ) ) {
+	return;
+}
+
+class WC_REST_Connect_Subscriptions_Controller extends WC_REST_Connect_Base_Controller {
+	protected $rest_base = 'connect/shipping/subscriptions';
+
+	public function get() {
+		$response = $this->api_client->get_wccom_subscriptions();
+		if ( is_wp_error( $response ) ) {
+			$error = new WP_Error(
+				$response->get_error_code(),
+				$response->get_error_message(),
+				array( 'message' => $response->get_error_message() )
+			);
+			$this->logger->log( $error, __CLASS__ );
+			return $error;
+		}
+
+		return $response;
+	}
+}

--- a/client/apps/shipping-settings/index.js
+++ b/client/apps/shipping-settings/index.js
@@ -18,7 +18,7 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import { middleware as rawWpcomApiMiddleware } from 'state/data-layer/wpcom-api-middleware';
 import { combineReducers } from 'state/utils';
 
-export default ( { order_id: orderId, order_href: orderHref, carrier: carrier, continents, carriers } ) => ( {
+export default ( { order_id: orderId, order_href: orderHref, carrier: carrier, continents, carriers, subscriptions } ) => ( {
 	getReducer() {
 		return combineReducers( {
 			extensions: combineReducers( {
@@ -74,5 +74,5 @@ export default ( { order_id: orderId, order_href: orderHref, carrier: carrier, c
 		return [ rawWpcomApiMiddleware( mergeHandlers( wcsUiDataLayer, actionList ) ) ];
 	},
 
-	View: () => <ViewWrapper orderId={ orderId } orderHref={ orderHref } carrier={ carrier } carriers={ carriers } />,
+	View: () => <ViewWrapper orderId={ orderId } orderHref={ orderHref } carrier={ carrier } carriers={ carriers } subscriptions = { subscriptions } />,
 } );

--- a/client/apps/shipping-settings/view-wrapper.js
+++ b/client/apps/shipping-settings/view-wrapper.js
@@ -16,6 +16,7 @@ import LabelSettings from '../../extensions/woocommerce/woocommerce-services/vie
 import notices from 'notices';
 import Packages from '../../extensions/woocommerce/woocommerce-services/views/packages';
 import CarrierAccounts from '../../extensions/woocommerce/woocommerce-services/views/carrier-accounts';
+import SubscriptionsUsage from '../../extensions/woocommerce/woocommerce-services/views/subscriptions-usage';
 import UpsSettingsForm from '../../extensions/woocommerce/woocommerce-services/views/carrier-accounts/ups-settings-form';
 import DynamicCarrierAccountSettings from '../../extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings';
 import { ProtectFormGuard } from 'lib/protect-form';
@@ -60,7 +61,7 @@ class LabelSettingsWrapper extends Component {
 	};
 
 	render() {
-		const { carrier, carriers, isSaving, translate } = this.props;
+		const { carrier, carriers, subscriptions, isSaving, translate } = this.props;
 
 		if ( ! carrier ) {
 			return (
@@ -69,6 +70,7 @@ class LabelSettingsWrapper extends Component {
 					<LabelSettings onChange={ this.onChange } />
 					<Packages onChange={ this.onChange } />
 					<CarrierAccounts carriers={ carriers } />
+					<SubscriptionsUsage subscriptions={ subscriptions } />
 					<Button primary onClick={ this.onSaveChanges } busy={ isSaving } disabled={ isSaving }>
 						{ translate( 'Save changes' ) }
 					</Button>

--- a/client/extensions/woocommerce/woocommerce-services/api/url.js
+++ b/client/extensions/woocommerce/woocommerce-services/api/url.js
@@ -11,5 +11,6 @@ export const addressNormalization = () => 'connect/normalize-address';
 export const serviceSettings = ( methodId, instanceId = 0 ) => `connect/services/${ methodId }/${ instanceId }`;
 export const shippingCarrier = () => 'connect/shipping/carrier';
 export const shippingCarriers = () => 'connect/shipping/carriers';
+export const subscriptions = () => 'connect/subscriptions';
 export const shippingCarrierDelete = ( carrier ) => `connect/shipping/carrier/${ carrier }`;
 export const shippingCarrierTypes = () => 'connect/shipping/carrier-types';

--- a/client/extensions/woocommerce/woocommerce-services/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/style.scss
@@ -6,6 +6,7 @@
 @import 'components/text/style';
 @import 'views/label-settings/style';
 @import 'views/carrier-accounts/style';
+@import 'views/subscriptions-usage/style';
 @import 'views/packages/style';
 @import 'views/service-settings/settings-form/style';
 @import 'views/service-settings/shipping-services/style';

--- a/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/index.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import React  from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import ExtendedHeader from 'woocommerce/components/extended-header';
+import SubscriptionsUsageListItem from './list-item';
+
+const SubscriptionsUsage = ({ translate, subscriptions = [] }) => {
+	if ( subscriptions.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<div>
+			<ExtendedHeader
+				label={translate('Shipping method')}
+				description={translate('View and manage your subscription usage')}
+			/>
+			<Card className="subscriptions-usage__list">
+				<div className="subscriptions-usage__header">
+					<div className="subscriptions-usage__header-icon" />
+					<div className="subscriptions-usage__header-name">{ translate( 'Name' ) }</div>
+					<div className="subscriptions-usage__header-usage">{ translate( 'Usage' ) }</div>
+					<div className="subscriptions-usage__header-actions" />
+				</div>
+				{ subscriptions.map( ( subscription, index ) => <SubscriptionsUsageListItem key={ index } data={ subscription } /> ) }
+			</Card>
+		</div>
+	);
+}
+
+SubscriptionsUsage.propTypes = {
+	subscriptions: PropTypes.arrayOf(
+		PropTypes.shape( {
+			product_name: PropTypes.string.isRequired,
+			usage_limit: PropTypes.number.isRequired,
+			usage_count: PropTypes.number,
+		} )
+	),
+};
+
+export default localize( SubscriptionsUsage );

--- a/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/list-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/list-item.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import CarrierIcon from '../../components/carrier-icon';
+
+const SubscriptionsUsageListItem = ( props ) => {
+	const { translate, data } = props;
+	 
+	 const getIcon = ( productName ) => {
+		const subscriptionToIconRules = [
+			[/^DHL/g, 'dhlexpress'],
+			[/^UPS/g, 'ups'],
+			[/^USPS/g, 'usps'],
+		];
+
+		const i = subscriptionToIconRules.findIndex( ( [rule] ) => rule.test( productName ));
+		if (i > -1) return subscriptionToIconRules[i][1];
+		
+		return '';
+	 };
+
+	return (
+		<div className= "subscriptions-usage__list-item" >
+			<div className="subscriptions-usage__list-item-carrier-icon">
+				<CarrierIcon carrier={ getIcon( data.product_name ) } size={ 18 } />
+			</div>
+			<div className="subscriptions-usage__list-item-name">
+				<span>{ data.product_name }</span>
+			</div>
+			<div className="subscriptions-usage__list-item-usage">
+				<span>{ data.usage_count }/{ data.usage_limit }</span>
+			</div>
+			<div className="subscriptions-usage__list-item-actions">
+				<a
+					href={
+						`https://woocommerce.com/my-account/my-subscriptions/`
+					}
+					// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+					className="button is-compact"
+				>
+					{ translate( 'Manage' ) }
+				</a>
+			</div>
+		</div>
+	);
+};
+
+SubscriptionsUsageListItem.propTypes = {
+	data: PropTypes.shape( {
+		product_name: PropTypes.string.isRequired,
+		usage_limit: PropTypes.number.isRequired,
+		usage_count: PropTypes.number,
+	} ).isRequired,
+};
+
+export default localize( SubscriptionsUsageListItem );

--- a/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/list-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/list-item.js
@@ -14,19 +14,20 @@ import CarrierIcon from '../../components/carrier-icon';
 const SubscriptionsUsageListItem = ( props ) => {
 	const { translate, data } = props;
 	 
-	 const getIcon = ( productName ) => {
-		const subscriptionToIconRules = [
-			[/^DHL/g, 'dhlexpress'],
-			[/^UPS/g, 'ups'],
-			[/^USPS/g, 'usps'],
-		];
+	const getIcon = ( productName ) => {
+	const subscriptionToIconRules = [
+		[/^DHL/g, 'dhlexpress'],
+		[/^UPS/g, 'ups'],
+		[/^USPS/g, 'usps'],
+	];
 
-		const i = subscriptionToIconRules.findIndex( ( [rule] ) => rule.test( productName ));
-		if (i > -1) return subscriptionToIconRules[i][1];
-		
-		return '';
-	 };
+	const i = subscriptionToIconRules.findIndex( ( [rule] ) => rule.test( productName ));
+	if (i > -1) return subscriptionToIconRules[i][1];
+	
+	return '';
+	};
 
+	const usage = `${ data.usage_count }/${ data.usage_limit }`;
 	return (
 		<div className= "subscriptions-usage__list-item" >
 			<div className="subscriptions-usage__list-item-carrier-icon">
@@ -36,7 +37,7 @@ const SubscriptionsUsageListItem = ( props ) => {
 				<span>{ data.product_name }</span>
 			</div>
 			<div className="subscriptions-usage__list-item-usage">
-				<span>{ data.usage_count }/{ data.usage_limit }</span>
+				<span>{ usage }</span>
 			</div>
 			<div className="subscriptions-usage__list-item-actions">
 				<a

--- a/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/style.scss
@@ -1,0 +1,56 @@
+.subscriptions-usage__list {
+	padding: 0;
+
+	.subscriptions-usage__list-item {
+		display: flex;
+		align-items: center;
+		padding: 8px 0;
+
+		.subscriptions-usage__list-item-carrier-icon {
+			width: 48px;
+			padding-left: 16px;
+
+			@include breakpoint( '>480px' ) {
+				padding-left: 24px;
+			}
+		}
+
+		.subscriptions-usage__list-item-name {
+			width: 35%;
+		}
+
+		.subscriptions-usage__list-item-usage {
+			width: 30%;
+		}
+
+		.subscriptions-usage__list-item-actions {
+			width: 25%;
+			text-align: right;
+			padding-right: 16px;
+
+			@include breakpoint( '>480px' ) {
+				padding-right: 24px;
+			}
+		}
+	}
+}
+
+.subscriptions-usage__header {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	font-weight: 600;
+	padding: 12px 0;
+	font-size: 14px;
+	border-top: 0;
+	border-bottom: 1px solid var( --color-neutral-0 );
+	border-bottom-color: var( --color-neutral-100 );
+	background: var( --color-neutral-0 );
+
+	.subscriptions-usage__header-icon {
+		width: 72px;
+	}
+	.subscriptions-usage__header-name {
+		width: 35%;
+	}
+}

--- a/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/test/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/test/index.js
@@ -1,0 +1,120 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { mount } from 'enzyme';
+import configureMockStore from 'redux-mock-store'
+import { Provider } from 'react-redux'
+
+/**
+ * Internal dependencies
+ */
+import SubscriptionsUsage from '..';
+
+const mockStore = configureMockStore([]);
+const Wrapper = ({children}) => (
+	<Provider store={mockStore({
+		ui: {
+			selectedSiteId: 1234
+		}
+	})}>
+		{children}
+	</Provider>
+);
+
+describe( 'Carrier Accounts', () => {
+	it('should render nothing when no subscriptions are provided', () => {
+		const wrapper = mount(
+			<Wrapper>
+				<SubscriptionsUsage />
+			</Wrapper>
+		);
+
+		expect(wrapper.html()).toBeFalsy();
+	});
+
+	it('should render a list of subscriptions usage info', () => {
+
+		const subscriptions = [
+			{
+				product_key:"W00-bfd64110-4ff9-b179-dca3903f62b0",
+				product_keys_all:
+					["W00-bfd64110-4ff9-b179-dca3903f62b0"],
+				product_id:1770503,
+				product_name:"DHL Express rates",
+				product_url:"https:\/\/woocommerce.com\/products\/DHL-subscriptions\/",
+				key_type:"single",
+				key_type_label:"Single site",
+				key_parent_order_item_id:null,
+				autorenew:true,
+				connections:[751464],
+				legacy_connections:[],
+				shares:[],
+				lifetime:false,
+				expires:1639008000,
+				expired:false,
+				expiring:false,
+				sites_max:1,
+				sites_active:1,
+				maxed:false,
+				product_status:"publish",
+				usage_limit:1000,
+				usage_count:250
+			},
+			{
+				product_key:"W00-bfd64110-4ff9-b179-dca3903f62b1",
+				product_keys_all:
+					["W00-bfd64110-4ff9-b179-dca3903f62b1"],
+				product_id:1770504,
+				product_name:"UPS rates",
+				product_url:"https:\/\/woocommerce.com\/products\/UPS-subscriptions\/",
+				key_type:"single",
+				key_type_label:"Single site",
+				key_parent_order_item_id:null,
+				autorenew:true,
+				connections:[751464],
+				legacy_connections:[],
+				shares:[],
+				lifetime:false,
+				expires:1639008000,
+				expired:false,
+				expiring:false,
+				sites_max:1,
+				sites_active:1,
+				maxed:false,
+				product_status:"publish",
+				usage_limit:50,
+				usage_count:8
+			},
+
+		];
+		const wrapper = mount(
+			
+			<Wrapper>
+				<SubscriptionsUsage subscriptions={ subscriptions } />
+			</Wrapper>
+		);
+
+		// Find list items for subscriptions.
+		const dhlExpressRatesListItem = wrapper.find('.subscriptions-usage__list-item').at(0)
+		const upsLabelsListItem = wrapper.find('.subscriptions-usage__list-item').at(1)
+
+		// Expect subscription names.
+		expect(dhlExpressRatesListItem.find('span[children="DHL Express rates"]')).toHaveLength(1);
+		expect(upsLabelsListItem.find('span[children="UPS rates"]')).toHaveLength(1);
+
+		// Expect subscription usage.
+		expect(dhlExpressRatesListItem.find('span[children="250/1000"]')).toHaveLength(1);
+		expect(upsLabelsListItem.find('span[children="8/50"]')).toHaveLength(1);
+		
+		// Expect button manage.
+		const dhlExpressmanageButton = dhlExpressRatesListItem.find('a[href="https://woocommerce.com/my-account/my-subscriptions/"]');
+		expect(dhlExpressmanageButton.text()).toBe('Manage');
+		const upsLabelsmanageButton = upsLabelsListItem.find('a[href="https://woocommerce.com/my-account/my-subscriptions/"]');
+		expect(upsLabelsmanageButton.text()).toBe('Manage');
+	
+	});
+
+} );

--- a/tests/php/classes/test-class-wc-rest-connect-subscriptions-controller.php
+++ b/tests/php/classes/test-class-wc-rest-connect-subscriptions-controller.php
@@ -115,7 +115,7 @@ class WP_Test_WC_REST_Connect_Subscriptions_Controller extends WC_Unit_Test_Case
 			->willReturn( $api_client_response );
 
 		$wc_connect_subscriptions_controller = new WC_REST_Connect_Subscriptions_Controller( $this->api_client_mock, $this->setting_store_mock, $this->connect_logger_mock );
-		$actual                              = $wc_connect_subscriptions_controller->get();
+		$actual                              = $wc_connect_subscriptions_controller->post();
 		$expected                            =  $api_client_response->subscriptions ;
 
 		$expected                                     = [
@@ -143,7 +143,7 @@ class WP_Test_WC_REST_Connect_Subscriptions_Controller extends WC_Unit_Test_Case
 			->with( $api_response, WC_REST_Connect_Subscriptions_Controller::class );
 
 		$wc_connect_subscriptions_controller = new WC_REST_Connect_Subscriptions_Controller( $this->api_client_mock, $this->setting_store_mock, $this->connect_logger_mock );
-		$actual                              = $wc_connect_subscriptions_controller->get();
+		$actual                              = $wc_connect_subscriptions_controller->post();
 
 		$this->assertInstanceOf( WP_Error::class, $actual );
 		$this->assertEquals( $api_response, $actual );

--- a/tests/php/classes/test-class-wc-rest-connect-subscriptions-controller.php
+++ b/tests/php/classes/test-class-wc-rest-connect-subscriptions-controller.php
@@ -1,0 +1,151 @@
+<?php
+
+
+
+/**
+ * Unit test for WC_Connect_API_Client_Live
+ */
+class WP_Test_WC_REST_Connect_Subscriptions_Controller extends WC_Unit_Test_Case {
+
+	/** @var WC_Connect_API_Client_Live $api_client_mock */
+	protected $api_client_mock;
+
+	/** @var WC_Connect_Service_Settings_Store $setting_store_mock */
+	protected $setting_store_mock;
+
+	/** @var WC_Connect_Logger $connect_logger_mock */
+	protected $connect_logger_mock;
+
+	/**
+	 * @inherit
+	 */
+	public static function setupBeforeClass() {
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-api-client-live.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-service-settings-store.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-logger.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-rest-connect-base-controller.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-rest-connect-subscriptions-controller.php';
+	}
+
+	/**
+	 * Setup the test case.
+	 *
+	 * @see WC_Unit_Test_Case::setUp()
+	 */
+	public function setUp() {
+		// Creating a mock class and overide protected request method so that we can mock the API response.
+		$this->api_client_mock = $this->getMockBuilder( WC_Connect_API_Client_Live::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'request' ] )
+			->getMock();
+
+		$this->setting_store_mock  = $this->createMock( WC_Connect_Service_Settings_Store::class );
+		$this->connect_logger_mock = $this->createMock( WC_Connect_Logger::class );
+	}
+
+	/**
+	 * Test GET request on connect/subscriptions end point.
+	 */
+	public function test_get() {
+		$api_response        = '{
+			"subscriptions": [
+				{
+					"product_key": "W00-5705e69b-4cbe-85ae-bb62bf204675",
+					"product_keys_all": [
+						"W00-5705e69b-4cbe-85ae-bb62bf204675"
+					],
+					"product_id": 1770503,
+					"product_name": "UPS Live Rates",
+					"product_url": "https://woocommerce.com/products/UPS-live-rates/",
+					"key_type": "single",
+					"key_type_label": "Single site",
+					"key_parent_order_item_id": null,
+					"autorenew": true,
+					"connections": [
+						742089
+					],
+					"legacy_connections": [],
+					"shares": [],
+					"lifetime": false,
+					"expires": 1634774400,
+					"expired": false,
+					"expiring": false,
+					"sites_max": 1,
+					"sites_active": 1,
+					"maxed": false,
+					"product_status": "publish",
+					"usage_limit": 50,
+					"usage_count": 8
+				},
+				{
+					"product_key": "W00-5705e69b-4cbe-85ae-bb62bf204675",
+					"product_keys_all": [
+						"W00-5705e69b-4cbe-85ae-bb62bf204675"
+					],
+					"product_id": 1770504,
+					"product_name": "DHL Express Live Rates",
+					"product_url": "https://woocommerce.com/products/DHLExpress-live-rates/",
+					"key_type": "single",
+					"key_type_label": "Single site",
+					"key_parent_order_item_id": null,
+					"autorenew": true,
+					"connections": [
+						742089
+					],
+					"legacy_connections": [],
+					"shares": [],
+					"lifetime": false,
+					"expires": 1634774400,
+					"expired": false,
+					"expiring": false,
+					"sites_max": 1,
+					"sites_active": 1,
+					"maxed": false,
+					"product_status": "publish",
+					"usage_limit": 1000,
+					"usage_count": 250
+				}
+			]
+		}';
+		$api_client_response = json_decode( $api_response ); // assumes api_client->request() successfully returns the JSON decoded response body.
+
+		$this->api_client_mock->expects( $this->once() )
+			->method( 'request' )
+			->with( 'POST', '/subscriptions' )
+			->willReturn( $api_client_response );
+
+		$wc_connect_subscriptions_controller = new WC_REST_Connect_Subscriptions_Controller( $this->api_client_mock, $this->setting_store_mock, $this->connect_logger_mock );
+		$actual                              = $wc_connect_subscriptions_controller->get();
+		$expected                            =  $api_client_response->subscriptions ;
+
+		$expected                                     = [
+			'success'  => true,
+			'subscriptions' => $api_client_response->subscriptions,
+		];
+
+		$this->assertEquals( 200, $actual->status );
+		$this->assertEquals( $expected, $actual->data );
+	}
+
+	/**
+	 * Test error thrown during a GET request on connect/subscriptions end point.
+	 */
+	public function test_get_with_error() {
+		$api_response = new WP_Error( 'error_code_123', 'something is wrong' );
+
+		$this->api_client_mock->expects( $this->once() )
+			->method( 'request' )
+			->with( 'POST', '/subscriptions' )
+			->willReturn( $api_response );
+
+		$this->connect_logger_mock->expects( $this->once() )
+			->method( 'log' )
+			->with( $api_response, WC_REST_Connect_Subscriptions_Controller::class );
+
+		$wc_connect_subscriptions_controller = new WC_REST_Connect_Subscriptions_Controller( $this->api_client_mock, $this->setting_store_mock, $this->connect_logger_mock );
+		$actual                              = $wc_connect_subscriptions_controller->get();
+
+		$this->assertInstanceOf( WP_Error::class, $actual );
+		$this->assertEquals( $api_response, $actual );
+	}
+}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -339,6 +339,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->rest_carriers_controller = $rest_carriers_controller;
 		}
 
+		public function set_rest_subscriptions_controller( WC_REST_Connect_Subscriptions_Controller $rest_subscriptions_controller ) {
+			$this->rest_subscriptions_controller = $rest_subscriptions_controller;
+		}
+
 		public function set_rest_carrier_controller( WC_REST_Connect_Shipping_Carrier_Controller $rest_carrier_controller ) {
 			$this->rest_carrier_controller = $rest_carrier_controller;
 		}
@@ -877,6 +881,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$rest_carriers_controller = new WC_REST_Connect_Shipping_Carriers_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_carriers_controller( $rest_carriers_controller );
 			$rest_carriers_controller->register_routes();
+
+			require_once( plugin_basename( 'classes/class-wc-rest-connect-subscriptions-controller.php' ) );
+			$rest_subscriptions_controller = new WC_REST_Connect_Subscriptions_Controller( $this->api_client, $settings_store, $logger );
+			$this->set_rest_subscriptions_controller( $rest_subscriptions_controller );
+			$rest_subscriptions_controller->register_routes();
 
 			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-carrier-delete-controller.php' ) );
 			$rest_carrier_delete_controller = new WC_REST_Connect_Shipping_Carrier_Delete_Controller( $this->api_client, $settings_store, $logger );


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
This PR displays the subscriptions usage under wp-admin > WooCommerce > Settings > Shipping > WooCommerce Services.
It uses the subscriptions end point from the connect server.

I have also added the Rest Controller that was missing from the new end point.

The subscriptions endpoint on WCS had a `$body` parameter but there was nothing to send that was not generated by the API client. I have removed it. 

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
closes #2257 
### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

To test the subscriptions usage display:

1) Use [this branch](https://github.com/Automattic/woocommerce-connect-server/tree/add/1615-subscription-usage-endpoint) on the connect servers and follow [steps 1 and 2 here](https://github.com/Automattic/woocommerce-connect-server/pull/1661) to activate the subscription for Square. ( I had to add the key on the Square plugin headers ).
With that branch, the display will look like this:
<img width="1619" alt="Screen Shot on 2020-12-10 at 09-09-40" src="https://user-images.githubusercontent.com/8002881/101955092-cb927780-3bc2-11eb-90be-b54e72531cc1.png">


2) Another way to test is to mock the connect server response inside of the plugin.
You can use this diff: https://mc.a8c.com/pb/27855/#diff
With the mocked data the display will look like this:
<img width="1628" alt="Screen Shot on 2020-12-11 at 15-07-52" src="https://user-images.githubusercontent.com/8002881/101955044-b6b5e400-3bc2-11eb-89c4-6c0acb5b4067.png">

3) Unit tests are on this file: `client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/test/index.js`

To test the new Rest controller, follow the steps here ( thanks @harriswong ):
1. We will be using this https://docs.woocommerce.com/document/woocommerce-rest-api/ to make a completely separate script to make API calls.
1. Create a new folder `mkdir woocommerce-api-test`
2. `composer install automattic/woocommerce` ([link](https://packagist.org/packages/automattic/woocommerce))
3. vim `index.php` 
4. paste this in there
```
<?php

require __DIR__ . '/vendor/autoload.php';

use Automattic\WooCommerce\Client;

$woocommerce = new Client(
    'http://localhost',
    'ck_***', // this needs to be your own key
    'cs_***', // this needs to be your own secrets
    [
        'version' => 'wc/v1',
    ]
);

print_r($woocommerce->post('connect/subscriptions'));
```

5. For the keys and secrets, follow the instructions [here](https://docs.woocommerce.com/document/woocommerce-rest-api/). 
6. run `php index.php` in your console.
7. You should see the results back.

Unit tests are on this file: `tests/php/classes/test-class-wc-rest-connect-subscriptions-controller.php`

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

