### PR TITLE
refactor: live rates response caching

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.25.6 - 202x-xx-xx =
 * Fix 	- Refreshes shipping methods after registering or removing carrier accounts.
+* Tweak	- Changed rates response caching method from cache to transient.
 
 = 1.25.5 - 2021-01-11 =
 * Fix	- Redux DevTools usage update.

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -343,16 +343,17 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				'wcs_rates_%s',
 				md5( serialize( array( $services, $package, $custom_boxes, $predefined_boxes ) ) )
 			);
-			$debug_mode = 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' );
-			$response_body = wp_cache_get( $cache_key );
-			if ( ! $debug_mode && false !== $response_body ) {
+			$is_debug_mode = 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' );
+			$response_body = get_transient( $cache_key );
+			$this->debug( false === $response_body ? 'Cache contains rates response' : 'Cache does not contain rates response' );
+			if ( ! $is_debug_mode && false !== $response_body ) {
 				$this->debug( 'Rates response retrieved from cache' );
 			} else {
 				$response_body = $this->api_client->get_shipping_rates( $services, $package, $custom_boxes, $predefined_boxes );
 				if ( $this->check_and_handle_response_error( $response_body, $service_settings ) ) {
 					return;
 				}
-				wp_cache_set( $cache_key, $response_body, '', 3600 );
+				set_transient( $cache_key, $response_body, HOUR_IN_SECONDS );
 			}
 
 			$instances = $response_body->rates;

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -345,7 +345,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			);
 			$is_debug_mode = 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' );
 			$response_body = get_transient( $cache_key );
-			$this->debug( false === $response_body ? 'Cache contains rates response' : 'Cache does not contain rates response' );
+			$this->debug( false === $response_body ? 'Cache does not contain rates response' : 'Cache contains rates response' );
 			if ( ! $is_debug_mode && false !== $response_body ) {
 				$this->debug( 'Rates response retrieved from cache' );
 			} else {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Changing from `wp_cache_get` to `get_transient`, so that the API response is set with transients (rather than WP cache).
If a store does not have the WP cache configured, they would not benefit from the caching of the API response.
By using the transients, we're leveraging `wp_options` instead, which is always configured.

I ensured that the transient key length is short enough ([must be 172 character or shorter](https://developer.wordpress.org/reference/functions/set_transient/#parameters)).
I also added 2 new debug messages, to help with the debugging:
- "Cache contains rates response"
- "Cache does not rates response"

I am aware that I am using the word "cache", but I didn't think that the word "transient" would be useful, in this case. After all, we're using the `transient`s as a caching mechanism.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

fixes https://github.com/Automattic/woocommerce-services/issues/2285

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

- Put your site in debug mode, by going to **WooCommerce > Status > WooCommerce Shipping & Tax > Debug**
- Put WooCommerce in debug mode in **WooCommerce > Settings > Shipping > Shipping options > Debug mode**
- Ensure your site has permissions to get live rates (set the `can_use_live_rates` flag on the server)
- Ensure your site is US-based
- Add and configure the USPS shipping method by WooCommerce Shipping in **WooCommerce > Settings > Shipping > Shipping Zones** in one of your shipping zones
- Live rates should still be working in your checkout
- With debug _disabled_, you should not see as many requests on the server

First request:
![Screen Shot 2021-01-15 at 2 59 08 PM](https://user-images.githubusercontent.com/273592/104778021-46aaf880-5742-11eb-994b-fab2acf5703d.png)


Subsequent requests:
![Screen Shot 2021-01-15 at 2 57 14 PM](https://user-images.githubusercontent.com/273592/104778035-50346080-5742-11eb-8d37-eba42fe737a4.png)



### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

