### PR TITLE
Send WCCOM connection info in request header

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Add	- Allows registration of additional accounts.
 * Tweak - Carrier description on dynamic carrier registration form.
 * Fix   - Adjust documentation links.
+* Tweak - Adds WCCom access token and site ID to connect server request headers.
 
 = 1.25.3 - 2020-11-24 =
 * Add   - Initial code for WooCommerce.com subscriptions API.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.25.5 - 202x-xx-xx =
 * Fix	- Redux DevTools usage update.
 * Add	- Display subscriptions usage.
+* Tweak - Adds WCCom access token and site ID to connect server request headers.
 
 = 1.25.4 - 2020-12-08 =
 * Tweak - Remove Stripe connect functionality.
@@ -11,7 +12,6 @@
 * Add	- Allows registration of additional accounts.
 * Tweak - Carrier description on dynamic carrier registration form.
 * Fix   - Adjust documentation links.
-* Tweak - Adds WCCom access token and site ID to connect server request headers.
 
 = 1.25.3 - 2020-11-24 =
 * Add   - Initial code for WooCommerce.com subscriptions API.

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -480,7 +480,9 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 
 			$wc_helper_auth_info = WC_Connect_Functions::get_wc_helper_auth_info();
 			if ( ! is_wp_error( $wc_helper_auth_info ) ) {
-				$headers[ 'X-Woo-Signature' ] = $this->request_signature_wccom( $wc_helper_auth_info['access_token_secret'], 'subscriptions', 'GET', array() );
+				$headers[ 'X-Woo-Signature' ]    = $this->request_signature_wccom( $wc_helper_auth_info['access_token_secret'], 'subscriptions', 'GET', array() );
+				$headers[ 'X-Woo-Access-Token' ] = $wc_helper_auth_info['access_token'];
+				$headers[ 'X-Woo-Site-Id' ]      = $wc_helper_auth_info['site_id'];
 			}
 			return $headers;
 		}

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -444,17 +444,6 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				)
 			);
 
-			// Add WC Helper auth info if connected to WC.com.
-			$helper_auth_data = WC_Connect_Functions::get_wc_helper_auth_info();
-
-			if ( ! is_wp_error( $helper_auth_data ) ) {
-				$body[ 'settings' ] = wp_parse_args( $body[ 'settings' ], array(
-					'access_token' => $helper_auth_data['access_token'],
-					'site_id'      => $helper_auth_data['site_id'],
-					)
-				);
-			}
-
 			return $body;
 		}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
Subscription flags should be able to enable carriers in carrier account list. The items in the carrier account list will depend on current subscriptions, so the request to populate this list need to include WCCOM connection info in order to get subscription status on request.

![New carrier account list](https://user-images.githubusercontent.com/6209518/102676766-f2692480-4153-11eb-9537-b545e06d7c84.png)

Currently, this WCCOM connection info is only sent in the body of `POST` requests. This PR adds this information to the header of all requests to the Connect Server, so that all request types will be able to send this information and have the Connect Server check existing subscription flags for a user's site. 

Our other options to resolve this would be to change the `GET /shipping/carriers` and `GET /shipping/carrier-types` requests to `POST` requests or to include the extra parameters as query parameters. Changing the requests to `POST` requests would require changes to the Connect Server API endpoints and could cause backwards compatability issues. I felt using the request header felt more appropriate than using query parameters, because these fields are fairly static and could be useful for many other requests/request types as well. Using the header also keeps the Connect Server integration relatively the same, as the server side code is already checking the request headers for the `X-Woo-Signature` to use to make the WCCOM request to fetch a user's WCCOM subscriptions. Additionally, when generating the request header values we are already making the request for the WCCOM connection information with `WC_Connect_Functions::get_wc_helper_auth_info()` to get the `X-Woo-Signature`, so we already have these additional fields unused without necessitating any further API calls. Since I was now able to remove these fields from POST requests, we only need to make this API call once on each request now.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
Closes Automattic/woocommerce-shipping-issues#147

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
1. Please pull, review, and approve the changes in this [PR for the Connect Server](https://github.com/Automattic/woocommerce-connect-server/pull/1673).
2. Add a free extension from WooCommerce.com to your site (e.g. WooCommerce Payments, Square for WooCommerce, etc.) and activate it on your site admin from **WooCommerce > Extensions > WooCommerce.com Subscriptions**.
3. Add a row in the `wcc_subscription_flags` table, using the `product_id` value for a subscription connected to your site, to enable a carrier (e.g. `can_use_dhlexpress_live_rates` to enable DHL Express). You can find the `product_id` value for subscriptions for your WooCommerce account by making a request to the Connect Server to `POST /subscriptions`, containing correct header values for `X-Woo-Signature`, `X-Woo-Access-Token`, and `X-Woo-Site-Id`. Ensure that the flag that you add is not also present in the `wcc_site_flags` table already.

![wcc_subscription_flags](https://cdn-std.droplr.net/files/acc_1104206/ZyyLy3)
_Example row in `wcc_subscription_flags` to use Square extension to enable DHL Express_

4. You should now see the carrier you chose above as an available carrier to connect from the WooCommerce Shipping settings page. 

![WooCommerce Shipping carriers](https://cdn-std.droplr.net/files/acc_1104206/GLo4CS)
_Example DHL Express is now available to connect_


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

