### PR TITLE
Remove error notices from checkout page load

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.7 - 2021-xx-xx =
+* Fix	- Prevent error notices on checkout page load
+
 = 1.25.6 - 2021-01-26 =
 * Fix 	- Refreshes shipping methods after registering or removing carrier accounts.
 * Tweak	- Changed rates response caching method from cache to transient.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -326,7 +326,8 @@ class WC_Connect_TaxJar_Integration {
 				$message = sprintf( _x( 'Invalid %s entered.', '%s - ZIP/Postal code checkout field label', 'woocommerce-services' ), $postcode_field_name );
 			}
 
-			if ( ! wc_has_notice( $message, 'error' ) ) {
+			// if on checkout page load (not ajax), don't set an error as it prevents checkout page from displaying
+			if ( ( is_cart() || ( is_checkout() && is_ajax() ) ) && ! wc_has_notice( $message, 'error' ) ) {
 				wc_add_notice( $message, 'error' );
 			}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
As described in #1576 there was a situation where if the tax calculation failed while loading the checkout page, the checkout page would not display. This error primarily came up as an address, particularly zip code error. The only way to fix it previously was to modify the address some other way as you could no longer do it from the checkout page. There was a lot of digging on this issue to find the best approach and @Ferdev pinpointed an approach of not calculating tax on the checkout page load. I then picked up the issue and modified it slightly so that it may still calculate the tax on page load, but if it fails it doesn't add an error notice, which was breaking the checkout page and instead fail silently to give the user a chance to fix the error.

The taxes are actually calculated in two ways on the checkout page, once from the page load and one through AJAX (after updating the address or attempting to place the order). This PR checks to see if the request to calculate tax was from the checkout page and if it was AJAX or not. If it was not AJAX it will not add an error notice. I had previously experimented with adding a "notice" level notice instead of skipping it entirely, but found that these don't clear out as you update the page and would cause confusion.

![Screen Shot 2021-01-26 at 4 01 04 PM](https://user-images.githubusercontent.com/68524302/105907407-ee51e180-5ff2-11eb-8302-5170fa20c712.png)

I feel it is safe to not display an error notice on the page load as the AJAX requests will catch and display the errors. If the user has AJAX disabled, other functionality for the checkout won't work well, but as a fallback there is still a check on valid address data when processing the checkout. 

### Related issue(s)

Fixes #1576 

### Steps to reproduce & screenshots/GIFs

1. Start with a WCS site with tax calculations enabled.
2. Go through a normal shopping experience up to the checkout page.
3. On the checkout page, enter a valid address with valid zip code.
4. Confirm that taxes calculated properly when the zip code was entered.
5. Change the zip code to an invalid zip code.
6. Confirm an error notice is displayed.
7. Refresh the checkout page.
8. No notice should be displayed at first while the subtotals are calculated. This happens quickly so may miss it while it's calculating subtotals.
9. Subtotals will be calculated and at that point the error notice should display.
10. Attempt to checkout with the error notice and receive more errors and are unable to checkout with invalid zip.

To test with AJAX disabled on the checkout page add the following hook to an mu-plugin or something similar:

```
add_action( 'wp_enqueue_scripts', function() {
	wp_dequeue_script( 'wc-checkout' );
} );
```

Attempt the same process as above, you won't get an error notice at first. Once clicking Place Order though, you should get a page refresh with the errors displayed.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

