### PR TITLE
Highlight rate call usage in red and display tooltip when over limit

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.25.7 - 2021-xx-xx =
 * Fix	- Prevent error notices on checkout page load
+* Tweak	- Highlight rate call usage over limit on WooCommerce Shipping settings page.
 
 = 1.25.6 - 2021-01-26 =
 * Fix 	- Refreshes shipping methods after registering or removing carrier accounts.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 1.25.7 - 2021-xx-xx =
-* Fix   - Prevent error notices on checkout page load.
-* Tweak	- Highlight rate call usage over limit on WooCommerce Shipping settings page.
+* Fix   - ∫Prevent error notices on checkout page load.
+* Tweak - Highlight rate call usage over limit on WooCommerce Shipping settings page.
 * Fix   - Connect carrier account link broken on subdirectory installs.
 
 = 1.25.6 - 2021-01-26 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 1.25.7 - 2021-xx-xx =
-* Fix   - ∫Prevent error notices on checkout page load.
+* Fix   - Prevent error notices on checkout page load.
 * Tweak - Highlight rate call usage over limit on WooCommerce Shipping settings page.
 * Fix   - Connect carrier account link broken on subdirectory installs.
 

--- a/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/list-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/list-item.js
@@ -7,6 +7,9 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
+import { Tooltip } from '@wordpress/components';
+import Gridicon from 'gridicons';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -21,7 +24,7 @@ const SubscriptionsUsageListItem = ( props ) => {
 	const { translate, data, errorNotice, successNotice, siteId } = props;
 	const [isActive, setisActive] = React.useState( data.is_active );
 	const [isSaving, setIsSaving] = React.useState(false);
-	 
+
 	const getIcon = ( productName ) => {
 		const subscriptionToIconRules = [
 			[/^DHL/g, 'dhlexpress'],
@@ -31,14 +34,14 @@ const SubscriptionsUsageListItem = ( props ) => {
 
 		const i = subscriptionToIconRules.findIndex( ( [rule] ) => rule.test( productName ) );
 		if ( i > -1 ) return subscriptionToIconRules[i][1];
-		
+
 		return '';
 	};
 
 	const handleActivate = () =>{
 		const submitActivation = async () => {
 			setIsSaving(true);
-		
+
 			try {
 				await api.post( siteId, api.url.subscriptionActivate( data.product_key ) );
 				setisActive( true );
@@ -54,6 +57,8 @@ const SubscriptionsUsageListItem = ( props ) => {
 
 	const usage_count = data.usage_count ? data.usage_count : 0 ;
 	const usage = data.usage_limit ? `${ usage_count }/${ data.usage_limit }` : '';
+	const isUsageOverLimit = data.usage_count && data.usage_limit && data.usage_count > data.usage_limit;
+
 	return (
 		<div className= "subscriptions-usage__list-item" >
 			<div className="subscriptions-usage__list-item-carrier-icon">
@@ -62,8 +67,18 @@ const SubscriptionsUsageListItem = ( props ) => {
 			<div className="subscriptions-usage__list-item-name">
 				<span>{ data.product_name }</span>
 			</div>
-			<div className="subscriptions-usage__list-item-usage">
-				<span>{ usage }</span>
+			<div className={ classNames( 'subscriptions-usage__list-item-usage', { 'is-over-limit': isUsageOverLimit } ) }>
+				<span className="subscriptions-usage__list-item-usage-numbers">{ usage }</span>
+				<Tooltip
+					text={ translate(
+						'Your store is over the limit for rate calls this month and your account will be charged for overages. ' +
+						'To prevent future overage charges you can upgrade your plan.'
+					) }
+				>
+					<span className="subscriptions-usage__list-item-usage-icon">
+						<Gridicon icon="info-outline" size={ 18 } />
+					</span>
+				</Tooltip>
 			</div>
 			<div className="subscriptions-usage__list-item-actions">
 				{ isActive ? (
@@ -77,8 +92,8 @@ const SubscriptionsUsageListItem = ( props ) => {
 						{ translate( 'Manage' ) }
 					</a>
 				) : (
-					<Button 
-						onClick={ handleActivate } 
+					<Button
+						onClick={ handleActivate }
 						disabled={ isSaving }
 						busy={ isSaving }
 						compact

--- a/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/style.scss
@@ -20,7 +20,29 @@
 		}
 
 		.subscriptions-usage__list-item-usage {
+			display: flex;
 			width: 30%;
+
+			& > .subscriptions-usage__list-item-usage-icon {
+				display: none;
+			}
+
+			&.is-over-limit {
+				& > .subscriptions-usage__list-item-usage-numbers {
+					color: var( --color-red-light );
+					font-weight: 600;
+				}
+
+				& > .subscriptions-usage__list-item-usage-icon {
+					display: block;
+					margin-left: 5px;
+				}
+
+				.components-popover__content {
+					white-space: normal;
+					width: 200px;
+				}
+			}
 		}
 
 		.subscriptions-usage__list-item-actions {

--- a/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/style.scss
@@ -21,7 +21,16 @@
 
 		.subscriptions-usage__list-item-usage {
 			display: flex;
+			flex-flow: column;
+			justify-content: center;
+			text-align: center;
 			width: 30%;
+
+			@include breakpoint( '>480px' ) {
+				flex-flow: row;
+				justify-content: flex-start;
+				text-align: left;
+			}
 
 			& > .subscriptions-usage__list-item-usage-icon {
 				display: none;
@@ -35,7 +44,12 @@
 
 				& > .subscriptions-usage__list-item-usage-icon {
 					display: block;
-					margin-left: 5px;
+					margin-top: 5px;
+
+					@include breakpoint( '>480px' ) {
+						margin-left: 5px;
+						margin-top: 0;
+					}
 				}
 
 				.components-popover__content {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

When the rate call usage is over limit, highlight the text in red and increase the font weight. Display a tooltip with the following message:

> Your store is over the limit for rate calls this month and your account will be charged for overages. To prevent future overage charges you can upgrade your plan.

Some things that I would like to point out in case they require further adjustment:

* The implemented view is not pixel-perfect but rather an approximation of the mockup.
* I have used the `--color-red-400` color rather than e.g. one of the `--color-error-*` colors.
* I have set the tooltip width to `200px` to be more like the design mockup as by default it is displayed as a single line.
  
  Relevant CSS:
  ```css
  .components-popover__content {
	  white-space: normal;
	  width: 200px;
  }
  ```
* The design mockup shows a cursor similar to when using `cursor: pointer`. I have left it in the default state as this is the default for the Tooltip component from `@wordpress/components` in hope this results in a more uniform experience.
* For the mobile view, I have placed the icon in a column and centered the text.

### Potential todos:

- [ ] On mobile devices, the tooltip is not displayed (tested on Safari and Firefox on iOS 14.4).

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

On desktop:

![Desktop preview](https://user-images.githubusercontent.com/1759681/106327297-1d2fb800-627e-11eb-9d5e-e83dc40775ec.png)

On mobile:

![Mobile preview](https://user-images.githubusercontent.com/1759681/106327218-05583400-627e-11eb-8b87-80fccb76212f.png)

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

