### PR TITLE
Use relative path so links work on subdirectory installs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.7 - 2021-x-x =
+* Fix   - Connect carrier account link broken on subdirectory installs
+
 = 1.25.6 - 2021-01-26 =
 * Fix 	- Refreshes shipping methods after registering or removing carrier accounts.
 * Tweak	- Changed rates response caching method from cache to transient.

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/list-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/list-item.js
@@ -104,7 +104,7 @@ const CarrierAccountListItem = ( props ) => {
 				) : (
 					<a
 						href={
-							`/wp-admin/admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings&carrier=${data.type}`
+							`admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings&carrier=${data.type}`
 						}
 						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 						className="button is-compact"


### PR DESCRIPTION
## Description
Link to connect a carrier account will break if WP is installed in a subdirectory.

### Related issue(s)

closes #2298 

### Steps to reproduce & screenshots/GIFs
Install WordPress into a subdirectory.
Try to connect a carrier account.
Should not 404.

### Checklist

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

