### PR TITLE
release 1.25.6

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.25.6 - 202x-xx-xx =
 * Fix 	- Refreshes shipping methods after registering or removing carrier accounts.
+* Tweak	- Changed rates response caching method from cache to transient.
 
 = 1.25.5 - 2021-01-11 =
 * Fix	- Redux DevTools usage update.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.6 - 202x-xx-xx =
+* Fix 	- Refreshes shipping methods after registering or removing carrier accounts.
+
 = 1.25.5 - 2021-01-11 =
 * Fix	- Redux DevTools usage update.
 * Add	- Display subscriptions usage.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
-= 1.25.6 - 2021-xx-xx =
+= 1.25.6 - 2021-01-26 =
 * Fix 	- Refreshes shipping methods after registering or removing carrier accounts.
 * Tweak	- Changed rates response caching method from cache to transient.
 * Tweak	- Update "WC Tested up to" version.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
-= 1.25.6 - 202x-xx-xx =
+= 1.25.6 - 2021-xx-xx =
 * Fix 	- Refreshes shipping methods after registering or removing carrier accounts.
 * Tweak	- Changed rates response caching method from cache to transient.
 * Tweak	- Update "WC Tested up to" version.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.25.6 - 202x-xx-xx =
 * Fix 	- Refreshes shipping methods after registering or removing carrier accounts.
 * Tweak	- Changed rates response caching method from cache to transient.
+* Tweak	- Update "WC Tested up to" version.
 
 = 1.25.5 - 2021-01-11 =
 * Fix	- Redux DevTools usage update.

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -343,16 +343,17 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				'wcs_rates_%s',
 				md5( serialize( array( $services, $package, $custom_boxes, $predefined_boxes ) ) )
 			);
-			$debug_mode = 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' );
-			$response_body = wp_cache_get( $cache_key );
-			if ( ! $debug_mode && false !== $response_body ) {
+			$is_debug_mode = 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' );
+			$response_body = get_transient( $cache_key );
+			$this->debug( false === $response_body ? 'Cache does not contain rates response' : 'Cache contains rates response' );
+			if ( ! $is_debug_mode && false !== $response_body ) {
 				$this->debug( 'Rates response retrieved from cache' );
 			} else {
 				$response_body = $this->api_client->get_shipping_rates( $services, $package, $custom_boxes, $predefined_boxes );
 				if ( $this->check_and_handle_response_error( $response_body, $service_settings ) ) {
 					return;
 				}
-				wp_cache_set( $cache_key, $response_body, '', 3600 );
+				set_transient( $cache_key, $response_body, HOUR_IN_SECONDS );
 			}
 
 			$instances = $response_body->rates;

--- a/classes/class-wc-rest-connect-shipping-carrier-controller.php
+++ b/classes/class-wc-rest-connect-shipping-carrier-controller.php
@@ -26,6 +26,7 @@ class WC_REST_Connect_Shipping_Carrier_Controller extends WC_REST_Connect_Base_C
 			return $error;
 		}
 
+		do_action( 'wc_connect_fetch_service_schemas' );
 		return $response;
 	}
 

--- a/classes/class-wc-rest-connect-shipping-carrier-delete-controller.php
+++ b/classes/class-wc-rest-connect-shipping-carrier-delete-controller.php
@@ -25,6 +25,7 @@ class WC_REST_Connect_Shipping_Carrier_Delete_Controller extends WC_REST_Connect
 			return $error;
 		}
 
+		do_action( 'wc_connect_fetch_service_schemas' );
 		return array( 'success' => true );
 	}
 }

