### PR TITLE
release 1.25.7

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,8 @@
 * Fix   - Prevent error notices on checkout page load.
 * Tweak - Highlight rate call usage over limit on WooCommerce Shipping settings page.
 * Fix   - Connect carrier account link broken on subdirectory installs.
+* Fix   - Position dot in the center of radio buttons in "Create shipping label".
+* Fix   - Adjust radio button dot style in "Create shipping label" in high contrast mode on Windows.
 
 = 1.25.6 - 2021-01-26 =
 * Fix 	- Refreshes shipping methods after registering or removing carrier accounts.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 1.25.7 - 2021-xx-xx =
-* Fix	- Prevent error notices on checkout page load
+* Fix   - Connect carrier account link broken on subdirectory installs
+* Fix	  - Prevent error notices on checkout page load
 
 = 1.25.6 - 2021-01-26 =
 * Fix 	- Refreshes shipping methods after registering or removing carrier accounts.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.7 - 2021-xx-xx =
+* Fix	- Prevent error notices on checkout page load
+
 = 1.25.6 - 2021-01-26 =
 * Fix 	- Refreshes shipping methods after registering or removing carrier accounts.
 * Tweak	- Changed rates response caching method from cache to transient.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,9 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 1.25.7 - 2021-xx-xx =
-* Fix   - Connect carrier account link broken on subdirectory installs
-* Fix	  - Prevent error notices on checkout page load
+* Fix   - Prevent error notices on checkout page load.
+* Tweak - Highlight rate call usage over limit on WooCommerce Shipping settings page.
+* Fix   - Connect carrier account link broken on subdirectory installs.
 
 = 1.25.6 - 2021-01-26 =
 * Fix 	- Refreshes shipping methods after registering or removing carrier accounts.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -326,7 +326,8 @@ class WC_Connect_TaxJar_Integration {
 				$message = sprintf( _x( 'Invalid %s entered.', '%s - ZIP/Postal code checkout field label', 'woocommerce-services' ), $postcode_field_name );
 			}
 
