### PR TITLE
Add API support for creating packages with `/connect/packages/create`

### DIFF
--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -492,6 +492,20 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		}
 
 		/**
+		 * Extends the global list of packages with a list of new packages
+		 *
+		 * @param array new_packages - packages to extend
+		 */
+		public function create_packages( $new_packages ) {
+			if (is_null($new_packages)) {
+				return;
+			}
+			$packages = $this->get_packages();
+			$packages = array_merge($packages, $new_packages);
+			WC_Connect_Options::update_option( 'packages', $packages );
+		}
+
+		/**
 		 * Updates the global list of packages
 		 *
 		 * @param array packages
@@ -522,6 +536,20 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			}
 
 			return $packages[ $service_id ];
+		}
+
+		/**
+		 * Extends the global list of enabled predefined packages with a list of new packages
+		 *
+		 * @param array new_packages - packages to extend
+		 */
+		public function create_predefined_packages( $new_packages ) {
+			if (is_null($new_packages)) {
+				return;
+			}
+			$packages = $this->get_predefined_packages();
+			$packages = array_merge_recursive($packages, $new_packages);
+			WC_Connect_Options::update_option( 'predefined_packages', $packages );
 		}
 
 		/**

--- a/classes/class-wc-rest-connect-packages-controller.php
+++ b/classes/class-wc-rest-connect-packages-controller.php
@@ -23,6 +23,18 @@ class WC_REST_Connect_Packages_Controller extends WC_REST_Connect_Base_Controlle
 		);
 	}
 
+	public function register_routes() {
+		parent::register_routes();
+
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/create', array(
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'create_packages' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			),
+		) );
+	}
+
 	public function get() {
 		return new WP_REST_Response( array_merge(
 			array( 'success' => true ),
@@ -39,4 +51,19 @@ class WC_REST_Connect_Packages_Controller extends WC_REST_Connect_Base_Controlle
 		return new WP_REST_Response( array( 'success' => true ), 200 );
 	}
 
+	public function create_packages( $request ) {
+		$packages = $request->get_json_params();
+		fwrite(STDERR, print_r($packages));
+
+		$custom_packages = isset($packages['custom']) ? $packages['custom'] : null;
+		$predefined_packages = isset($packages['predefined']) ? $packages['predefined'] : null;
+		if (!is_null($custom_packages)) {
+			$this->settings_store->create_packages( $custom_packages );
+		}
+		if (!is_null($predefined_packages)) {
+			$this->settings_store->create_predefined_packages( $predefined_packages );
+		}
+
+		return new WP_REST_Response( array( 'success' => true ), 200 );
+	}
 }

--- a/classes/class-wc-rest-connect-packages-controller.php
+++ b/classes/class-wc-rest-connect-packages-controller.php
@@ -53,7 +53,6 @@ class WC_REST_Connect_Packages_Controller extends WC_REST_Connect_Base_Controlle
 
 	public function create_packages( $request ) {
 		$packages = $request->get_json_params();
-		fwrite(STDERR, print_r($packages));
 
 		$custom_packages = isset($packages['custom']) ? $packages['custom'] : null;
 		$predefined_packages = isset($packages['predefined']) ? $packages['predefined'] : null;

--- a/tests/php/classes/test-class-wc-rest-connect-packages-controller.php
+++ b/tests/php/classes/test-class-wc-rest-connect-packages-controller.php
@@ -83,8 +83,6 @@ class WP_Test_WC_REST_Connect_Packages_Controller extends WC_REST_Unit_Test_Case
 		$request->set_body(json_encode(array(
 			'custom' => $new_packages
 		)));
-		fwrite(STDERR, print_r($request->get_json_params()));
-		fwrite(STDERR, print_r($request->get_body_params()));
 		$response = $controller->create_packages($request);
 
 		// Then
@@ -129,8 +127,6 @@ class WP_Test_WC_REST_Connect_Packages_Controller extends WC_REST_Unit_Test_Case
 		$request->set_body(json_encode(array(
 			'predefined' => $new_predefined_packages
 		)));
-		fwrite(STDERR, print_r($request->get_json_params()));
-		fwrite(STDERR, print_r($request->get_body_params()));
 		$response = $controller->create_packages($request);
 
 		// Then
@@ -199,8 +195,6 @@ class WP_Test_WC_REST_Connect_Packages_Controller extends WC_REST_Unit_Test_Case
 			'predefined' => $new_predefined_packages,
 			'custom' => array($package_2)
 		)));
-		fwrite(STDERR, print_r($request->get_json_params()));
-		fwrite(STDERR, print_r($request->get_body_params()));
 		$response = $controller->create_packages($request);
 
 		// Then

--- a/tests/php/classes/test-class-wc-rest-connect-packages-controller.php
+++ b/tests/php/classes/test-class-wc-rest-connect-packages-controller.php
@@ -1,0 +1,224 @@
+<?php
+
+/**
+ * Unit test for WC_REST_Connect_Packages_Controller
+ */
+class WP_Test_WC_REST_Connect_Packages_Controller extends WC_REST_Unit_Test_Case {
+
+	/** @var WC_Connect_API_Client_Live $api_client_mock */
+	protected $api_client_mock;
+
+	/** @var WC_Connect_Logger $connect_logger_mock */
+	protected $connect_logger_mock;
+
+	/** @var WC_Connect_Service_Schemas_Store $service_schemas_store_mock */
+	protected $service_schemas_store_mock;
+
+	/** @var WC_Connect_Service_Settings_Store $settings_store */
+	protected $settings_store;
+
+	/**
+	 * @inherit
+	 */
+	public static function setupBeforeClass() {
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-api-client-live.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-service-settings-store.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-logger.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-service-schemas-store.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-package-settings.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-rest-connect-base-controller.php';
+		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-rest-connect-packages-controller.php';
+	}
+
+	/**
+	 * Setup the test case.
+	 *
+	 * @see WC_Unit_Test_Case::setUp()
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Creating a mock class and override protected request method so that we can mock the API response.
+		$this->api_client_mock = $this->getMockBuilder( WC_Connect_API_Client_Live::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'request' ] )
+			->getMock();
+
+		$this->connect_logger_mock = $this->createMock( WC_Connect_Logger::class );
+		$this->service_schemas_store_mock = $this->createMock( WC_Connect_Service_Schemas_Store::class );
+		$this->settings_store = new WC_Connect_Service_Settings_Store( $this->service_schemas_store_mock, $this->api_client_mock, $this->connect_logger_mock );
+	}
+
+	/**
+	 * Test that creating custom packages updates the custom packages in settings store while predefined packages remain the same.
+	 */
+	public function test_creating_packages_with_only_custom_packages_updates_packages_in_settings_store() {
+		// Given
+		$controller = new WC_REST_Connect_Packages_Controller( $this->api_client_mock, $this->settings_store, $this->connect_logger_mock, $this->service_schemas_store_mock );
+
+		$package_1 = array(
+			'is_user_defined' => true,
+			'name' => 'Fun box',
+			'inner_dimensions' => '10 x 20 x 5',
+			'box_weight' => 0.23,
+			'max_weight' => 0
+		);
+		$package_2 = array(
+			'is_user_defined' => true,
+			'name' => 'Fun envelope',
+			'inner_dimensions' => '12 x 16 x 11',
+			'box_weight' => 0.5,
+			'max_weight' => 0
+		);
+
+		$existing_packages = array($package_1);
+		$new_packages = array($package_2);
+		$this->settings_store->update_packages($existing_packages);
+
+		$predefined_packages_before_creation = $this->settings_store->get_predefined_packages();
+
+		// When
+		$request = new WP_REST_Request( 'POST', '/wc/v1/connect/packages/create' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(json_encode(array(
+			'custom' => $new_packages
+		)));
+		fwrite(STDERR, print_r($request->get_json_params()));
+		fwrite(STDERR, print_r($request->get_body_params()));
+		$response = $controller->create_packages($request);
+
+		// Then
+		$this->assertEquals( 200, $response->status );
+
+		$actual_packages_after_creation = $this->settings_store->get_packages();
+		$expected_packages_after_creation = array($package_1, $package_2);
+		$this->assertEquals( $expected_packages_after_creation, $actual_packages_after_creation );
+
+		// Predefined packages should not change from the creation request.
+		$predefined_packages_after_creation = $this->settings_store->get_predefined_packages();
+		$this->assertEquals( $predefined_packages_before_creation, $predefined_packages_after_creation );
+	}
+
+	/**
+	 * Test that creating predefined packages updates the predefined packages in settings store while custom packages remain the same.
+	 */
+	public function test_creating_packages_with_only_predefined_packages_updates_predefined_packages_in_settings_store() {
+		// Given
+		$controller = new WC_REST_Connect_Packages_Controller( $this->api_client_mock, $this->settings_store, $this->connect_logger_mock, $this->service_schemas_store_mock );
+
+		$existing_predefined_packages = array(
+			'usps' => array(
+				'flat_envelope', 'padded_flat_envelope'
+			),
+		);
+		$new_predefined_packages = array(
+			'dhlexpress' => array(
+				'SmallPaddedPouch', 'Box2Cube'
+			),
+			'usps' => array(
+				'legal_flat_envelope'
+			),
+		);
+		$this->settings_store->update_predefined_packages($existing_predefined_packages);
+
+		$custom_packages_before_creation = $this->settings_store->get_packages();
+
+		// When
+		$request = new WP_REST_Request( 'POST', '/wc/v1/connect/packages/create' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(json_encode(array(
+			'predefined' => $new_predefined_packages
+		)));
+		fwrite(STDERR, print_r($request->get_json_params()));
+		fwrite(STDERR, print_r($request->get_body_params()));
+		$response = $controller->create_packages($request);
+
+		// Then
+		$this->assertEquals( 200, $response->status );
+
+		$actual_predefined_packages_after_creation = $this->settings_store->get_predefined_packages();
+		$expected_predefined_packages_after_creation = array(
+			'usps' => array(
+				'flat_envelope', 'padded_flat_envelope', 'legal_flat_envelope'
+			),
+			'dhlexpress' => array(
+				'SmallPaddedPouch', 'Box2Cube'
+			),
+		);
+		$this->assertEquals( $expected_predefined_packages_after_creation, $actual_predefined_packages_after_creation );
+
+		// Predefined packages should not change from the creation request.
+		$custom_packages_after_creation = $this->settings_store->get_packages();
+		$this->assertEquals( $custom_packages_before_creation, $custom_packages_after_creation );
+	}
+
+	/**
+	 * Test that creating both custom and predefined packages updates the both package types in settings store.
+	 */
+	public function test_creating_packages_with_both_custom_and_predefined_packages_updates_both_types_of_packages_in_settings_store() {
+		// Given
+		$controller = new WC_REST_Connect_Packages_Controller( $this->api_client_mock, $this->settings_store, $this->connect_logger_mock, $this->service_schemas_store_mock );
+
+		// Set up custom packages
+		$package_1 = array(
+			'is_user_defined' => true,
+			'name' => 'Fun box',
+			'inner_dimensions' => '10 x 20 x 5',
+			'box_weight' => 0.23,
+			'max_weight' => 0
+		);
+		$package_2 = array(
+			'is_user_defined' => true,
+			'name' => 'Fun envelope',
+			'inner_dimensions' => '12 x 16 x 11',
+			'box_weight' => 0.5,
+			'max_weight' => 0
+		);
+		$this->settings_store->update_packages(array($package_1));
+
+		// Set up predefined packages
+		$existing_predefined_packages = array(
+			'usps' => array(
+				'flat_envelope', 'padded_flat_envelope'
+			),
+		);
+		$new_predefined_packages = array(
+			'dhlexpress' => array(
+				'SmallPaddedPouch', 'Box2Cube'
+			),
+			'usps' => array(
+				'legal_flat_envelope'
+			),
+		);
+		$this->settings_store->update_predefined_packages($existing_predefined_packages);
+
+		// When
+		$request = new WP_REST_Request( 'POST', '/wc/v1/connect/packages/create' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(json_encode(array(
+			'predefined' => $new_predefined_packages,
+			'custom' => array($package_2)
+		)));
+		fwrite(STDERR, print_r($request->get_json_params()));
+		fwrite(STDERR, print_r($request->get_body_params()));
+		$response = $controller->create_packages($request);
+
+		// Then
+		$this->assertEquals( 200, $response->status );
+
+		$actual_packages_after_creation = $this->settings_store->get_packages();
+		$expected_packages_after_creation = array($package_1, $package_2);
+		$this->assertEquals( $expected_packages_after_creation, $actual_packages_after_creation );
+
+		$actual_predefined_packages_after_creation = $this->settings_store->get_predefined_packages();
+		$expected_predefined_packages_after_creation = array(
+			'usps' => array(
+				'flat_envelope', 'padded_flat_envelope', 'legal_flat_envelope'
+			),
+			'dhlexpress' => array(
+				'SmallPaddedPouch', 'Box2Cube'
+			),
+		);
+		$this->assertEquals( $expected_predefined_packages_after_creation, $actual_predefined_packages_after_creation );
+	}
+}

--- a/tests/php/test_class-wc-connect-service-settings-store.php
+++ b/tests/php/test_class-wc-connect-service-settings-store.php
@@ -180,4 +180,70 @@ class WP_Test_WC_Connect_Service_Settings_Store extends WC_Unit_Test_Case {
 
 		$this->assertEquals( $actual, $expected );
 	}
+
+	public function test_create_packages_extends_existing_packages() {
+		// Given
+		$settings_store = $this->get_settings_store();
+		$package_1 = array(
+			'is_user_defined' => true,
+			'name' => 'Fun box',
+			'inner_dimensions' => '10 x 20 x 5',
+			'box_weight' => 0.23,
+			'max_weight' => 0
+		);
+		$package_2 = array(
+			'is_user_defined' => true,
+			'name' => 'Fun envelope',
+			'inner_dimensions' => '12 x 16 x 11',
+			'box_weight' => 0.5,
+			'max_weight' => 0
+		);
+		$existing_packages = array($package_1);
+		$new_packages = array($package_2);
+		$settings_store->update_packages($existing_packages);
+
+		// When
+		$settings_store->create_packages($new_packages);
+
+		// Then
+		$actual = $settings_store->get_packages();
+		$expected = array($package_1, $package_2);
+
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function test_create_predefined_packages_extends_existing_packages() {
+		// Given
+		$settings_store = $this->get_settings_store();
+		$existing_predefined_packages = array(
+			'usps' => array(
+				'flat_envelope', 'padded_flat_envelope'
+			),
+		);
+		$new_predefined_packages = array(
+			'dhlexpress' => array(
+				'SmallPaddedPouch', 'Box2Cube'
+			),
+			'usps' => array(
+				'legal_flat_envelope'
+			),
+		);
+		$settings_store->update_predefined_packages($existing_predefined_packages);
+
+		// When
+		$settings_store->create_predefined_packages($new_predefined_packages);
+
+		// Then
+		$actual = $settings_store->get_predefined_packages();
+		$expected = array(
+			'usps' => array(
+				'flat_envelope', 'padded_flat_envelope', 'legal_flat_envelope'
+			),
+			'dhlexpress' => array(
+				'SmallPaddedPouch', 'Box2Cube'
+			),
+		);
+
+		$this->assertEquals($expected, $actual);
+	}
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

[TODO: p2 link here]

Currently, there is one endpoint `POST /connect/packages` to **update** all the packages. In Woo mobile, we'd like to **create** packages without modifying the existing packages - it prevents the client from accidentally deleting packages that it hasn't fetched since mobile might not be always in sync with the backend.

This PR added support for creating packages by adding a new endpoint `POST /connect/packages/create` to create new packages. This approach isn't very RESTful, as `POST /connect/packages` is usually the endpoint that creates resources. Below is a list of major changes:

- Added functions to create custom and predefined packages in `WC_Connect_Service_Settings_Store`
- In `WC_REST_Connect_Packages_Controller`, added a new endpoint `POST /connect/packages/create` to create packages

### Testing steps

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

Please confidence check on the existing behavior to update packages in wp-admin:

#### WCS settings

- Go to the WCS settings under `WooCommerce --> Settings --> Shipping --> WooCommerce Settings` (`/wp-admin/admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings`)
- In the Packaging section, tap "Add package"
- Add a custom package or select from any of the service packages
- Tap "Add package" to add the package(s)
- Tap "Save changes" at the bottom of the section --> the success banner "Your shipping settings have been saved." should appear, and the new package(s) should be shown after reloading the settings page

#### Order details > create shipping label

- Go to an order where a shipping label can be created
- Tap "Create shipping label" CTA
- Expand the Packaging tab, and tap "Add package" next to "Package details"
- Add a custom package or select from any of the service packages
- Tap "Add package" to add the package(s) --> the success banner "Your shipping packages have been saved.", and the created packages should appear in the "Package details" dropdown list

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added