--- a/client/extensions/woocommerce/woocommerce-services/components/carrier-icon/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/carrier-icon/index.js
@@ -19,7 +19,6 @@ const carrierLogos = {
 	"dhlexpress": dhlLogo,
 	"dhlecommerce": dhlLogo,
 	"dhlecommerceasia": dhlLogo,
-	"dhlecommerceinternational": dhlLogo,
 };
 
 const sizeToPixels = ( size ) => {

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/list-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/list-item.js
@@ -80,9 +80,8 @@ const CarrierAccountListItem = ( props ) => {
 
 	const carrierTypeIconMap = {
 		DhlExpressAccount: 'dhlexpress',
-		DhlEcommerceAccount: 'dhlecommerce',
+		DhlEcsAccount: 'dhlecommerce',
 		DhlEcommerceAsiaAccount: 'dhlecommerceasia',
-		DHLGMIAccount: 'dhlecommerceinternational',
 		UpsAccount: 'ups',
 	}
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-services",
-  "version": "1.25.5",
+  "version": "1.25.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-services",
-  "version": "1.25.5",
+  "version": "1.25.6",
   "scripts": {
     "start": "cross-env NODE_ENV=development CALYPSO_CLIENT=true webpack-dev-server --hot --inline --watch --content-base dist --port 8085",
     "prepare": "cd wp-calypso && npm ci && cd ..",

--- a/readme.txt
+++ b/readme.txt
@@ -76,6 +76,10 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 1.25.6 - 2021-xx-xx =
+* Fix 	- Refreshes shipping methods after registering or removing carrier accounts.
+* Tweak	- Changed rates response caching method from cache to transient.
+
 = 1.25.5 - 2021-01-11 =
 * Fix	- Redux DevTools usage update.
 * Add	- Display subscriptions usage.
@@ -125,41 +129,3 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 * Tweak - Update carrier logo
 * Tweak - Plugin rename
 * Add   - Link to print the customs form for all shipments that need it
-
-= 1.24.3 - 2020-09-16 =
-* Fix   - Asset paths incompatible with some hosts
-* Fix   - Select all posts checkbox not working
-* Fix   - Use of deprecated jQuery.load
-* Tweak - Updating carrier logo and tracking links
-
-= 1.24.2 - 2020-09-03 =
-* Fix   - Optional preloading for wc-admin install compatibility
-* Fix   - Remove duplicate rate errors
-* Fix   - Compatibility with WooCommerce order page install prompt
-* Add   - Introduce 'wc_connect_meta_box_payload' filter for modifying order data
-* Tweak - Update UPS failed connection error message
-
-= 1.24.1 - 2020-08-19 =
-* Tweak - Zip/Postcode/Postal code messaging consistency
-* Fix   - Services management CSS table layout
-* Fix   - Carrier "disconnect modal" layout
-* Fix   - Primary button busy state updated to match color
-* Fix   - Remove padding from notice bar
-* Fix   - Add missing box in rate step for how much customer paid for shipping
-* Tweak - Bump WP tested version to 5.5
-* Fix   - Issue with dismiss modal popup blocking access to edit order
-
-= 1.24.0 - 2020-07-30 =
-* Fix   - PHP 7.4 notice for taxes at checkout.
-* Add   - Carrier logos next to rates.
-* Tweak - Remove spinner from create shipping label button
-* Add   - Upgrade React to 16.13
-* Add   - Optimize bundle
-* Fix   - Fix svg images not showing on dev
-* Fix   - Fix 404 taxjar.js on new order page
-* Add   - Add e2e tests for toggling shipping label
-* Add   - Add e2e tests for label refund
-* Fix   - Show which nexus automatted taxes will work with and link to doc
-* Fix   - Fix localization issues
-* Tweak - Improve service listing readability
-* Add   - Support UPS as a carrier (beta)

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: shipping, stamps, usps, woocommerce, taxes, payment, dhl, labels
 Requires at least: 4.6
 Requires PHP: 5.3
 Tested up to: 5.6
-Stable tag: 1.25.5
+Stable tag: 1.25.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -76,7 +76,7 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
-= 1.25.6 - 2021-xx-xx =
+= 1.25.6 - 2021-01-26 =
 * Fix 	- Refreshes shipping methods after registering or removing carrier accounts.
 * Tweak	- Changed rates response caching method from cache to transient.
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -7,7 +7,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-services
  * Domain Path: /i18n/languages/
- * Version: 1.25.5
+ * Version: 1.25.6
  * WC requires at least: 3.0.0
  * WC tested up to: 5.0
  *

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -9,7 +9,7 @@
  * Domain Path: /i18n/languages/
  * Version: 1.25.5
  * WC requires at least: 3.0.0
- * WC tested up to: 4.2
+ * WC tested up to: 5.0
  *
  * Copyright (c) 2017-2020 Automattic
  *


### PR DESCRIPTION
## Release PR for 1.25.6
### Changes in this release
- https://github.com/Automattic/woocommerce-services/pull/2293 : Refreshes shipping methods after registering or removing carrier accounts
- https://github.com/Automattic/woocommerce-services/pull/2301 : Changed rates response caching method from cache to transient
- https://github.com/Automattic/woocommerce-services/pull/2308 : chore: update WC version

This release branch is branched from latest `develop` .

### Test notes
- Test against WC 5.0 beta (use the [WC beta tester plugin](https://wordpress.org/plugins/woocommerce-beta-tester/) for an easy switch)
- Test live rates
- Test account connection

### Changelog
* Fix 	- Refreshes shipping methods after registering or removing carrier accounts.
* Tweak	- Changed rates response caching method from cache to transient.

## Build File
Built from this branch using `php woorelease.phar simulate --product_version=1.25.6 https://github.com/Automattic/woocommerce-services/tree/release/1.25.6`

[woocommerce-services.zip](https://github.com/Automattic/woocommerce-services/files/5857026/woocommerce-services.zip)
