### PR TITLE
Remember post-print notification checkbox state

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.25.6 - 202x-xx-xx =
 * Fix 	- Refreshes shipping methods after registering or removing carrier accounts.
+* Add	- Remember state of "Mark this order as complete and notify the customer" and "Notify the customer with shipment details" checkboxes.
 
 = 1.25.5 - 2021-01-11 =
 * Fix	- Redux DevTools usage update.

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -43,6 +43,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				'payment_methods',
 				'account_settings',
 				'paper_size',
+				'post_print_notification_settings',
 				'packages',
 				'predefined_packages',
 				'shipping_methods_migrated',

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -161,6 +161,67 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		}
 
 		/**
+		 * Gets post-label-printing notification settings.
+		 *
+		 * @return array Array of boolean values, indexed by setting names.
+		 */
+		public function get_post_print_notification_settings() {
+			$defaults = array(
+				'mark_order_complete_and_notify_customer' => false,
+				'notify_customer_with_shipment_details'   => false,
+			);
+
+			$settings = WC_Connect_Options::get_option( 'post_print_notification_settings', $defaults );
+
+			return array_merge( $defaults, $settings );
+		}
+
+		/**
+		 * Updates post-label-printing notification settings.
+		 *
+		 * @param string $name    Name of the setting to enable/disable.
+		 * @param bool   $enabled Whether the setting should be enabled.
+		 *
+		 * @return true|WP_Error WP_Error if an error occurred, `true` otherwise.
+		 */
+		public function set_post_print_notification_setting( $name, $enabled ) {
+			$allowed_names = array(
+				'mark_order_complete_and_notify_customer',
+				'notify_customer_with_shipment_details',
+			);
+
+			if ( ! in_array( $name, $allowed_names, true ) ) {
+				return new WP_Error(
+					'invalid_notification_setting_name',
+					__( 'Invalid notification setting name supplied.', 'woocommerce-services' )
+				);
+			}
+
+			$old_settings      = WC_Connect_Options::get_option( 'post_print_notification_settings' );
+			$settings          = $old_settings;
+			$settings[ $name ] = (bool) $enabled;
+
+			/*
+			 * WC_Connect_Options::update_option() returns `false` if the new value is the same as the old one.
+			 * As this is not an issue in this case, we return `true` here and leave the option unchanged.
+			 */
+			if ( $settings === $old_settings ) {
+				return true;
+			}
+
+			$result = WC_Connect_Options::update_option( 'post_print_notification_settings', $settings );
+
+			if ( ! $result ) {
+				return new WP_Error(
+					'save_failed',
+					__( 'Updating the option failed.', 'woocommerce-services' )
+				);
+			}
+
+			return $result;
+		}
+
+		/**
 		 * Attempts to recover faulty json string fields that might contain strings with unescaped quotes
 		 *
 		 * @param string $field_name

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -391,10 +391,14 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				return false;
 			}
 
+			$notification_settings = $this->settings_store->get_post_print_notification_settings();
+
 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
 			$payload = array(
 				'orderId'            => $order_id,
 				'paperSize'          => $this->settings_store->get_preferred_paper_size(),
+				'fulfillOrder'       => $notification_settings['mark_order_complete_and_notify_customer'],
+				'emailDetails'       => $notification_settings['notify_customer_with_shipment_details'],
 				'formData'           => $this->get_form_data( $order ),
 				'labelsData'         => $this->settings_store->get_label_order_meta_data( $order_id ),
 				'storeOptions'       => $this->settings_store->get_store_options(),

--- a/classes/class-wc-rest-connect-post-print-notification-settings-controller.php
+++ b/classes/class-wc-rest-connect-post-print-notification-settings-controller.php
@@ -1,0 +1,34 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit();
+}
+
+if ( class_exists( 'WC_REST_Connect_Post_Print_Notification_Settings_Controller' ) ) {
+	return;
+}
+
+class WC_REST_Connect_Post_Print_Notification_Settings_Controller extends WC_REST_Connect_Base_Controller {
+	protected $rest_base = 'connect/post-print-notification-settings';
+
+	public function post( $request ) {
+		$result = $this->settings_store->set_post_print_notification_setting( $request['name'], $request['enabled'] );
+
+		if ( is_wp_error( $result ) ) {
+			$error = new WP_Error(
+				'save_failed',
+				sprintf(
+					__( 'Unable to update notification setting. %s', 'woocommerce-services' ),
+					$result->get_error_message()
+				),
+				array( 'status' => 400 )
+			);
+
+			$this->logger->log( $error, __CLASS__ );
+
+			return $error;
+		}
+
+		return new WP_REST_Response( array( 'success' => true ), 200 );
+	}
+}

--- a/client/extensions/woocommerce/woocommerce-services/api/url.js
+++ b/client/extensions/woocommerce/woocommerce-services/api/url.js
@@ -1,5 +1,6 @@
 /** @format */
 export const accountSettings = 'connect/account/settings';