-			if ( ! wc_has_notice( $message, 'error' ) ) {
+			// if on checkout page load (not ajax), don't set an error as it prevents checkout page from displaying
+			if ( ( is_cart() || ( is_checkout() && is_ajax() ) ) && ! wc_has_notice( $message, 'error' ) ) {
 				wc_add_notice( $message, 'error' );
 			}
 

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/list-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/list-item.js
@@ -104,7 +104,7 @@ const CarrierAccountListItem = ( props ) => {
 				) : (
 					<a
 						href={
-							`/wp-admin/admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings&carrier=${data.type}`
+							`admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings&carrier=${data.type}`
 						}
 						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 						className="button is-compact"

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
@@ -61,6 +61,11 @@
 	input[type='radio']:checked::before {
 		margin: 2px;
 		background-color: #d52c82;
+
+		// For radio buttons to be visible in high contrast mode on Windows, a border or outline is required
+		// See: https://github.com/WordPress/gutenberg/pull/23706
+		border: 4px solid #d52c82;
+		box-sizing: border-box;
 	}
 }
 

--- a/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/list-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/list-item.js
@@ -7,6 +7,9 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
+import { Tooltip } from '@wordpress/components';
+import Gridicon from 'gridicons';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -21,7 +24,7 @@ const SubscriptionsUsageListItem = ( props ) => {
 	const { translate, data, errorNotice, successNotice, siteId } = props;
 	const [isActive, setisActive] = React.useState( data.is_active );
 	const [isSaving, setIsSaving] = React.useState(false);
-	 
+
 	const getIcon = ( productName ) => {
 		const subscriptionToIconRules = [
 			[/^DHL/g, 'dhlexpress'],
@@ -31,14 +34,14 @@ const SubscriptionsUsageListItem = ( props ) => {
 
 		const i = subscriptionToIconRules.findIndex( ( [rule] ) => rule.test( productName ) );
 		if ( i > -1 ) return subscriptionToIconRules[i][1];
-		
+
 		return '';
 	};
 
 	const handleActivate = () =>{
 		const submitActivation = async () => {
 			setIsSaving(true);
-		
+
 			try {
 				await api.post( siteId, api.url.subscriptionActivate( data.product_key ) );
 				setisActive( true );
@@ -54,6 +57,8 @@ const SubscriptionsUsageListItem = ( props ) => {
 
 	const usage_count = data.usage_count ? data.usage_count : 0 ;
 	const usage = data.usage_limit ? `${ usage_count }/${ data.usage_limit }` : '';
+	const isUsageOverLimit = data.usage_count && data.usage_limit && data.usage_count > data.usage_limit;
+
 	return (
 		<div className= "subscriptions-usage__list-item" >
 			<div className="subscriptions-usage__list-item-carrier-icon">
@@ -62,8 +67,18 @@ const SubscriptionsUsageListItem = ( props ) => {
 			<div className="subscriptions-usage__list-item-name">
 				<span>{ data.product_name }</span>
 			</div>
-			<div className="subscriptions-usage__list-item-usage">
-				<span>{ usage }</span>
+			<div className={ classNames( 'subscriptions-usage__list-item-usage', { 'is-over-limit': isUsageOverLimit } ) }>
+				<span className="subscriptions-usage__list-item-usage-numbers">{ usage }</span>
+				<Tooltip
+					text={ translate(
+						'Your store is over the limit for rate calls this month and your account will be charged for overages. ' +
+						'To prevent future overage charges you can upgrade your plan.'
+					) }
+				>
+					<span className="subscriptions-usage__list-item-usage-icon">
+						<Gridicon icon="info-outline" size={ 18 } />
+					</span>
+				</Tooltip>
 			</div>
 			<div className="subscriptions-usage__list-item-actions">
 				{ isActive ? (
@@ -77,8 +92,8 @@ const SubscriptionsUsageListItem = ( props ) => {
 						{ translate( 'Manage' ) }
 					</a>
 				) : (
-					<Button 
-						onClick={ handleActivate } 
+					<Button
+						onClick={ handleActivate }
 						disabled={ isSaving }
 						busy={ isSaving }
 						compact

--- a/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/style.scss
@@ -20,7 +20,43 @@
 		}
 
 		.subscriptions-usage__list-item-usage {
+			display: flex;
+			flex-flow: column;
+			justify-content: center;
+			text-align: center;
 			width: 30%;
+
+			@include breakpoint( '>480px' ) {
+				flex-flow: row;
+				justify-content: flex-start;
+				text-align: left;
+			}
+
+			& > .subscriptions-usage__list-item-usage-icon {
+				display: none;
+			}
+
+			&.is-over-limit {
+				& > .subscriptions-usage__list-item-usage-numbers {
+					color: var( --color-red-light );
+					font-weight: 600;
+				}
+
+				& > .subscriptions-usage__list-item-usage-icon {
+					display: block;
+					margin-top: 5px;
+
+					@include breakpoint( '>480px' ) {
+						margin-left: 5px;
+						margin-top: 0;
+					}
+				}
+
+				.components-popover__content {
+					white-space: normal;
+					width: 200px;
+				}
+			}
 		}
 
 		.subscriptions-usage__list-item-actions {

--- a/readme.txt
+++ b/readme.txt
@@ -76,6 +76,13 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 1.25.7 - 2021-xx-xx =
+* Fix   - Prevent error notices on checkout page load.
+* Tweak - Highlight rate call usage over limit on WooCommerce Shipping settings page.
+* Fix   - Connect carrier account link broken on subdirectory installs.
+* Fix   - Position dot in the center of radio buttons in "Create shipping label".
+* Fix   - Adjust radio button dot style in "Create shipping label" in high contrast mode on Windows.
+
 = 1.25.6 - 2021-01-26 =
 * Fix 	- Refreshes shipping methods after registering or removing carrier accounts.
 * Tweak	- Changed rates response caching method from cache to transient.


### PR DESCRIPTION
## Release PR for 1.25.7
### Changes in this release
- https://github.com/Automattic/woocommerce-services/pull/2303 : Fix radio button dot alignment in "Create shipping label"
- https://github.com/Automattic/woocommerce-services/pull/2314 : Highlight rate call usage in red and display tooltip when over limit
- https://github.com/Automattic/woocommerce-services/pull/2315 : Use relative path so links work on subdirectory installs
- https://github.com/Automattic/woocommerce-services/pull/2310 : Remove error notices from checkout page load

This release branch is branched from latest `develop` .

### Test notes
- Test against WC 5.0 beta (use the [WC beta tester plugin](https://wordpress.org/plugins/woocommerce-beta-tester/) for an easy switch)
- Test live rates
- Test UI when creating shipping labels on different browsers
- Test TaxJar integration with incorrect ZIP codes and debug mode on/off

### Changelog
* Fix   - Prevent error notices on checkout page load.
* Tweak - Highlight rate call usage over limit on WooCommerce Shipping settings page.
* Fix   - Connect carrier account link broken on subdirectory installs.
* Fix   - Position dot in the center of radio buttons in "Create shipping label".
* Fix   - Adjust radio button dot style in "Create shipping label" in high contrast mode on Windows.

## Build File
Built from this branch using `php woorelease.phar simulate --product_version=1.25.7 https://github.com/Automattic/woocommerce-services/tree/release/1.25.7`

[woocommerce-services.zip](https://github.com/Automattic/woocommerce-services/files/5933897/woocommerce-services.zip)
