### PR TITLE
Reuse DHL logos for DHL eCommerce, DHL eCommerce Asia, and DHL eCommerce International

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix	- Redux DevTools usage update.
 * Add	- Display subscriptions usage.
 * Add	- Subscription activation.
+* Add 	- Uses same DHL logo for all registered DHL accounts.
 
 = 1.25.4 - 2020-12-08 =
 * Tweak - Remove Stripe connect functionality.
@@ -12,7 +13,6 @@
 * Add	- Allows registration of additional accounts.
 * Tweak - Carrier description on dynamic carrier registration form.
 * Fix   - Adjust documentation links.
-* Add 	- Uses same DHL logo for all registered DHL accounts.
 
 = 1.25.3 - 2020-11-24 =
 * Add   - Initial code for WooCommerce.com subscriptions API.

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Add	- Allows registration of additional accounts.
 * Tweak - Carrier description on dynamic carrier registration form.
 * Fix   - Adjust documentation links.
+* Add 	- Uses same DHL logo for all registered DHL accounts.
 
 = 1.25.3 - 2020-11-24 =
 * Add   - Initial code for WooCommerce.com subscriptions API.

--- a/client/extensions/woocommerce/woocommerce-services/components/carrier-icon/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/carrier-icon/index.js
@@ -11,12 +11,13 @@ import PropTypes from 'prop-types';
  */
 import upsLogo from './logos/ups.png';
 import uspsLogo from './logos/usps.png';
-import dhlExpressLogo from './logos/dhlExpress.png';
+import dhlLogo from './logos/dhlExpress.png';
 
 const carrierLogos = {
 	"ups": upsLogo,
 	"usps": uspsLogo,
-	"dhlexpress": dhlExpressLogo,
+	"dhlexpress": dhlLogo,
+	"dhlecommerce": dhlLogo,
 };
 
 const sizeToPixels = ( size ) => {

--- a/client/extensions/woocommerce/woocommerce-services/components/carrier-icon/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/carrier-icon/index.js
@@ -18,6 +18,8 @@ const carrierLogos = {
 	"usps": uspsLogo,
 	"dhlexpress": dhlLogo,
 	"dhlecommerce": dhlLogo,
+	"dhlecommerceasia": dhlLogo,
+	"dhlecommerceinternational": dhlLogo,
 };
 
 const sizeToPixels = ( size ) => {

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/list-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/list-item.js
@@ -81,6 +81,8 @@ const CarrierAccountListItem = ( props ) => {
 	const carrierTypeIconMap = {
 		DhlExpressAccount: 'dhlexpress',
 		DhlEcommerceAccount: 'dhlecommerce',
+		DhlEcommerceAsiaAccount: 'dhlecommerceasia',
+		DHLGMIAccount: 'dhlecommerceinternational',
 		UpsAccount: 'ups',
 	}
 

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/list-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/list-item.js
@@ -80,6 +80,7 @@ const CarrierAccountListItem = ( props ) => {
 
 	const carrierTypeIconMap = {
 		DhlExpressAccount: 'dhlexpress',
+		DhlEcommerceAccount: 'dhlecommerce',
 		UpsAccount: 'ups',
 	}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
This allows DHL merchant carrier accounts to be displayed with the same DHL logo that is used by DHL Express.

### Related issue(s)
Automattic/woocommerce-shipping-issues#125.

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
1. Pull the changes from Automattic/woocommerce-connect-server#1666 and follow the steps to enable DHL Express, DHL eCommerce, DHL eCommerce Asia, and DHL eCommerce International.
2. Visit **WooCommerce > Settings > Shipping > WooCommerceShipping**. You should now see the new DHL carrier accounts appear in the list of available Carrier Accounts, all using the same DHL logo as DHL Express.

![DHL carrier account logos](https://cdn-std.droplr.net/files/acc_1104206/SBmBb5)
_New DHL carrier accounts with correct logos_

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