+export const postPrintNotificationSettings = 'connect/post-print-notification-settings';
 export const packages = 'connect/packages';
 export const orderLabels = ( orderId ) => `connect/label/${ orderId }`;
 export const getLabelRates = ( orderId ) => `connect/label/${ orderId }/rates`;

--- a/client/extensions/woocommerce/woocommerce-services/lib/initialize-labels-state/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/initialize-labels-state/index.js
@@ -31,12 +31,10 @@ export default data => {
 			loaded: false,
 			isFetching: false,
 			error: false,
-			fulfillOrder: false,
-			emailDetails: false,
 		};
 	}
 
-	const { formData, labelsData, paperSize, storeOptions, canChangeCountries } = data;
+	const { formData, labelsData, paperSize, fulfillOrder, emailDetails, storeOptions, canChangeCountries } = data;
 	//old WCS required a phone number and detected normalization status based on the existence of the phone field
 	//newer versions send the normalized flag
 	const originNormalized = Boolean( formData.origin_normalized || formData.origin.phone );
@@ -74,8 +72,8 @@ export default data => {
 		loaded: true,
 		isFetching: false,
 		error: false,
-		fulfillOrder: false,
-		emailDetails: false,
+		fulfillOrder,
+		emailDetails,
 		refreshedLabelStatus: false,
 		labels: labelsData || [],
 		paperSize,

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -739,12 +739,12 @@ export const updatePostPrintNotificationSettings = ( state, orderId, siteId ) =>
 	if ( isOrderFinished( order.status ) ) {
 		data = {
 			name: 'notify_customer_with_shipment_details',
-			value: emailDetails,
+			enabled: emailDetails,
 		};
 	} else {
 		data = {
 			name: 'mark_order_complete_and_notify_customer',
-			value: fulfillOrder,
+			enabled: fulfillOrder,
 		};
 	}
 

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -44,6 +44,8 @@ import {
 } from './selectors';
 import { createNote } from 'woocommerce/state/sites/orders/notes/actions';
 import { saveOrder } from 'woocommerce/state/sites/orders/actions';
+import { getOrder } from 'woocommerce/state/sites/orders/selectors';
+import { isOrderFinished } from 'woocommerce/lib/order-status';
 import { getAllPackageDefinitions } from 'woocommerce/woocommerce-services/state/packages/selectors';
 import { getEmailReceipts } from 'woocommerce/woocommerce-services/state/label-settings/selectors';
 import getAddressValues from 'woocommerce/woocommerce-services/lib/utils/get-address-values';
@@ -729,6 +731,26 @@ export const setFulfillOrderOption = ( orderId, siteId, value ) => {
 	};
 };
 
+export const updatePostPrintNotificationSettings = ( state, orderId, siteId ) => {
+	const { fulfillOrder, emailDetails } = getShippingLabel( state, orderId, siteId );
+	const order                          = getOrder( state, orderId );
+	let data                             = {};
+
+	if ( isOrderFinished( order.status ) ) {
+		data = {
+			name: 'notify_customer_with_shipment_details',
+			value: emailDetails,
+		};
+	} else {
+		data = {
+			name: 'mark_order_complete_and_notify_customer',
+			value: fulfillOrder,
+		};
+	}
+
+	api.post( siteId, api.url.postPrintNotificationSettings, data );
+};
+
 const purchaseLabelResponse = ( orderId, siteId, response, error ) => {
 	return {
 		type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_PURCHASE_RESPONSE,
@@ -777,7 +799,7 @@ const labelStatusTask = ( orderId, siteId, labelId, retryCount ) => {
 		} );
 };
 
-const handlePrintFinished = ( orderId, siteId, dispatch, getState, hasError, labels ) => {
+export const handlePrintFinished = ( orderId, siteId, dispatch, getState, hasError, labels ) => {
 	dispatch( exitPrintingFlow( orderId, siteId, true ) );
 	dispatch( clearAvailableRates( orderId, siteId ) );
 
@@ -824,6 +846,8 @@ const handlePrintFinished = ( orderId, siteId, dispatch, getState, hasError, lab
 			} )
 		);
 	}
