### PR TITLE
release 1.25.5

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.25.5 - 202x-xx-xx =
 * Fix	- Redux DevTools usage update.
 * Add	- Display subscriptions usage.
+* Add	- Subscription activation.
 
 = 1.25.4 - 2020-12-08 =
 * Tweak - Remove Stripe connect functionality.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
-= 1.25.5 - 202x-xx-xx =
+= 1.25.5 - 2021-XX-XX =
 * Fix	- Redux DevTools usage update.
 * Add	- Display subscriptions usage.
 * Add	- Subscription activation.

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Add	- Display subscriptions usage.
 * Add	- Subscription activation.
 * Add 	- Uses same DHL logo for all registered DHL accounts.
+* Tweak - Adds WCCom access token and site ID to connect server request headers.
 
 = 1.25.4 - 2020-12-08 =
 * Tweak - Remove Stripe connect functionality.

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix	- Redux DevTools usage update.
 * Add	- Display subscriptions usage.
 * Add	- Subscription activation.
+* Add 	- Uses same DHL logo for all registered DHL accounts.
 
 = 1.25.4 - 2020-12-08 =
 * Tweak - Remove Stripe connect functionality.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.25.5 - 202x-xx-xx =
 * Fix	- Redux DevTools usage update.
+* Add	- Display subscriptions usage.
 
 = 1.25.4 - 2020-12-08 =
 * Tweak - Remove Stripe connect functionality.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.5 - 202x-xx-xx =
+* Fix	- Redux DevTools usage update.
+
 = 1.25.4 - 2020-12-08 =
 * Tweak - Remove Stripe connect functionality.
 * Tweak - Remove unused method in shipping settings view.

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -466,17 +466,6 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				)
 			);
 
-			// Add WC Helper auth info if connected to WC.com.
-			$helper_auth_data = WC_Connect_Functions::get_wc_helper_auth_info();
-
-			if ( ! is_wp_error( $helper_auth_data ) ) {
-				$body[ 'settings' ] = wp_parse_args( $body[ 'settings' ], array(
-					'access_token' => $helper_auth_data['access_token'],
-					'site_id'      => $helper_auth_data['site_id'],
-					)
-				);
-			}
-
 			return $body;
 		}
 
@@ -502,7 +491,9 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 
 			$wc_helper_auth_info = WC_Connect_Functions::get_wc_helper_auth_info();
 			if ( ! is_wp_error( $wc_helper_auth_info ) ) {
-				$headers[ 'X-Woo-Signature' ] = $this->request_signature_wccom( $wc_helper_auth_info['access_token_secret'], 'subscriptions', 'GET', array() );
+				$headers[ 'X-Woo-Signature' ]    = $this->request_signature_wccom( $wc_helper_auth_info['access_token_secret'], 'subscriptions', 'GET', array() );
+				$headers[ 'X-Woo-Access-Token' ] = $wc_helper_auth_info['access_token'];
+				$headers[ 'X-Woo-Site-Id' ]      = $wc_helper_auth_info['site_id'];
 			}
 			return $headers;
 		}

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -316,8 +316,8 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 * @param $body
 		 * @param object|WP_Error
 		 */
