### PR TITLE
Disable E2E tests unless env(DONT_SKIP_E2E_TESTS) is present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ os: linux
 dist: xenial
 services:
     - mysql
+env:
+    - DONT_SKIP_E2E_TESTS=1
 
 # Define our matrix of build configurations to test against.
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ os: linux
 dist: xenial
 services:
     - mysql
-env:
-    - DONT_SKIP_E2E_TESTS=1
 
 # Define our matrix of build configurations to test against.
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ jobs:
      before_script: skip
      script: npm run eslint
    - name: "E2E tests"
+     if: env(DONT_SKIP_E2E_TESTS) IS present
      dist: trusty
      php: 7.2
      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=4.0.1 RUN_E2E=1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description

E2E tests are currently failing. This PR adds support for the `DONT_SKIP_E2E_TESTS` environment variable that, unless present, disables the `E2E tests` Travis job by default.

Once E2E tests are fixed, the condition can be removed from `.travis.yml`.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Fixes #2305.

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

**Before:** E2E tests fail on all PRs. Example: #2303.

**After:** E2E tests are not executed unless the `env(DONT_SKIP_E2E_TESTS)` variable is present either in `.travis.yml` or the repository settings. See the [Environment Variables chapter of the Travis documentation](https://docs.travis-ci.com/user/environment-variables/) for more information.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added