+
+	updatePostPrintNotificationSettings( getState(), orderId, siteId );
 };
 
 /**

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -55,6 +55,8 @@ import {
 	hasStates,
 } from 'woocommerce/state/sites/data/locations/selectors';
 import { isWcsInternationalLabelsEnabled } from 'woocommerce/state/selectors/plugins';
+import { getOrder } from 'woocommerce/state/sites/orders/selectors';
+import { isOrderFinished } from '../../../lib/order-status';
 
 export const getShippingLabel = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
 	return get(
@@ -92,12 +94,14 @@ export const getLabelById = ( state, orderId, siteId, labelId ) => {
 
 export const shouldFulfillOrder = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
 	const shippingLabel = getShippingLabel( state, orderId, siteId );
-	return shippingLabel && shippingLabel.fulfillOrder;
+	const order         = getOrder( state, orderId );
+	return shippingLabel && shippingLabel.fulfillOrder && order && ! isOrderFinished( order.status );
 };
 
 export const shouldEmailDetails = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
 	const shippingLabel = getShippingLabel( state, orderId, siteId );
-	return shippingLabel && shippingLabel.emailDetails;
+	const order         = getOrder( state, orderId );
+	return shippingLabel && shippingLabel.emailDetails && order && isOrderFinished( order.status );
 };
 
 export const getSelectedPaymentMethod = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
@@ -322,22 +322,22 @@ describe( 'Shipping label Actions', () => {
 		{
 			orderStatus: 'completed',
 			state: { name: 'emailDetails', value: true },
-			expectedBody: { name: 'notify_customer_with_shipment_details', value: true },
+			expectedBody: { name: 'notify_customer_with_shipment_details', enabled: true },
 		},
 		{
 			orderStatus: 'completed',
 			state: { name: 'emailDetails', value: false },
-			expectedBody: { name: 'notify_customer_with_shipment_details', value: false },
+			expectedBody: { name: 'notify_customer_with_shipment_details', enabled: false },
 		},
 		{
 			orderStatus: 'pending',
 			state: { name: 'fulfillOrder', value: true },
-			expectedBody: { name: 'mark_order_complete_and_notify_customer', value: true },
+			expectedBody: { name: 'mark_order_complete_and_notify_customer', enabled: true },
 		},
 		{
 			orderStatus: 'pending',
 			state: { name: 'fulfillOrder', value: false },
-			expectedBody: { name: 'mark_order_complete_and_notify_customer', value: false },
+			expectedBody: { name: 'mark_order_complete_and_notify_customer', enabled: false },
 		},
 	];
 

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
@@ -12,6 +12,7 @@ import nock from 'nock';
  */
 import {
 	openPrintingFlow,
+	handlePrintFinished,
 	convertToApiPackage,
 	submitAddressForNormalization,
 	confirmAddressSuggestion,
@@ -267,6 +268,85 @@ describe( 'Shipping label Actions', () => {
 		} );
 
 		nock.cleanAll();
+	} );
+
+	const createGetStateFnForPostPrintNotificationSettings = ( orderStatus, notificationSettings ) => () => ( {
+		ui: {
+			selectedSiteId: siteId,
+		},
+		extensions: {
+			woocommerce: {
+				sites: {
+					[ siteId ]: {
+						orders: {
+							items: {
+								[ orderId ]: {
+									status: orderStatus,
+								},
+							}
+						}
+					},
+				},
+				woocommerceServices: {
+					[ siteId ]: {
+						shippingLabel: {
+							[ orderId ]: notificationSettings,
+						},
+					},
+				},
+			},
+		},
+	} );
+
+	const mockPostPrintNotificationSettingsUpdateRequest = expectedBody => {
+		return nock( 'https://public-api.wordpress.com:443' )
+			.post(
+				`/rest/v1.1/jetpack-blogs/${ siteId }/rest-api/`,
+				body => {
+					const expectedPath = '/wc/v1/connect/post-print-notification-settings&_via_calypso&_method=post';
+
+					return expectedPath === body.path && JSON.stringify( expectedBody ) === body.body;
+				}
+			)
+			.reply( 200, { success: true } );
+	};
+
+	const testPostPrintNotificationSettingsUpdate = ( orderStatus, state, expectedBody ) => {
+		const getState = createGetStateFnForPostPrintNotificationSettings( orderStatus, state );
+		const request  = mockPostPrintNotificationSettingsUpdateRequest( expectedBody );
+		handlePrintFinished( orderId, siteId, sinon.spy(), getState, false, [] );
+		request.done();
+	};
+
+	const testCases = [
+		{
+			orderStatus: 'completed',
+			state: { name: 'emailDetails', value: true },
+			expectedBody: { name: 'notify_customer_with_shipment_details', value: true },
+		},
+		{
+			orderStatus: 'completed',
+			state: { name: 'emailDetails', value: false },
+			expectedBody: { name: 'notify_customer_with_shipment_details', value: false },
+		},
+		{
+			orderStatus: 'pending',
+			state: { name: 'fulfillOrder', value: true },
+			expectedBody: { name: 'mark_order_complete_and_notify_customer', value: true },
+		},
+		{
+			orderStatus: 'pending',
+			state: { name: 'fulfillOrder', value: false },
+			expectedBody: { name: 'mark_order_complete_and_notify_customer', value: false },
+		},
+	];
+
+	describe.each( testCases )( '#handlePrintFinished', testCase => {
+		const { expectedBody, orderStatus, state } = testCase;
+
+		it( `sets "${expectedBody.name}" to ${expectedBody.value}`, () => {
+			testPostPrintNotificationSettingsUpdate( orderStatus, { [ state.name ]: state.value }, expectedBody );
+		} );
 	} );
 
 	describe( '#convertToApiPackage', () => {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/test/shipping-rate.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/test/shipping-rate.js
@@ -8,6 +8,7 @@ import { expect } from 'chai';
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16'
 import { CheckboxControl, RadioControl } from '@wordpress/components';
+import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -94,7 +95,9 @@ describe( 'ShippingRate', () => {
 		} );
 
 		it( 'renders the delivery date', () => {
-			expect( shippingRateWrapper ).to.contain( <div className="rates-step__shipping-rate-delivery-date">January 1</div> ); // eslint-disable-line
+			const expectedDate = moment( shippingRateWrapper.props().rateObject.delivery_date ).format( 'LL' ).split( ',' )[0];
+
+			expect( shippingRateWrapper ).to.contain( <div className="rates-step__shipping-rate-delivery-date">{ expectedDate }</div> ); // eslint-disable-line
 		} );
 
 	} );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/test/sidebar.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/test/sidebar.js