-		public function get_wccom_subscriptions( $body ) {
-			return $this->request( 'POST', '/subscriptions', $body );
+		public function get_wccom_subscriptions() {
+			return $this->request( 'POST', '/subscriptions' );
 		}
 
 		/**

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -367,6 +367,28 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		/**
+		 * Activate a subscrption with WCCOM API.
+		 *
+		 * @param  string $subscription_key Product Key on WCCOM.
+		 * @return WP_Error|Array  API Response.
+		 */
+		public function activate_subscription( $subscription_key ) {
+			$activation_response = WC_Helper_API::post(
+				'activate',
+				array(
+					'authenticated' => true,
+					'body'          => wp_json_encode(
+						array(
+							'product_key' => $subscription_key,
+						)
+					),
+				)
+			);
+
+			return $activation_response;
+		}
+
+		/**
 		 * Sends a request to the WooCommerce Shipping & Tax Server
 		 *
 		 * @param $method

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -86,6 +86,11 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 				$extra_args[ 'carriers' ] = $carriers_response->carriers;
 			}
 
+			$subscriptions_usage_response = $this->api_client->get_wccom_subscriptions();
+			if ( ! is_wp_error( $subscriptions_usage_response ) && $subscriptions_usage_response ) {
+				$extra_args[ 'subscriptions' ] = $subscriptions_usage_response->subscriptions;
+			}
+
 			if ( isset( $_GET['from_order'] ) ) {
 				$extra_args['order_id'] = $_GET['from_order'];
 				$extra_args['order_href'] = get_edit_post_link( $_GET['from_order'] );

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -87,6 +87,7 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 			}
 
 			$subscriptions_usage_response = $this->api_client->get_wccom_subscriptions();
+
 			if ( ! is_wp_error( $subscriptions_usage_response ) && $subscriptions_usage_response ) {
 				$extra_args[ 'subscriptions' ] = $subscriptions_usage_response->subscriptions;
 			}

--- a/classes/class-wc-rest-connect-subscription-activate-controller.php
+++ b/classes/class-wc-rest-connect-subscription-activate-controller.php
@@ -1,0 +1,38 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit();
+}
+
+if ( class_exists( 'WC_REST_Connect_Subscription_Activate_Controller' ) ) {
+	return;
+}
+
+class WC_REST_Connect_Subscription_Activate_Controller extends WC_REST_Connect_Base_Controller {
+	protected $rest_base = 'connect/subscription/(?P<subscription_key>.+)/activate';
+
+	public function post( $request ) {
+		$subscription_key = $request['subscription_key'];
+
+		$response = $this->api_client->activate_subscription( $subscription_key );
+		if ( is_wp_error( $response ) ) {
+			$this->logger->log( $response, __CLASS__ );
+			return $response;
+		}
+
+		$activated = wp_remote_retrieve_response_code( $activation_response ) === 200;
+		$body      = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ( ! $activated && ! empty( $body['code'] ) && 'already_connected' === $body['code'] ) ) {
+			return new WP_Error(
+				'already_active',
+				__( 'The subscription is already active.', 'woocommerce-services' )
+			);
+		}
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+			)
+		);
+	}
+}

--- a/classes/class-wc-rest-connect-subscriptions-controller.php
+++ b/classes/class-wc-rest-connect-subscriptions-controller.php
@@ -1,0 +1,28 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit();
+}
+
+if ( class_exists( 'WC_REST_Connect_Subscriptions_Controller' ) ) {
+	return;
+}
+
+class WC_REST_Connect_Subscriptions_Controller extends WC_REST_Connect_Base_Controller {
+	protected $rest_base = 'connect/subscriptions';
+
+	public function post() {
+		$response = $this->api_client->get_wccom_subscriptions();
+		if ( is_wp_error( $response ) ) {
+			$this->logger->log( $response, __CLASS__ );
+			return $response;
+		}
+
+		return new WP_REST_Response(
+			array(
+				'success'  => true,
+				'subscriptions' => $response->subscriptions,
+			)
+		);
+	}
+}

--- a/client/apps/shipping-settings/index.js
+++ b/client/apps/shipping-settings/index.js
@@ -18,7 +18,7 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import { middleware as rawWpcomApiMiddleware } from 'state/data-layer/wpcom-api-middleware';
 import { combineReducers } from 'state/utils';
 
-export default ( { order_id: orderId, order_href: orderHref, carrier: carrier, continents, carriers } ) => ( {
+export default ( { order_id: orderId, order_href: orderHref, carrier: carrier, continents, carriers, subscriptions } ) => ( {
 	getReducer() {
 		return combineReducers( {
 			extensions: combineReducers( {
@@ -74,5 +74,5 @@ export default ( { order_id: orderId, order_href: orderHref, carrier: carrier, c
 		return [ rawWpcomApiMiddleware( mergeHandlers( wcsUiDataLayer, actionList ) ) ];
 	},
 
-	View: () => <ViewWrapper orderId={ orderId } orderHref={ orderHref } carrier={ carrier } carriers={ carriers } />,
+	View: () => <ViewWrapper orderId={ orderId } orderHref={ orderHref } carrier={ carrier } carriers={ carriers } subscriptions = { subscriptions } />,
 } );

--- a/client/apps/shipping-settings/view-wrapper.js
+++ b/client/apps/shipping-settings/view-wrapper.js
@@ -16,6 +16,7 @@ import LabelSettings from '../../extensions/woocommerce/woocommerce-services/vie
 import notices from 'notices';
 import Packages from '../../extensions/woocommerce/woocommerce-services/views/packages';
 import CarrierAccounts from '../../extensions/woocommerce/woocommerce-services/views/carrier-accounts';
+import SubscriptionsUsage from '../../extensions/woocommerce/woocommerce-services/views/subscriptions-usage';
 import UpsSettingsForm from '../../extensions/woocommerce/woocommerce-services/views/carrier-accounts/ups-settings-form';
 import DynamicCarrierAccountSettings from '../../extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings';
 import { ProtectFormGuard } from 'lib/protect-form';
@@ -60,7 +61,7 @@ class LabelSettingsWrapper extends Component {
 	};
 
 	render() {
-		const { carrier, carriers, isSaving, translate } = this.props;
+		const { carrier, carriers, subscriptions, isSaving, translate } = this.props;
 
 		if ( ! carrier ) {
 			return (
@@ -69,6 +70,7 @@ class LabelSettingsWrapper extends Component {
 					<LabelSettings onChange={ this.onChange } />
 					<Packages onChange={ this.onChange } />
 					<CarrierAccounts carriers={ carriers } />
+					<SubscriptionsUsage subscriptions={ subscriptions } />
 					<Button primary onClick={ this.onSaveChanges } busy={ isSaving } disabled={ isSaving }>
 						{ translate( 'Save changes' ) }
 					</Button>

--- a/client/extensions/woocommerce/woocommerce-services/api/url.js
+++ b/client/extensions/woocommerce/woocommerce-services/api/url.js
@@ -12,5 +12,6 @@ export const serviceSettings = ( methodId, instanceId = 0 ) => `connect/services
 export const shippingCarrier = () => 'connect/shipping/carrier';
 export const shippingCarriers = () => 'connect/shipping/carriers';
 export const subscriptions = () => 'connect/subscriptions';
+export const subscriptionActivate = ( subscriptionKey ) => `connect/subscription/${ subscriptionKey }/activate`;
 export const shippingCarrierDelete = ( carrier ) => `connect/shipping/carrier/${ carrier }`;
 export const shippingCarrierTypes = () => 'connect/shipping/carrier-types';

--- a/client/extensions/woocommerce/woocommerce-services/api/url.js
+++ b/client/extensions/woocommerce/woocommerce-services/api/url.js
@@ -11,5 +11,6 @@ export const addressNormalization = () => 'connect/normalize-address';
 export const serviceSettings = ( methodId, instanceId = 0 ) => `connect/services/${ methodId }/${ instanceId }`;
 export const shippingCarrier = () => 'connect/shipping/carrier';
 export const shippingCarriers = () => 'connect/shipping/carriers';
+export const subscriptions = () => 'connect/subscriptions';
 export const shippingCarrierDelete = ( carrier ) => `connect/shipping/carrier/${ carrier }`;
 export const shippingCarrierTypes = () => 'connect/shipping/carrier-types';

--- a/client/extensions/woocommerce/woocommerce-services/components/carrier-icon/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/carrier-icon/index.js
@@ -11,12 +11,15 @@ import PropTypes from 'prop-types';
  */
 import upsLogo from './logos/ups.png';
 import uspsLogo from './logos/usps.png';
-import dhlExpressLogo from './logos/dhlExpress.png';
+import dhlLogo from './logos/dhlExpress.png';
 
 const carrierLogos = {
 	"ups": upsLogo,
 	"usps": uspsLogo,
-	"dhlexpress": dhlExpressLogo,
+	"dhlexpress": dhlLogo,
+	"dhlecommerce": dhlLogo,
+	"dhlecommerceasia": dhlLogo,
+	"dhlecommerceinternational": dhlLogo,
 };
 
 const sizeToPixels = ( size ) => {

--- a/client/extensions/woocommerce/woocommerce-services/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/style.scss
@@ -6,6 +6,7 @@
 @import 'components/text/style';
 @import 'views/label-settings/style';
 @import 'views/carrier-accounts/style';
+@import 'views/subscriptions-usage/style';
 @import 'views/packages/style';
 @import 'views/service-settings/settings-form/style';
 @import 'views/service-settings/shipping-services/style';

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/list-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/list-item.js
@@ -80,6 +80,9 @@ const CarrierAccountListItem = ( props ) => {
 
 	const carrierTypeIconMap = {
 		DhlExpressAccount: 'dhlexpress',
+		DhlEcommerceAccount: 'dhlecommerce',
+		DhlEcommerceAsiaAccount: 'dhlecommerceasia',
+		DHLGMIAccount: 'dhlecommerceinternational',
 		UpsAccount: 'ups',
 	}
 

--- a/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/index.js
@@ -40,7 +40,7 @@ SubscriptionsUsage.propTypes = {
 	subscriptions: PropTypes.arrayOf(
 		PropTypes.shape( {
 			product_name: PropTypes.string.isRequired,
-			usage_limit: PropTypes.number.isRequired,
+			usage_limit: PropTypes.number,
 			usage_count: PropTypes.number,
 		} )
 	),

--- a/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/index.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import React  from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import ExtendedHeader from 'woocommerce/components/extended-header';
+import SubscriptionsUsageListItem from './list-item';
+
+const SubscriptionsUsage = ({ translate, subscriptions = [] }) => {
+	if ( subscriptions.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<div>
+			<ExtendedHeader
+				label={translate('Shipping method')}
+				description={translate('View and manage your subscription usage')}
+			/>
+			<Card className="subscriptions-usage__list">
+				<div className="subscriptions-usage__header">
+					<div className="subscriptions-usage__header-icon" />
+					<div className="subscriptions-usage__header-name">{ translate( 'Name' ) }</div>
+					<div className="subscriptions-usage__header-usage">{ translate( 'Usage' ) }</div>
+					<div className="subscriptions-usage__header-actions" />
+				</div>
+				{ subscriptions.map( ( subscription, index ) => <SubscriptionsUsageListItem key={ index } data={ subscription } /> ) }
+			</Card>
+		</div>
+	);
+}
+
+SubscriptionsUsage.propTypes = {
+	subscriptions: PropTypes.arrayOf(
+		PropTypes.shape( {
+			product_name: PropTypes.string.isRequired,
+			usage_limit: PropTypes.number.isRequired,
+			usage_count: PropTypes.number,
+		} )
+	),
+};
+
+export default localize( SubscriptionsUsage );

--- a/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/list-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/list-item.js
@@ -5,29 +5,55 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import { compose } from 'redux';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import CarrierIcon from '../../components/carrier-icon';
+import Button from 'components/button';
+import * as api from 'woocommerce/woocommerce-services/api';
+import { errorNotice as errorNoticeAction, successNotice as successNoticeAction } from 'state/notices/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 const SubscriptionsUsageListItem = ( props ) => {
-	const { translate, data } = props;
+	const { translate, data, errorNotice, successNotice, siteId } = props;
+	const [isActive, setisActive] = React.useState( data.is_active );
+	const [isSaving, setIsSaving] = React.useState(false);
 	 
 	const getIcon = ( productName ) => {
-	const subscriptionToIconRules = [
-		[/^DHL/g, 'dhlexpress'],
-		[/^UPS/g, 'ups'],
-		[/^USPS/g, 'usps'],
-	];
+		const subscriptionToIconRules = [
+			[/^DHL/g, 'dhlexpress'],
+			[/^UPS/g, 'ups'],
+			[/^USPS/g, 'usps'],
+		];
 
-	const i = subscriptionToIconRules.findIndex( ( [rule] ) => rule.test( productName ));
-	if (i > -1) return subscriptionToIconRules[i][1];
-	
-	return '';
+		const i = subscriptionToIconRules.findIndex( ( [rule] ) => rule.test( productName ) );
+		if ( i > -1 ) return subscriptionToIconRules[i][1];
+		
+		return '';
 	};
 
-	const usage = `${ data.usage_count }/${ data.usage_limit }`;
+	const handleActivate = () =>{
+		const submitActivation = async () => {
+			setIsSaving(true);
+		
+			try {
+				await api.post( siteId, api.url.subscriptionActivate( data.product_key ) );
+				setisActive( true );
+				successNotice( translate( 'Your subscription was succesfully activated.' ) );
+			} catch (err) {
+				errorNotice( translate( 'There was an error trying to activate your subscription.' ) );
+			}
+
+			setIsSaving(false);
+		}
+		submitActivation();
+	}
+
+	const usage_count = data.usage_count ? data.usage_count : 0 ;
+	const usage = data.usage_limit ? `${ usage_count }/${ data.usage_limit }` : '';
 	return (
 		<div className= "subscriptions-usage__list-item" >
 			<div className="subscriptions-usage__list-item-carrier-icon">
@@ -40,26 +66,50 @@ const SubscriptionsUsageListItem = ( props ) => {
 				<span>{ usage }</span>
 			</div>
 			<div className="subscriptions-usage__list-item-actions">
-				<a
-					href={
+				{ isActive ? (
+					<a
+						href={
 						`https://woocommerce.com/my-account/my-subscriptions/`
-					}
-					// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-					className="button is-compact"
-				>
-					{ translate( 'Manage' ) }
-				</a>
+						}
+						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+						className="button is-compact"
+					>
+						{ translate( 'Manage' ) }
+					</a>
+				) : (
+					<Button 
+						onClick={ handleActivate } 
+						disabled={ isSaving }
+						busy={ isSaving }
+						compact
+					>
+						{ translate( 'Activate' ) }
+				   </Button>
+				) }
 			</div>
 		</div>
 	);
 };
 
 SubscriptionsUsageListItem.propTypes = {
+	errorNotice: PropTypes.func.isRequired,
+	successNotice: PropTypes.func.isRequired,
+	siteId: PropTypes.number.isRequired,
 	data: PropTypes.shape( {
 		product_name: PropTypes.string.isRequired,
-		usage_limit: PropTypes.number.isRequired,
+		is_active: PropTypes.bool.isRequired,
+		usage_limit: PropTypes.number,
 		usage_count: PropTypes.number,
 	} ).isRequired,
 };
 
-export default localize( SubscriptionsUsageListItem );
+const mapStateToProps = (state) => ({
+	siteId: getSelectedSiteId( state ),
+});
+
+const mapDispatchToProps = {
+	errorNotice:errorNoticeAction,
+	successNotice:successNoticeAction,
+}
+
+export default compose( connect( mapStateToProps, mapDispatchToProps ), localize )( SubscriptionsUsageListItem );

--- a/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/list-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/list-item.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import CarrierIcon from '../../components/carrier-icon';
+
+const SubscriptionsUsageListItem = ( props ) => {
+	const { translate, data } = props;
+	 
+	const getIcon = ( productName ) => {
+	const subscriptionToIconRules = [
+		[/^DHL/g, 'dhlexpress'],
+		[/^UPS/g, 'ups'],
+		[/^USPS/g, 'usps'],
+	];
+
+	const i = subscriptionToIconRules.findIndex( ( [rule] ) => rule.test( productName ));
+	if (i > -1) return subscriptionToIconRules[i][1];
+	
+	return '';
+	};
+
+	const usage = `${ data.usage_count }/${ data.usage_limit }`;
+	return (
+		<div className= "subscriptions-usage__list-item" >
+			<div className="subscriptions-usage__list-item-carrier-icon">
+				<CarrierIcon carrier={ getIcon( data.product_name ) } size={ 18 } />
+			</div>
+			<div className="subscriptions-usage__list-item-name">
+				<span>{ data.product_name }</span>
+			</div>
+			<div className="subscriptions-usage__list-item-usage">
+				<span>{ usage }</span>
+			</div>
+			<div className="subscriptions-usage__list-item-actions">
+				<a
+					href={
+						`https://woocommerce.com/my-account/my-subscriptions/`
+					}
+					// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+					className="button is-compact"
+				>
+					{ translate( 'Manage' ) }
+				</a>
+			</div>
+		</div>
+	);
+};
+
+SubscriptionsUsageListItem.propTypes = {
+	data: PropTypes.shape( {
+		product_name: PropTypes.string.isRequired,
+		usage_limit: PropTypes.number.isRequired,
+		usage_count: PropTypes.number,
+	} ).isRequired,
+};
+
+export default localize( SubscriptionsUsageListItem );

--- a/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/style.scss
@@ -1,0 +1,56 @@
+.subscriptions-usage__list {
+	padding: 0;
+
+	.subscriptions-usage__list-item {
+		display: flex;
+		align-items: center;
+		padding: 8px 0;
+
+		.subscriptions-usage__list-item-carrier-icon {
+			width: 48px;
+			padding-left: 16px;
+
+			@include breakpoint( '>480px' ) {
+				padding-left: 24px;
+			}
+		}
+
+		.subscriptions-usage__list-item-name {
+			width: 35%;
+		}
+
+		.subscriptions-usage__list-item-usage {
+			width: 30%;
+		}
+
+		.subscriptions-usage__list-item-actions {
+			width: 25%;
+			text-align: right;
+			padding-right: 16px;
+
+			@include breakpoint( '>480px' ) {
+				padding-right: 24px;
+			}
+		}
+	}
+}
+
+.subscriptions-usage__header {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	font-weight: 600;
+	padding: 12px 0;
+	font-size: 14px;
+	border-top: 0;
+	border-bottom: 1px solid var( --color-neutral-0 );
+	border-bottom-color: var( --color-neutral-100 );
+	background: var( --color-neutral-0 );
+
+	.subscriptions-usage__header-icon {
+		width: 72px;
+	}
+	.subscriptions-usage__header-name {
+		width: 35%;
+	}
+}

--- a/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/test/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/test/index.js
@@ -1,0 +1,120 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { mount } from 'enzyme';
+import configureMockStore from 'redux-mock-store'
+import { Provider } from 'react-redux'
+
+/**
+ * Internal dependencies
+ */
+import SubscriptionsUsage from '..';
+
+const mockStore = configureMockStore([]);
+const Wrapper = ({children}) => (
+	<Provider store={mockStore({
+		ui: {
+			selectedSiteId: 1234
+		}
+	})}>
+		{children}
+	</Provider>
+);
+
+describe( 'Carrier Accounts', () => {
+	it('should render nothing when no subscriptions are provided', () => {
+		const wrapper = mount(
+			<Wrapper>
+				<SubscriptionsUsage />
+			</Wrapper>
+		);
+
+		expect(wrapper.html()).toBeFalsy();
+	});
+
+	it('should render a list of subscriptions usage info', () => {
+
+		const subscriptions = [
+			{
+				product_key:"W00-bfd64110-4ff9-b179-dca3903f62b0",
+				product_keys_all:
+					["W00-bfd64110-4ff9-b179-dca3903f62b0"],
+				product_id:1770503,
+				product_name:"DHL Express rates",
+				product_url:"https:\/\/woocommerce.com\/products\/DHL-subscriptions\/",
+				key_type:"single",
+				key_type_label:"Single site",
+				key_parent_order_item_id:null,
+				autorenew:true,
+				connections:[751464],
+				legacy_connections:[],
+				shares:[],
+				lifetime:false,
+				expires:1639008000,
+				expired:false,
+				expiring:false,
+				sites_max:1,
+				sites_active:1,
+				maxed:false,
+				product_status:"publish",
+				usage_limit:1000,
+				usage_count:250
+			},
+			{
+				product_key:"W00-bfd64110-4ff9-b179-dca3903f62b1",
+				product_keys_all:
+					["W00-bfd64110-4ff9-b179-dca3903f62b1"],
+				product_id:1770504,
+				product_name:"UPS rates",
+				product_url:"https:\/\/woocommerce.com\/products\/UPS-subscriptions\/",
+				key_type:"single",
+				key_type_label:"Single site",
+				key_parent_order_item_id:null,
+				autorenew:true,
+				connections:[751464],
+				legacy_connections:[],
+				shares:[],
+				lifetime:false,
+				expires:1639008000,
+				expired:false,
+				expiring:false,
+				sites_max:1,
+				sites_active:1,
+				maxed:false,
+				product_status:"publish",
+				usage_limit:50,
+				usage_count:8
+			},
+
+		];
+		const wrapper = mount(
+			
+			<Wrapper>
+				<SubscriptionsUsage subscriptions={ subscriptions } />
+			</Wrapper>
+		);
+
+		// Find list items for subscriptions.
+		const dhlExpressRatesListItem = wrapper.find('.subscriptions-usage__list-item').at(0)
+		const upsLabelsListItem = wrapper.find('.subscriptions-usage__list-item').at(1)
+
+		// Expect subscription names.
+		expect(dhlExpressRatesListItem.find('span[children="DHL Express rates"]')).toHaveLength(1);
+		expect(upsLabelsListItem.find('span[children="UPS rates"]')).toHaveLength(1);
+
+		// Expect subscription usage.
+		expect(dhlExpressRatesListItem.find('span[children="250/1000"]')).toHaveLength(1);
+		expect(upsLabelsListItem.find('span[children="8/50"]')).toHaveLength(1);
+		
+		// Expect button manage.
+		const dhlExpressmanageButton = dhlExpressRatesListItem.find('a[href="https://woocommerce.com/my-account/my-subscriptions/"]');
+		expect(dhlExpressmanageButton.text()).toBe('Manage');
+		const upsLabelsmanageButton = upsLabelsListItem.find('a[href="https://woocommerce.com/my-account/my-subscriptions/"]');
+		expect(upsLabelsmanageButton.text()).toBe('Manage');
+	
+	});
+
+} );

--- a/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/test/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/test/index.js
@@ -7,11 +7,17 @@ import React from 'react';
 import { mount } from 'enzyme';
 import configureMockStore from 'redux-mock-store'
 import { Provider } from 'react-redux'
+import { act } from 'react-dom/test-utils';
 
 /**
  * Internal dependencies
  */
 import SubscriptionsUsage from '..';
+import * as api from 'woocommerce/woocommerce-services/api';
+
+const apiPostSpy = jest.spyOn(api, 'post').mockImplementation(() =>
+	Promise.resolve({})
+);
 
 const mockStore = configureMockStore([]);
 const Wrapper = ({children}) => (
@@ -24,7 +30,63 @@ const Wrapper = ({children}) => (
 	</Provider>
 );
 
-describe( 'Carrier Accounts', () => {
+const subscriptions = [
+	{
+		product_key:"W00-bfd64110-4ff9-b179-dca3903f62b0",
+		product_keys_all:
+			["W00-bfd64110-4ff9-b179-dca3903f62b0"],
+		product_id:1770503,
+		product_name:"DHL Express rates",
+		product_url:"https:\/\/woocommerce.com\/products\/DHL-subscriptions\/",
+		key_type:"single",
+		key_type_label:"Single site",
+		key_parent_order_item_id:null,
+		autorenew:true,
+		connections:[751464],
+		legacy_connections:[],
+		shares:[],
+		lifetime:false,
+		expires:1639008000,
+		expired:false,
+		expiring:false,
+		sites_max:1,
+		sites_active:1,
+		maxed:false,
+		product_status:"publish",
+		usage_limit:1000,
+		usage_count:250,
+		is_active: true,
+	},
+	{
+		product_key:"W00-bfd64110-4ff9-b179-dca3903f62b1",
+		product_keys_all:
+			["W00-bfd64110-4ff9-b179-dca3903f62b1"],
+		product_id:1770504,
+		product_name:"UPS rates",
+		product_url:"https:\/\/woocommerce.com\/products\/UPS-subscriptions\/",
+		key_type:"single",
+		key_type_label:"Single site",
+		key_parent_order_item_id:null,
+		autorenew:true,
+		connections:[751464],
+		legacy_connections:[],
+		shares:[],
+		lifetime:false,
+		expires:1639008000,
+		expired:false,
+		expiring:false,
+		sites_max:1,
+		sites_active:0,
+		maxed:false,
+		product_status:"publish",
+		usage_limit:50,
+		usage_count:8,
+		is_active:false,
+	},
+
+];
+
+describe( 'Subscriptions Usage', () => {
 	it('should render nothing when no subscriptions are provided', () => {
 		const wrapper = mount(
 			<Wrapper>
@@ -36,60 +98,6 @@ describe( 'Carrier Accounts', () => {
 	});
 
 	it('should render a list of subscriptions usage info', () => {
-
-		const subscriptions = [
-			{
-				product_key:"W00-bfd64110-4ff9-b179-dca3903f62b0",
-				product_keys_all:
-					["W00-bfd64110-4ff9-b179-dca3903f62b0"],
-				product_id:1770503,
-				product_name:"DHL Express rates",
-				product_url:"https:\/\/woocommerce.com\/products\/DHL-subscriptions\/",
-				key_type:"single",
-				key_type_label:"Single site",
-				key_parent_order_item_id:null,
-				autorenew:true,
-				connections:[751464],
-				legacy_connections:[],
-				shares:[],
-				lifetime:false,
-				expires:1639008000,
-				expired:false,
-				expiring:false,
-				sites_max:1,
-				sites_active:1,
-				maxed:false,
-				product_status:"publish",
-				usage_limit:1000,
-				usage_count:250
-			},
-			{
-				product_key:"W00-bfd64110-4ff9-b179-dca3903f62b1",
-				product_keys_all:
-					["W00-bfd64110-4ff9-b179-dca3903f62b1"],
-				product_id:1770504,
-				product_name:"UPS rates",
-				product_url:"https:\/\/woocommerce.com\/products\/UPS-subscriptions\/",
-				key_type:"single",
-				key_type_label:"Single site",
-				key_parent_order_item_id:null,
-				autorenew:true,
-				connections:[751464],
-				legacy_connections:[],
-				shares:[],
-				lifetime:false,
-				expires:1639008000,
-				expired:false,
-				expiring:false,
-				sites_max:1,
-				sites_active:1,
-				maxed:false,
-				product_status:"publish",
-				usage_limit:50,
-				usage_count:8
-			},
-
-		];
 		const wrapper = mount(
 			
 			<Wrapper>
@@ -112,9 +120,24 @@ describe( 'Carrier Accounts', () => {
 		// Expect button manage.
 		const dhlExpressmanageButton = dhlExpressRatesListItem.find('a[href="https://woocommerce.com/my-account/my-subscriptions/"]');
 		expect(dhlExpressmanageButton.text()).toBe('Manage');
-		const upsLabelsmanageButton = upsLabelsListItem.find('a[href="https://woocommerce.com/my-account/my-subscriptions/"]');
-		expect(upsLabelsmanageButton.text()).toBe('Manage');
+		// Expect button activate.
+		expect(upsLabelsListItem.find('button').text()).toBe('Activate');
 	
+	});
+
+	it('should call the API to activate the subscription when clicking on the button', async () => {
+		const wrapper = mount(
+			
+			<Wrapper>
+				<SubscriptionsUsage subscriptions={ subscriptions } />
+			</Wrapper>
+		);
+		const upsLabelsListItem = wrapper.find('.subscriptions-usage__list-item').at(1);
+		await act(async () => {
+			// Click the Activate button
+			upsLabelsListItem.find('button').simulate('click');
+		} );
+		expect(apiPostSpy).toHaveBeenCalledWith(1234, 'connect/subscription/W00-bfd64110-4ff9-b179-dca3903f62b1/activate');
 	});
 
 } );

--- a/client/main.js
+++ b/client/main.js
@@ -114,7 +114,9 @@ Array.from( document.getElementsByClassName( 'wcc-root' ) ).forEach( ( container
 
 			const enhancers = [
 				applyMiddleware( ...middlewares ),
-				window.devToolsExtension && window.devToolsExtension(),
+				window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__({
+					name: `wc/wcs/${routeClassName}`
+				}),
 			].filter( Boolean );
 
 			const store = compose( ...enhancers )( createStore )( Route.getReducer(), initialState );

--- a/readme.txt
+++ b/readme.txt
@@ -76,6 +76,13 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 1.25.5 - 2021-XX-XX =
+* Fix	- Redux DevTools usage update.
+* Add	- Display subscriptions usage.
+* Add	- Subscription activation.
+* Add 	- Uses same DHL logo for all registered DHL accounts.
+* Tweak - Adds WCCom access token and site ID to connect server request headers.
+
 = 1.25.4 - 2020-12-08 =
 * Tweak - Remove Stripe connect functionality.
 * Tweak - Remove unused method in shipping settings view.

--- a/tests/php/classes/test-class-wc-rest-connect-subscriptions-controller.php
+++ b/tests/php/classes/test-class-wc-rest-connect-subscriptions-controller.php
@@ -1,0 +1,151 @@
+<?php
+
+
+
+/**
+ * Unit test for WC_Connect_API_Client_Live
+ */
+class WP_Test_WC_REST_Connect_Subscriptions_Controller extends WC_Unit_Test_Case {
+
+	/** @var WC_Connect_API_Client_Live $api_client_mock */
+	protected $api_client_mock;
+
+	/** @var WC_Connect_Service_Settings_Store $setting_store_mock */
+	protected $setting_store_mock;
+
+	/** @var WC_Connect_Logger $connect_logger_mock */
+	protected $connect_logger_mock;
+
+	/**
+	 * @inherit
+	 */
+	public static function setupBeforeClass() {
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-api-client-live.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-service-settings-store.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-logger.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-rest-connect-base-controller.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-rest-connect-subscriptions-controller.php';
+	}
+
+	/**
+	 * Setup the test case.
+	 *
+	 * @see WC_Unit_Test_Case::setUp()
+	 */
+	public function setUp() {
+		// Creating a mock class and overide protected request method so that we can mock the API response.
+		$this->api_client_mock = $this->getMockBuilder( WC_Connect_API_Client_Live::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'request' ] )
+			->getMock();
+
+		$this->setting_store_mock  = $this->createMock( WC_Connect_Service_Settings_Store::class );
+		$this->connect_logger_mock = $this->createMock( WC_Connect_Logger::class );
+	}
+
+	/**
+	 * Test GET request on connect/subscriptions end point.
+	 */
+	public function test_get() {
+		$api_response        = '{
+			"subscriptions": [
+				{
+					"product_key": "W00-5705e69b-4cbe-85ae-bb62bf204675",
+					"product_keys_all": [
+						"W00-5705e69b-4cbe-85ae-bb62bf204675"
+					],
+					"product_id": 1770503,
+					"product_name": "UPS Live Rates",
+					"product_url": "https://woocommerce.com/products/UPS-live-rates/",
+					"key_type": "single",
+					"key_type_label": "Single site",
+					"key_parent_order_item_id": null,
+					"autorenew": true,
+					"connections": [
+						742089
+					],
+					"legacy_connections": [],
+					"shares": [],
+					"lifetime": false,
+					"expires": 1634774400,
+					"expired": false,
+					"expiring": false,
+					"sites_max": 1,
+					"sites_active": 1,
+					"maxed": false,
+					"product_status": "publish",
+					"usage_limit": 50,
+					"usage_count": 8
+				},
+				{
+					"product_key": "W00-5705e69b-4cbe-85ae-bb62bf204675",
+					"product_keys_all": [
+						"W00-5705e69b-4cbe-85ae-bb62bf204675"
+					],
+					"product_id": 1770504,
+					"product_name": "DHL Express Live Rates",
+					"product_url": "https://woocommerce.com/products/DHLExpress-live-rates/",
+					"key_type": "single",
+					"key_type_label": "Single site",
+					"key_parent_order_item_id": null,
+					"autorenew": true,
+					"connections": [
+						742089
+					],
+					"legacy_connections": [],
+					"shares": [],
+					"lifetime": false,
+					"expires": 1634774400,
+					"expired": false,
+					"expiring": false,
+					"sites_max": 1,
+					"sites_active": 1,
+					"maxed": false,
+					"product_status": "publish",
+					"usage_limit": 1000,
+					"usage_count": 250
+				}
+			]
+		}';
+		$api_client_response = json_decode( $api_response ); // assumes api_client->request() successfully returns the JSON decoded response body.
+
+		$this->api_client_mock->expects( $this->once() )
+			->method( 'request' )
+			->with( 'POST', '/subscriptions' )
+			->willReturn( $api_client_response );
+
+		$wc_connect_subscriptions_controller = new WC_REST_Connect_Subscriptions_Controller( $this->api_client_mock, $this->setting_store_mock, $this->connect_logger_mock );
+		$actual                              = $wc_connect_subscriptions_controller->post();
+		$expected                            =  $api_client_response->subscriptions ;
+
+		$expected                                     = [
+			'success'  => true,
+			'subscriptions' => $api_client_response->subscriptions,
+		];
+
+		$this->assertEquals( 200, $actual->status );
+		$this->assertEquals( $expected, $actual->data );
+	}
+
+	/**
+	 * Test error thrown during a GET request on connect/subscriptions end point.
+	 */
+	public function test_get_with_error() {
+		$api_response = new WP_Error( 'error_code_123', 'something is wrong' );
+
+		$this->api_client_mock->expects( $this->once() )
+			->method( 'request' )
+			->with( 'POST', '/subscriptions' )
+			->willReturn( $api_response );
+
+		$this->connect_logger_mock->expects( $this->once() )
+			->method( 'log' )
+			->with( $api_response, WC_REST_Connect_Subscriptions_Controller::class );
+
+		$wc_connect_subscriptions_controller = new WC_REST_Connect_Subscriptions_Controller( $this->api_client_mock, $this->setting_store_mock, $this->connect_logger_mock );
+		$actual                              = $wc_connect_subscriptions_controller->post();
+
+		$this->assertInstanceOf( WP_Error::class, $actual );
+		$this->assertEquals( $api_response, $actual );
+	}
+}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -339,6 +339,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->rest_carriers_controller = $rest_carriers_controller;
 		}
 
+		public function set_rest_subscriptions_controller( WC_REST_Connect_Subscriptions_Controller $rest_subscriptions_controller ) {
+			$this->rest_subscriptions_controller = $rest_subscriptions_controller;
+		}
+
 		public function set_rest_carrier_controller( WC_REST_Connect_Shipping_Carrier_Controller $rest_carrier_controller ) {
 			$this->rest_carrier_controller = $rest_carrier_controller;
 		}
@@ -877,6 +881,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$rest_carriers_controller = new WC_REST_Connect_Shipping_Carriers_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_carriers_controller( $rest_carriers_controller );
 			$rest_carriers_controller->register_routes();
+
+			require_once( plugin_basename( 'classes/class-wc-rest-connect-subscriptions-controller.php' ) );
+			$rest_subscriptions_controller = new WC_REST_Connect_Subscriptions_Controller( $this->api_client, $settings_store, $logger );
+			$this->set_rest_subscriptions_controller( $rest_subscriptions_controller );
+			$rest_subscriptions_controller->register_routes();
 
 			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-carrier-delete-controller.php' ) );
 			$rest_carrier_delete_controller = new WC_REST_Connect_Shipping_Carrier_Delete_Controller( $this->api_client, $settings_store, $logger );

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -343,6 +343,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->rest_subscriptions_controller = $rest_subscriptions_controller;
 		}
 
+		public function set_rest_subscription_activate_controller( WC_REST_Connect_Subscription_Activate_Controller $rest_subscription_activate_controller ) {
+			$this->rest_subscription_activate_controller = $rest_subscription_activate_controller;
+		}
+
 		public function set_rest_carrier_controller( WC_REST_Connect_Shipping_Carrier_Controller $rest_carrier_controller ) {
 			$this->rest_carrier_controller = $rest_carrier_controller;
 		}
@@ -886,6 +890,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$rest_subscriptions_controller = new WC_REST_Connect_Subscriptions_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_subscriptions_controller( $rest_subscriptions_controller );
 			$rest_subscriptions_controller->register_routes();
+
+			require_once( plugin_basename( 'classes/class-wc-rest-connect-subscription-activate-controller.php' ) );
+			$rest_subscription_activate_controller = new WC_REST_Connect_Subscription_activate_Controller( $this->api_client, $settings_store, $logger );
+			$this->set_rest_subscription_activate_controller( $rest_subscription_activate_controller );
+			$rest_subscription_activate_controller->register_routes();
 
 			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-carrier-delete-controller.php' ) );
 			$rest_carrier_delete_controller = new WC_REST_Connect_Shipping_Carrier_Delete_Controller( $this->api_client, $settings_store, $logger );


### PR DESCRIPTION
## Release PR for 1.25.5
### Changes in this release
- https://github.com/Automattic/woocommerce-services/pull/2287 : Send WCCOM connection info in request header
- https://github.com/Automattic/woocommerce-services/pull/2284 : Reuse DHL logos for DHL eCommerce, DHL eCommerce Asia, and DHL eCommerce International
- https://github.com/Automattic/woocommerce-services/pull/2286 : Display inactive subscriptions with button to activate them
- https://github.com/Automattic/woocommerce-services/pull/2281 : Show subscriptions usage in admin
- https://github.com/Automattic/woocommerce-services/pull/2270 : chore(ReduxDevtools): upgrade deprecated usage

This release branch is branched from latest `develop` .
Closes https://github.com/Automattic/woocommerce-shipping-issues/issues/151

### Test notes
- Test live rates
- Test label printing
- Test account connection
- Test settings view
  - Subscriptions are not live yet, so we should be ok

### Changelog
* Fix	- Redux DevTools usage update.
* Add - Display subscriptions usage.
* Add - Subscription activation.
* Add - Uses same DHL logo for all registered DHL accounts.
* Tweak - Adds WCCom access token and site ID to connect server request headers.

## Build File
Built from this branch using `php woorelease.phar simulate --product_version=1.25.5 https://github.com/Automattic/woocommerce-services/tree/release/1.25.5`


[woocommerce-services.zip](https://github.com/Automattic/woocommerce-services/files/5772341/woocommerce-services.zip)
