### PR TITLE
Fix radio button dot alignment in "Create shipping label"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,8 @@
 
 = 1.25.6 - 202x-xx-xx =
 * Fix 	- Refreshes shipping methods after registering or removing carrier accounts.
+* Fix	- Position dot in the center of radio buttons in "Create shipping label".
+* Fix	- Adjust radio button dot style in "Create shipping label" in high contrast mode on Windows.
 
 = 1.25.5 - 2021-01-11 =
 * Fix	- Redux DevTools usage update.

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
@@ -61,6 +61,11 @@
 	input[type='radio']:checked::before {
 		margin: 2px;
 		background-color: #d52c82;
+
+		// For radio buttons to be visible in high contrast mode on Windows, a border or outline is required
+		// See: https://github.com/WordPress/gutenberg/pull/23706
+		border: 4px solid #d52c82;
+		box-sizing: border-box;
 	}
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
There was [a change introduced in `@wordpress/base-styles` to support high contrast mode on Windows](https://github.com/WordPress/gutenberg/pull/23706/files) that the styles in WCS&T are not compatible with.

How to reproduce:

1. Clone both the WooCommerce and WooCommerce Admin repos.
1. Compile WooCommerce:
    * `git checkout 4.8.0 && npm install && composer install && npm run build`
1. Compile WooCommerce Admin using the commit where `@wordpress/base-styles` was upgraded:
    * `git checkout c27e266051d4fc72b1e7fb87b2c4ac365d629cef && composer install && npm install && npm run build`
1. Copy the compiled problematic WC Admin stylesheet to WC:
    * `cp woocommerce-admin/dist/app/style.css woocommerce/packages/woocommerce-admin/dist/app/style.css`
1. The radio button is off-center.
1. Compile WC Admin from the previous commit:
    * `git checkout HEAD~1 && npm install && npm run build`
1. Copy the compiled WC Admin stylesheet to WC:
    * `cp woocommerce-admin/dist/app/style.css woocommerce/packages/woocommerce-admin/dist/app/style.css`
1. The radio button is OK.

This PR fixes the off-center dots in the **Create shipping label** modal and improves styles in high contrast mode on Windows.

I have tested the solution on WooCommerce 4.7.0, 4.8.0, and the current `master` (5.0.0-dev).

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Fixes #2279 

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

All screenshots were taken in Firefox on Windows 10.

Before:

![Before](https://user-images.githubusercontent.com/1759681/105035150-d3afc380-5a5a-11eb-93b6-eb1660db2dbf.png)

Before in high contrast mode:

![Before - high contrast mode](https://user-images.githubusercontent.com/1759681/105035165-d6aab400-5a5a-11eb-8c90-d26c719d1c04.png)

After:

![After](https://user-images.githubusercontent.com/1759681/105035172-da3e3b00-5a5a-11eb-8f64-93e072a4cd00.png)

After in high contrast mode:

![After - high contrast mode](https://user-images.githubusercontent.com/1759681/105035180-dca09500-5a5a-11eb-9a0c-9e97c117eb44.png)

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