@@ -27,7 +27,7 @@ function createSidebarWrapper( initProps = {} ) {
 		},
 		paperSize: 'letter',
 		errors: {},
-		form: { 
+		form: {
 			origin: { values: { country: 'US' } },
 			rates: {},
 		},
@@ -65,8 +65,7 @@ describe( 'Sidebar', () => {
 			renderedCheckboxControl.props().onChange( false )
 			expect( props.setFulfillOrderOption.mock.calls ).to.have.lengthOf( 1 );
 			expect( props.setFulfillOrderOption.mock.calls[0][2] ).to.equal( false );
-			expect( props.setEmailDetailsOption.mock.calls ).to.have.lengthOf( 1 );
-			expect( props.setEmailDetailsOption.mock.calls[0][2] ).to.equal( false );
+			expect( props.setEmailDetailsOption.mock.calls ).to.have.lengthOf( 0 );
 		} );
 
 		it( 'it is checked', function() {
@@ -83,7 +82,7 @@ describe( 'Sidebar', () => {
 
 	} );
 	describe( 'for completed orders', () => {
-		const { wrapper } = createSidebarWrapper( { order: { status: 'completed' }, fulfillOrder: false, emailDetails: false } );
+		const { wrapper, props } = createSidebarWrapper( { order: { status: 'completed' }, fulfillOrder: false, emailDetails: false } );
 		const renderedCheckboxControl = wrapper.find( CheckboxControl );
 
 		it( 'Has a the Correct Label', function () {
@@ -92,6 +91,13 @@ describe( 'Sidebar', () => {
 
 		it( 'it is not checked', function() {
 			expect( renderedCheckboxControl.props().checked ).to.equal( false );
+		} );
+
+		it( 'Unchecked checkbox disables sending email', function() {
+			renderedCheckboxControl.props().onChange( false );
+			expect( props.setFulfillOrderOption.mock.calls ).to.have.lengthOf( 0 );
+			expect( props.setEmailDetailsOption.mock.calls ).to.have.lengthOf( 1 );
+			expect( props.setEmailDetailsOption.mock.calls[0][2] ).to.equal( false );
 		} );
 	} );
 	describe( 'for no payment method and no selected rates', () => {
@@ -113,7 +119,7 @@ describe( 'Sidebar', () => {
 				origin: { values: { country: 'US' } },
 				rates: upsFormRates,
 			},
-			hasLabelsPaymentMethod: false 
+			hasLabelsPaymentMethod: false
 		} );
 
 		it( 'has paper size dropdown', function () {
@@ -132,7 +138,7 @@ describe( 'Sidebar', () => {
 				origin: { values: { country: 'US' } },
 				rates: uspsFormRates,
 			},
-			hasLabelsPaymentMethod: false 
+			hasLabelsPaymentMethod: false
 		} );
 
 		it( 'does not have paper size dropdown', function () {

--- a/tests/php/classes/test-class-wc-rest-connect-post-print-notification-settings-controller.php
+++ b/tests/php/classes/test-class-wc-rest-connect-post-print-notification-settings-controller.php
@@ -1,0 +1,115 @@
+<?php
+
+class WP_Test_WC_REST_Connect_Post_Print_Notification_Settings_Controller extends WC_Unit_Test_Case {
+
+	/** @var WC_Connect_Service_Settings_Store $settings_store_mock */
+	protected $settings_store_mock;
+
+	/** @var WC_Connect_Logger $connect_logger_mock */
+	protected $connect_logger_mock;
+
+	/** @var WC_REST_Connect_Notification_Settings_Controller $controller */
+	protected $controller;
+
+	/**
+	 * @inherit
+	 */
+	public static function setupBeforeClass() {
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-api-client-live.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-service-settings-store.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-logger.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-rest-connect-base-controller.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-rest-connect-post-print-notification-settings-controller.php';
+	}
+
+	/**
+	 * Setup the test case.
+	 *
+	 * @see WC_Unit_Test_Case::setUp()
+	 */
+	public function setUp() {
+		$api_client_mock = $this->getMockBuilder( WC_Connect_API_Client_Live::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->settings_store_mock = $this->createMock( WC_Connect_Service_Settings_Store::class );
+		$this->connect_logger_mock = $this->createMock( WC_Connect_Logger::class );
+
+		$this->controller = new WC_REST_Connect_Post_Print_Notification_Settings_Controller( $api_client_mock, $this->settings_store_mock, $this->connect_logger_mock );
+	}
+
+	public function test_it_updates_the_setting() {
+		$request = array(
+			'name'    => 'foo',
+			'enabled' => true,
+		);
+
+		$this->settings_store_mock->expects( $this->once() )
+			->method( 'set_post_print_notification_setting' )
+			->with( 'foo', true );
+
+		$result = $this->controller->post( $request );
+
+		$this->assertEquals( new WP_REST_Response( array( 'success' => true ), 200 ), $result );
+	}
+
+	public function test_it_returns_wp_error_if_error_occurs() {
+		$request = array(
+			'name'    => 'foo',
+			'enabled' => true,
+		);
+
+		$store_wp_error = new WP_Error(
+			'some code',
+			'some message'
+		);
+
+		$this->settings_store_mock->expects( $this->once() )
+			->method( 'set_post_print_notification_setting' )
+			->willReturn( $store_wp_error );
+
+		$expected_wp_error = new WP_Error(
+			'save_failed',
+			sprintf(
+				__( 'Unable to update notification setting. %s', 'woocommerce-services' ),
+				$store_wp_error->get_error_message()
+			),
+			array( 'status' => 400 )
+		);
+
+		$result = $this->controller->post( $request );
+
+		$this->assertEquals( $expected_wp_error, $result );
+	}
+
+	public function test_it_logs_wp_error_if_it_occurs() {
+		$request = array(
+			'name'    => 'foo',
+			'enabled' => true,
+		);
+
+		$store_wp_error = new WP_Error(
+			'some code',
+			'some message'
+		);
+
+		$this->settings_store_mock->expects( $this->once() )
+			->method( 'set_post_print_notification_setting' )
+			->willReturn( $store_wp_error );
+
+		$expected_logged_wp_error = new WP_Error(
+			'save_failed',
+			sprintf(
+				__( 'Unable to update notification setting. %s', 'woocommerce-services' ),
+				$store_wp_error->get_error_message()
+			),
+			array( 'status' => 400 )
+		);
+
+		$this->connect_logger_mock->expects( $this->once() )
+			->method( 'log' )
+			->with( $expected_logged_wp_error, WC_REST_Connect_Post_Print_Notification_Settings_Controller::class );
+
+		$this->controller->post( $request );
+	}
+}

--- a/tests/php/test_class-wc-connect-service-settings-store.php
+++ b/tests/php/test_class-wc-connect-service-settings-store.php
@@ -180,4 +180,97 @@ class WP_Test_WC_Connect_Service_Settings_Store extends WC_Unit_Test_Case {
 
 		$this->assertEquals( $actual, $expected );
 	}
+
+	public function test_get_notification_settings() {
+		$expected = array(
+			'mark_order_complete_and_notify_customer' => true,
+			'notify_customer_with_shipment_details'   => false,
+		);
+
+		WC_Connect_Options::update_option( 'post_print_notification_settings', $expected );
+
+		$settings_store = $this->get_settings_store();
+		$actual         = $settings_store->get_post_print_notification_settings();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	public function test_get_notification_settings_returns_defaults_if_settings_are_empty() {
+		WC_Connect_Options::delete_option( 'post_print_notification_settings' );
+
+		$expected = array(
+			'mark_order_complete_and_notify_customer' => false,
+			'notify_customer_with_shipment_details'   => false,
+		);
+
+		$settings_store = $this->get_settings_store();
+		$actual         = $settings_store->get_post_print_notification_settings();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	public function test_get_notification_settings_fills_missing_options_with_defaults() {
+		$partial_settings = array(
+			'mark_order_complete_and_notify_customer' => true,
+		);
+
+		WC_Connect_Options::update_option( 'post_print_notification_settings', $partial_settings );
+
+		$expected = array(
+			'mark_order_complete_and_notify_customer' => true,
+			'notify_customer_with_shipment_details'   => false,
+		);
+
+		$settings_store = $this->get_settings_store();
+		$actual         = $settings_store->get_post_print_notification_settings();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	public function test_set_notification_setting_updates_settings() {
+		WC_Connect_Options::delete_option( 'post_print_notification_settings' );
+
+		$settings_store = $this->get_settings_store();
+		$settings_store->set_post_print_notification_setting( 'mark_order_complete_and_notify_customer', true );
+		$settings_store->set_post_print_notification_setting( 'notify_customer_with_shipment_details', true );
+
+		$settings = $settings_store->get_post_print_notification_settings();
+
+		$this->assertTrue( $settings['mark_order_complete_and_notify_customer'] );
+		$this->assertTrue( $settings['notify_customer_with_shipment_details'] );
+	}
+
+	public function test_set_notification_setting_returns_error_for_invalid_setting_names() {
+		$settings_store = $this->get_settings_store();
+		$result         = $settings_store->set_post_print_notification_setting( 'not a valid setting name', true );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertEquals( 'invalid_notification_setting_name', $result->get_error_code() );
+	}
+
+	public function test_set_notification_setting_casts_values_to_bool() {
+		WC_Connect_Options::delete_option( 'post_print_notification_settings' );
+
+		$settings_store = $this->get_settings_store();
+		$settings_store->set_post_print_notification_setting( 'mark_order_complete_and_notify_customer', 'foo' );
+		$settings_store->set_post_print_notification_setting( 'notify_customer_with_shipment_details', '' );
+
+		$settings = $settings_store->get_post_print_notification_settings();
+
+		$this->assertSame( true, $settings['mark_order_complete_and_notify_customer'] );
+		$this->assertSame( false, $settings['notify_customer_with_shipment_details'] );
+	}
+
+	public function test_set_notfication_setting_returns_true_when_setting_same_value_as_before() {
+		$settings = array(
+			'mark_order_complete_and_notify_customer' => true,
+			'notify_customer_with_shipment_details'   => true,
+		);
+		WC_Connect_Options::update_option( 'post_print_notification_settings', $settings );
+
+		$settings_store = $this->get_settings_store();
+		$result         = $settings_store->set_post_print_notification_setting( 'mark_order_complete_and_notify_customer', true );
+
+		$this->assertTrue( $result );
+	}
 }

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -99,6 +99,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		protected $rest_account_settings_controller;
 
 		/**
+		 * @var WC_REST_Connect_Post_Print_Notification_Settings_Controller
+		 */
+		protected $rest_post_print_notification_settings_controller;
+
+		/**
 		 * @var WC_REST_Connect_Packages_Controller
 		 */
 		protected $rest_packages_controller;
@@ -327,6 +332,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			return $this->rest_account_settings_controller;
 		}
 
+		public function get_rest_post_print_notification_settings_controller() {
+			return $this->rest_post_print_notification_settings_controller;
+		}
+
 		public function set_rest_tos_controller( WC_REST_Connect_Tos_Controller $rest_tos_controller ) {
 			$this->rest_tos_controller = $rest_tos_controller;
 		}
@@ -361,6 +370,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		public function set_rest_account_settings_controller( WC_REST_Connect_Account_Settings_Controller $rest_account_settings_controller ) {
 			$this->rest_account_settings_controller = $rest_account_settings_controller;
+		}
+
+		public function set_rest_post_print_notification_settings_controller( WC_REST_Connect_Post_Print_Notification_Settings_Controller $rest_post_print_notification_settings_controller ) {
+			$this->rest_post_print_notification_settings_controller = $rest_post_print_notification_settings_controller;
 		}
 
 		public function get_rest_services_controller() {
@@ -825,6 +838,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$rest_account_settings_controller = new WC_REST_Connect_Account_Settings_Controller( $this->api_client, $settings_store, $logger, $this->payment_methods_store );
 			$this->set_rest_account_settings_controller( $rest_account_settings_controller );
 			$rest_account_settings_controller->register_routes();
+
+			require_once( plugin_basename( 'classes/class-wc-rest-connect-post-print-notification-settings-controller.php' ) );
+			$rest_post_print_notification_settings_controller = new WC_REST_Connect_Post_Print_Notification_Settings_Controller( $this->api_client, $settings_store, $logger );
+			$this->set_rest_post_print_notification_settings_controller( $rest_post_print_notification_settings_controller );
+			$rest_post_print_notification_settings_controller->register_routes();
 
 			require_once( plugin_basename( 'classes/class-wc-rest-connect-services-controller.php' ) );
 			$rest_services_controller = new WC_REST_Connect_Services_Controller( $this->api_client, $settings_store, $logger, $schemas_store );


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Currently, the **Mark this order as complete and notify the customer** and **Notify the customer with shipment details** checkboxes in the **Create shipping label** modal are always set to a default state (unchecked). This is problematic for users who have workflows that do not match this behavior.

This PR introduces a new option `post_print_notification_settings` in `WC_Connect_Options` which stores the state of both checkboxes.

The settings can be manipulated via a REST controller which automatically happens when a label is printed (automatically or after **Print** is clicked) in the **Create shipping label** modal.

### Important changes

#### Relying on functions rather than state when sending

Previously, the state values `fulfillOrder` and `emailDetails` were set to a result calculated from checkbox state and order status:

```js
const onFulfillAndEmailOrderChange = ( value ) => {
	// Don't change order status if already finished.
	props.setFulfillOrderOption( orderId, siteId, value && ! isOrderFinished( order.status ) );
	// Email only if order is already complete.
	props.setEmailDetailsOption( orderId, siteId, value && isOrderFinished( order.status ) );
};
```

This PR repurposes these values to only contain the user preference of whether to send the notification if applicable.

Instead of relying on the state directly, the `shouldFulfillOrder()` and `shouldEmailDetails()` functions should be used instead.

#### Naming

The name is pretty long. :) I was also considering "Post-Print Actions" or just "Notification Settings" but for now settled for the most verbose "Post-Print Notification Settings".

#### Default state removal

I have removed the default state for the `emailDetails` and `fulfillOrder` fields from `/client/extensions/woocommerce/woocommerce-services/lib/initialize-labels-state/index.js`. I believe it was not used anywhere. If someone more familiar with the inner workings of the plugin could please let me know if this might be problematic, that would be great!

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Fixes #2005 

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

![Markup on 2021-01-13 at 18:50:41](https://user-images.githubusercontent.com/1759681/104489738-44289180-55d0-11eb-83c8-5fc6567c5be7.png)

![Markup on 2021-01-13 at 18:24:23](https://user-images.githubusercontent.com/1759681/104486813-949df000-55cc-11eb-83f9-6ed50e45ecc9.png)

The screenshot shows an order that is not completed yet. The **Notify the customer with shipment details** checkbox is presented in the same modal for completed orders.

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

