### PR TITLE
Run phpcbf to fix most code standards issues

### DIFF
--- a/classes/class-wc-connect-account-settings.php
+++ b/classes/class-wc-connect-account-settings.php
@@ -15,7 +15,7 @@ class WC_Connect_Account_Settings {
 		WC_Connect_Service_Settings_Store $settings_store,
 		WC_Connect_Payment_Methods_Store $payment_methods_store
 	) {
-			$this->settings_store = $settings_store;
+			$this->settings_store        = $settings_store;
 			$this->payment_methods_store = $payment_methods_store;
 	}
 
@@ -28,25 +28,25 @@ class WC_Connect_Account_Settings {
 			$payment_methods_warning = __( 'There was a problem updating your saved credit cards.', 'woocommerce-services' );
 		}
 
-		$master_user = WC_Connect_Jetpack::get_master_user();
+		$master_user    = WC_Connect_Jetpack::get_master_user();
 		$connected_data = WC_Connect_Jetpack::get_connected_user_data( $master_user->ID );
-		$last_box_id = get_user_meta( get_current_user_id(), 'wc_connect_last_box_id', true );
-		$last_box_id = $last_box_id === "individual" ? "" : $last_box_id;
+		$last_box_id    = get_user_meta( get_current_user_id(), 'wc_connect_last_box_id', true );
+		$last_box_id    = $last_box_id === 'individual' ? '' : $last_box_id;
 
 		return array(
 			'storeOptions' => $this->settings_store->get_store_options(),
-			'formData' => $this->settings_store->get_account_settings(),
-			'formMeta' => array(
-				'can_manage_payments' => $this->settings_store->can_user_manage_payment_methods(),
-				'can_edit_settings' => true,
-				'master_user_name' => $master_user->display_name,
-				'master_user_login' => $master_user->user_login,
+			'formData'     => $this->settings_store->get_account_settings(),
+			'formMeta'     => array(
+				'can_manage_payments'     => $this->settings_store->can_user_manage_payment_methods(),
+				'can_edit_settings'       => true,
+				'master_user_name'        => $master_user->display_name,
+				'master_user_login'       => $master_user->user_login,
 				'master_user_wpcom_login' => $connected_data['login'],
-				'master_user_email' => $connected_data['email'],
-				'payment_methods' => $this->payment_methods_store->get_payment_methods(),
-				'warnings' => array( 'payment_methods' => $payment_methods_warning ),
+				'master_user_email'       => $connected_data['email'],
+				'payment_methods'         => $this->payment_methods_store->get_payment_methods(),
+				'warnings'                => array( 'payment_methods' => $payment_methods_warning ),
 			),
-			'userMeta' => array(
+			'userMeta'     => array(
 				'last_box_id' => $last_box_id,
 			),
 		);

--- a/classes/class-wc-connect-api-client-live.php
+++ b/classes/class-wc-connect-api-client-live.php
@@ -10,7 +10,7 @@ if ( ! defined( 'WOOCOMMERCE_CONNECT_SERVER_URL' ) ) {
 }
 
 if ( ! class_exists( 'WC_Connect_API_Client_Live' ) ) {
-	require_once( plugin_basename( 'class-wc-connect-api-client.php' ) );
+	require_once plugin_basename( 'class-wc-connect-api-client.php' );
 
 	class WC_Connect_API_Client_Live extends WC_Connect_API_Client {
 
@@ -65,16 +65,16 @@ if ( ! class_exists( 'WC_Connect_API_Client_Live' ) ) {
 				wc_set_time_limit( $http_timeout + 10 );
 			}
 			$args = array(
-				'headers' => $headers,
-				'method' => $method,
-				'body' => $body,
+				'headers'     => $headers,
+				'method'      => $method,
+				'body'        => $body,
 				'redirection' => 0,
-				'compress' => true,
-				'timeout' => $http_timeout,
+				'compress'    => true,
+				'timeout'     => $http_timeout,
 			);
 			$args = apply_filters( 'wc_connect_request_args', $args );
 
-			$response = wp_remote_request( $url, $args );
+			$response      = wp_remote_request( $url, $args );
 			$response_code = wp_remote_retrieve_response_code( $response );
 
 			// If the received response is not JSON, return the raw response

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -25,7 +25,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			WC_Connect_Loader $wc_connect_loader
 		) {
 
-			$this->validator = $validator;
+			$this->validator         = $validator;
 			$this->wc_connect_loader = $wc_connect_loader;
 
 		}
@@ -73,20 +73,20 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 * @param $package Package provided to WC_Shipping_Method::calculate_shipping()
 		 *
 		 * @return array|WP_Error {
-		 * 		@type float $height Product height.
-		 * 		@type float $width Product width.
-		 * 		@type float $length Product length.
-		 * 		@type int $product_id Product ID (or Variation ID).
-		 * 		@type int $quantity Quantity of product in shipment.
-		 * 		@type float $weight Product weight.
+		 *      @type float $height Product height.
+		 *      @type float $width Product width.
+		 *      @type float $length Product length.
+		 *      @type int $product_id Product ID (or Variation ID).
+		 *      @type int $quantity Quantity of product in shipment.
+		 *      @type float $weight Product weight.
 		 * }
 		 */
 		public function build_shipment_contents( $package ) {
 			$contents = array();
 
-			foreach ( $package[ 'contents' ] as $package_item ) {
-				$product  = $package_item[ 'data' ];
-				$quantity = $package_item[ 'quantity' ];
+			foreach ( $package['contents'] as $package_item ) {
+				$product  = $package_item['data'];
+				$quantity = $package_item['quantity'];
 
 				if ( ( $quantity > 0 ) && $product->needs_shipping() ) {
 
@@ -122,12 +122,12 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 					$width  = $product->get_width();
 
 					$contents[] = array(
-						'height'     => ( float ) $height,
+						'height'     => (float) $height,
 						'product_id' => $product->get_id(),
-						'length'     => ( float ) $length,
-						'quantity'   => $package_item[ 'quantity' ],
-						'weight'     => ( float ) $weight,
-						'width'      => ( float ) $width,
+						'length'     => (float) $length,
+						'quantity'   => $package_item['quantity'],
+						'weight'     => (float) $weight,
+						'width'      => (float) $width,
 					);
 				}
 			}
@@ -164,7 +164,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			// Then, make the request
 			$body = array(
 				'contents'         => $contents,
-				'destination'      => $package[ 'destination' ],
+				'destination'      => $package['destination'],
 				'services'         => $services,
 				'boxes'            => $custom_boxes,
 				'predefined_boxes' => $predefined_boxes,
@@ -194,38 +194,38 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 * Gets shipping rates (for labels) from the WooCommerce Shipping & Tax Server
 		 *
 		 * @param array $request - array(
-		 *	'packages' => array(
-		 *		array(
-		 * 			'id' => 'box_1',
-		 *			'height' => 10,
-		 *			'length' => 10,
-		 *			'width' => 10,
-		 *			'weight' => 10,
-		 *		),
-		 *		array(
-		 *			'id' => 'box_2',
-		 *			'box_id' => 'medium_flat_box_top',
-		 *			'weight' => 5,
-		 *		),
-		 *		...
-		 * 	),
-		 *	'carrier' => 'usps',
-		 *	'origin' => array(
-		 *		'address' => '132 Hawthorne St',
-		 *		'address_2' => '',
-		 *		'city' => 'San Francisco',
-		 *		'state' => 'CA',
-		 *		'postcode' => '94107',
-		 *		'country' => 'US',
-		 *	),
-		 *	'destination' => array(
-		 *		'address' => '1550 Snow Creek Dr',
-		 *		'address_2' => '',
-		 *		'city' => 'Park City',
-		 *		'state' => 'UT',
-		 *		'postcode' => '84060',
-		 *		'country' => 'US',
-		 *	),
+		 *  'packages' => array(
+		 *      array(
+		 *          'id' => 'box_1',
+		 *          'height' => 10,
+		 *          'length' => 10,
+		 *          'width' => 10,
+		 *          'weight' => 10,
+		 *      ),
+		 *      array(
+		 *          'id' => 'box_2',
+		 *          'box_id' => 'medium_flat_box_top',
+		 *          'weight' => 5,
+		 *      ),
+		 *      ...
+		 *  ),
+		 *  'carrier' => 'usps',
+		 *  'origin' => array(
+		 *      'address' => '132 Hawthorne St',
+		 *      'address_2' => '',
+		 *      'city' => 'San Francisco',
+		 *      'state' => 'CA',
+		 *      'postcode' => '94107',
+		 *      'country' => 'US',
+		 *  ),
+		 *  'destination' => array(
+		 *      'address' => '1550 Snow Creek Dr',
+		 *      'address_2' => '',
+		 *      'city' => 'Park City',
+		 *      'state' => 'UT',
+		 *      'postcode' => '84060',
+		 *      'country' => 'US',
+		 *  ),
 		 * )
 		 * @return object|WP_Error
 		 */
@@ -313,6 +313,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 
 		/**
 		 * Get a list of the subscriptions for WooCommerce.com linked account.
+		 *
 		 * @param $body
 		 * @param object|WP_Error
 		 */
@@ -327,7 +328,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 *
 		 * @return object|WP_Error
 		 */
-		public function get_carrier_types( ) {
+		public function get_carrier_types() {
 			return $this->request( 'GET', '/shipping/carrier-types' );
 		}
 
@@ -359,7 +360,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			}
 
 			$is_alive_request = $this->is_alive();
-			$new_is_alive = ! is_wp_error( $is_alive_request );
+			$new_is_alive     = ! is_wp_error( $is_alive_request );
 			if ( $new_is_alive ) {
 				set_transient( 'connect_server_is_alive_transient', true, MINUTE_IN_SECONDS );
 			}
@@ -407,7 +408,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 * @return array|WP_Error
 		 */
 		public function proxy_request( $path, $args ) {
-			$proxy_url = trailingslashit( WOOCOMMERCE_CONNECT_SERVER_URL );
+			$proxy_url  = trailingslashit( WOOCOMMERCE_CONNECT_SERVER_URL );
 			$proxy_url .= ltrim( $path, '/' );
 
 			$authorization = $this->authorization_header();
@@ -415,7 +416,6 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				return $authorization;
 			}
 			$args['headers']['Authorization'] = $authorization;
-
 
 			$http_timeout = 60; // 1 minute
 
@@ -443,26 +443,28 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			$body         = array_merge( $default_body, $initial_body );
 
 			// Add interesting fields to the body of each request
-			$body[ 'settings' ] = wp_parse_args( $body[ 'settings' ], array(
-				'store_guid'           => $this->get_guid(),
-				'base_city'            => WC()->countries->get_base_city(),
-				'base_country'         => WC()->countries->get_base_country(),
-				'base_state'           => WC()->countries->get_base_state(),
-				'base_postcode'        => WC()->countries->get_base_postcode(),
-				'currency'             => get_woocommerce_currency(),
-				'dimension_unit'       => strtolower( get_option( 'woocommerce_dimension_unit' ) ),
-				'weight_unit'          => strtolower( get_option( 'woocommerce_weight_unit' ) ),
-				'wcs_version'          => WC_Connect_Loader::get_wcs_version(),
-				'jetpack_version'      => JETPACK__VERSION,
-				'is_atomic'            => WC_Connect_Jetpack::is_atomic_site(),
-				'wc_version'           => WC()->version,
-				'wp_version'           => get_bloginfo( 'version' ),
-				'last_services_update' => WC_Connect_Options::get_option( 'services_last_update', 0 ),
-				'last_heartbeat'       => WC_Connect_Options::get_option( 'last_heartbeat', 0 ),
-				'last_rate_request'    => WC_Connect_Options::get_option( 'last_rate_request', 0 ),
-				'active_services'      => $this->wc_connect_loader->get_active_services(),
-				'disable_stats'        => WC_Connect_Jetpack::is_staging_site(),
-				'taxes_enabled'        => wc_tax_enabled() && 'yes' === get_option( 'wc_connect_taxes_enabled' ),
+			$body['settings'] = wp_parse_args(
+				$body['settings'],
+				array(
+					'store_guid'           => $this->get_guid(),
+					'base_city'            => WC()->countries->get_base_city(),
+					'base_country'         => WC()->countries->get_base_country(),
+					'base_state'           => WC()->countries->get_base_state(),
+					'base_postcode'        => WC()->countries->get_base_postcode(),
+					'currency'             => get_woocommerce_currency(),
+					'dimension_unit'       => strtolower( get_option( 'woocommerce_dimension_unit' ) ),
+					'weight_unit'          => strtolower( get_option( 'woocommerce_weight_unit' ) ),
+					'wcs_version'          => WC_Connect_Loader::get_wcs_version(),
+					'jetpack_version'      => JETPACK__VERSION,
+					'is_atomic'            => WC_Connect_Jetpack::is_atomic_site(),
+					'wc_version'           => WC()->version,
+					'wp_version'           => get_bloginfo( 'version' ),
+					'last_services_update' => WC_Connect_Options::get_option( 'services_last_update', 0 ),
+					'last_heartbeat'       => WC_Connect_Options::get_option( 'last_heartbeat', 0 ),
+					'last_rate_request'    => WC_Connect_Options::get_option( 'last_rate_request', 0 ),
+					'active_services'      => $this->wc_connect_loader->get_active_services(),
+					'disable_stats'        => WC_Connect_Jetpack::is_staging_site(),
+					'taxes_enabled'        => wc_tax_enabled() && 'yes' === get_option( 'wc_connect_taxes_enabled' ),
 				)
 			);
 
@@ -480,20 +482,20 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				return $authorization;
 			}
 
-			$headers = array();
-			$locale = strtolower( str_replace( '_', '-', get_locale() ) );
-			$locale_elements = explode( '-', $locale );
-			$lang = $locale_elements[ 0 ];
-			$headers[ 'Accept-Language' ] = $locale . ',' . $lang;
-			$headers[ 'Content-Type' ] = 'application/json; charset=utf-8';
-			$headers[ 'Accept' ] = 'application/vnd.woocommerce-connect.v' . static::API_VERSION;
-			$headers[ 'Authorization' ] = $authorization;
+			$headers                    = array();
+			$locale                     = strtolower( str_replace( '_', '-', get_locale() ) );
+			$locale_elements            = explode( '-', $locale );
+			$lang                       = $locale_elements[0];
+			$headers['Accept-Language'] = $locale . ',' . $lang;
+			$headers['Content-Type']    = 'application/json; charset=utf-8';
+			$headers['Accept']          = 'application/vnd.woocommerce-connect.v' . static::API_VERSION;
+			$headers['Authorization']   = $authorization;
 
 			$wc_helper_auth_info = WC_Connect_Functions::get_wc_helper_auth_info();
 			if ( ! is_wp_error( $wc_helper_auth_info ) ) {
-				$headers[ 'X-Woo-Signature' ]    = $this->request_signature_wccom( $wc_helper_auth_info['access_token_secret'], 'subscriptions', 'GET', array() );
-				$headers[ 'X-Woo-Access-Token' ] = $wc_helper_auth_info['access_token'];
-				$headers[ 'X-Woo-Site-Id' ]      = $wc_helper_auth_info['site_id'];
+				$headers['X-Woo-Signature']    = $this->request_signature_wccom( $wc_helper_auth_info['access_token_secret'], 'subscriptions', 'GET', array() );
+				$headers['X-Woo-Access-Token'] = $wc_helper_auth_info['access_token'];
+				$headers['X-Woo-Site-Id']      = $wc_helper_auth_info['site_id'];
 			}
 			return $headers;
 		}
@@ -516,10 +518,10 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			}
 
 			list( $token_key, $token_secret ) = explode( '.', $token->secret );
-			$token_key = sprintf( '%s:%d:%d', $token_key, JETPACK__API_VERSION, $token->external_user_id );
-			$time_diff = (int)Jetpack_Options::get_option( 'time_diff' );
-			$timestamp = time() + $time_diff;
-			$nonce = wp_generate_password( 10, false );
+			$token_key                        = sprintf( '%s:%d:%d', $token_key, JETPACK__API_VERSION, $token->external_user_id );
+			$time_diff                        = (int) Jetpack_Options::get_option( 'time_diff' );
+			$timestamp                        = time() + $time_diff;
+			$nonce                            = wp_generate_password( 10, false );
 
 			$signature = $this->request_signature( $token_key, $token_secret, $timestamp, $nonce, $time_diff );
 			if ( is_wp_error( $signature ) ) {
@@ -527,9 +529,9 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			}
 
 			$auth = array(
-				'token' => $token_key,
+				'token'     => $token_key,
 				'timestamp' => $timestamp,
-				'nonce' => $nonce,
+				'nonce'     => $nonce,
 				'signature' => $signature,
 			);
 
@@ -548,7 +550,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 * @param string $token_secret
 		 * @param string $endpoint
 		 * @param string $method
-		 * @param array $body
+		 * @param array  $body
 		 * @return string
 		 */
 		protected function request_signature_wccom( $token_secret, $endpoint, $method, $body = array() ) {
@@ -576,11 +578,14 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				);
 			}
 
-			$normalized_request_string = join( "\n", array(
+			$normalized_request_string = join(
+				"\n",
+				array(
 					$token_key,
 					$timestamp,
-					$nonce
-				) ) . "\n";
+					$nonce,
+				)
+			) . "\n";
 
 			return base64_encode( hash_hmac( 'sha1', $normalized_request_string, $token_secret, true ) );
 		}
@@ -603,16 +608,19 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 * @return string
 		 */
 		private function generate_guid() {
-			return strtolower( sprintf( '%04X%04X-%04X-%04X-%04X-%04X%04X%04X',
-				mt_rand( 0, 65535 ),
-				mt_rand( 0, 65535 ),
-				mt_rand( 0, 65535 ),
-				mt_rand( 16384, 20479 ),
-				mt_rand( 32768, 49151 ),
-				mt_rand( 0, 65535 ),
-				mt_rand( 0, 65535 ),
-				mt_rand( 0, 65535 )
-			) );
+			return strtolower(
+				sprintf(
+					'%04X%04X-%04X-%04X-%04X-%04X%04X%04X',
+					mt_rand( 0, 65535 ),
+					mt_rand( 0, 65535 ),
+					mt_rand( 0, 65535 ),
+					mt_rand( 16384, 20479 ),
+					mt_rand( 32768, 49151 ),
+					mt_rand( 0, 65535 ),
+					mt_rand( 0, 65535 ),
+					mt_rand( 0, 65535 )
+				)
+			);
 		}
 	}
 

--- a/classes/class-wc-connect-compatibility-wc26.php
+++ b/classes/class-wc-connect-compatibility-wc26.php
@@ -48,7 +48,7 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC26' ) ) {
 		/**
 		 * Retrieve the corresponding Product for the given Order Item.
 		 *
-		 * @param WC_Order $order
+		 * @param WC_Order                                  $order
 		 * @param WC_Order_Item|WC_Order_Item_Product|array $item
 		 *
 		 * @return WC_Product
@@ -61,7 +61,7 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC26' ) ) {
 		 * Get formatted list of Product Variations, if applicable.
 		 *
 		 * @param WC_Product_Variation $product
-		 * @param bool $flat
+		 * @param bool                 $flat
 		 *
 		 * @return string
 		 */
@@ -100,15 +100,15 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC26' ) ) {
 		 * This is useful when an order has a product which was later deleted from the
 		 * store.
 		 *
-		 * @param int $product_id Product ID or variation ID
+		 * @param int      $product_id Product ID or variation ID
 		 * @param WC_Order $order
 		 * @return string The product (or variation) name, ready to print
 		 */
 		public function get_product_name_from_order( $product_id, $order ) {
 			foreach ( $order->get_items() as $line_item ) {
-				if ( (int) $line_item[ 'product_id' ] === $product_id || (int) $line_item[ 'variation_id' ] === $product_id ) {
+				if ( (int) $line_item['product_id'] === $product_id || (int) $line_item['variation_id'] === $product_id ) {
 					/* translators: %1$d: Product ID, %2$s: Product Name */
-					return sprintf( __( '#%1$d - %2$s', 'woocommerce-services' ), $product_id, $line_item[ 'name' ] );
+					return sprintf( __( '#%1$d - %2$s', 'woocommerce-services' ), $product_id, $line_item['name'] );
 				}
 			}
 
@@ -119,14 +119,14 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC26' ) ) {
 		/**
 		 * For a given product ID, it tries to find its price inside an order's line items.
 		 *
-		 * @param int $product_id Product ID or variation ID
+		 * @param int      $product_id Product ID or variation ID
 		 * @param WC_Order $order
 		 * @return float The product (or variation) price, or NULL if it wasn't found
 		 */
 		public function get_product_price_from_order( $product_id, $order ) {
 			foreach ( $order->get_items() as $line_item ) {
-				if ( (int) $line_item[ 'product_id' ] === $product_id || (int) $line_item[ 'variation_id' ] === $product_id ) {
-					return round( floatval( $line_item[ 'total' ] ) / $line_item[ 'qty' ], 2 );
+				if ( (int) $line_item['product_id'] === $product_id || (int) $line_item['variation_id'] === $product_id ) {
+					return round( floatval( $line_item['total'] ) / $line_item['qty'], 2 );
 				}
 			}
 			return null;

--- a/classes/class-wc-connect-compatibility-wc30.php
+++ b/classes/class-wc-connect-compatibility-wc30.php
@@ -48,14 +48,14 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC30' ) ) {
 		/**
 		 * Retrieve the corresponding Product for the given Order Item.
 		 *
-		 * @param WC_Order $order
+		 * @param WC_Order                                  $order
 		 * @param WC_Order_Item|WC_Order_Item_Product|array $item
 		 *
 		 * @return WC_Product
 		 */
 		public function get_item_product( WC_Order $order, $item ) {
 			if ( is_array( $item ) ) {
-				return wc_get_product( $item[ 'product_id' ] );
+				return wc_get_product( $item['product_id'] );
 			}
 			return $item->get_product();
 		}
@@ -64,7 +64,7 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC30' ) ) {
 		 * Get formatted list of Product Variations, if applicable.
 		 *
 		 * @param WC_Product_Variation $product
-		 * @param bool $flat
+		 * @param bool                 $flat
 		 *
 		 * @return string
 		 */
@@ -103,13 +103,13 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC30' ) ) {
 		 * This is useful when an order has a product which was later deleted from the
 		 * store.
 		 *
-		 * @param int $product_id Product ID or variation ID
+		 * @param int      $product_id Product ID or variation ID
 		 * @param WC_Order $order
 		 * @return string The product (or variation) name, ready to print
 		 */
 		public function get_product_name_from_order( $product_id, $order ) {
 			foreach ( $order->get_items() as $line_item ) {
-				$line_product_id = $line_item->get_product_id();
+				$line_product_id   = $line_item->get_product_id();
 				$line_variation_id = $line_item->get_variation_id();
 
 				if ( ! $line_product_id ) {
@@ -133,13 +133,13 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC30' ) ) {
 		/**
 		 * For a given product ID, it tries to find its price inside an order's line items.
 		 *
-		 * @param int $product_id Product ID or variation ID
+		 * @param int      $product_id Product ID or variation ID
 		 * @param WC_Order $order
 		 * @return float The product (or variation) price, or NULL if it wasn't found
 		 */
 		public function get_product_price_from_order( $product_id, $order ) {
 			foreach ( $order->get_items() as $line_item ) {
-				$line_product_id = $line_item->get_product_id();
+				$line_product_id   = $line_item->get_product_id();
 				$line_variation_id = $line_item->get_variation_id();
 
 				if ( ! $line_product_id ) {

--- a/classes/class-wc-connect-compatibility.php
+++ b/classes/class-wc-connect-compatibility.php
@@ -41,12 +41,12 @@ if ( ! class_exists( 'WC_Connect_Compatibility' ) ) {
 
 		public static function set_version( $value ) {
 			self::$singleton = null;
-			self::$version = $value;
+			self::$version   = $value;
 		}
 
 		public static function reset_version() {
 			self::$singleton = null;
-			self::$version = WC_VERSION;
+			self::$version   = WC_VERSION;
 		}
 
 		/**
@@ -79,7 +79,7 @@ if ( ! class_exists( 'WC_Connect_Compatibility' ) ) {
 		/**
 		 * Retrieve the corresponding Product for the given Order Item.
 		 *
-		 * @param WC_Order $order
+		 * @param WC_Order                                  $order
 		 * @param WC_Order_Item|WC_Order_Item_Product|array $item
 		 *
 		 * @return WC_Product
@@ -90,7 +90,7 @@ if ( ! class_exists( 'WC_Connect_Compatibility' ) ) {
 		 * Get formatted list of Product Variations, if applicable.
 		 *
 		 * @param WC_Product_Variation $product
-		 * @param bool $flat
+		 * @param bool                 $flat
 		 *
 		 * @return string
 		 */
@@ -123,7 +123,7 @@ if ( ! class_exists( 'WC_Connect_Compatibility' ) ) {
 		 * This is useful when an order has a product which was later deleted from the
 		 * store.
 		 *
-		 * @param int $product_id Product ID or variation ID
+		 * @param int      $product_id Product ID or variation ID
 		 * @param WC_Order $order
 		 * @return string The product (or variation) name, ready to print
 		 */
@@ -132,7 +132,7 @@ if ( ! class_exists( 'WC_Connect_Compatibility' ) ) {
 		/**
 		 * For a given product ID, it tries to find its price inside an order's line items.
 		 *
-		 * @param int $product_id Product ID or variation ID
+		 * @param int      $product_id Product ID or variation ID
 		 * @param WC_Order $order
 		 * @return float The product (or variation) price, or NULL if it wasn't found
 		 */

--- a/classes/class-wc-connect-continents.php
+++ b/classes/class-wc-connect-continents.php
@@ -14,7 +14,7 @@ class WC_Connect_Continents {
 	 * Return the list of countries and states for a given continent.
 	 *
 	 * @since  3.1.0
-	 * @param  string          $continent_code
+	 * @param  string $continent_code
 	 * @return array|mixed Response data, ready for insertion into collection data.
 	 */
 	public function get_continent( $continent_code = false ) {
@@ -46,15 +46,18 @@ class WC_Connect_Continents {
 				// If we have detailed locale information include that in the response
 				if ( array_key_exists( $country_code, $locale_info ) ) {
 					// Defensive programming against unexpected changes in locale-info.php
-					$country_data = wp_parse_args( $locale_info[ $country_code ], array(
-						'currency_code'  => 'USD',
-						'currency_pos'   => 'left',
-						'decimal_sep'    => '.',
-						'dimension_unit' => 'in',
-						'num_decimals'   => 2,
-						'thousand_sep'   => ',',
-						'weight_unit'    => 'lbs',
-					) );
+					$country_data = wp_parse_args(
+						$locale_info[ $country_code ],
+						array(
+							'currency_code'  => 'USD',
+							'currency_pos'   => 'left',
+							'decimal_sep'    => '.',
+							'dimension_unit' => 'in',
+							'num_decimals'   => 2,
+							'thousand_sep'   => ',',
+							'weight_unit'    => 'lbs',
+						)
+					);
 
 					$country = array_merge( $country, $country_data );
 				}

--- a/classes/class-wc-connect-debug-tools.php
+++ b/classes/class-wc-connect-debug-tools.php
@@ -2,37 +2,37 @@
 
 // No direct access please
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 
-    class WC_Connect_Debug_Tools {
+	class WC_Connect_Debug_Tools {
 
-        function __construct( WC_Connect_API_Client $api_client ) {
-            $this->api_client = $api_client;
+		function __construct( WC_Connect_API_Client $api_client ) {
+			$this->api_client = $api_client;
 
-            add_filter( 'woocommerce_debug_tools', array( $this, 'woocommerce_debug_tools' ) );
-        }
+			add_filter( 'woocommerce_debug_tools', array( $this, 'woocommerce_debug_tools' ) );
+		}
 
-        function woocommerce_debug_tools( $tools ) {
-            $tools['test_wcc_connection'] = array(
-                'name'    => __( 'Test your WooCommerce Shipping & Tax connection', 'woocommerce-services' ),
-                'button'  => __( 'Test Connection', 'woocommerce-services' ),
-                'desc'    => __( 'This will test your WooCommerce Shipping & Tax connection to ensure everything is working correctly', 'woocommerce-services' ),
-                'callback' => array( $this, 'test_connection' ),
-            );
-            return $tools;
-        }
+		function woocommerce_debug_tools( $tools ) {
+			$tools['test_wcc_connection'] = array(
+				'name'     => __( 'Test your WooCommerce Shipping & Tax connection', 'woocommerce-services' ),
+				'button'   => __( 'Test Connection', 'woocommerce-services' ),
+				'desc'     => __( 'This will test your WooCommerce Shipping & Tax connection to ensure everything is working correctly', 'woocommerce-services' ),
+				'callback' => array( $this, 'test_connection' ),
+			);
+			return $tools;
+		}
 
-        function test_connection() {
-            $test_request = $this->api_client->auth_test();
-            if ( $test_request && ! is_wp_error( $test_request ) && $test_request->authorized ) {
-                echo '<div class="updated inline"><p>' . __( 'Your site is succesfully communicating to the WooCommerce Shipping & Tax API.', 'woocommerce-services' ) . '</p></div>';
-            } else {
-                echo '<div class="error inline"><p>' . __( 'ERROR: Your site has a problem connecting to the WooCommerce Shipping & Tax API. Please make sure your Jetpack connection is working.', 'woocommerce-services' ) . '</p></div>';
-            }
-        }
+		function test_connection() {
+			$test_request = $this->api_client->auth_test();
+			if ( $test_request && ! is_wp_error( $test_request ) && $test_request->authorized ) {
+				echo '<div class="updated inline"><p>' . __( 'Your site is succesfully communicating to the WooCommerce Shipping & Tax API.', 'woocommerce-services' ) . '</p></div>';
+			} else {
+				echo '<div class="error inline"><p>' . __( 'ERROR: Your site has a problem connecting to the WooCommerce Shipping & Tax API. Please make sure your Jetpack connection is working.', 'woocommerce-services' ) . '</p></div>';
+			}
+		}
 
-    }
+	}
 }

--- a/classes/class-wc-connect-error-notice.php
+++ b/classes/class-wc-connect-error-notice.php
@@ -61,12 +61,12 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 			$message = false;
 
 			if (
-				'product_missing_weight'    === $error->get_error_code() ||
+				'product_missing_weight' === $error->get_error_code() ||
 				'product_missing_dimension' === $error->get_error_code()
 			) {
 				$error_data = $error->get_error_data();
-				$id = $error_data['product_id'];
-				$product = wc_get_product( $id );
+				$id         = $error_data['product_id'];
+				$product    = wc_get_product( $id );
 
 				if (
 					! $product ||
@@ -82,10 +82,11 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 				}
 
 				$product_name = WC_Connect_Compatibility::instance()->get_product_name( $product );
-				$product_id = is_a( $product, 'WC_Product_Variation' ) ? $product->get_parent_id() : $id;
-				$message = sprintf(
+				$product_id   = is_a( $product, 'WC_Product_Variation' ) ? $product->get_parent_id() : $id;
+				$message      = sprintf(
 					__( '<strong>"%2$s" is missing weight, length, width, or height.</strong><br />Shipping rates cannot be calculated. <a href="%1$s">Enter dimensions and weight for %2$s</a> so your customers can purchase this item.', 'woocommerce-services' ),
-					get_edit_post_link( $product_id ), $product_name
+					get_edit_post_link( $product_id ),
+					$product_name
 				);
 			}
 
@@ -98,13 +99,13 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 				'strong' => array(),
 				'br'     => array(),
 			);
-?>
+			?>
 			<div class='notice notice-error' style="position: relative;">
 				<a href="<?php echo esc_url( $link_dismiss ); ?>" style="text-decoration: none;" class="notice-dismiss" title="<?php esc_attr_e( 'Dismiss this notice', 'woocommerce-services' ); ?>"></a>
 				<p><?php echo wp_kses( $message, $allowed_html ); ?></p>
 			</div>
-<?php
-			echo "";
+			<?php
+			echo '';
 		}
 	}
 

--- a/classes/class-wc-connect-extension-compatibility.php
+++ b/classes/class-wc-connect-extension-compatibility.php
@@ -10,9 +10,9 @@ if ( ! class_exists( 'WC_Connect_Extension_Compatibility' ) ) {
 		 * @param $tracking_number - tracking number string
 		 */
 		public static function on_new_tracking_number( $order_id, $carrier_id, $tracking_number ) {
-			//call WooCommerce Shipment Tracking if it's installed
+			// call WooCommerce Shipment Tracking if it's installed
 			if ( function_exists( 'wc_st_add_tracking_number' ) ) {
-				//note: the only carrier ID we use at the moment is 'usps', which is the same in WC_ST, but this might require a mapping
+				// note: the only carrier ID we use at the moment is 'usps', which is the same in WC_ST, but this might require a mapping
 				wc_st_add_tracking_number( $order_id, $tracking_number, $carrier_id );
 			}
 		}

--- a/classes/class-wc-connect-functions.php
+++ b/classes/class-wc-connect-functions.php
@@ -5,6 +5,7 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 		/**
 		 * Checks if the potentially expensive Shipping/Tax API requests should be sent
 		 * based on the context in which they are initialized
+		 *
 		 * @return bool true if the request can be sent, false otherwise
 		 */
 		public static function should_send_cart_api_request() {

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -28,9 +28,9 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			WC_Connect_Service_Settings_Store $service_settings_store,
 			WC_Connect_Logger $logger ) {
 
-			$this->service_schemas_store = $service_schemas_store;
+			$this->service_schemas_store  = $service_schemas_store;
 			$this->service_settings_store = $service_settings_store;
-			$this->logger = $logger;
+			$this->logger                 = $logger;
 
 			add_filter( 'woocommerce_admin_status_tabs', array( $this, 'status_tabs' ) );
 			add_action( 'woocommerce_admin_status_content_connect', array( $this, 'page' ) );
@@ -44,23 +44,23 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			// Check that WooCommerce is at least 2.6 or higher (feature-plugin only)
 			// Check that WooCommerce base_country is set
 			$base_country = WC()->countries->get_base_country();
-			if ( version_compare( WC()->version, WOOCOMMERCE_CONNECT_MINIMUM_WOOCOMMERCE_VERSION, "<" ) ) {
+			if ( version_compare( WC()->version, WOOCOMMERCE_CONNECT_MINIMUM_WOOCOMMERCE_VERSION, '<' ) ) {
 				$health_item = array(
-					'state' => 'error',
+					'state'   => 'error',
 					'message' => sprintf(
-						__( 'WooCommerce %s or higher is required (You are running %s)', 'woocommerce-services' ),
+						__( 'WooCommerce %1$s or higher is required (You are running %2$s)', 'woocommerce-services' ),
 						WOOCOMMERCE_CONNECT_MINIMUM_WOOCOMMERCE_VERSION,
 						WC()->version
 					),
 				);
-			} else if ( empty( $base_country ) ) {
+			} elseif ( empty( $base_country ) ) {
 				$health_item = array(
-					'state' => 'error',
+					'state'   => 'error',
 					'message' => __( 'Please set Base Location in WooCommerce Settings > General', 'woocommerce-services' ),
 				);
 			} else {
 				$health_item = array(
-					'state' => 'success',
+					'state'   => 'success',
 					'message' => sprintf(
 						__( 'WooCommerce %s is configured correctly', 'woocommerce-services' ),
 						WC()->version
@@ -73,38 +73,38 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			// Only one of the following should present
 			// Check that Jetpack is active
 			// Check that Jetpack is connected
-			include_once ( ABSPATH . 'wp-admin/includes/plugin.php' ); // required for is_plugin_active
+			include_once ABSPATH . 'wp-admin/includes/plugin.php'; // required for is_plugin_active
 			$is_connected = WC_Connect_Jetpack::is_active() || WC_Connect_Jetpack::is_development_mode();
 			if ( ! is_plugin_active( 'jetpack/jetpack.php' ) ) {
 				$health_item = array(
-					'state' => 'error',
+					'state'   => 'error',
 					'message' => sprintf(
 						__( 'Please install and activate the Jetpack plugin, version %s or higher', 'woocommerce-services' ),
 						WOOCOMMERCE_CONNECT_MINIMUM_JETPACK_VERSION
 					),
 				);
-			} else if ( version_compare( JETPACK__VERSION, WOOCOMMERCE_CONNECT_MINIMUM_JETPACK_VERSION, "<" ) ) {
+			} elseif ( version_compare( JETPACK__VERSION, WOOCOMMERCE_CONNECT_MINIMUM_JETPACK_VERSION, '<' ) ) {
 				$health_item = array(
-					'state' => 'error',
+					'state'   => 'error',
 					'message' => sprintf(
-						__( 'Jetpack %s or higher is required (You are running %s)', 'woocommerce-services' ),
+						__( 'Jetpack %1$s or higher is required (You are running %2$s)', 'woocommerce-services' ),
 						WOOCOMMERCE_CONNECT_MINIMUM_JETPACK_VERSION,
 						JETPACK__VERSION
 					),
 				);
-			} else if ( ! $is_connected ) {
+			} elseif ( ! $is_connected ) {
 				$health_item = array(
-					'state' => 'error',
+					'state'   => 'error',
 					'message' => __( 'Jetpack is not connected to WordPress.com. Make sure the Jetpack plugin is installed, activated, and connected.', 'woocommerce-services' ),
 				);
-			} else if ( WC_Connect_Jetpack::is_staging_site() ) {
+			} elseif ( WC_Connect_Jetpack::is_staging_site() ) {
 				$health_item = array(
-					'state' => 'warning',
+					'state'   => 'warning',
 					'message' => __( 'This is a Jetpack staging site', 'woocommerce-services' ),
 				);
 			} else {
 				$health_item = array(
-					'state' => 'success',
+					'state'   => 'success',
 					'message' => sprintf(
 						__( 'Jetpack %s is connected and working correctly', 'woocommerce-services' ),
 						JETPACK__VERSION
@@ -116,42 +116,42 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			// Lastly, do the WooCommerce Shipping & Tax health check
 			// Check that we have schema
 			// Check that we are able to talk to the WooCommerce Shipping & Tax server
-			$schemas = $this->service_schemas_store->get_service_schemas();
+			$schemas              = $this->service_schemas_store->get_service_schemas();
 			$last_fetch_timestamp = $this->service_schemas_store->get_last_fetch_timestamp();
 			if ( isset( $_GET['refresh'] ) && 'failed' === $_GET['refresh'] ) {
 				$health_item = array(
-					'state' => 'error',
-					'message' => __( 'An error occurred while refreshing service data.', 'woocommerce-services' ),
+					'state'     => 'error',
+					'message'   => __( 'An error occurred while refreshing service data.', 'woocommerce-services' ),
 					'timestamp' => $last_fetch_timestamp,
 				);
-			} else if ( is_null( $schemas ) ) {
+			} elseif ( is_null( $schemas ) ) {
 				$health_item = array(
-					'state' => 'error',
+					'state'   => 'error',
 					'message' => __( 'No service data available', 'woocommerce-services' ),
 				);
-			} else if ( is_null( $last_fetch_timestamp ) ) {
+			} elseif ( is_null( $last_fetch_timestamp ) ) {
 				$health_item = array(
-					'state' => 'warning',
-					'message' => __( 'Service data was found, but may be out of date', 'woocommerce-services' ),
-					'timestamp' => $last_fetch_timestamp
+					'state'     => 'warning',
+					'message'   => __( 'Service data was found, but may be out of date', 'woocommerce-services' ),
+					'timestamp' => $last_fetch_timestamp,
 				);
-			} else if ( $last_fetch_timestamp < time() - WOOCOMMERCE_CONNECT_SCHEMA_AGE_ERROR_THRESHOLD ) {
+			} elseif ( $last_fetch_timestamp < time() - WOOCOMMERCE_CONNECT_SCHEMA_AGE_ERROR_THRESHOLD ) {
 				$health_item = array(
-					'state' => 'error',
-					'message' => __( 'Service data was found, but is more than three days old', 'woocommerce-services' ),
-					'timestamp' => $last_fetch_timestamp
+					'state'     => 'error',
+					'message'   => __( 'Service data was found, but is more than three days old', 'woocommerce-services' ),
+					'timestamp' => $last_fetch_timestamp,
 				);
-			} else if ( $last_fetch_timestamp < time() - WOOCOMMERCE_CONNECT_SCHEMA_AGE_WARNING_THRESHOLD ) {
+			} elseif ( $last_fetch_timestamp < time() - WOOCOMMERCE_CONNECT_SCHEMA_AGE_WARNING_THRESHOLD ) {
 				$health_item = array(
-					'state' => 'warning',
-					'message' => __( 'Service data was found, but is more than one day old', 'woocommerce-services' ),
-					'timestamp' => $last_fetch_timestamp
+					'state'     => 'warning',
+					'message'   => __( 'Service data was found, but is more than one day old', 'woocommerce-services' ),
+					'timestamp' => $last_fetch_timestamp,
 				);
 			} else {
 				$health_item = array(
-					'state' => 'success',
-					'message' => __( 'Service data is up-to-date', 'woocommerce-services' ),
-					'timestamp' => $last_fetch_timestamp
+					'state'     => 'success',
+					'message'   => __( 'Service data is up-to-date', 'woocommerce-services' ),
+					'timestamp' => $last_fetch_timestamp,
 				);
 			}
 
@@ -173,28 +173,30 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			foreach ( (array) $enabled_services as $enabled_service ) {
 				$last_failed_request_timestamp = intval( WC_Connect_Options::get_shipping_method_option( 'failure_timestamp', -1, $enabled_service->method_id, $enabled_service->instance_id ) );
 
-				$service_settings_url = esc_url( add_query_arg(
-					array(
-						'page' => 'wc-settings',
-						'tab' => 'shipping',
-						'instance_id' => $enabled_service->instance_id
-					),
-					admin_url( 'admin.php' )
-				) );
+				$service_settings_url = esc_url(
+					add_query_arg(
+						array(
+							'page'        => 'wc-settings',
+							'tab'         => 'shipping',
+							'instance_id' => $enabled_service->instance_id,
+						),
+						admin_url( 'admin.php' )
+					)
+				);
 
 				// Figure out if the service has any settings saved at all
 				$service_settings = $this->service_settings_store->get_service_settings( $enabled_service->method_id, $enabled_service->instance_id );
 				if ( empty( $service_settings ) ) {
-					$state = 'error';
+					$state   = 'error';
 					$message = __( 'Setup for this service has not yet been completed', 'woocommerce-services' );
-				} else if ( -1 === $last_failed_request_timestamp ) {
-					$state = 'warning';
+				} elseif ( -1 === $last_failed_request_timestamp ) {
+					$state   = 'warning';
 					$message = __( 'No rate requests have yet been made for this service', 'woocommerce-services' );
-				} else if ( 0 === $last_failed_request_timestamp ) {
-					$state = 'success';
+				} elseif ( 0 === $last_failed_request_timestamp ) {
+					$state   = 'success';
 					$message = __( 'The most recent rate request was successful', 'woocommerce-services' );
 				} else {
-					$state = 'error';
+					$state   = 'error';
 					$message = __( 'The most recent rate request failed', 'woocommerce-services' );
 				}
 
@@ -204,12 +206,12 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 				);
 
 				$service_items[] = (object) array(
-					'title' => $enabled_service->title,
-					'subtitle' => $subtitle,
-					'state' => $state,
-					'message' => $message,
+					'title'     => $enabled_service->title,
+					'subtitle'  => $subtitle,
+					'state'     => $state,
+					'message'   => $message,
 					'timestamp' => $last_failed_request_timestamp,
-					'url' => $service_settings_url,
+					'url'       => $service_settings_url,
 				);
 			}
 
@@ -220,7 +222,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 		 * Gets the last 10 lines from the WooCommerce Shipping & Tax log by feature, if it exists
 		 */
 		protected function get_debug_log_data( $feature = '' ) {
-			$data       = new stdClass;
+			$data       = new stdClass();
 			$data->key  = '';
 			$data->file = null;
 			$data->tail = array();
@@ -266,12 +268,12 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			}
 
 			return array(
-				'tail' => implode( $log_tail ),
-				'url'  => $url = add_query_arg(
+				'tail'  => implode( $log_tail ),
+				'url'   => $url = add_query_arg(
 					array(
 						'page'     => 'wc-status',
 						'tab'      => 'logs',
-						'log_file' => $data->key
+						'log_file' => $data->key,
 					),
 					admin_url( 'admin.php' )
 				),
@@ -289,7 +291,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			if ( ! is_array( $tabs ) ) {
 				$tabs = array();
 			}
-			$tabs[ 'connect' ] = _x( 'WooCommerce Shipping & Tax', 'The WooCommerce Shipping & Tax brandname', 'woocommerce-services' );
+			$tabs['connect'] = _x( 'WooCommerce Shipping & Tax', 'The WooCommerce Shipping & Tax brandname', 'woocommerce-services' );
 			return $tabs;
 		}
 
@@ -305,10 +307,10 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 				'logging_enabled' => $this->logger->is_logging_enabled(),
 				'debug_enabled'   => $this->logger->is_debug_enabled(),
 				'logs'            => array(
-					'shipping'    => $this->get_debug_log_data( 'shipping' ),
-					'taxes'       => $this->get_debug_log_data( 'taxes' ),
-					'other'       => $this->get_debug_log_data(),
-				)
+					'shipping' => $this->get_debug_log_data( 'shipping' ),
+					'taxes'    => $this->get_debug_log_data( 'taxes' ),
+					'other'    => $this->get_debug_log_data(),
+				),
 			);
 
 			return $form_data;
@@ -320,7 +322,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 		public function page() {
 			if ( isset( $_GET['refresh'] ) && 'true' === $_GET['refresh'] ) {
 				$fetched = $this->service_schemas_store->fetch_service_schemas_from_connect_server();
-				$url = add_query_arg( 'refresh', $fetched ? false : 'failed' );
+				$url     = add_query_arg( 'refresh', $fetched ? false : 'failed' );
 				wp_safe_redirect( $url );
 			}
 
@@ -330,14 +332,22 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 				</h2>
 			<?php
 
-			do_action( 'enqueue_wc_connect_script', 'wc-connect-admin-status', array(
-				'formData'           => $this->get_form_data(),
-			) );
+			do_action(
+				'enqueue_wc_connect_script',
+				'wc-connect-admin-status',
+				array(
+					'formData' => $this->get_form_data(),
+				)
+			);
 
-			do_action( 'enqueue_wc_connect_script', 'wc-connect-admin-test-print', array(
-				'storeOptions'       => $this->service_settings_store->get_store_options(),
-				'paperSize'          => $this->service_settings_store->get_preferred_paper_size(),
-			) );
+			do_action(
+				'enqueue_wc_connect_script',
+				'wc-connect-admin-test-print',
+				array(
+					'storeOptions' => $this->service_settings_store->get_store_options(),
+					'paperSize'    => $this->service_settings_store->get_preferred_paper_size(),
+				)
+			);
 		}
 
 	}

--- a/classes/class-wc-connect-jetpack.php
+++ b/classes/class-wc-connect-jetpack.php
@@ -4,6 +4,7 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 	class WC_Connect_Jetpack {
 		/**
 		 * Helper method to get if Jetpack is in development mode
+		 *
 		 * @return bool
 		 */
 		public static function is_development_mode() {
@@ -17,10 +18,11 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 
 		/**
 		 * Helper method to get if Jetpack is connected (aka active)
+		 *
 		 * @return bool
 		 */
 		public static function is_active() {
-			if ( defined( 'WOOCOMMERCE_SERVICES_LOCAL_TEST_MODE') && WOOCOMMERCE_SERVICES_LOCAL_TEST_MODE ) {
+			if ( defined( 'WOOCOMMERCE_SERVICES_LOCAL_TEST_MODE' ) && WOOCOMMERCE_SERVICES_LOCAL_TEST_MODE ) {
 				return true;
 			}
 			if ( method_exists( 'Jetpack', 'is_active' ) ) {
@@ -32,6 +34,7 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 
 		/**
 		 * Helper method to get if the current Jetpack website is marked as staging
+		 *
 		 * @return bool
 		 */
 		public static function is_staging_site() {
@@ -49,6 +52,7 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 
 		/**
 		 * Helper method to get whether the current site is an Atomic site
+		 *
 		 * @return bool
 		 */
 		public static function is_atomic_site() {
@@ -71,10 +75,11 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 
 		/**
 		 * Helper method to get the Jetpack master user, IF we are connected
+		 *
 		 * @return WP_User | false
 		 */
 		public static function get_master_user() {
-			include_once ( ABSPATH . 'wp-admin/includes/plugin.php' );
+			include_once ABSPATH . 'wp-admin/includes/plugin.php';
 			if ( self::is_active() && method_exists( 'Jetpack_Options', 'get_option' ) ) {
 				$master_user_id = Jetpack_Options::get_option( 'master_user' );
 				return get_userdata( $master_user_id );
@@ -86,6 +91,7 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 
 		/**
 		 * Builds a connect url
+		 *
 		 * @param $redirect_url
 		 * @return string
 		 */
@@ -99,6 +105,7 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 
 		/**
 		 * Records a Tracks event
+		 *
 		 * @param $user
 		 * @param $event_type
 		 * @param

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -1,7 +1,7 @@
 <?php
 
 if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
-	include_once( WC()->plugin_path() . '/includes/admin/reports/class-wc-admin-report.php' );
+	include_once WC()->plugin_path() . '/includes/admin/reports/class-wc-admin-report.php';
 
 	class WC_Connect_Label_Reports extends WC_Admin_Report {
 		const LABELS_TRANSIENT_KEY = 'wcs_label_reports';
@@ -35,9 +35,9 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 
 		private function get_all_labels() {
 			global $wpdb;
-			$query = "SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = 'wc_connect_labels'";
+			$query      = "SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = 'wc_connect_labels'";
 			$db_results = $wpdb->get_results( $query );
-			$results = array();
+			$results    = array();
 
 			foreach ( $db_results as $meta ) {
 				$labels = maybe_unserialize( $meta->meta_value );
@@ -60,16 +60,16 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 		}
 
 		private function query_labels() {
-			$all_labels =  get_transient( self::LABELS_TRANSIENT_KEY );
+			$all_labels = get_transient( self::LABELS_TRANSIENT_KEY );
 			if ( false === $all_labels ) {
 				$all_labels = $this->get_all_labels();
-				//set transient with ttl of 30 minutes
+				// set transient with ttl of 30 minutes
 				set_transient( self::LABELS_TRANSIENT_KEY, $all_labels, 1800 );
 			}
 
 			// translate timestamps to JS timestapms
 			$start_date = $this->start_date * 1000;
-			$end_date = $this->end_date * 1000;
+			$end_date   = $this->end_date * 1000;
 
 			$results = array();
 			foreach ( $all_labels as $label ) {
@@ -78,19 +78,19 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 					continue;
 				}
 
-				//labels are sorted in descending order, so if we reached the end, break the loop
+				// labels are sorted in descending order, so if we reached the end, break the loop
 				if ( $created < $start_date ) {
 					break;
 				}
 
-				if ( isset( $label['error'] ) || //ignore the error labels
-					! isset( $label['rate'] ) ) { //labels where purchase hasn't completed for any reason
+				if ( isset( $label['error'] ) || // ignore the error labels
+					! isset( $label['rate'] ) ) { // labels where purchase hasn't completed for any reason
 					continue;
 				}
 
-				//ignore labels with complete refunds
+				// ignore labels with complete refunds
 				if ( isset( $label['refund'] ) ) {
-					$refund = ( array ) $label['refund'];
+					$refund = (array) $label['refund'];
 					if ( isset( $refund['status'] ) && 'completed' === $refund['status'] ) {
 						continue;
 					}
@@ -121,7 +121,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 
 			$hide_sidebar = true;
 
-			include( WC()->plugin_path() . '/includes/admin/views/html-report-by-date.php' );
+			include WC()->plugin_path() . '/includes/admin/views/html-report-by-date.php';
 		}
 
 		private function get_order_url( $post_id ) {
@@ -134,7 +134,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 				return '';
 			}
 
-			$refund = ( array ) $label['refund'];
+			$refund = (array) $label['refund'];
 
 			if ( isset( $refund['status'] ) &&
 				( 'rejected' === $refund['status'] || 'complete' === $refund['status'] ) ) {

--- a/classes/class-wc-connect-logger.php
+++ b/classes/class-wc-connect-logger.php
@@ -50,11 +50,11 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 		public function enable_logging() {
 			WC_Connect_Options::update_option( 'debug_logging_enabled', true );
 			$this->is_logging_enabled = true;
-			$this->log( "Logging enabled" );
+			$this->log( 'Logging enabled' );
 		}
 
 		public function disable_logging() {
-			$this->log( "Logging disabled" );
+			$this->log( 'Logging disabled' );
 			WC_Connect_Options::update_option( 'debug_logging_enabled', false );
 			$this->is_logging_enabled = false;
 		}
@@ -86,7 +86,7 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 		 * @param string $type    Notice type.
 		 */
 		public function debug( $message, $type = 'notice' ) {
-			if ( $this->is_debug_enabled()  ) {
+			if ( $this->is_debug_enabled() ) {
 				wc_add_notice( $message, $type );
 			}
 		}
@@ -126,7 +126,6 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 			}
 
 			$this->logger->add( $log_file, $log_message );
-
 
 		}
 

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -6,11 +6,11 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		/**
 		 * Jetpack status constants.
 		 */
-		const JETPACK_NOT_INSTALLED = 'uninstalled';
+		const JETPACK_NOT_INSTALLED           = 'uninstalled';
 		const JETPACK_INSTALLED_NOT_ACTIVATED = 'installed';
 		const JETPACK_ACTIVATED_NOT_CONNECTED = 'activated';
-		const JETPACK_DEV = 'dev';
-		const JETPACK_CONNECTED = 'connected';
+		const JETPACK_DEV                     = 'dev';
+		const JETPACK_CONNECTED               = 'connected';
 
 		const IS_NEW_LABEL_USER = 'wcc_is_new_label_user';
 
@@ -31,7 +31,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		private $shipping_label;
 
 		function __construct( WC_Connect_Tracks $tracks, WC_Connect_Shipping_Label $shipping_label ) {
-			$this->tracks = $tracks;
+			$this->tracks         = $tracks;
 			$this->shipping_label = $shipping_label;
 
 			$this->init_pointers();
@@ -54,7 +54,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		}
 
 		public function dismiss_notice( $notice ) {
-			$notices = $this->get_notice_states();
+			$notices            = $this->get_notice_states();
 			$notices[ $notice ] = true;
 			update_user_meta( get_current_user_id(), 'wc_connect_nux_notices', $notices );
 		}
@@ -75,7 +75,8 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		}
 
 		public function show_pointers( $hook ) {
-			/* Get admin pointers for the current admin page.
+			/*
+			 Get admin pointers for the current admin page.
 			 *
 			 * @since 0.9.6
 			 *
@@ -88,11 +89,11 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			}
 
 			$dismissed_pointers = $this->get_dismissed_pointers();
-			$valid_pointers = array();
+			$valid_pointers     = array();
 
 			foreach ( $pointers as $pointer ) {
 				if ( ! in_array( $pointer['id'], $dismissed_pointers, true ) ) {
-					$valid_pointers[] =  $pointer;
+					$valid_pointers[] = $pointer;
 				}
 			}
 
@@ -126,7 +127,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			}
 
 			$dismissed_pointers[] = $pointer_to_dismiss;
-			$dismissed_data = implode( ',', $dismissed_pointers );
+			$dismissed_data       = implode( ',', $dismissed_pointers );
 			update_user_meta( get_current_user_id(), 'dismissed_wp_pointers', $dismissed_data );
 		}
 
@@ -134,8 +135,8 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			$is_new_user = get_transient( self::IS_NEW_LABEL_USER );
 			if ( false === $is_new_user ) {
 				global $wpdb;
-				$query = "SELECT meta_key FROM {$wpdb->postmeta} WHERE meta_key = 'wc_connect_labels' LIMIT 1";
-				$results = $wpdb->get_results( $query );
+				$query       = "SELECT meta_key FROM {$wpdb->postmeta} WHERE meta_key = 'wc_connect_labels' LIMIT 1";
+				$results     = $wpdb->get_results( $query );
 				$is_new_user = 0 === count( $results ) ? 'yes' : 'no';
 				set_transient( self::IS_NEW_LABEL_USER, $is_new_user );
 			}
@@ -161,16 +162,20 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			}
 
 			$pointers[] = array(
-				'id' => 'wc_services_labels_metabox',
-				'target' => '#woocommerce-order-label .button',
+				'id'      => 'wc_services_labels_metabox',
+				'target'  => '#woocommerce-order-label .button',
 				'options' => array(
-					'content' => sprintf( '<h3>%s</h3><p>%s</p>',
-						__( 'Discounted Shipping Labels' ,'woocommerce-services' ),
-						sprintf( __( "When you're ready, purchase and print discounted labels from %s right here.", 'woocommerce-services' ), implode(' or ', $supported_carriers) )
+					'content'  => sprintf(
+						'<h3>%s</h3><p>%s</p>',
+						__( 'Discounted Shipping Labels', 'woocommerce-services' ),
+						sprintf( __( "When you're ready, purchase and print discounted labels from %s right here.", 'woocommerce-services' ), implode( ' or ', $supported_carriers ) )
 					),
-					'position' => array( 'edge' => 'top', 'align' => 'left' ),
+					'position' => array(
+						'edge'  => 'top',
+						'align' => 'left',
+					),
 				),
-				'dim' => true,
+				'dim'     => true,
 			);
 
 			return $pointers;
@@ -190,16 +195,20 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			}
 
 			$pointers[] = array(
-				'id' => 'wc_services_new_carrier_dhl_express',
-				'target' => '#woocommerce-order-label .button',
+				'id'      => 'wc_services_new_carrier_dhl_express',
+				'target'  => '#woocommerce-order-label .button',
 				'options' => array(
-					'content' => sprintf( '<h3>%s</h3><p>%s</p>',
-						__( 'Discounted DHL Shipping Labels' ,'woocommerce-services' ),
-						__( "WooCommerce Shipping now supports DHL labels for international shipments. Purchase and print discounted labels from DHL and USPS right here.", 'woocommerce-services' )
+					'content'  => sprintf(
+						'<h3>%s</h3><p>%s</p>',
+						__( 'Discounted DHL Shipping Labels', 'woocommerce-services' ),
+						__( 'WooCommerce Shipping now supports DHL labels for international shipments. Purchase and print discounted labels from DHL and USPS right here.', 'woocommerce-services' )
 					),
-					'position' => array( 'edge' => 'top', 'align' => 'left' ),
+					'position' => array(
+						'edge'  => 'top',
+						'align' => 'left',
+					),
 				),
-				'dim' => true,
+				'dim'     => true,
 			);
 
 			return $pointers;
@@ -242,7 +251,8 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				return false;
 			}
 
-			/* The NUX Flow:
+			/*
+			 The NUX Flow:
 			- Case 1: Jetpack not connected (with TOS or no TOS accepted):
 				1. show_banner_before_connection()
 				2. connect to JP
@@ -283,7 +293,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 
 		public function get_jetpack_install_status() {
 			// we need to use validate_plugin to check that Jetpack is installed
-			include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+			include_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 			// check if jetpack is installed
 			if ( 0 !== validate_plugin( 'jetpack/jetpack.php' ) ) {
@@ -372,23 +382,23 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			$supports_taxes  = $this->is_taxjar_supported_country( $country );
 			$supports_labels = ( 'US' === $country );
 
-			$is_ppec_active = is_plugin_active( 'woocommerce-gateway-paypal-express-checkout/woocommerce-gateway-paypal-express-checkout.php' );
-			$ppec_settings  = get_option( 'woocommerce_ppec_paypal_settings', array() );
-			$supports_payments  = $is_ppec_active && ( ! isset( $ppec_settings['enabled'] ) || 'yes' === $ppec_settings['enabled'] );
+			$is_ppec_active    = is_plugin_active( 'woocommerce-gateway-paypal-express-checkout/woocommerce-gateway-paypal-express-checkout.php' );
+			$ppec_settings     = get_option( 'woocommerce_ppec_paypal_settings', array() );
+			$supports_payments = $is_ppec_active && ( ! isset( $ppec_settings['enabled'] ) || 'yes' === $ppec_settings['enabled'] );
 
 			if ( $supports_payments && $supports_taxes && $supports_labels ) {
 				$feature_list = __( 'automated tax calculation, shipping label printing, and smoother payment setup', 'woocommerce-services' );
 			} elseif ( $supports_payments && $supports_taxes ) {
 				$feature_list = __( 'automated tax calculation and smoother payment setup', 'woocommerce-services' );
-			} else if ( $supports_taxes && $supports_labels ) {
+			} elseif ( $supports_taxes && $supports_labels ) {
 				$feature_list = __( 'automated tax calculation and shipping label printing', 'woocommerce-services' );
-			} else if ( $supports_payments && $supports_labels ) {
+			} elseif ( $supports_payments && $supports_labels ) {
 				$feature_list = __( 'shipping label printing and smoother payment setup', 'woocommerce-services' );
-			} else if ( $supports_payments ) {
+			} elseif ( $supports_payments ) {
 				$feature_list = __( 'smoother payment setup', 'woocommerce-services' );
-			} else if ( $supports_taxes ) {
+			} elseif ( $supports_taxes ) {
 				$feature_list = __( 'automated tax calculation', 'woocommerce-services' );
-			} else if ( $supports_labels ) {
+			} elseif ( $supports_labels ) {
 				$feature_list = __( 'shipping label printing', 'woocommerce-services' );
 			}
 
@@ -399,7 +409,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			$full_path = add_query_arg( array() );
 			// Remove [...]/wp-admin so we can use admin_url().
 			$new_index = strpos( $full_path, '/wp-admin' ) + strlen( '/wp-admin' );
-			$path = substr( $full_path, $new_index );
+			$path      = substr( $full_path, $new_index );
 			return admin_url( $path );
 		}
 
@@ -417,12 +427,14 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				return;
 			}
 
-			$banner_to_display = self::get_banner_type_to_display( array(
-				'jetpack_connection_status'       => $jetpack_install_status,
-				'tos_accepted'                    => WC_Connect_Options::get_option( 'tos_accepted' ),
-				'can_accept_tos'                  => $this->can_accept_tos(),
-				'should_display_after_cxn_banner' => WC_Connect_Options::get_option( self::SHOULD_SHOW_AFTER_CXN_BANNER ),
-			) );
+			$banner_to_display = self::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => $jetpack_install_status,
+					'tos_accepted'                    => WC_Connect_Options::get_option( 'tos_accepted' ),
+					'can_accept_tos'                  => $this->can_accept_tos(),
+					'should_display_after_cxn_banner' => WC_Connect_Options::get_option( self::SHOULD_SHOW_AFTER_CXN_BANNER ),
+				)
+			);
 
 			switch ( $banner_to_display ) {
 				case 'before_jetpack_connection':
@@ -439,10 +451,12 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					);
 					wp_enqueue_script( 'wc_connect_banner' );
 					wp_localize_script( 'wc_connect_banner', 'wcs_nux_notice', $ajax_data );
-					add_action( 'wp_ajax_woocommerce_services_activate_jetpack',
+					add_action(
+						'wp_ajax_woocommerce_services_activate_jetpack',
 						array( $this, 'ajax_activate_jetpack' )
 					);
-					add_action( 'wp_ajax_woocommerce_services_get_jetpack_connect_url',
+					add_action(
+						'wp_ajax_woocommerce_services_get_jetpack_connect_url',
 						array( $this, 'ajax_get_jetpack_connect_url' )
 					);
 					wp_enqueue_style( 'wc_connect_banner' );
@@ -490,10 +504,10 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 
 			switch ( $jetpack_status ) {
 				case self::JETPACK_NOT_INSTALLED:
-					$button_text  = __( 'Install Jetpack and connect', 'woocommerce-services' );
+					$button_text = __( 'Install Jetpack and connect', 'woocommerce-services' );
 					break;
 				case self::JETPACK_INSTALLED_NOT_ACTIVATED:
-					$button_text  = __( 'Activate Jetpack and connect', 'woocommerce-services' );
+					$button_text = __( 'Activate Jetpack and connect', 'woocommerce-services' );
 					break;
 			}
 
@@ -540,19 +554,24 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			$description_base = __( 'You can now enjoy %s.', 'woocommerce-services' );
 			$feature_list     = $this->get_feature_list_for_country( $country );
 
-			$this->show_nux_banner( array(
-				'title'          => __( 'Setup complete.', 'woocommerce-services' ),
-				'description'    => esc_html( sprintf( $description_base, $feature_list ) ),
-				'button_text'    => __( 'Got it, thanks!', 'woocommerce-services' ),
-				'button_link'    => add_query_arg( array(
-					'wcs-nux-notice' => 'dismiss',
-				) ),
-				'image_url'      => plugins_url(
-					'images/wcs-notice.png', dirname( __FILE__ )
-				),
-				'should_show_jp' => false,
-				'should_show_terms' => false,
-			) );
+			$this->show_nux_banner(
+				array(
+					'title'             => __( 'Setup complete.', 'woocommerce-services' ),
+					'description'       => esc_html( sprintf( $description_base, $feature_list ) ),
+					'button_text'       => __( 'Got it, thanks!', 'woocommerce-services' ),
+					'button_link'       => add_query_arg(
+						array(
+							'wcs-nux-notice' => 'dismiss',
+						)
+					),
+					'image_url'         => plugins_url(
+						'images/wcs-notice.png',
+						dirname( __FILE__ )
+					),
+					'should_show_jp'    => false,
+					'should_show_terms' => false,
+				)
+			);
 		}
 
 		public function show_tos_banner() {
@@ -578,19 +597,24 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			$description_base = __( "WooCommerce Shipping & Tax is almost ready to go! Once you connect your store you'll have access to %s.", 'woocommerce-services' );
 			$feature_list     = $this->get_feature_list_for_country( $country );
 
-			$this->show_nux_banner( array(
-				'title'          => __( 'Connect your store to activate WooCommerce Shipping & Tax', 'woocommerce-services' ),
-				'description'    => esc_html( sprintf( $description_base, $feature_list ) ),
-				'button_text'    => __( 'Connect', 'woocommerce-services' ),
-				'button_link'    => add_query_arg( array(
-					'wcs-nux-tos' => 'accept',
-				) ),
-				'image_url'      => plugins_url(
-					'images/wcs-notice.png', dirname( __FILE__ )
-				),
-				'should_show_jp'    => false,
-				'should_show_terms' => true,
-			) );
+			$this->show_nux_banner(
+				array(
+					'title'             => __( 'Connect your store to activate WooCommerce Shipping & Tax', 'woocommerce-services' ),
+					'description'       => esc_html( sprintf( $description_base, $feature_list ) ),
+					'button_text'       => __( 'Connect', 'woocommerce-services' ),
+					'button_link'       => add_query_arg(
+						array(
+							'wcs-nux-tos' => 'accept',
+						)
+					),
+					'image_url'         => plugins_url(
+						'images/wcs-notice.png',
+						dirname( __FILE__ )
+					),
+					'should_show_jp'    => false,
+					'should_show_terms' => true,
+				)
+			);
 		}
 
 		public function show_nux_banner( $content ) {
@@ -607,7 +631,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 							src="<?php echo esc_url( plugins_url( 'images/jetpack-logo.png', dirname( __FILE__ ) ) ); ?>"
 						>
 					<?php endif; ?>
-					<img class="wcs-nux__notice-logo-graphic" src="<?php echo esc_url( $content['image_url'] );  ?>">
+					<img class="wcs-nux__notice-logo-graphic" src="<?php echo esc_url( $content['image_url'] ); ?>">
 				</div>
 				<div class="wcs-nux__notice-content">
 					<h1 class="wcs-nux__notice-content-title">
@@ -617,19 +641,24 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 						<?php echo $content['description']; ?>
 					</p>
 					<?php if ( isset( $content['should_show_terms'] ) && $content['should_show_terms'] ) : ?>
-						<p class="wcs-nux__notice-content-tos"><?php
+						<p class="wcs-nux__notice-content-tos">
+						<?php
 						/* translators: %1$s example values include "Install Jetpack and CONNECT >", "Activate Jetpack and CONNECT >", "CONNECT >" */
 						printf(
-							wp_kses( __( 'By clicking "%1$s", you agree to the <a href="%2$s">Terms of Service</a> and to <a href="%3$s">share certain data and settings</a> with WordPress.com and/or third parties.', 'woocommerce-services' ),
+							wp_kses(
+								__( 'By clicking "%1$s", you agree to the <a href="%2$s">Terms of Service</a> and to <a href="%3$s">share certain data and settings</a> with WordPress.com and/or third parties.', 'woocommerce-services' ),
 								array(
-								'a' => array(
-									'href' => array(),
-								),
-							) ),
+									'a' => array(
+										'href' => array(),
+									),
+								)
+							),
 							esc_html( $content['button_text'] ),
 							'https://wordpress.com/tos/',
 							'https://jetpack.com/support/what-data-does-jetpack-sync/'
-						); ?></p>
+						);
+						?>
+						</p>
 					<?php endif; ?>
 					<?php if ( isset( $content['button_link'] ) ) : ?>
 						<a
@@ -651,7 +680,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			if ( isset( $content['dismissible_id'] ) ) :
 				// Add handler for dismissing banner. Only supports a single banner at a time
 				wp_enqueue_script( 'wp-util' );
-			?>
+				?>
 				<script>
 				( function( $ ) {
 					$( '.wcs-nux__notice' ).on( 'click', '.notice-dismiss', function() {
@@ -663,7 +692,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					} );
 				} )( jQuery );
 				</script>
-			<?php
+				<?php
 			endif;
 		}
 
@@ -691,7 +720,6 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 
 		/**
 		 * Get Jetpack connection URL.
-		 *
 		 */
 		public function ajax_get_jetpack_connect_url() {
 			check_ajax_referer( 'wcs_nux_notice' );

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -4,6 +4,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 	class WC_Connect_Options {
 		/**
 		 * An array that maps a grouped option type to an option name.
+		 *
 		 * @var array
 		 */
 		private static $grouped_options = array(
@@ -60,8 +61,8 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				return;
 			}
 
-			foreach( self::$grouped_options as $group_key => $group ) {
-				//delete legacy options
+			foreach ( self::$grouped_options as $group_key => $group ) {
+				// delete legacy options
 				foreach ( self::get_option_names( $group_key ) as $group_option ) {
 					delete_option( "wc_connect_$group_option" );
 				}
@@ -81,7 +82,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 		 * Returns the requested option.  Looks in wc_connect_options or wc_connect_$name as appropriate.
 		 *
 		 * @param string $name Option name
-		 * @param mixed $default (optional)
+		 * @param mixed  $default (optional)
 		 *
 		 * @return mixed
 		 */
@@ -104,11 +105,11 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 		 * Updates the single given option.  Updates wc_connect_options or wc_connect_$name as appropriate.
 		 *
 		 * @param string $name Option name
-		 * @param mixed $value Option value
+		 * @param mixed  $value Option value
 		 *
 		 * @return bool Was the option successfully updated?
 		 */
-		public static function update_option( $name, $value) {
+		public static function update_option( $name, $value ) {
 			if ( self::is_valid( $name, 'non_compact' ) ) {
 				return update_option( "wc_connect_$name", $value );
 			}
@@ -231,8 +232,8 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				return $options[ $name ];
 			}
 
-			//make the grouped options backwards-compatible and migrate the old options
-			$legacy_name = "wc_connect_$name";
+			// make the grouped options backwards-compatible and migrate the old options
+			$legacy_name   = "wc_connect_$name";
 			$legacy_option = get_option( $legacy_name, false );
 			if ( ! $legacy_option ) {
 				return $default;
@@ -254,7 +255,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 		}
 
 		private static function delete_grouped_option( $group, $names ) {
-			$options = get_option( self::$grouped_options[ $group ], array() );
+			$options   = get_option( self::$grouped_options[ $group ], array() );
 			$to_delete = array_intersect( $names, self::get_option_names( $group ), array_keys( $options ) );
 			if ( $to_delete ) {
 				foreach ( $to_delete as $name ) {
@@ -289,8 +290,8 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 		/**
 		 * Is the option name valid?
 		 *
-		 * @param string      $name  The name of the option
-		 * @param string      $group The name of the group that the option is in. Defaults to compact.
+		 * @param string $name  The name of the option
+		 * @param string $group The name of the group that the option is in. Defaults to compact.
 		 *
 		 * @return bool Is the option name valid?
 		 */

--- a/classes/class-wc-connect-order-presenter.php
+++ b/classes/class-wc-connect-order-presenter.php
@@ -13,7 +13,7 @@ if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
 		 */
 		public function get_order_for_api( WC_Order $order ) {
 			$decimal_point = 2;
-			$order_data = array(
+			$order_data    = array(
 				'id'                        => $order->get_id(),
 				'order_number'              => $order->get_order_number(),
 				'order_key'                 => $order->get_order_key(),
@@ -31,12 +31,12 @@ if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
 				'shipping_tax'              => wc_format_decimal( $order->get_shipping_tax(), $decimal_point ),
 				'total_discount'            => wc_format_decimal( $order->get_total_discount(), $decimal_point ),
 				'shipping_methods'          => $order->get_shipping_method(),
-				'payment_details' => array(
+				'payment_details'           => array(
 					'method_id'    => $order->get_payment_method(),
 					'method_title' => $order->get_payment_method_title(),
 					'paid'         => ! is_null( $order->get_date_paid() ),
 				),
-				'billing_address' => array(
+				'billing_address'           => array(
 					'first_name' => $order->get_billing_first_name(),
 					'last_name'  => $order->get_billing_last_name(),
 					'company'    => $order->get_billing_company(),
@@ -49,7 +49,7 @@ if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
 					'email'      => $order->get_billing_email(),
 					'phone'      => $order->get_billing_phone(),
 				),
-				'shipping_address' => array(
+				'shipping_address'          => array(
 					'first_name' => $order->get_shipping_first_name(),
 					'last_name'  => $order->get_shipping_last_name(),
 					'company'    => $order->get_shipping_company(),
@@ -74,8 +74,8 @@ if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
 
 			// Add line items.
 			foreach ( $order->get_items() as $item_id => $item ) {
-				$product    = $item->get_product();
-				$item_meta  = $item->get_formatted_meta_data();
+				$product   = $item->get_product();
+				$item_meta = $item->get_formatted_meta_data();
 
 				foreach ( $item_meta as $key => $values ) {
 					$item_meta[ $key ]->label = $values->display_key;

--- a/classes/class-wc-connect-package-settings.php
+++ b/classes/class-wc-connect-package-settings.php
@@ -19,20 +19,20 @@ class WC_Connect_Package_Settings {
 		WC_Connect_Service_Settings_Store $settings_store,
 		WC_Connect_Service_Schemas_Store $service_schemas_store
 	) {
-		$this->settings_store = $settings_store;
+		$this->settings_store        = $settings_store;
 		$this->service_schemas_store = $service_schemas_store;
 	}
 	public function get() {
 		return array(
 			'storeOptions' => $this->settings_store->get_store_options(),
 			'formSchema'   => array(
-				'custom' => $this->service_schemas_store->get_packages_schema(),
-				'predefined' => $this->service_schemas_store->get_predefined_packages_schema()
+				'custom'     => $this->service_schemas_store->get_packages_schema(),
+				'predefined' => $this->service_schemas_store->get_predefined_packages_schema(),
 			),
 			'formData'     => array(
-				'custom' => $this->settings_store->get_packages(),
-				'predefined' => $this->settings_store->get_predefined_packages()
-			)
+				'custom'     => $this->settings_store->get_packages(),
+				'predefined' => $this->settings_store->get_predefined_packages(),
+			),
 		);
 	}
 }

--- a/classes/class-wc-connect-payment-methods-store.php
+++ b/classes/class-wc-connect-payment-methods-store.php
@@ -48,7 +48,7 @@ if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 				return false;
 			}
 
-			// If we made it this far, it is safe to store the object
+			// If we made it this far, it is safe to store the object.
 			$this->update_payment_methods( $payment_methods );
 
 			$this->potentially_update_selected_payment_method_from_payment_methods( $payment_methods );
@@ -66,19 +66,19 @@ if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 				}
 			}
 
-			// No payment methods at all? Clear anything we have stored
+			// No payment methods at all? Clear anything we have stored.
 			if ( 0 === count( $payment_method_ids ) ) {
 				$this->service_settings_store->set_selected_payment_method_id( 0 );
 				return;
 			}
 
-			// Has the stored method ID been removed, or is there only one available? Select the first available one
+			// Has the stored method ID been removed, or is there only one available? Select the first available one.
 			$selected_payment_method_id = $this->service_settings_store->get_selected_payment_method_id();
 			if (
 				( $selected_payment_method_id || 1 === count( $payment_method_ids ) ) &&
 				! in_array( $selected_payment_method_id, $payment_method_ids )
 			) {
-				$this->service_settings_store->set_selected_payment_method_id( $payment_method_ids[ 0 ] );
+				$this->service_settings_store->set_selected_payment_method_id( $payment_method_ids[0] );
 			}
 		}
 

--- a/classes/class-wc-connect-paypal-ec.php
+++ b/classes/class-wc-connect-paypal-ec.php
@@ -30,7 +30,7 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 
 		public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Nux $nux ) {
 			$this->api_client = $api_client;
-			$this->nux = $nux;
+			$this->nux        = $nux;
 		}
 
 		public function init() {
@@ -60,8 +60,8 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 				empty( $settings->sandbox_api_username ) &&
 				empty( $settings->api_username )
 			) {
-				$email = isset( $settings->email ) ? $settings->email : $settings->api_subject;
-				$settings->api_subject = $email;
+				$email                         = isset( $settings->email ) ? $settings->email : $settings->api_subject;
+				$settings->api_subject         = $email;
 				$settings->sandbox_api_subject = $email;
 				$settings->save();
 			}
@@ -126,25 +126,29 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 		 */
 		public function register_refund_pointer( $pointers ) {
 			$pointers[] = array(
-				'id' => 'wc_services_refund_via_ppec',
-				'target' => '.refund-actions > button:first-child',
-				'options' => array(
-					'content' => sprintf( '<h3>%s</h3><p>%s</p>',
-						__( 'Link a PayPal account' ,'woocommerce-services' ),
+				'id'              => 'wc_services_refund_via_ppec',
+				'target'          => '.refund-actions > button:first-child',
+				'options'         => array(
+					'content'  => sprintf(
+						'<h3>%s</h3><p>%s</p>',
+						__( 'Link a PayPal account', 'woocommerce-services' ),
 						sprintf(
 							wp_kses(
 								__( 'To issue refunds via PayPal Checkout, you will need to <a href="%s">link a PayPal account</a> with the email address that received this payment.', 'woocommerce-services' ),
-								array(  'a' => array( 'href' => array() ) )
+								array( 'a' => array( 'href' => array() ) )
 							),
 							wc_gateway_ppec()->ips->get_signup_url( wc_gateway_ppec()->settings->environment )
 						)
 					),
-					'position' => array( 'edge' => 'bottom', 'align' => 'top' ),
+					'position' => array(
+						'edge'  => 'bottom',
+						'align' => 'top',
+					),
 				),
 				'delayed_opening' => array(
-					'show_button' => '.refund-items',
-					'hide_button' => '.cancel-action',
-					'animating_container' => '.wc-order-refund-items',
+					'show_button'          => '.refund-items',
+					'hide_button'          => '.cancel-action',
+					'animating_container'  => '.wc-order-refund-items',
 					'delegation_container' => '#woocommerce-order-items',
 				),
 			);
@@ -202,15 +206,17 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 		 * Show a NUX banner prompting the merchant to link a PayPal account
 		 */
 		public function banner() {
-			$this->nux->show_nux_banner( array(
-				'title'          => __( 'Link your PayPal account', 'woocommerce-services' ),
-				'description'    => esc_html( __( 'Link a new or existing PayPal account to make sure future orders are marked “Processing” instead of “On hold”, and so refunds can be issued without leaving WooCommerce.', 'woocommerce-services' ) ),
-				'button_text'    => __( 'Link account', 'woocommerce-services' ),
-				'button_link'    => wc_gateway_ppec()->ips->get_signup_url( 'live' ),
-				'image_url'      => plugins_url( 'images/cashier.svg', dirname( __FILE__ ) ),
-				'should_show_jp' => false,
-				'dismissible_id' => 'ppec',
-			) );
+			$this->nux->show_nux_banner(
+				array(
+					'title'          => __( 'Link your PayPal account', 'woocommerce-services' ),
+					'description'    => esc_html( __( 'Link a new or existing PayPal account to make sure future orders are marked “Processing” instead of “On hold”, and so refunds can be issued without leaving WooCommerce.', 'woocommerce-services' ) ),
+					'button_text'    => __( 'Link account', 'woocommerce-services' ),
+					'button_link'    => wc_gateway_ppec()->ips->get_signup_url( 'live' ),
+					'image_url'      => plugins_url( 'images/cashier.svg', dirname( __FILE__ ) ),
+					'should_show_jp' => false,
+					'dismissible_id' => 'ppec',
+				)
+			);
 		}
 
 		/**
@@ -225,7 +231,7 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 				return;
 			} elseif ( ! isset( $settings['button_size'] ) ) { // Check if settings are initialized, represented by button_size as its absence would be first to affect the customer
 				$payment_gateways = WC()->payment_gateways->payment_gateways();
-				$gateway = $payment_gateways['ppec_paypal'];
+				$gateway          = $payment_gateways['ppec_paypal'];
 
 				foreach ( $gateway->form_fields as $key => $form_field ) {
 					if ( ! isset( $settings[ $key ] ) && isset( $form_field['default'] ) ) {
@@ -257,35 +263,40 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 				$form_fields = $this->adjust_api_subject_form_field( $form_fields );
 
 				// Prevent user from changing Payment Action away from "Sale", the only option for which payments will work
-				$form_fields['paymentaction']['disabled'] = true;
+				$form_fields['paymentaction']['disabled']    = true;
 				$form_fields['paymentaction']['description'] = sprintf( __( '%s (Note that "authorizing payment only" requires linking a PayPal account.)', 'woocommerce-services' ), $form_fields['paymentaction']['description'] );
 
 				// Communicate WCS proxying and provide option to disable
-				$reset_link = add_query_arg(
-					array( 'reroute_requests' => 'no', 'nonce' => wp_create_nonce( 'reroute_requests' ) ),
+				$reset_link         = add_query_arg(
+					array(
+						'reroute_requests' => 'no',
+						'nonce'            => wp_create_nonce( 'reroute_requests' ),
+					),
 					wc_gateway_ppec()->get_admin_setting_link()
 				);
 				$api_creds_template = __( 'Payments will be authenticated by WooCommerce Shipping & Tax and directed to the following email address. To disable this feature and link a PayPal account, <a href="%s">click here</a>.', 'woocommerce-services' );
 				if ( empty( $settings->api_username ) ) {
-					$api_creds_text = sprintf( $api_creds_template, add_query_arg( 'environment', 'live', $reset_link ) );
+					$api_creds_text                                = sprintf( $api_creds_template, add_query_arg( 'environment', 'live', $reset_link ) );
 					$form_fields['api_credentials']['description'] = $api_creds_text;
 					unset( $form_fields['api_username'], $form_fields['api_password'], $form_fields['api_signature'], $form_fields['api_certificate'] );
 				}
 				if ( empty( $settings->sandbox_api_username ) ) {
-					$api_creds_text = sprintf( $api_creds_template, add_query_arg( 'environment', 'sandbox', $reset_link ) );
+					$api_creds_text                                        = sprintf( $api_creds_template, add_query_arg( 'environment', 'sandbox', $reset_link ) );
 					$form_fields['sandbox_api_credentials']['description'] = $api_creds_text;
 					unset( $form_fields['sandbox_api_username'], $form_fields['sandbox_api_password'], $form_fields['sandbox_api_signature'], $form_fields['sandbox_api_certificate'] );
 				}
-
 			} else {
 				// Provide option to enable request proxying
-				$reset_link = add_query_arg(
-					array( 'reroute_requests' => 'yes', 'nonce' => wp_create_nonce( 'reroute_requests' ) ),
+				$reset_link         = add_query_arg(
+					array(
+						'reroute_requests' => 'yes',
+						'nonce'            => wp_create_nonce( 'reroute_requests' ),
+					),
 					wc_gateway_ppec()->get_admin_setting_link()
 				);
 				$api_creds_template = __( 'To authenticate payments with WooCommerce Shipping & Tax, <a href="%s">click here</a>.', 'woocommerce-services' );
 				if ( empty( $settings->api_username ) ) {
-					$api_creds_text = sprintf( $api_creds_template, add_query_arg( 'environment', 'live', $reset_link ) );
+					$api_creds_text                                 = sprintf( $api_creds_template, add_query_arg( 'environment', 'live', $reset_link ) );
 					$form_fields['api_credentials']['description'] .= '<br /><br />' . $api_creds_text;
 				}
 				if ( empty( $settings->sandbox_api_username ) ) {
@@ -301,16 +312,16 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 		 * Present the "API Subject" setting in a way that's simpler, more comprehensible, and more appropriate to the way it's being used
 		 */
 		public function adjust_api_subject_form_field( $form_fields ) {
-			$api_subject_title = __( 'Payment Email', 'woocommerce-services' );
-			$form_fields['api_subject']['title'] = $api_subject_title;
+			$api_subject_title                           = __( 'Payment Email', 'woocommerce-services' );
+			$form_fields['api_subject']['title']         = $api_subject_title;
 			$form_fields['sandbox_api_subject']['title'] = $api_subject_title;
 
-			$api_subject_description = __( 'Enter your email address at which to accept payments. You\'ll need to link your own account in order to perform anything other than "sale" transactions.', 'woocommerce-services' );
-			$form_fields['api_subject']['description'] = $api_subject_description;
+			$api_subject_description                           = __( 'Enter your email address at which to accept payments. You\'ll need to link your own account in order to perform anything other than "sale" transactions.', 'woocommerce-services' );
+			$form_fields['api_subject']['description']         = $api_subject_description;
 			$form_fields['sandbox_api_subject']['description'] = $api_subject_description;
 
-			$api_subject_placeholder = __( 'Required', 'woocommerce-services' );
-			$form_fields['api_subject']['placeholder'] = $api_subject_placeholder;
+			$api_subject_placeholder                           = __( 'Required', 'woocommerce-services' );
+			$form_fields['api_subject']['placeholder']         = $api_subject_placeholder;
 			$form_fields['sandbox_api_subject']['placeholder'] = $api_subject_placeholder;
 
 			return $form_fields;
@@ -328,7 +339,7 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 				return;
 			}
 
-			$settings = wc_gateway_ppec()->settings;
+			$settings                   = wc_gateway_ppec()->settings;
 			$settings->reroute_requests = 'yes' === $_GET['reroute_requests'] ? 'yes' : 'no';
 			if ( isset( $_GET['environment'] ) ) {
 				$settings->environment = 'sandbox' === $_GET['environment'] ? 'sandbox' : 'live';

--- a/classes/class-wc-connect-privacy.php
+++ b/classes/class-wc-connect-privacy.php
@@ -17,7 +17,7 @@ class WC_Connect_Privacy {
 
 	public function __construct( WC_Connect_Service_Settings_Store $settings_store, WC_Connect_API_Client $api_client ) {
 		$this->settings_store = $settings_store;
-		$this->api_client = $api_client;
+		$this->api_client     = $api_client;
 
 		add_action( 'admin_init', array( $this, 'add_privacy_message' ) );
 		add_action( 'admin_notices', array( $this, 'add_erasure_notice' ) );
@@ -33,12 +33,17 @@ class WC_Connect_Privacy {
 			return;
 		}
 
-		$title = __( 'WooCommerce Shipping & Tax', 'woocommerce-services' );
+		$title   = __( 'WooCommerce Shipping & Tax', 'woocommerce-services' );
 		$content = wpautop(
 			sprintf(
 				wp_kses(
 					__( 'By using this extension, you may be storing personal data or sharing data with external services. <a href="%s" target="_blank">Learn more about how this works, including what you may want to include in your privacy policy.</a>', 'woocommerce-services' ),
-					array( 'a' => array( 'href' => array(), 'target' => array() ) )
+					array(
+						'a' => array(
+							'href'   => array(),
+							'target' => array(),
+						),
+					)
 				),
 				'https://jetpack.com/support/for-your-privacy-policy/#woocommerce-services'
 			)
@@ -70,13 +75,14 @@ class WC_Connect_Privacy {
 
 	/**
 	 * Filter for woocommerce_privacy_export_order_personal_data that adds WCS personal data to the exported orders
+	 *
 	 * @param array  $personal_data
 	 * @param object $order
 	 * @return array
 	 */
 	public function label_data_exporter( $personal_data, $order ) {
 		$order_id = $order->get_id();
-		$labels = $this->settings_store->get_label_order_meta_data( $order_id );
+		$labels   = $this->settings_store->get_label_order_meta_data( $order_id );
 
 		foreach ( $labels as $label ) {
 			if ( empty( $label['tracking'] ) ) {
@@ -97,18 +103,19 @@ class WC_Connect_Privacy {
 
 	/**
 	 * Hooks into woocommerce_privacy_before_remove_order_personal_data to remove WCS personal data from orders
+	 *
 	 * @param object $order
 	 */
 	public function label_data_eraser( $order ) {
 		$order_id = $order->get_id();
-		$labels = $this->settings_store->get_label_order_meta_data( $order_id );
+		$labels   = $this->settings_store->get_label_order_meta_data( $order_id );
 		if ( empty( $labels ) ) {
 			return;
 		}
 
 		foreach ( $labels as $label_idx => $label ) {
 			$labels[ $label_idx ]['tracking'] = '';
-			$labels[ $label_idx ]['status'] = 'ANONYMIZED';
+			$labels[ $label_idx ]['status']   = 'ANONYMIZED';
 		}
 
 		$this->api_client->anonymize_order( $order_id );

--- a/classes/class-wc-connect-service-schemas-store.php
+++ b/classes/class-wc-connect-service-schemas-store.php
@@ -36,7 +36,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 
 			$old_schemas = $this->get_service_schemas();
 			if ( $old_schemas == $response_body ) {
-				//schemas weren't changed, but were fetched without problems
+				// schemas weren't changed, but were fetched without problems
 				return true;
 			}
 
@@ -62,7 +62,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 
 		protected function maybe_update_heartbeat() {
 			$last_heartbeat = WC_Connect_Options::get_option( 'last_heartbeat' );
-			$now = time();
+			$now            = time();
 
 			if ( ! $last_heartbeat ) {
 				$should_update = true;
@@ -72,7 +72,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 					// last heartbeat in the future? wacky
 					$should_update = true;
 				} else {
-					$elapsed = $now - $last_heartbeat;
+					$elapsed       = $now - $last_heartbeat;
 					$should_update = $elapsed > DAY_IN_SECONDS;
 				}
 			}
@@ -115,7 +115,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 		 */
 		public function get_all_shipping_method_ids() {
 			$shipping_method_ids = array();
-			$service_schemas = $this->get_service_schemas();
+			$service_schemas     = $this->get_service_schemas();
 			if ( ! is_object( $service_schemas ) || ! property_exists( $service_schemas, 'shipping' ) || ! is_array( $service_schemas->shipping ) ) {
 				return $shipping_method_ids;
 			}
@@ -236,7 +236,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 			}
 
 			$predefined_packages = array();
-			foreach( $service_schemas->shipping as $service_schema ) {
+			foreach ( $service_schemas->shipping as $service_schema ) {
 				if ( ! isset( $service_schema->packages ) ) {
 					continue;
 				}

--- a/classes/class-wc-connect-service-schemas-validator.php
+++ b/classes/class-wc-connect-service-schemas-validator.php
@@ -61,9 +61,9 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Validator' ) ) {
 		 * Validates a particular service schema, especially the parts of the service that WC relies
 		 * on like id, method_title, method_description, etc
 		 *
-		 * @param string $service_type
+		 * @param string  $service_type
 		 * @param integer $service_counter
-		 * @param object $service
+		 * @param object  $service
 		 *
 		 * @return WP_Error|true
 		 */
@@ -73,7 +73,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Validator' ) ) {
 				'method_description' => 'string',
 				'method_title'       => 'string',
 				'service_settings'   => 'object',
-				'form_layout'        => 'array'
+				'form_layout'        => 'array',
 			);
 
 			foreach ( $required_properties as $required_property => $required_property_type ) {
@@ -121,7 +121,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Validator' ) ) {
 			$required_properties = array(
 				'type'       => 'string',
 				'required'   => 'array',
-				'properties' => 'object'
+				'properties' => 'object',
 			);
 
 			foreach ( $required_properties as $required_property => $required_property_type ) {
@@ -171,7 +171,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Validator' ) ) {
 		 */
 		protected function validate_service_settings_required_properties( $service_id, $service_settings_properties ) {
 			$required_properties = array(
-				'title'
+				'title',
 			);
 
 			foreach ( $required_properties as $required_property ) {

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -21,8 +21,8 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 
 		public function __construct( WC_Connect_Service_Schemas_Store $service_schemas_store, WC_Connect_API_Client $api_client, WC_Connect_Logger $logger ) {
 			$this->service_schemas_store = $service_schemas_store;
-			$this->api_client = $api_client;
-			$this->logger     = $logger;
+			$this->api_client            = $api_client;
+			$this->logger                = $logger;
 		}
 
 		/**
@@ -32,15 +32,15 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 */
 		public function get_store_options() {
 			$currency_symbol = sanitize_text_field( html_entity_decode( get_woocommerce_currency_symbol() ) );
-			$dimension_unit = sanitize_text_field( strtolower( get_option( 'woocommerce_dimension_unit' ) ) );
-			$weight_unit = sanitize_text_field( strtolower( get_option( 'woocommerce_weight_unit' ) ) );
-			$base_location = wc_get_base_location();
+			$dimension_unit  = sanitize_text_field( strtolower( get_option( 'woocommerce_dimension_unit' ) ) );
+			$weight_unit     = sanitize_text_field( strtolower( get_option( 'woocommerce_weight_unit' ) ) );
+			$base_location   = wc_get_base_location();
 
 			return array(
 				'currency_symbol' => $currency_symbol,
-				'dimension_unit' => $this->translate_unit( $dimension_unit ),
-				'weight_unit' => $this->translate_unit( $weight_unit ),
-				'origin_country' => $base_location['country'],
+				'dimension_unit'  => $this->translate_unit( $dimension_unit ),
+				'weight_unit'     => $this->translate_unit( $weight_unit ),
+				'origin_country'  => $base_location['country'],
 			);
 		}
 
@@ -52,12 +52,12 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		public function get_account_settings() {
 			$default = array(
 				'selected_payment_method_id' => 0,
-				'enabled' => true,
+				'enabled'                    => true,
 			);
 
-			$result = WC_Connect_Options::get_option( 'account_settings', $default );
+			$result               = WC_Connect_Options::get_option( 'account_settings', $default );
 			$result['paper_size'] = $this->get_preferred_paper_size();
-			$result = array_merge( $default, $result );
+			$result               = array_merge( $default, $result );
 
 			if ( ! isset( $result['email_receipts'] ) ) {
 				$result['email_receipts'] = true;
@@ -74,7 +74,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @return true
 		 */
 		public function update_account_settings( $settings ) {
-			// simple validation for now
+			// simple validation for now.
 			if ( ! is_array( $settings ) ) {
 				$this->logger->log( 'Array expected but not received', __FUNCTION__ );
 				return false;
@@ -94,7 +94,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 
 		public function set_selected_payment_method_id( $new_payment_method_id ) {
 			$new_payment_method_id = intval( $new_payment_method_id );
-			$account_settings = $this->get_account_settings();
+			$account_settings      = $this->get_account_settings();
 			$old_payment_method_id = intval( $account_settings['selected_payment_method_id'] );
 			if ( $old_payment_method_id === $new_payment_method_id ) {
 				return;
@@ -111,33 +111,33 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		}
 
 		public function get_origin_address() {
-			$wc_address_fields = array();
+			$wc_address_fields            = array();
 			$wc_address_fields['company'] = html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES ); // HTML entities may be saved in the option.
-			$wc_address_fields['name'] = wp_get_current_user()->display_name;
-			$wc_address_fields['phone'] = '';
+			$wc_address_fields['name']    = wp_get_current_user()->display_name;
+			$wc_address_fields['phone']   = '';
 
 			$wc_countries = WC()->countries;
 			// WC 3.2 introduces ability to configure a full address in the settings
 			// Use it for address defaults if available
 			if ( method_exists( $wc_countries, 'get_base_address' ) ) {
-				$wc_address_fields['country'] = $wc_countries->get_base_country();
-				$wc_address_fields['state'] = $wc_countries->get_base_state();
-				$wc_address_fields['address'] = $wc_countries->get_base_address();
+				$wc_address_fields['country']   = $wc_countries->get_base_country();
+				$wc_address_fields['state']     = $wc_countries->get_base_state();
+				$wc_address_fields['address']   = $wc_countries->get_base_address();
 				$wc_address_fields['address_2'] = $wc_countries->get_base_address_2();
-				$wc_address_fields['city'] = $wc_countries->get_base_city();
-				$wc_address_fields['postcode'] = $wc_countries->get_base_postcode();
+				$wc_address_fields['city']      = $wc_countries->get_base_city();
+				$wc_address_fields['postcode']  = $wc_countries->get_base_postcode();
 			} else {
-				$base_location = wc_get_base_location();
-				$wc_address_fields['country'] = $base_location['country'];
-				$wc_address_fields['state'] = $base_location['state'];
-				$wc_address_fields['address'] = '';
+				$base_location                  = wc_get_base_location();
+				$wc_address_fields['country']   = $base_location['country'];
+				$wc_address_fields['state']     = $base_location['state'];
+				$wc_address_fields['address']   = '';
 				$wc_address_fields['address_2'] = '';
-				$wc_address_fields['city'] = '';
-				$wc_address_fields['postcode'] = '';
+				$wc_address_fields['city']      = '';
+				$wc_address_fields['postcode']  = '';
 			}
 
-			$stored_address_fields = WC_Connect_Options::get_option( 'origin_address', array() );
-			$merged_fields = array_merge( $wc_address_fields, $stored_address_fields );
+			$stored_address_fields    = WC_Connect_Options::get_option( 'origin_address', array() );
+			$merged_fields            = array_merge( $wc_address_fields, $stored_address_fields );
 			$merged_fields['company'] = html_entity_decode( $merged_fields['company'], ENT_QUOTES ); // Decode again for any existing stores that had some html entities saved in the option.
 			return $merged_fields;
 		}
@@ -148,7 +148,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				return $paper_size;
 			}
 			// According to https://en.wikipedia.org/wiki/Letter_(paper_size) US, Mexico, Canada and Dominican Republic
-			// use "Letter" size, and pretty much all the rest of the world use A4, so those are sensible defaults
+			// use "Letter" size, and pretty much all the rest of the world use A4, so those are sensible defaults.
 			$base_location = wc_get_base_location();
 			if ( in_array( $base_location['country'], array( 'US', 'CA', 'MX', 'DO' ), true ) ) {
 				return 'letter';
@@ -172,10 +172,10 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			$regex = '/"' . $field_name . '":"(.+?)","/';
 			preg_match_all( $regex, $json, $match_groups );
 			if ( 2 === count( $match_groups ) ) {
-				foreach ( $match_groups[ 0 ] as $idx => $match ) {
-					$value = $match_groups[ 1 ][ $idx ];
+				foreach ( $match_groups[0] as $idx => $match ) {
+					$value         = $match_groups[1][ $idx ];
 					$escaped_value = preg_replace( '/(?<!\\\)"/', '\\"', $value );
-					$json = str_replace( $match, '"' . $field_name . '":"' . $escaped_value . '","', $json );
+					$json          = str_replace( $match, '"' . $field_name . '":"' . $escaped_value . '","', $json );
 				}
 			}
 			return $json;
@@ -193,29 +193,29 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			$regex = '/"' . $field_name . '":\["(.+?)"\]/';
 			preg_match_all( $regex, $json, $match_groups );
 			if ( 2 === count( $match_groups ) ) {
-				foreach ( $match_groups[ 0 ] as $idx => $match ) {
-					$array = $match_groups[ 1 ][ $idx ];
+				foreach ( $match_groups[0] as $idx => $match ) {
+					$array         = $match_groups[1][ $idx ];
 					$escaped_array = preg_replace( '/(?<![,\\\])"(?!,)/', '\\"', $array );
-					$json = str_replace( '["' . $array . '"]', '["' . $escaped_array. '"]', $json );
+					$json          = str_replace( '["' . $array . '"]', '["' . $escaped_array . '"]', $json );
 				}
 			}
 			return $json;
 		}
 
 		public function try_deserialize_labels_json( $label_data ) {
-			//attempt to decode the JSON (legacy way of storing the labels data)
+			// attempt to decode the JSON (legacy way of storing the labels data).
 			$decoded_labels = json_decode( $label_data, true );
 			if ( $decoded_labels ) {
 				return $decoded_labels;
 			}
 
-			$label_data = $this->try_recover_invalid_json_string( 'package_name', $label_data );
+			$label_data     = $this->try_recover_invalid_json_string( 'package_name', $label_data );
 			$decoded_labels = json_decode( $label_data, true );
 			if ( $decoded_labels ) {
 				return $decoded_labels;
 			}
 
-			$label_data = $this->try_recover_invalid_json_array( 'product_names', $label_data );
+			$label_data     = $this->try_recover_invalid_json_array( 'product_names', $label_data );
 			$decoded_labels = json_decode( $label_data, true );
 			if ( $decoded_labels ) {
 				return $decoded_labels;
@@ -232,13 +232,13 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @return array
 		 */
 		public function get_label_order_meta_data( $order_id ) {
-			$label_data = get_post_meta( ( int ) $order_id, 'wc_connect_labels', true );
-			//return an empty array if the data doesn't exist
+			$label_data = get_post_meta( (int) $order_id, 'wc_connect_labels', true );
+			// return an empty array if the data doesn't exist.
 			if ( ! $label_data ) {
 				return array();
 			}
 
-			//labels stored as an array, return
+			// labels stored as an array, return.
 			if ( is_array( $label_data ) ) {
 				return $label_data;
 			}
@@ -255,11 +255,11 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @return array updated label info
 		 */
 		public function update_label_order_meta_data( $order_id, $new_label_data ) {
-			$result = $new_label_data;
+			$result      = $new_label_data;
 			$labels_data = $this->get_label_order_meta_data( $order_id );
-			foreach( $labels_data as $index => $label_data ) {
+			foreach ( $labels_data as $index => $label_data ) {
 				if ( $label_data['label_id'] === $new_label_data->label_id ) {
-					$result = array_merge( $label_data, (array) $new_label_data );
+					$result                = array_merge( $label_data, (array) $new_label_data );
 					$labels_data[ $index ] = $result;
 
 					if ( ! isset( $label_data['tracking'] )
@@ -276,7 +276,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * Adds new labels to the order
 		 *
 		 * @param $order_id
-		 * @param array $new_labels - labels to be added
+		 * @param array    $new_labels - labels to be added
 		 */
 		public function add_labels_to_order( $order_id, $new_labels ) {
 			$labels_data = $this->get_label_order_meta_data( $order_id );
@@ -289,13 +289,13 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		}
 
 		public function update_destination_address( $order_id, $api_address ) {
-			$order = wc_get_order( $order_id );
+			$order      = wc_get_order( $order_id );
 			$wc_address = $order->get_address( 'shipping' );
 
-			$new_address = array_merge( array(), ( array ) $wc_address, ( array ) $api_address );
-			//rename address to address_1
+			$new_address = array_merge( array(), (array) $wc_address, (array) $api_address );
+			// rename address to address_1.
 			$new_address['address_1'] = $new_address['address'];
-			//remove api-specific fields
+			// remove api-specific fields.
 			unset( $new_address['address'], $new_address['name'] );
 
 			$order->set_address( $new_address, 'shipping' );
@@ -346,7 +346,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			$enabled_services = array();
 
 			// Note: We use esc_sql here instead of prepare because we are using WHERE IN
-			// https://codex.wordpress.org/Function_Reference/esc_sql
+			// https://codex.wordpress.org/Function_Reference/esc_sql.
 
 			$escaped_list = '';
 			foreach ( $service_ids as $shipping_service ) {
@@ -362,7 +362,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				"LEFT JOIN {$wpdb->prefix}woocommerce_shipping_zones " .
 				"ON {$wpdb->prefix}woocommerce_shipping_zone_methods.zone_id = {$wpdb->prefix}woocommerce_shipping_zones.zone_id " .
 				"WHERE method_id IN ({$escaped_list}) " .
-				"ORDER BY zone_order, instance_id;"
+				'ORDER BY zone_order, instance_id;'
 			);
 
 			if ( empty( $methods ) ) {
@@ -370,19 +370,19 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			}
 
 			foreach ( (array) $methods as $method ) {
-				$service_schema = $this->service_schemas_store->get_service_schema_by_method_id( $method->method_id );
+				$service_schema   = $this->service_schemas_store->get_service_schema_by_method_id( $method->method_id );
 				$service_settings = $this->get_service_settings( $method->method_id, $method->instance_id );
 				if ( is_object( $service_settings ) && property_exists( $service_settings, 'title' ) ) {
 					$title = $service_settings->title;
-				} else if ( is_object( $service_schema ) && property_exists( $service_schema, 'method_title' ) ) {
+				} elseif ( is_object( $service_schema ) && property_exists( $service_schema, 'method_title' ) ) {
 					$title = $service_schema->method_title;
 				} else {
 					$title = _x( 'Unknown', 'A service with an unknown title and unknown method_title', 'woocommerce-services' );
 				}
 				$method->service_type = 'shipping';
-				$method->title = $title;
-				$method->zone_name = empty( $method->zone_name ) ? __( 'Rest of the World', 'woocommerce-services' ) : $method->zone_name;
-				$enabled_services[] = $method;
+				$method->title        = $title;
+				$method->zone_name    = empty( $method->zone_name ) ? __( 'Rest of the World', 'woocommerce-services' ) : $method->zone_name;
+				$enabled_services[]   = $method;
 			}
 
 			usort( $enabled_services, array( $this, 'sort_services' ) );
@@ -393,24 +393,24 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * Checks if the shipping method ids have been migrated to the "wc_services_*" format and migrates them
 		 */
 		public function migrate_legacy_services() {
-			if ( WC_Connect_Options::get_option( 'shipping_methods_migrated', false ) //check if the method have already been migrated
-				|| ! $this->service_schemas_store->fetch_service_schemas_from_connect_server() ) { //ensure the latest schemas are fetched
+			if ( WC_Connect_Options::get_option( 'shipping_methods_migrated', false ) // check if the method have already been migrated.
+				|| ! $this->service_schemas_store->fetch_service_schemas_from_connect_server() ) { // ensure the latest schemas are fetched.
 				return;
 			}
 
 			global $wpdb;
 
-			//old services used the id field instead of method_id
+			// old services used the id field instead of method_id.
 			$shipping_service_ids = $this->service_schemas_store->get_all_service_ids_of_type( 'shipping' );
-			$legacy_services = $this->get_enabled_services_by_ids( $shipping_service_ids );
+			$legacy_services      = $this->get_enabled_services_by_ids( $shipping_service_ids );
 
 			foreach ( $legacy_services as $legacy_service ) {
-				$service_id = $legacy_service->method_id;
-				$instance_id = $legacy_service->instance_id;
-				$service_schema = $this->service_schemas_store->get_service_schema_by_id( $service_id );
+				$service_id       = $legacy_service->method_id;
+				$instance_id      = $legacy_service->instance_id;
+				$service_schema   = $this->service_schemas_store->get_service_schema_by_id( $service_id );
 				$service_settings = $this->get_service_settings( $service_id, $instance_id );
-				if ( ( is_array( $service_settings ) && ! $service_settings ) //check for an empty array
-					|| ( ! is_array( $service_settings ) && ! is_object( $service_settings ) ) ) { //settings are neither an array nor an object
+				if ( ( is_array( $service_settings ) && ! $service_settings ) // check for an empty array.
+					|| ( ! is_array( $service_settings ) && ! is_object( $service_settings ) ) ) { // settings are neither an array nor an object.
 					continue;
 				}
 
@@ -419,13 +419,17 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				$wpdb->update(
 					"{$wpdb->prefix}woocommerce_shipping_zone_methods",
 					array( 'method_id' => $new_method_id ),
-					array( 'instance_id' => $instance_id, 'method_id' => $service_id ),
+					array(
+						'instance_id' => $instance_id,
+						'method_id'   => $service_id,
+					),
 					array( '%s' ),
-					array( '%d', '%s' ) );
+					array( '%d', '%s' )
+				);
 
-				//update the migrated service settings
+				// update the migrated service settings.
 				WC_Connect_Options::update_shipping_method_option( 'form_settings', $service_settings, $new_method_id, $instance_id );
-				//delete the old service settings
+				// delete the old service settings.
 				WC_Connect_Options::delete_shipping_method_options( $service_id, $instance_id );
 			}
 
@@ -436,7 +440,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * Given a service's id and optional instance, returns the settings for that
 		 * service or an empty array
 		 *
-		 * @param string $service_id
+		 * @param string  $service_id
 		 * @param integer $service_instance
 		 *
 		 * @return object|array
@@ -452,7 +456,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 */
 		public function validate_and_possibly_update_settings( $settings, $id, $instance = false ) {
 
-			// Validate instance or at least id if no instance is given
+			// Validate instance or at least id if no instance is given.
 			if ( ! empty( $instance ) ) {
 				$service_schema = $this->service_schemas_store->get_service_schema_by_instance_id( $instance );
 				if ( ! $service_schema ) {
@@ -465,7 +469,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				}
 			}
 
-			// Validate settings with WCC server
+			// Validate settings with WCC server.
 			$response_body = $this->api_client->validate_service_settings( $service_schema->id, $settings );
 
 			if ( is_wp_error( $response_body ) ) {
@@ -473,9 +477,9 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				return $response_body;
 			}
 
-			// On success, save the settings to the database and exit
+			// On success, save the settings to the database and exit.
 			WC_Connect_Options::update_shipping_method_option( 'form_settings', $settings, $id, $instance );
-			// Invalidate shipping rates session cache
+			// Invalidate shipping rates session cache.
 			WC_Cache_Helper::get_transient_version( 'shipping', /* $refresh = */ true );
 			do_action( 'wc_connect_saved_service_settings', $id, $instance, $settings );
 
@@ -536,7 +540,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		public function get_package_lookup() {
 			$lookup = array();
 
-			$custom_packages =  $this->get_packages();
+			$custom_packages = $this->get_packages();
 			foreach ( $custom_packages as $custom_package ) {
 				$lookup[ $custom_package['name'] ] = $custom_package;
 			}
@@ -549,7 +553,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			foreach ( $predefined_packages_schema as $service_id => $groups ) {
 				foreach ( $groups as $group ) {
 					foreach ( $group->definitions as $predefined ) {
-						$lookup[ $predefined->id ] = ( array ) $predefined;
+						$lookup[ $predefined->id ] = (array) $predefined;
 					}
 				}
 			}
@@ -560,23 +564,23 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		private function translate_unit( $value ) {
 			switch ( $value ) {
 				case 'kg':
-					return __('kg', 'woocommerce-services');
+					return __( 'kg', 'woocommerce-services' );
 				case 'g':
-					return __('g', 'woocommerce-services');
+					return __( 'g', 'woocommerce-services' );
 				case 'lbs':
-					return __('lbs', 'woocommerce-services');
+					return __( 'lbs', 'woocommerce-services' );
 				case 'oz':
-					return __('oz', 'woocommerce-services');
+					return __( 'oz', 'woocommerce-services' );
 				case 'm':
-					return __('m', 'woocommerce-services');
+					return __( 'm', 'woocommerce-services' );
 				case 'cm':
-					return __('cm', 'woocommerce-services');
+					return __( 'cm', 'woocommerce-services' );
 				case 'mm':
-					return __('mm', 'woocommerce-services');
+					return __( 'mm', 'woocommerce-services' );
 				case 'in':
-					return __('in', 'woocommerce-services');
+					return __( 'in', 'woocommerce-services' );
 				case 'yd':
-					return __('yd', 'woocommerce-services');
+					return __( 'yd', 'woocommerce-services' );
 				default:
 					$this->logger->log( 'Unexpected measurement unit: ' . $value, __FUNCTION__ );
 					return $value;

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -20,10 +20,10 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 		protected $api_client;
 
 		public function __construct( WC_Connect_API_Client $api_client ) {
-			$this->id    = 'connect';
-			$this->label = _x( 'WooCommerce Shipping', 'The WooCommerce Shipping & Tax brandname', 'woocommerce-services' );
+			$this->id         = 'connect';
+			$this->label      = _x( 'WooCommerce Shipping', 'The WooCommerce Shipping & Tax brandname', 'woocommerce-services' );
 			$this->continents = new WC_Connect_Continents();
-            $this->api_client = $api_client;
+			$this->api_client = $api_client;
 
 			add_filter( 'woocommerce_get_sections_shipping', array( $this, 'get_sections' ), 30 );
 			add_action( 'woocommerce_settings_shipping', array( $this, 'output_settings_screen' ), 5 );
@@ -39,7 +39,7 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 				$shipping_tabs = array();
 			}
 
-			$shipping_tabs[ 'woocommerce-services-settings' ] = __( 'WooCommerce Shipping', 'woocommerce-services' );
+			$shipping_tabs['woocommerce-services-settings'] = __( 'WooCommerce Shipping', 'woocommerce-services' );
 			return $shipping_tabs;
 		}
 
@@ -61,7 +61,7 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 		 * Localizes the bootstrap, enqueues the script and styles for the settings page
 		 */
 		public function output_shipping_settings_screen() {
-			// hiding the save button because the react container has its own
+			// hiding the save button because the react container has its own.
 			global $hide_save_button;
 			$hide_save_button = true;
 
@@ -80,40 +80,45 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 				<?php
 			}
 
-			$extra_args = array();
+			$extra_args        = array();
 			$carriers_response = $this->api_client->get_carrier_accounts();
 			if ( ! is_wp_error( $carriers_response ) && $carriers_response ) {
-				$extra_args[ 'carriers' ] = $carriers_response->carriers;
+				$extra_args['carriers'] = $carriers_response->carriers;
 			}
 
 			$subscriptions_usage_response = $this->api_client->get_wccom_subscriptions();
 
 			if ( ! is_wp_error( $subscriptions_usage_response ) && $subscriptions_usage_response ) {
-				$extra_args[ 'subscriptions' ] = $subscriptions_usage_response->subscriptions;
+				$extra_args['subscriptions'] = $subscriptions_usage_response->subscriptions;
 			}
 
 			if ( isset( $_GET['from_order'] ) ) {
-				$extra_args['order_id'] = $_GET['from_order'];
+				$extra_args['order_id']   = $_GET['from_order'];
 				$extra_args['order_href'] = get_edit_post_link( $_GET['from_order'] );
 			}
 
-			if ( !empty( $_GET['carrier'] ) ) {
+			if ( ! empty( $_GET['carrier'] ) ) {
 				$extra_args['carrier']    = $_GET['carrier'];
 				$extra_args['continents'] = $this->continents->get();
 
 				$carrier_information = [];
-				if( $extra_args[ 'carriers' ] ) {
-					$carrier_information = array_values( array_filter( $extra_args[ 'carriers' ], function( $carrier ) {
-						return $carrier->type === $_GET['carrier'];
-					} ) );
+				if ( $extra_args['carriers'] ) {
+					$carrier_information = array_values(
+						array_filter(
+							$extra_args['carriers'],
+							function( $carrier ) {
+								return $carrier->type === $_GET['carrier'];
+							}
+						)
+					);
 				}
-				if ( !empty( $carrier_information ) ) {
-				?>
+				if ( ! empty( $carrier_information ) ) {
+					?>
 					<h2>
 						<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings' ) ); ?>"><?php esc_html_e( 'WooCommerce Shipping & Tax', 'woocommerce-services' ); ?></a> &gt;
 						<span><?php echo esc_html( $carrier_information[0]->carrier ); ?></span>
 					</h2>
-				<?php
+					<?php
 				}
 			}
 

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -52,18 +52,18 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			WC_Connect_Service_Schemas_Store $service_schemas_store,
 			WC_Connect_Payment_Methods_Store $payment_methods_store
 		) {
-			$this->api_client = $api_client;
-			$this->settings_store = $settings_store;
+			$this->api_client            = $api_client;
+			$this->settings_store        = $settings_store;
 			$this->service_schemas_store = $service_schemas_store;
-			$this->account_settings = new WC_Connect_Account_Settings(
-					$settings_store,
-					$payment_methods_store
+			$this->account_settings      = new WC_Connect_Account_Settings(
+				$settings_store,
+				$payment_methods_store
 			);
-			$this->package_settings = new WC_Connect_Package_Settings(
-					$settings_store,
-					$service_schemas_store
+			$this->package_settings      = new WC_Connect_Package_Settings(
+				$settings_store,
+				$service_schemas_store
 			);
-			$this->continents = new WC_Connect_Continents();
+			$this->continents            = new WC_Connect_Continents();
 		}
 
 		public function get_item_data( WC_Order $order, $item ) {
@@ -74,7 +74,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			$height = 0;
 			$length = 0;
 			$weight = $product->get_weight();
-			$width = 0;
+			$width  = 0;
 
 			if ( $product->has_dimensions() ) {
 				$height = $product->get_height();
@@ -110,25 +110,25 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				return array();
 			}
 
-			// WC3 retrieves metadata as non-scalar values
+			// WC3 retrieves metadata as non-scalar values.
 			if ( is_array( $packages_data ) ) {
 				return $packages_data;
 			}
 
-			// WC2.6 stores non-scalar values as string, but doesn't deserialize it on retrieval
+			// WC2.6 stores non-scalar values as string, but doesn't deserialize it on retrieval.
 			$packages = maybe_unserialize( $packages_data );
 			if ( is_array( $packages ) ) {
 				return $packages;
 			}
 
-			// legacy WCS stored the labels as JSON
+			// legacy WCS stored the labels as JSON.
 			$packages = json_decode( $packages_data, true );
 			if ( $packages ) {
 				return $packages;
 			}
 
 			$packages_data = $this->settings_store->try_recover_invalid_json_string( 'box_id', $packages_data );
-			$packages = json_decode( $packages_data, true );
+			$packages      = json_decode( $packages_data, true );
 			if ( $packages ) {
 				return $packages;
 			}
@@ -161,7 +161,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		public function get_selected_packages( WC_Order $order ) {
 			$packages = $this->get_packaging_metadata( $order );
 			if ( ! $packages ) {
-				$items = $this->get_all_items( $order );
+				$items  = $this->get_all_items( $order );
 				$weight = array_sum( wp_list_pluck( $items, 'weight' ) );
 
 				$packages = array(
@@ -180,19 +180,19 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			$formatted_packages = array();
 
 			foreach ( $packages as $package_obj ) {
-				$package = ( array ) $package_obj;
-				$package_id = $package['id'];
+				$package                           = (array) $package_obj;
+				$package_id                        = $package['id'];
 				$formatted_packages[ $package_id ] = $package;
 
 				foreach ( $package['items'] as $item_index => $item ) {
-					$product_data = ( array ) $item;
-					$product = WC_Connect_Compatibility::instance()->get_item_product( $order, $product_data );
+					$product_data = (array) $item;
+					$product      = WC_Connect_Compatibility::instance()->get_item_product( $order, $product_data );
 
 					if ( $product ) {
 						$product_data['name'] = $this->get_name( $product );
-						$product_data['url'] = get_edit_post_link( WC_Connect_Compatibility::instance()->get_parent_product_id( $product ), null );
+						$product_data['url']  = get_edit_post_link( WC_Connect_Compatibility::instance()->get_parent_product_id( $product ), null );
 						if ( $product->is_type( 'variation' ) ) {
-							$formatted = WC_Connect_Compatibility::instance()->get_formatted_variation( $product, true );
+							$formatted                  = WC_Connect_Compatibility::instance()->get_formatted_variation( $product, true );
 							$product_data['attributes'] = $formatted;
 						}
 						$customs_info = get_post_meta( $product_data['product_id'], 'wc_connect_customs_info', true );
@@ -236,12 +236,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 		public function get_selected_rates( WC_Order $order ) {
 			$shipping_methods = $order->get_shipping_methods();
-			$shipping_method = reset( $shipping_methods );
-			$packages = $this->get_packaging_from_shipping_method( $shipping_method );
-			$rates = array();
+			$shipping_method  = reset( $shipping_methods );
+			$packages         = $this->get_packaging_from_shipping_method( $shipping_method );
+			$rates            = array();
 
 			foreach ( $packages as $idx => $package_obj ) {
-				$package = ( array ) $package_obj;
+				$package = (array) $package_obj;
 				// Abort if the package data is malformed
 				if ( ! isset( $package['id'] ) || ! isset( $package['service_id'] ) ) {
 					return array();
@@ -254,7 +254,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		}
 
 		protected function format_address_for_api( $address ) {
-			// Combine first and last name
+			// Combine first and last name.
 			if ( ! isset( $address['name'] ) ) {
 				$first_name = isset( $address['first_name'] ) ? trim( $address['first_name'] ) : '';
 				$last_name  = isset( $address['last_name'] ) ? trim( $address['last_name'] ) : '';
@@ -262,12 +262,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				$address['name'] = $first_name . ' ' . $last_name;
 			}
 
-			// Rename address_1 to address
+			// Rename address_1 to address.
 			if ( ! isset( $address['address'] ) && isset( $address['address_1'] ) ) {
 				$address['address'] = $address['address_1'];
 			}
 
-			// Remove now defunct keys
+			// Remove now defunct keys.
 			unset( $address['first_name'], $address['last_name'], $address['address_1'] );
 
 			return $address;
@@ -287,24 +287,24 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		}
 
 		protected function get_form_data( WC_Order $order ) {
-			$order_id               = WC_Connect_Compatibility::instance()->get_order_id( $order );
-			$selected_packages      = $this->get_selected_packages( $order );
-			$is_packed              = ( false !== $this->get_packaging_metadata( $order ) );
-			$origin                 = $this->get_origin_address();
-			$selected_rates         = $this->get_selected_rates( $order );
-			$destination            = $this->get_destination_address( $order );
+			$order_id          = WC_Connect_Compatibility::instance()->get_order_id( $order );
+			$selected_packages = $this->get_selected_packages( $order );
+			$is_packed         = ( false !== $this->get_packaging_metadata( $order ) );
+			$origin            = $this->get_origin_address();
+			$selected_rates    = $this->get_selected_rates( $order );
+			$destination       = $this->get_destination_address( $order );
 
 			if ( ! $destination['country'] ) {
 				$destination['country'] = $origin['country'];
 			}
 
-			$origin_normalized = ( bool ) WC_Connect_Options::get_option( 'origin_address', false );
-			$destination_normalized = ( bool ) get_post_meta( $order_id, '_wc_connect_destination_normalized', true );
+			$origin_normalized      = (bool) WC_Connect_Options::get_option( 'origin_address', false );
+			$destination_normalized = (bool) get_post_meta( $order_id, '_wc_connect_destination_normalized', true );
 
 			$form_data = compact( 'is_packed', 'selected_packages', 'origin', 'destination', 'origin_normalized', 'destination_normalized' );
 
 			$form_data['rates'] = array(
-				'selected'  => (object) $selected_rates,
+				'selected' => (object) $selected_rates,
 			);
 
 			$form_data['order_id'] = $order_id;
@@ -323,17 +323,21 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		public function is_dhl_express_available() {
 			$dhl_express = $this->service_schemas_store->get_service_schema_by_id( 'dhlexpress' );
 
-			return !! $dhl_express;
+			return ! ! $dhl_express;
 		}
 
 		public function is_order_dhl_express_eligible() {
-			if( ! $this-> is_dhl_express_available() ) return false;
+			if ( ! $this->is_dhl_express_available() ) {
+				return false;
+			}
 
 			$order = wc_get_order();
-			if ( ! $order ) return false;
+			if ( ! $order ) {
+				return false;
+			}
 
-			$origin         = $this->get_origin_address();
-			$destination    = $this->get_destination_address( $order );
+			$origin      = $this->get_origin_address();
+			$destination = $this->get_destination_address( $order );
 
 			return $origin['country'] !== $destination['country'];
 		}
@@ -369,12 +373,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				return false;
 			}
 
-			// If the order was created using WCS checkout rates, show the meta-box regardless of the products' state
+			// If the order was created using WCS checkout rates, show the meta-box regardless of the products' state.
 			if ( $this->get_packaging_metadata( $order ) ) {
 				return true;
 			}
 
-			// At this point (no packaging data), only show if there's at least one existing and shippable product
+			// At this point (no packaging data), only show if there's at least one existing and shippable product.
 			foreach ( $order->get_items() as $item ) {
 				$product = WC_Connect_Compatibility::instance()->get_item_product( $order, $item );
 				if ( $product && $product->needs_shipping() ) {
@@ -392,13 +396,13 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			}
 
 			$order_id = WC_Connect_Compatibility::instance()->get_order_id( $order );
-			$payload = array(
+			$payload  = array(
 				'orderId'            => $order_id,
 				'paperSize'          => $this->settings_store->get_preferred_paper_size(),
 				'formData'           => $this->get_form_data( $order ),
 				'labelsData'         => $this->settings_store->get_label_order_meta_data( $order_id ),
 				'storeOptions'       => $this->settings_store->get_store_options(),
-				//for backwards compatibility, still disable the country dropdown for calypso users with older plugin versions
+				// for backwards compatibility, still disable the country dropdown for calypso users with older plugin versions.
 				'canChangeCountries' => true,
 			);
 
@@ -435,7 +439,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			$order_id                = WC_Connect_Compatibility::instance()->get_order_id( $order );
 			$items                   = array_filter( $order->get_items(), array( $this, 'filter_items_needing_shipping' ) );
 			$items_count             = array_reduce( $items, array( $this, 'reducer_items_quantity' ), 0 );
-			$payload                 = apply_filters( 'wc_connect_meta_box_payload',
+			$payload                 = apply_filters(
+				'wc_connect_meta_box_payload',
 				array(
 					'order'             => $connect_order_presenter->get_order_for_api( $order ),
 					'accountSettings'   => $this->account_settings->get(),
@@ -443,7 +448,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 					'shippingLabelData' => $this->get_label_payload( $order_id ),
 					'continents'        => $this->continents->get(),
 					'context'           => $args['args']['context'],
-					'items'             => $items_count
+					'items'             => $items_count,
 				),
 				$args,
 				$order,

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -27,8 +27,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		public function __construct( $id_or_instance_id = null ) {
 			parent::__construct( $id_or_instance_id );
 
-			// If $arg looks like a number, treat it as an instance_id
-			// Otherwise, treat it as a (method) id (e.g. wc_connect_usps)
+			// If $arg looks like a number, treat it as an instance_id,
+			// otherwise, treat it as a (method) id (e.g. wc_connect_usps).
 			if ( is_numeric( $id_or_instance_id ) ) {
 				$this->instance_id = absint( $id_or_instance_id );
 			} else {
@@ -53,30 +53,30 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 					'Error. A WC_Connect_Shipping_Method was constructed without an id or instance_id',
 					__FUNCTION__
 				);
-				$this->id = 'wc_connect_uninitialized_shipping_method';
-				$this->method_title = '';
+				$this->id                 = 'wc_connect_uninitialized_shipping_method';
+				$this->method_title       = '';
 				$this->method_description = '';
-				$this->supports = array();
-				$this->title = '';
+				$this->supports           = array();
+				$this->title              = '';
 			} else {
-				$this->id = $this->service_schema->method_id;
-				$this->method_title = $this->service_schema->method_title;
+				$this->id                 = $this->service_schema->method_id;
+				$this->method_title       = $this->service_schema->method_title;
 				$this->method_description = $this->service_schema->method_description;
-				$this->supports = array(
+				$this->supports           = array(
 					'shipping-zones',
-					'instance-settings'
+					'instance-settings',
 				);
 
-				// Set title to default value
+				// Set title to default value.
 				$this->title = $this->service_schema->method_title;
 
-				// Load form values from options, updating title if present
+				// Load form values from options, updating title if present.
 				$this->init_form_settings();
 
 				// Note - we cannot hook admin_enqueue_scripts here because we need an instance id
 				// and this constructor is not called with an instance id until after
 				// admin_enqueue_scripts has already fired.  This is why WC_Connect_Loader
-				// does it instead
+				// does it instead.
 			}
 		}
 
@@ -136,7 +136,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		 *
 		 * @see WC_Connect_Logger::debug()
 		 * @param string|WP_Error $message
-		 * @param string $context
+		 * @param string          $context
 		 */
 		protected function log( $message, $context = '' ) {
 
@@ -160,14 +160,13 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		/**
 		 * Restores any values persisted to the DB for this service instance
 		 * and sets up title for WC core to work properly
-		 *
 		 */
 		protected function init_form_settings() {
 
 			$form_settings = $this->get_service_settings();
 
 			// We need to initialize the instance title ($this->title)
-			// from the settings blob
+			// from the settings blob.
 			if ( property_exists( $form_settings, 'title' ) ) {
 				$this->title = $form_settings->title;
 			}
@@ -207,19 +206,19 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			$postcode = isset( $package['destination']['postcode'] ) ? $package['destination']['postcode'] : '';
 			$state    = isset( $package['destination']['state'] ) ? $package['destination']['state'] : '';
 
-			// Ensure that Country is specified
+			// Ensure that Country is specified.
 			if ( empty( $country ) ) {
 				$this->debug( 'Skipping rate calculation - missing country', 'error' );
 				return false;
 			}
 
-			// Validate Postcode
+			// Validate Postcode.
 			if ( ! WC_Validation::is_postcode( $postcode, $country ) ) {
 				$this->debug( 'Skipping rate calculation - invalid postcode', 'error' );
 				return false;
 			}
 
-			// Validate State
+			// Validate State.
 			$valid_states = WC()->countries->get_states( $country );
 
 			if ( $valid_states && ! array_key_exists( $state, $valid_states ) ) {
@@ -232,9 +231,9 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		}
 
 		private function lookup_product( $package, $product_id ) {
-			foreach ( $package[ 'contents' ] as $item ) {
-				if ( $item[ 'product_id' ] === $product_id || $item[ 'variation_id' ] === $product_id ) {
-					return $item[ 'data' ];
+			foreach ( $package['contents'] as $item ) {
+				if ( $item['product_id'] === $product_id || $item['variation_id'] === $product_id ) {
+					return $item['data'];
 				}
 			}
 
@@ -288,9 +287,9 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			$this->debug( 'No rates found, adding fallback.', 'error' );
 
 			$rate_to_add = array(
-				'id'        => self::format_rate_id( 'fallback', $this->id, 0 ),
-				'label'     => self::format_rate_title( $this->service_schema->carrier_name ),
-				'cost'      => $service_settings->fallback_rate,
+				'id'    => self::format_rate_id( 'fallback', $this->id, 0 ),
+				'label' => self::format_rate_title( $this->service_schema->carrier_name ),
+				'cost'  => $service_settings->fallback_rate,
 			);
 
 			$this->add_rate( $rate_to_add );
@@ -301,10 +300,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				return;
 			}
 
-			$this->debug( sprintf(
-				'WooCommerce Shipping & Tax debug mode is on - to hide these messages, turn debug mode off in the <a href="%s" style="text-decoration: underline;">settings</a>.',
-				admin_url( 'admin.php?page=wc-status&tab=connect' )
-			) );
+			$this->debug(
+				sprintf(
+					'WooCommerce Shipping & Tax debug mode is on - to hide these messages, turn debug mode off in the <a href="%s" style="text-decoration: underline;">settings</a>.',
+					admin_url( 'admin.php?page=wc-status&tab=connect' )
+				)
+			);
 
 			if ( ! $this->is_valid_package_destination( $package ) ) {
 				return;
@@ -326,7 +327,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			}
 
 			// TODO: Request rates for all WooCommerce Shipping & Tax powered methods in
-			// the current shipping zone to avoid each method making an independent request
+			// the current shipping zone to avoid each method making an independent request.
 			$services = array(
 				array(
 					'id'               => $this->service_schema->id,
@@ -335,13 +336,13 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				),
 			);
 
-			$custom_boxes = $this->service_settings_store->get_packages();
+			$custom_boxes     = $this->service_settings_store->get_packages();
 			$predefined_boxes = $this->service_settings_store->get_predefined_packages_for_service( $this->service_schema->id );
 			$predefined_boxes = array_values( array_filter( $predefined_boxes, array( $this, 'filter_preset_boxes' ) ) );
 
-			$cache_key = sprintf(
+			$cache_key     = sprintf(
 				'wcs_rates_%s',
-				md5( serialize( array( $services, $package, $custom_boxes, $predefined_boxes ) ) )
+				md5( serialize( array( $services, $package, $custom_boxes, $predefined_boxes ) ) ) // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 			);
 			$is_debug_mode = 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' );
 			$response_body = get_transient( $cache_key );
@@ -379,24 +380,24 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 					$measurements_format = '(%s x %s x %s ' . $dimension_unit . ', %s ' . $weight_unit . ')';
 
 					foreach ( $rate->packages as $rate_package ) {
-						$service_ids[]  = $rate_package->service_id;
+						$service_ids[] = $rate_package->service_id;
 
 						$item_product_ids = array();
 						$item_by_product  = array();
 						foreach ( $rate_package->items as $package_item ) {
-							$item_product_ids[] = $package_item->product_id;
+							$item_product_ids[]                           = $package_item->product_id;
 							$item_by_product[ $package_item->product_id ] = $package_item;
 						}
 
 						$product_summaries = array();
-						$product_counts = array_count_values( $item_product_ids );
+						$product_counts    = array_count_values( $item_product_ids );
 						foreach ( $product_counts as $product_id => $count ) {
 							/** @var WC_Product $product */
 							$product = $this->lookup_product( $package, $product_id );
 							if ( $product ) {
-								$item_name = WC_Connect_Compatibility::instance()->get_product_name( $product );
-								$item = $item_by_product[ $product_id ];
-								$item_measurements = sprintf( $measurements_format, $item->length, $item->width, $item->height, $item->weight );
+								$item_name           = WC_Connect_Compatibility::instance()->get_product_name( $product );
+								$item                = $item_by_product[ $product_id ];
+								$item_measurements   = sprintf( $measurements_format, $item->length, $item->width, $item->height, $item->weight );
 								$product_summaries[] =
 									( $count > 1 ? sprintf( '<em>%d x</em> ', $count ) : '' ) .
 									sprintf( '(ID: %d) <strong>%s</strong> %s', $product_id, esc_html( $item_name ), esc_html( $item_measurements ) );
@@ -407,13 +408,13 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 						if ( ! property_exists( $rate_package, 'box_id' ) ) {
 							$package_name = __( 'Unknown package', 'woocommerce-services' );
-						} else if ( 'individual' === $rate_package->box_id ) {
+						} elseif ( 'individual' === $rate_package->box_id ) {
 							$package_name = __( 'Individual packaging', 'woocommerce-services' );
-						} else if (
+						} elseif (
 							isset( $packaging_lookup[ $rate_package->box_id ] ) &&
 							isset( $packaging_lookup[ $rate_package->box_id ]['name'] )
 						) {
-							$package_name = $packaging_lookup[ $rate_package->box_id ]['name'];
+							$package_name         = $packaging_lookup[ $rate_package->box_id ]['name'];
 							$package_measurements = sprintf(
 								$measurements_format,
 								$rate_package->length,
@@ -438,7 +439,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 						'label'     => self::format_rate_title( $rate->title ),
 						'cost'      => $rate->rate,
 						'meta_data' => array(
-							'wc_connect_packages' => $rate->packages,
+							'wc_connect_packages'    => $rate->packages,
 							__( 'Packaging', 'woocommerce-services' ) => $packaging_info,
 							'wc_connect_packing_log' => $box_packing_log,
 						),
@@ -497,7 +498,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		}
 
 		public function admin_options() {
-			// hide WP native save button on settings page
+			// hide WP native save button on settings page.
 			global $hide_save_button;
 			$hide_save_button = true;
 
@@ -506,7 +507,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 		/**
 		 * @param string $method_id
-		 * @param int $instance_id
+		 * @param int    $instance_id
 		 * @param string $service_ids
 		 *
 		 * @return string
@@ -519,11 +520,11 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			$formatted_title = wp_kses(
 				html_entity_decode( $rate_title ),
 				array(
-					'sup' => array(),
-					'del' => array(),
-					'small' => array(),
-					'em' => array(),
-					'i' => array(),
+					'sup'    => array(),
+					'del'    => array(),
+					'small'  => array(),
+					'em'     => array(),
+					'i'      => array(),
 					'strong' => array(),
 				)
 			);
@@ -582,7 +583,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				return true;
 			}
 
-			// Go through the cart contents and check if all products are supported
+			// Go through the cart contents and check if all products are supported.
 			foreach ( $package['contents'] as $item ) {
 				$shipping_class_id = $item['data']->get_shipping_class_id();
 
@@ -605,11 +606,13 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 					}
 				}
 
-				$method_classes = get_terms( array(
-					'taxonomy'   => 'product_shipping_class',
-					'hide_empty' => false,
-					'include'    => $method_classes,
-				) );
+				$method_classes = get_terms(
+					array(
+						'taxonomy'   => 'product_shipping_class',
+						'hide_empty' => false,
+						'include'    => $method_classes,
+					)
+				);
 
 				if ( ! is_wp_error( $method_classes ) && ! empty( $method_classes ) ) {
 					$class_names = implode( ', ', wp_list_pluck( $method_classes, 'name' ) );

--- a/classes/class-wc-connect-tracks.php
+++ b/classes/class-wc-connect-tracks.php
@@ -16,7 +16,7 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 		protected $logger;
 
 		public function __construct( WC_Connect_Logger $logger, $plugin_file ) {
-			$this->logger = $logger;
+			$this->logger      = $logger;
 			$this->plugin_file = $plugin_file;
 		}
 
@@ -70,7 +70,7 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 				$this->debug( 'Error. jetpack_tracks_record_event is not defined.' );
 				return;
 			}
-			$user = wp_get_current_user();
+			$user     = wp_get_current_user();
 			$site_url = get_option( 'siteurl' );
 
 			$wcs_version = WC_Connect_Loader::get_wcs_version();
@@ -97,16 +97,16 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 				$data = array();
 			}
 
-			$data['_via_ua'] = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
-			$data['_via_ip'] = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : '';
-			$data['_lg'] = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? $_SERVER['HTTP_ACCEPT_LANGUAGE'] : '';
-			$data['blog_url'] = $site_url;
-			$data['blog_id'] = $jetpack_blog_id;
-			$data['wcs_version'] = $wcs_version;
+			$data['_via_ua']         = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
+			$data['_via_ip']         = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : '';
+			$data['_lg']             = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? $_SERVER['HTTP_ACCEPT_LANGUAGE'] : '';
+			$data['blog_url']        = $site_url;
+			$data['blog_id']         = $jetpack_blog_id;
+			$data['wcs_version']     = $wcs_version;
 			$data['jetpack_version'] = $jp_version;
-			$data['is_atomic'] = $is_atomic;
-			$data['wc_version'] = $wc_version;
-			$data['wp_version'] = get_bloginfo( 'version' );
+			$data['is_atomic']       = $is_atomic;
+			$data['wc_version']      = $wc_version;
+			$data['wp_version']      = get_bloginfo( 'version' );
 
 			$event_type = self::$product_name . '_' . $event_type;
 

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -27,15 +27,19 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 		$this->payment_methods_store = $payment_methods_store;
 
 		$this->account_settings = new WC_Connect_Account_Settings(
-					$settings_store,
-					$payment_methods_store );
+			$settings_store,
+			$payment_methods_store
+		);
 	}
 
 	public function get() {
-		return new WP_REST_Response( array_merge(
-			array( 'success' => true ),
-			$this->account_settings->get()
-		), 200);
+		return new WP_REST_Response(
+			array_merge(
+				array( 'success' => true ),
+				$this->account_settings->get()
+			),
+			200
+		);
 	}
 
 	public function post( $request ) {
@@ -43,14 +47,15 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 
 		if ( ! $this->settings_store->can_user_manage_payment_methods() ) {
 			// Ignore the user-provided payment method ID if they don't have permission to change it
-			$old_settings = $this->settings_store->get_account_settings();
+			$old_settings                           = $this->settings_store->get_account_settings();
 			$settings['selected_payment_method_id'] = $old_settings['selected_payment_method_id'];
 		}
 
 		$result = $this->settings_store->update_account_settings( $settings );
 
 		if ( is_wp_error( $result ) ) {
-			$error = new WP_Error( 'save_failed',
+			$error = new WP_Error(
+				'save_failed',
 				sprintf(
 					__( 'Unable to update settings. %s', 'woocommerce-services' ),
 					$result->get_error_message()

--- a/classes/class-wc-rest-connect-address-normalization-controller.php
+++ b/classes/class-wc-rest-connect-address-normalization-controller.php
@@ -13,14 +13,14 @@ class WC_REST_Connect_Address_Normalization_Controller extends WC_REST_Connect_B
 
 	public function post( $request ) {
 		$data    = $request->get_json_params();
-		$address = $data[ 'address' ];
-		$name    = $address[ 'name' ];
-		$company = $address[ 'company' ];
-		$phone   = $address[ 'phone' ];
+		$address = $data['address'];
+		$name    = $address['name'];
+		$company = $address['company'];
+		$phone   = $address['phone'];
 
-		unset( $address[ 'name' ], $address[ 'company' ], $address[ 'phone' ] );
+		unset( $address['name'], $address['company'], $address['phone'] );
 
-		$body = array(
+		$body     = array(
 			'destination' => $address,
 		);
 		$response = $this->api_client->send_address_normalization_request( $body );
@@ -38,19 +38,19 @@ class WC_REST_Connect_Address_Normalization_Controller extends WC_REST_Connect_B
 		if ( isset( $response->field_errors ) ) {
 			$this->logger->log( 'Address validation errors: ' . implode( '; ', array_values( (array) $response->field_errors ) ), __CLASS__ );
 			return array(
-				'success' => true,
+				'success'      => true,
 				'field_errors' => $response->field_errors,
 			);
 		}
 
-		$response->normalized->name = $name;
+		$response->normalized->name    = $name;
 		$response->normalized->company = $company;
-		$response->normalized->phone = $phone;
-		$is_trivial_normalization = isset( $response->is_trivial_normalization ) ? $response->is_trivial_normalization : false;
+		$response->normalized->phone   = $phone;
+		$is_trivial_normalization      = isset( $response->is_trivial_normalization ) ? $response->is_trivial_normalization : false;
 
 		return array(
-			'success' => true,
-			'normalized' => $response->normalized,
+			'success'                  => true,
+			'normalized'               => $response->normalized,
 			'is_trivial_normalization' => $is_trivial_normalization,
 		);
 	}

--- a/classes/class-wc-rest-connect-assets-controller.php
+++ b/classes/class-wc-rest-connect-assets-controller.php
@@ -14,12 +14,15 @@ class WC_REST_Connect_Assets_Controller extends WC_REST_Connect_Base_Controller 
 
 	public function get() {
 
-		return new WP_REST_Response( array(
-			'success'  => true,
-			'assets' => array(
-				'wc_connect_admin_script' => WC_Connect_Loader::get_wcs_admin_script_url(),
-				'wc_connect_admin_style'  => WC_Connect_Loader::get_wcs_admin_style_url(),
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'assets'  => array(
+					'wc_connect_admin_script' => WC_Connect_Loader::get_wcs_admin_script_url(),
+					'wc_connect_admin_style'  => WC_Connect_Loader::get_wcs_admin_style_url(),
+				),
 			),
-		), 200 );
+			200
+		);
 	}
 }

--- a/classes/class-wc-rest-connect-base-controller.php
+++ b/classes/class-wc-rest-connect-base-controller.php
@@ -33,38 +33,50 @@ abstract class WC_REST_Connect_Base_Controller extends WP_REST_Controller {
 	protected $logger;
 
 	public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Service_Settings_Store $settings_store, WC_Connect_Logger $logger ) {
-		$this->api_client = $api_client;
+		$this->api_client     = $api_client;
 		$this->settings_store = $settings_store;
-		$this->logger = $logger;
+		$this->logger         = $logger;
 	}
 
 	public function register_routes() {
 		if ( method_exists( $this, 'get' ) ) {
-			register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			register_rest_route(
+				$this->namespace,
+				'/' . $this->rest_base,
 				array(
-					'methods'             => 'GET',
-					'callback'            => array( $this, 'get_internal' ),
-					'permission_callback' => array( $this, 'check_permission' ),
-				),
-			) );
+					array(
+						'methods'             => 'GET',
+						'callback'            => array( $this, 'get_internal' ),
+						'permission_callback' => array( $this, 'check_permission' ),
+					),
+				)
+			);
 		}
 		if ( method_exists( $this, 'post' ) ) {
-			register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			register_rest_route(
+				$this->namespace,
+				'/' . $this->rest_base,
 				array(
-					'methods'             => 'POST',
-					'callback'            => array( $this, 'post_internal' ),
-					'permission_callback' => array( $this, 'check_permission' ),
-				),
-			) );
+					array(
+						'methods'             => 'POST',
+						'callback'            => array( $this, 'post_internal' ),
+						'permission_callback' => array( $this, 'check_permission' ),
+					),
+				)
+			);
 		}
 		if ( method_exists( $this, 'delete' ) ) {
-			register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			register_rest_route(
+				$this->namespace,
+				'/' . $this->rest_base,
 				array(
-					'methods'             => 'DELETE',
-					'callback'            => array( $this, 'delete_internal' ),
-					'permission_callback' => array( $this, 'check_permission' ),
-				),
-			) );
+					array(
+						'methods'             => 'DELETE',
+						'callback'            => array( $this, 'delete_internal' ),
+						'permission_callback' => array( $this, 'check_permission' ),
+					),
+				)
+			);
 		}
 	}
 
@@ -87,7 +99,7 @@ abstract class WC_REST_Connect_Base_Controller extends WP_REST_Controller {
 	 * See: https://pantheon.io/docs/cache-control/
 	 *
 	 * @param WP_REST_Response $response
-	 * @param WP_REST_Server $server
+	 * @param WP_REST_Server   $server
 	 *
 	 * @return WP_REST_Response passthrough $response parameter
 	 */

--- a/classes/class-wc-rest-connect-packages-controller.php
+++ b/classes/class-wc-rest-connect-packages-controller.php
@@ -19,22 +19,26 @@ class WC_REST_Connect_Packages_Controller extends WC_REST_Connect_Base_Controlle
 	public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Service_Settings_Store $settings_store, WC_Connect_Logger $logger, WC_Connect_Service_Schemas_Store $service_schemas_store ) {
 		parent::__construct( $api_client, $settings_store, $logger );
 		$this->package_settings = new WC_Connect_Package_Settings(
-			$settings_store, $service_schemas_store
+			$settings_store,
+			$service_schemas_store
 		);
 	}
 
 	public function get() {
-		return new WP_REST_Response( array_merge(
-			array( 'success' => true ),
-			$this->package_settings->get()
-		), 200 );
+		return new WP_REST_Response(
+			array_merge(
+				array( 'success' => true ),
+				$this->package_settings->get()
+			),
+			200
+		);
 	}
 
 	public function post( $request ) {
 		$packages = $request->get_json_params();
 
-		$this->settings_store->update_packages( $packages[ 'custom' ] );
-		$this->settings_store->update_predefined_packages( $packages[ 'predefined' ] );
+		$this->settings_store->update_packages( $packages['custom'] );
+		$this->settings_store->update_predefined_packages( $packages['predefined'] );
 
 		return new WP_REST_Response( array( 'success' => true ), 200 );
 	}

--- a/classes/class-wc-rest-connect-self-help-controller.php
+++ b/classes/class-wc-rest-connect-self-help-controller.php
@@ -19,7 +19,8 @@ class WC_REST_Connect_Self_Help_Controller extends WC_REST_Connect_Base_Controll
 			|| ! array_key_exists( 'wcc_debug_on', $settings )
 			|| ! array_key_exists( 'wcc_logging_on', $settings )
 		) {
-			$error = new WP_Error( 'bad_form_data',
+			$error = new WP_Error(
+				'bad_form_data',
 				__( 'Unable to update settings. The form data could not be read.', 'woocommerce-services' ),
 				array( 'status' => 400 )
 			);

--- a/classes/class-wc-rest-connect-services-controller.php
+++ b/classes/class-wc-rest-connect-services-controller.php
@@ -23,24 +23,31 @@ class WC_REST_Connect_Services_Controller extends WC_REST_Connect_Base_Controlle
 		WC_Connect_Service_Schemas_Store $schemas_store
 	) {
 		parent::__construct( $api_client, $settings_store, $logger );
-		$this->service_schemas_store  = $schemas_store;
+		$this->service_schemas_store = $schemas_store;
 	}
 
 	public function get( $request ) {
-		$method_id = $request[ 'id' ];
-		$instance_id = isset( $request[ 'instance' ] ) ? $request[ 'instance' ] : false;
+		$method_id   = $request['id'];
+		$instance_id = isset( $request['instance'] ) ? $request['instance'] : false;
 
-		$service_schema = $this->service_schemas_store->get_service_schema_by_id_or_instance_id( $instance_id
+		$service_schema = $this->service_schemas_store->get_service_schema_by_id_or_instance_id(
+			$instance_id
 			? $instance_id
-			: $method_id );
+			: $method_id
+		);
 
 		if ( ! $service_schema ) {
 			return new WP_Error( 'schemas_not_found', __( 'Service schemas were not loaded', 'woocommerce-services' ), array( 'status' => 500 ) );
 		}
 
-		$payload = apply_filters( 'wc_connect_shipping_service_settings', array(
-			'success' => true,
-		), $method_id, $instance_id );
+		$payload = apply_filters(
+			'wc_connect_shipping_service_settings',
+			array(
+				'success' => true,
+			),
+			$method_id,
+			$instance_id
+		);
 
 		return new WP_REST_Response( $payload, 200 );
 	}
@@ -51,11 +58,12 @@ class WC_REST_Connect_Services_Controller extends WC_REST_Connect_Base_Controlle
 	public function post( $request ) {
 		$request_params = $request->get_params();
 
-		$id = array_key_exists( 'id', $request_params ) ? $request_params['id'] : '';
+		$id       = array_key_exists( 'id', $request_params ) ? $request_params['id'] : '';
 		$instance = array_key_exists( 'instance', $request_params ) ? absint( $request_params['instance'] ) : false;
 
 		if ( empty( $id ) ) {
-			$error = new WP_Error( 'service_id_missing',
+			$error = new WP_Error(
+				'service_id_missing',
 				__( 'Unable to update service settings. Form data is missing service ID.', 'woocommerce-services' ),
 				array( 'status' => 400 )
 			);
@@ -63,10 +71,11 @@ class WC_REST_Connect_Services_Controller extends WC_REST_Connect_Base_Controlle
 			return $error;
 		}
 
-		$settings = ( object ) $request->get_json_params();
+		$settings = (object) $request->get_json_params();
 
 		if ( empty( $settings ) ) {
-			$error = new WP_Error( 'bad_form_data',
+			$error = new WP_Error(
+				'bad_form_data',
 				__( 'Unable to update service settings. The form data could not be read.', 'woocommerce-services' ),
 				array( 'status' => 400 )
 			);
@@ -77,7 +86,8 @@ class WC_REST_Connect_Services_Controller extends WC_REST_Connect_Base_Controlle
 		$validation_result = $this->settings_store->validate_and_possibly_update_settings( $settings, $id, $instance );
 
 		if ( is_wp_error( $validation_result ) ) {
-			$error = new WP_Error( 'validation_failed',
+			$error = new WP_Error(
+				'validation_failed',
 				sprintf(
 					__( 'Unable to update service settings. Validation failed. %s', 'woocommerce-services' ),
 					$validation_result->get_error_message()

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -23,38 +23,38 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 
 	public function get( $request ) {
 		$order_id = $request['order_id'];
-		$payload = $this->shipping_label->get_label_payload( $order_id );
+		$payload  = $this->shipping_label->get_label_payload( $order_id );
 		if ( ! $payload ) {
 			return new WP_Error( 'not_found', __( 'Order not found', 'woocommerce-services' ), array( 'status' => 404 ) );
 		}
-		$payload[ 'success' ] = true;
+		$payload['success'] = true;
 		return new WP_REST_Response( $payload, 200 );
 	}
 
 	public function post( $request ) {
-		$settings = $request->get_json_params();
-		$order_id = $request[ 'order_id' ];
-		$settings[ 'order_id' ] = $order_id;
+		$settings             = $request->get_json_params();
+		$order_id             = $request['order_id'];
+		$settings['order_id'] = $order_id;
 
-		if ( empty( $settings[ 'payment_method_id' ] ) || ! $this->settings_store->can_user_manage_payment_methods() ) {
-			$settings[ 'payment_method_id' ] = $this->settings_store->get_selected_payment_method_id();
+		if ( empty( $settings['payment_method_id'] ) || ! $this->settings_store->can_user_manage_payment_methods() ) {
+			$settings['payment_method_id'] = $this->settings_store->get_selected_payment_method_id();
 		} else {
-			$this->settings_store->set_selected_payment_method_id( $settings[ 'payment_method_id' ] );
+			$this->settings_store->set_selected_payment_method_id( $settings['payment_method_id'] );
 		}
 
-		$last_box_id = '';
+		$last_box_id   = '';
 		$service_names = array();
-		foreach ( $settings[ 'packages' ] as $index => $package ) {
-			$service_names[] = $package[ 'service_name' ];
-			unset( $package[ 'service_name' ] );
-			$settings[ 'packages' ][ $index ] = $package;
+		foreach ( $settings['packages'] as $index => $package ) {
+			$service_names[] = $package['service_name'];
+			unset( $package['service_name'] );
+			$settings['packages'][ $index ] = $package;
 
 			if ( empty( $last_box_id ) && ! empty( $package['box_id'] ) ) {
 				$last_box_id = $package['box_id'];
 			}
 		}
 
-		if ( ! empty( $last_box_id ) && $last_box_id !== "individual" ) {
+		if ( ! empty( $last_box_id ) && $last_box_id !== 'individual' ) {
 			update_user_meta( get_current_user_id(), 'wc_connect_last_box_id', $last_box_id );
 		}
 
@@ -70,9 +70,9 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 			return $error;
 		}
 
-		$label_ids = array();
+		$label_ids             = array();
 		$purchased_labels_meta = array();
-		$package_lookup = $this->settings_store->get_package_lookup();
+		$package_lookup        = $this->settings_store->get_package_lookup();
 		foreach ( $response->labels as $index => $label_data ) {
 			if ( isset( $label_data->error ) ) {
 				$error = new WP_Error(
@@ -86,44 +86,44 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 			$label_ids[] = $label_data->label->label_id;
 
 			$label_meta = array(
-				'label_id' => $label_data->label->label_id,
-				'tracking' => $label_data->label->tracking_id,
-				'refundable_amount' => $label_data->label->refundable_amount,
-				'created' => $label_data->label->created,
-				'carrier_id' => $label_data->label->carrier_id,
-				'service_name' => $service_names[ $index ],
-				'status' => $label_data->label->status,
+				'label_id'               => $label_data->label->label_id,
+				'tracking'               => $label_data->label->tracking_id,
+				'refundable_amount'      => $label_data->label->refundable_amount,
+				'created'                => $label_data->label->created,
+				'carrier_id'             => $label_data->label->carrier_id,
+				'service_name'           => $service_names[ $index ],
+				'status'                 => $label_data->label->status,
 				'commercial_invoice_url' => $label_data->label->commercial_invoice_url,
 			);
 
-			$package = $settings[ 'packages' ][ $index ];
-			$box_id = $package[ 'box_id' ];
+			$package = $settings['packages'][ $index ];
+			$box_id  = $package['box_id'];
 			if ( 'individual' === $box_id ) {
-				$label_meta[ 'package_name' ] = __( 'Individual packaging', 'woocommerce-services' );
-			} else if ( isset( $package_lookup[ $box_id ] ) ) {
-				$label_meta[ 'package_name' ] = $package_lookup[ $box_id ][ 'name' ];
+				$label_meta['package_name'] = __( 'Individual packaging', 'woocommerce-services' );
+			} elseif ( isset( $package_lookup[ $box_id ] ) ) {
+				$label_meta['package_name'] = $package_lookup[ $box_id ]['name'];
 			} else {
-				$label_meta[ 'package_name' ] = __( 'Unknown package', 'woocommerce-services' );
+				$label_meta['package_name'] = __( 'Unknown package', 'woocommerce-services' );
 			}
 
-			$label_meta[ 'is_letter' ] = isset( $package[ 'is_letter' ] ) ? $package[ 'is_letter' ] : false;
+			$label_meta['is_letter'] = isset( $package['is_letter'] ) ? $package['is_letter'] : false;
 
 			$product_names = array();
-			$product_ids = array();
-			foreach ( $package[ 'products' ] as $product_id ) {
-				$product = wc_get_product( $product_id );
+			$product_ids   = array();
+			foreach ( $package['products'] as $product_id ) {
+				$product       = wc_get_product( $product_id );
 				$product_ids[] = $product_id;
 
 				if ( $product ) {
 					$product_names[] = $product->get_title();
 				} else {
-					$order = wc_get_order( $order_id );
+					$order           = wc_get_order( $order_id );
 					$product_names[] = WC_Connect_Compatibility::instance()->get_product_name_from_order( $product_id, $order );
 				}
 			}
 
-			$label_meta[ 'product_names' ] = $product_names;
-			$label_meta[ 'product_ids' ] = $product_ids;
+			$label_meta['product_names'] = $product_names;
+			$label_meta['product_ids']   = $product_ids;
 
 			array_unshift( $purchased_labels_meta, $label_meta );
 		}
@@ -131,7 +131,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WC_REST_Connect_Base_Con
 		$this->settings_store->add_labels_to_order( $order_id, $purchased_labels_meta );
 
 		return array(
-			'labels' => $purchased_labels_meta,
+			'labels'  => $purchased_labels_meta,
 			'success' => true,
 		);
 	}

--- a/classes/class-wc-rest-connect-shipping-label-preview-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-preview-controller.php
@@ -13,16 +13,16 @@ class WC_REST_Connect_Shipping_Label_Preview_Controller extends WC_REST_Connect_
 
 	public function get( $request ) {
 		$raw_params = $request->get_params();
-		$params = array();
+		$params     = array();
 
-		$params[ 'paper_size' ] = $raw_params[ 'paper_size' ];
-		$this->settings_store->set_preferred_paper_size( $params[ 'paper_size' ] );
-		$params[ 'carrier' ] = 'usps';
-		$params[ 'labels' ] = array();
-		$captions = empty( $raw_params[ 'caption_csv' ] ) ? array() : explode( ',', $raw_params[ 'caption_csv' ] );
+		$params['paper_size'] = $raw_params['paper_size'];
+		$this->settings_store->set_preferred_paper_size( $params['paper_size'] );
+		$params['carrier'] = 'usps';
+		$params['labels']  = array();
+		$captions          = empty( $raw_params['caption_csv'] ) ? array() : explode( ',', $raw_params['caption_csv'] );
 
 		foreach ( $captions as $caption ) {
-			$params[ 'labels' ][] = array( 'caption' => urldecode( $caption ) );
+			$params['labels'][] = array( 'caption' => urldecode( $caption ) );
 		}
 
 		$raw_response = $this->api_client->get_labels_preview_pdf( $params );
@@ -32,8 +32,8 @@ class WC_REST_Connect_Shipping_Label_Preview_Controller extends WC_REST_Connect_
 			return $raw_response;
 		}
 
-		header( 'content-type: ' . $raw_response[ 'headers' ][ 'content-type' ] );
-		echo $raw_response[ 'body' ];
+		header( 'content-type: ' . $raw_response['headers']['content-type'] );
+		echo $raw_response['body'];
 		die();
 	}
 

--- a/classes/class-wc-rest-connect-shipping-label-print-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-print-controller.php
@@ -13,36 +13,36 @@ class WC_REST_Connect_Shipping_Label_Print_Controller extends WC_REST_Connect_Ba
 
 	public function get( $request ) {
 		$raw_params = $request->get_params();
-		$params = array();
+		$params     = array();
 
-		$params[ 'paper_size' ] = $raw_params[ 'paper_size' ];
-		$this->settings_store->set_preferred_paper_size( $params[ 'paper_size' ] );
+		$params['paper_size'] = $raw_params['paper_size'];
+		$this->settings_store->set_preferred_paper_size( $params['paper_size'] );
 
-		$label_ids = ! empty( $raw_params[ 'label_id_csv' ] ) ? explode( ',', $raw_params[ 'label_id_csv' ] ) : array();
+		$label_ids   = ! empty( $raw_params['label_id_csv'] ) ? explode( ',', $raw_params['label_id_csv'] ) : array();
 		$n_label_ids = count( $label_ids );
-		$captions = ! empty( $raw_params[ 'caption_csv' ] ) ? explode( ',', $raw_params[ 'caption_csv' ] ) : array();
-		$n_captions = count( $captions );
+		$captions    = ! empty( $raw_params['caption_csv'] ) ? explode( ',', $raw_params['caption_csv'] ) : array();
+		$n_captions  = count( $captions );
 		// Either there are the same number of captions as labels, or no captions at all
 		if ( ! $n_label_ids || ( $n_captions && $n_captions !== $n_label_ids ) ) {
 			$message = __( 'Invalid PDF request.', 'woocommerce-services' );
-			$error = new WP_Error(
+			$error   = new WP_Error(
 				'invalid_pdf_request',
 				$message,
 				array(
 					'message' => $message,
-					'status' => 400
+					'status'  => 400,
 				)
 			);
 			$this->logger->log( $error, __CLASS__ );
 			return $error;
 		}
-		$params[ 'labels' ] = array();
+		$params['labels'] = array();
 		for ( $i = 0; $i < $n_label_ids; $i++ ) {
-			$params[ 'labels' ][ $i ] = array();
-			$params[ 'labels' ][ $i ][ 'label_id' ] = (int) $label_ids[ $i ];
+			$params['labels'][ $i ]             = array();
+			$params['labels'][ $i ]['label_id'] = (int) $label_ids[ $i ];
 
 			if ( $n_captions ) {
-				$params[ 'labels' ][ $i ][ 'caption' ] = urldecode( $captions[ $i ] );
+				$params['labels'][ $i ]['caption'] = urldecode( $captions[ $i ] );
 			}
 		}
 
@@ -53,15 +53,15 @@ class WC_REST_Connect_Shipping_Label_Print_Controller extends WC_REST_Connect_Ba
 			return $raw_response;
 		}
 
-		if ( isset( $raw_params[ 'json' ] ) && $raw_params[ 'json' ] ) {
+		if ( isset( $raw_params['json'] ) && $raw_params['json'] ) {
 			return array(
-				'mimeType' => $raw_response[ 'headers' ][ 'content-type' ],
-				'b64Content' => base64_encode( $raw_response[ 'body' ] ),
-				'success' => true,
+				'mimeType'   => $raw_response['headers']['content-type'],
+				'b64Content' => base64_encode( $raw_response['body'] ),
+				'success'    => true,
 			);
 		} else {
-			header( 'content-type: ' . $raw_response[ 'headers' ][ 'content-type' ] );
-			echo $raw_response[ 'body' ];
+			header( 'content-type: ' . $raw_response['headers']['content-type'] );
+			echo $raw_response['body'];
 			die();
 		}
 	}

--- a/classes/class-wc-rest-connect-shipping-label-refund-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-refund-controller.php
@@ -12,7 +12,7 @@ class WC_REST_Connect_Shipping_Label_Refund_Controller extends WC_REST_Connect_B
 	protected $rest_base = 'connect/label/(?P<order_id>\d+)/(?P<label_id>\d+)/refund';
 
 	public function post( $request ) {
-		$response = $this->api_client->send_shipping_label_refund_request( $request[ 'label_id' ] );
+		$response = $this->api_client->send_shipping_label_refund_request( $request['label_id'] );
 
 		if ( isset( $response->error ) ) {
 			$response = new WP_Error(
@@ -22,9 +22,12 @@ class WC_REST_Connect_Shipping_Label_Refund_Controller extends WC_REST_Connect_B
 		}
 
 		if ( is_wp_error( $response ) ) {
-			$response->add_data( array(
-				'message' => $response->get_error_message(),
-			), $response->get_error_code() );
+			$response->add_data(
+				array(
+					'message' => $response->get_error_message(),
+				),
+				$response->get_error_code()
+			);
 
 			$this->logger->log( $response, __CLASS__ );
 			return $response;
@@ -32,13 +35,13 @@ class WC_REST_Connect_Shipping_Label_Refund_Controller extends WC_REST_Connect_B
 
 		$label_refund = (object) array(
 			'label_id' => (int) $response->label->id,
-			'refund'   => $response->refund ,
+			'refund'   => $response->refund,
 		);
-		$this->settings_store->update_label_order_meta_data( $request[ 'order_id' ], $label_refund );
+		$this->settings_store->update_label_order_meta_data( $request['order_id'], $label_refund );
 
 		return array(
 			'success' => true,
-			'refund'   => $response->refund,
+			'refund'  => $response->refund,
 		);
 	}
 

--- a/classes/class-wc-rest-connect-shipping-label-status-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-status-controller.php
@@ -12,7 +12,7 @@ class WC_REST_Connect_Shipping_Label_Status_Controller extends WC_REST_Connect_B
 	protected $rest_base = 'connect/label/(?P<order_id>\d+)/(?P<label_id>\d+)';
 
 	public function get( $request ) {
-		$response = $this->api_client->get_label_status( $request[ 'label_id' ] );
+		$response = $this->api_client->get_label_status( $request['label_id'] );
 
 		if ( is_wp_error( $response ) ) {
 			$error = new WP_Error(
@@ -24,11 +24,11 @@ class WC_REST_Connect_Shipping_Label_Status_Controller extends WC_REST_Connect_B
 			return $error;
 		}
 
-		$label = $this->settings_store->update_label_order_meta_data( $request[ 'order_id' ], $response->label );
+		$label = $this->settings_store->update_label_order_meta_data( $request['order_id'], $response->label );
 
 		return array(
 			'success' => true,
-			'label' => $label,
+			'label'   => $label,
 		);
 	}
 

--- a/classes/class-wc-rest-connect-subscriptions-controller.php
+++ b/classes/class-wc-rest-connect-subscriptions-controller.php
@@ -20,7 +20,7 @@ class WC_REST_Connect_Subscriptions_Controller extends WC_REST_Connect_Base_Cont
 
 		return new WP_REST_Response(
 			array(
-				'success'  => true,
+				'success'       => true,
 				'subscriptions' => $response->subscriptions,
 			)
 		);

--- a/classes/class-wc-rest-connect-tos-controller.php
+++ b/classes/class-wc-rest-connect-tos-controller.php
@@ -13,25 +13,31 @@ class WC_REST_Connect_Tos_Controller extends WC_REST_Connect_Base_Controller {
 	protected $rest_base = 'connect/tos';
 
 	public function get() {
-		return new WP_REST_Response( array(
-			'success'  => true,
-			'accepted' => WC_Connect_Options::get_option( 'tos_accepted' ),
-		), 200 );
+		return new WP_REST_Response(
+			array(
+				'success'  => true,
+				'accepted' => WC_Connect_Options::get_option( 'tos_accepted' ),
+			),
+			200
+		);
 	}
 
 	public function post( $request ) {
 		$settings = $request->get_json_params();
 
-		if ( ! $settings || ! isset( $settings[ 'accepted' ] ) || ! $settings[ 'accepted' ] ) {
+		if ( ! $settings || ! isset( $settings['accepted'] ) || ! $settings['accepted'] ) {
 			return new WP_Error( 'bad_request', __( 'Bad request', 'woocommerce-services' ), array( 'status' => 400 ) );
 		}
 
 		WC_Connect_Options::update_option( 'tos_accepted', true );
 
-		return new WP_REST_Response( array(
-			'success'  => true,
-			'accepted' => WC_Connect_Options::get_option( 'tos_accepted' ),
-		), 200 );
+		return new WP_REST_Response(
+			array(
+				'success'  => true,
+				'accepted' => WC_Connect_Options::get_option( 'tos_accepted' ),
+			),
+			200
+		);
 	}
 
 	/**

--- a/classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php
+++ b/classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php
@@ -54,28 +54,36 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 	 * @since 3.1.0
 	 */
 	public function register_routes() {
-		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
 			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_items' ),
-				'permission_callback' => array( $this, 'get_items_permissions_check' ),
-			),
-			'schema' => array( $this, 'get_public_item_schema' ),
-		) );
-		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<location>[\w-]+)', array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<location>[\w-]+)',
 			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_item' ),
-				'permission_callback' => array( $this, 'get_items_permissions_check' ),
-				'args' => array(
-					'continent' => array(
-						'description' => __( '2 character continent code.', 'woocommerce' ),
-						'type'        => 'string',
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => array(
+						'continent' => array(
+							'description' => __( '2 character continent code.', 'woocommerce' ),
+							'type'        => 'string',
+						),
 					),
 				),
-			),
-			'schema' => array( $this, 'get_public_item_schema' ),
-		) );
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
 	}
 
 	/**
@@ -117,7 +125,7 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 	 * Prepare the data object for response.
 	 *
 	 * @since  3.1.0
-	 * @param object $item Data object.
+	 * @param object          $item Data object.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response $response Response data.
 	 */
@@ -148,8 +156,8 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 	 */
 	protected function prepare_links( $item ) {
 		$continent_code = strtolower( $item['code'] );
-		$links = array(
-			'self' => array(
+		$links          = array(
+			'self'       => array(
 				'href' => rest_url( sprintf( '/%s/%s/%s', $this->namespace, $this->rest_base, $continent_code ) ),
 			),
 			'collection' => array(
@@ -167,17 +175,17 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 	 */
 	public function get_item_schema() {
 		$schema = array(
-			'$schema' => 'http://json-schema.org/draft-04/schema#',
-			'title'   => 'data_continents',
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'data_continents',
 			'type'       => 'object',
 			'properties' => array(
-				'code' => array(
+				'code'      => array(
 					'type'        => 'string',
 					'description' => __( '2 character continent code.', 'woocommerce' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
-				'name' => array(
+				'name'      => array(
 					'type'        => 'string',
 					'description' => __( 'Full name of continent.', 'woocommerce' ),
 					'context'     => array( 'view' ),
@@ -193,25 +201,25 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 						'context'    => array( 'view' ),
 						'readonly'   => true,
 						'properties' => array(
-							'code' => array(
+							'code'           => array(
 								'type'        => 'string',
 								'description' => __( 'ISO3166 alpha-2 country code.', 'woocommerce' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
-							'currency_code' => array(
+							'currency_code'  => array(
 								'type'        => 'string',
 								'description' => __( 'Default ISO4127 alpha-3 currency code for the country.', 'woocommerce' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
-							'currency_pos' => array(
+							'currency_pos'   => array(
 								'type'        => 'string',
 								'description' => __( 'Currency symbol position for this country.', 'woocommerce' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
-							'decimal_sep' => array(
+							'decimal_sep'    => array(
 								'type'        => 'string',
 								'description' => __( 'Decimal separator for displayed prices for this country.', 'woocommerce' ),
 								'context'     => array( 'view' ),
@@ -223,19 +231,19 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
-							'name' => array(
+							'name'           => array(
 								'type'        => 'string',
 								'description' => __( 'Full name of country.', 'woocommerce' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
-							'num_decimals' => array(
+							'num_decimals'   => array(
 								'type'        => 'integer',
 								'description' => __( 'Number of decimal points shown in displayed prices for this country.', 'woocommerce' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
-							'states' => array(
+							'states'         => array(
 								'type'        => 'array',
 								'description' => __( 'List of states in this country.', 'woocommerce' ),
 								'context'     => array( 'view' ),
@@ -260,13 +268,13 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 									),
 								),
 							),
-							'thousand_sep' => array(
+							'thousand_sep'   => array(
 								'type'        => 'string',
 								'description' => __( 'Thousands separator for displayed prices in this country.', 'woocommerce' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
-							'weight_unit' => array(
+							'weight_unit'    => array(
 								'type'        => 'string',
 								'description' => __( 'The unit weights are defined in for this country.', 'woocommerce' ),
 								'context'     => array( 'view' ),

--- a/classes/wc-api-dev/class-wc-rest-dev-data-controller.php
+++ b/classes/wc-api-dev/class-wc-rest-dev-data-controller.php
@@ -44,14 +44,18 @@ class WC_REST_Dev_Data_Controller extends WC_REST_Controller {
 	 * @since 3.1.0
 	 */
 	public function register_routes() {
-		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
 			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_items' ),
-				'permission_callback' => array( $this, 'get_items_permissions_check' ),
-			),
-			'schema' => array( $this, 'get_public_item_schema' ),
-		) );
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
 	}
 
 	/**
@@ -90,7 +94,7 @@ class WC_REST_Dev_Data_Controller extends WC_REST_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		$data = array();
+		$data      = array();
 		$resources = array(
 			array(
 				'slug'        => 'continents',
@@ -117,7 +121,7 @@ class WC_REST_Dev_Data_Controller extends WC_REST_Controller {
 	/**
 	 * Prepare a data resource object for serialization.
 	 *
-	 * @param stdClass $report Report data.
+	 * @param stdClass        $report Report data.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response $response Response data.
 	 */
@@ -145,7 +149,7 @@ class WC_REST_Dev_Data_Controller extends WC_REST_Controller {
 	 */
 	protected function prepare_links( $item ) {
 		$links = array(
-			'self' => array(
+			'self'       => array(
 				'href' => rest_url( sprintf( '/%s/%s/%s', $this->namespace, $this->rest_base, $item->slug ) ),
 			),
 			'collection' => array(
@@ -168,7 +172,7 @@ class WC_REST_Dev_Data_Controller extends WC_REST_Controller {
 			'title'      => 'data_index',
 			'type'       => 'object',
 			'properties' => array(
-				'slug' => array(
+				'slug'        => array(
 					'description' => __( 'Data resource ID.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view' ),

--- a/tests/php/class-wc-connect-api-client-local-test-mock.php
+++ b/tests/php/class-wc-connect-api-client-local-test-mock.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! class_exists( 'WC_Connect_API_Client_Local_Test_Mock' ) ) {
-	require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client.php' );
+	require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client.php';
 
 	class WC_Connect_API_Client_Local_Test_Mock extends WC_Connect_API_Client {
 
@@ -52,11 +52,11 @@ if ( ! class_exists( 'WC_Connect_API_Client_Local_Test_Mock' ) ) {
 			}
 
 			$mock_data_associative = $this->get_mock_endpoints_associative();
-			if ( isset( $mock_data_associative[ 'mock_endpoints' ][ $path ] ) ) {
-				return $mock_data_associative[ 'mock_endpoints' ][ $path ];
+			if ( isset( $mock_data_associative['mock_endpoints'][ $path ] ) ) {
+				return $mock_data_associative['mock_endpoints'][ $path ];
 			}
 			// Just return empty data for requests not matching mock endpoint data.
-			return new stdClass;
+			return new stdClass();
 		}
 	}
 }

--- a/tests/php/classes/test-class-wc-rest-connect-subscriptions-controller.php
+++ b/tests/php/classes/test-class-wc-rest-connect-subscriptions-controller.php
@@ -116,10 +116,10 @@ class WP_Test_WC_REST_Connect_Subscriptions_Controller extends WC_Unit_Test_Case
 
 		$wc_connect_subscriptions_controller = new WC_REST_Connect_Subscriptions_Controller( $this->api_client_mock, $this->setting_store_mock, $this->connect_logger_mock );
 		$actual                              = $wc_connect_subscriptions_controller->post();
-		$expected                            =  $api_client_response->subscriptions ;
+		$expected                            = $api_client_response->subscriptions;
 
-		$expected                                     = [
-			'success'  => true,
+		$expected = [
+			'success'       => true,
 			'subscriptions' => $api_client_response->subscriptions,
 		];
 

--- a/tests/php/mocks/jetpack.php
+++ b/tests/php/mocks/jetpack.php
@@ -9,16 +9,16 @@ global $mock_recorded_tracks_events;
 function jetpack_tracks_record_event() {
 	global $mock_recorded_tracks_events;
 	$mock_recorded_tracks_events[] = func_get_args();
-    return func_get_args();
+	return func_get_args();
 }
 
 class Jetpack_Options {
-    static function get_option( $option ){
-        switch( $option ) {
-            case 'id':
-                return 12345;
-            default:
-                return false;
-        }
-    }
+	static function get_option( $option ) {
+		switch ( $option ) {
+			case 'id':
+				return 12345;
+			default:
+				return false;
+		}
+	}
 }

--- a/tests/php/test_class-wc-connect-order-presenter.php
+++ b/tests/php/test_class-wc-connect-order-presenter.php
@@ -2,8 +2,8 @@
 
 class WP_Test_WC_Connect_Order_Presenter extends WC_Unit_Test_Case {
 	public static function setupBeforeClass() {
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-compatibility.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-order-presenter.php' );
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-compatibility.php';
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-order-presenter.php';
 
 		WC_Connect_Compatibility::set_version( '3.0.0' );
 	}
@@ -14,14 +14,14 @@ class WP_Test_WC_Connect_Order_Presenter extends WC_Unit_Test_Case {
 		$order->save();
 
 		$connect_order_presenter = new WC_Connect_Order_Presenter();
-		$actual = $connect_order_presenter->get_order_for_api($order);
+		$actual                  = $connect_order_presenter->get_order_for_api( $order );
 
 		// Refer to WC_Helper_Order::create_order()
-		$this->assertEquals( 'pending', $actual['status']);
-		$this->assertEquals( 1, $actual['customer_id']);
-		$this->assertEquals( '50.00', $actual['total']);
-		$this->assertEquals( '40.00', $actual['subtotal']);
-		$this->assertEquals( '10.00', $actual['total_shipping']);
+		$this->assertEquals( 'pending', $actual['status'] );
+		$this->assertEquals( 1, $actual['customer_id'] );
+		$this->assertEquals( '50.00', $actual['total'] );
+		$this->assertEquals( '40.00', $actual['subtotal'] );
+		$this->assertEquals( '10.00', $actual['total_shipping'] );
 	}
 
 	public function test_get_order_for_api_shipping_lines() {
@@ -30,7 +30,7 @@ class WP_Test_WC_Connect_Order_Presenter extends WC_Unit_Test_Case {
 		$order->save();
 
 		$connect_order_presenter = new WC_Connect_Order_Presenter();
-		$actual = $connect_order_presenter->get_order_for_api($order);
+		$actual                  = $connect_order_presenter->get_order_for_api( $order );
 
 		$this->assertEquals( 'flat_rate_shipping', $actual['shipping_lines'][0]['method_id'] );
 		$this->assertEquals( 'Flat rate shipping', $actual['shipping_lines'][0]['method_title'] );
@@ -43,7 +43,7 @@ class WP_Test_WC_Connect_Order_Presenter extends WC_Unit_Test_Case {
 		$order->save();
 
 		$connect_order_presenter = new WC_Connect_Order_Presenter();
-		$actual = $connect_order_presenter->get_order_for_api($order);
+		$actual                  = $connect_order_presenter->get_order_for_api( $order );
 
 		$this->assertEquals( '40.00', $actual['line_items'][0]['subtotal'] );
 		$this->assertEquals( '40.00', $actual['line_items'][0]['total'] );
@@ -59,11 +59,11 @@ class WP_Test_WC_Connect_Order_Presenter extends WC_Unit_Test_Case {
 
 		// Setup order
 		$order = WC_Helper_Order::create_order();
-		$order->add_item($feeItem);
+		$order->add_item( $feeItem );
 		$order->save();
 
 		$connect_order_presenter = new WC_Connect_Order_Presenter();
-		$actual = $connect_order_presenter->get_order_for_api($order);
+		$actual                  = $connect_order_presenter->get_order_for_api( $order );
 
 		$this->assertEquals( '15.01', $actual['fee_lines'][0]['total'] );
 		$this->assertEquals( '5.01', $actual['fee_lines'][0]['total_tax'] );
@@ -74,11 +74,11 @@ class WP_Test_WC_Connect_Order_Presenter extends WC_Unit_Test_Case {
 
 		// Setup order
 		$order = WC_Helper_Order::create_order();
-		$order->apply_coupon($coupon);
+		$order->apply_coupon( $coupon );
 		$order->save();
 
 		$connect_order_presenter = new WC_Connect_Order_Presenter();
-		$actual = $connect_order_presenter->get_order_for_api($order);
+		$actual                  = $connect_order_presenter->get_order_for_api( $order );
 
 		// Refer to WC_Helper_Coupon::create_coupon()
 		$this->assertEquals( 'coupon_1', $actual['coupon_lines'][0]['code'] );

--- a/tests/php/test_class-wc-connect-service-settings-store.php
+++ b/tests/php/test_class-wc-connect-service-settings-store.php
@@ -41,11 +41,11 @@ class WP_Test_WC_Connect_Service_Settings_Store extends WC_Unit_Test_Case {
 	protected $order_id = 123;
 
 	public static function setupBeforeClass() {
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-service-settings-store.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client-live.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-service-schemas-store.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-logger.php' );
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-service-settings-store.php';
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client.php';
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client-live.php';
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-service-schemas-store.php';
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-logger.php';
 	}
 
 	private function get_settings_store( $service_schemas_store = false, $api_client = false, $logger = false ) {
@@ -78,13 +78,13 @@ class WP_Test_WC_Connect_Service_Settings_Store extends WC_Unit_Test_Case {
 	}
 
 	public function test_get_label_order_meta_data_regular_json() {
-		$labels_data = $this->labels_data;
-		$labels_data[ 0 ][ 'package_name' ] = 'box';
-		$labels_data[ 0 ][ 'product_names' ] = array( 'product' );
+		$labels_data                     = $this->labels_data;
+		$labels_data[0]['package_name']  = 'box';
+		$labels_data[0]['product_names'] = array( 'product' );
 		update_post_meta( $this->order_id, 'wc_connect_labels', json_encode( $labels_data ) );
 
 		$settings_store = $this->get_settings_store();
-		$actual = $settings_store->get_label_order_meta_data( $this->order_id );
+		$actual         = $settings_store->get_label_order_meta_data( $this->order_id );
 
 		$this->assertEquals( $actual, $labels_data );
 	}
@@ -93,19 +93,19 @@ class WP_Test_WC_Connect_Service_Settings_Store extends WC_Unit_Test_Case {
 		update_post_meta( $this->order_id, 'wc_connect_labels', json_encode( $this->labels_data ) );
 
 		$settings_store = $this->get_settings_store();
-		$actual = $settings_store->get_label_order_meta_data( $this->order_id );
+		$actual         = $settings_store->get_label_order_meta_data( $this->order_id );
 
 		$this->assertEquals( $actual, $this->labels_data );
 	}
 
 	public function test_get_label_order_meta_data_unescaped_json() {
-		//create a json and ensure that quotes are unescaped
+		// create a json and ensure that quotes are unescaped
 		$json = json_encode( $this->labels_data );
 		$json = str_replace( '\"', '"', $json );
 		update_post_meta( $this->order_id, 'wc_connect_labels', $json );
 
 		$settings_store = $this->get_settings_store();
-		$actual = $settings_store->get_label_order_meta_data( $this->order_id );
+		$actual         = $settings_store->get_label_order_meta_data( $this->order_id );
 
 		$this->assertEquals( $actual, $this->labels_data );
 	}
@@ -114,7 +114,7 @@ class WP_Test_WC_Connect_Service_Settings_Store extends WC_Unit_Test_Case {
 		update_post_meta( $this->order_id, 'wc_connect_labels', $this->labels_data );
 
 		$settings_store = $this->get_settings_store();
-		$actual = $settings_store->get_label_order_meta_data( $this->order_id );
+		$actual         = $settings_store->get_label_order_meta_data( $this->order_id );
 
 		$this->assertEquals( $actual, $this->labels_data );
 	}
@@ -123,19 +123,19 @@ class WP_Test_WC_Connect_Service_Settings_Store extends WC_Unit_Test_Case {
 		$expected = array();
 
 		$settings_store = $this->get_settings_store();
-		$actual = $settings_store->get_label_order_meta_data( $this->order_id );
+		$actual         = $settings_store->get_label_order_meta_data( $this->order_id );
 
 		$this->assertEquals( $actual, $expected );
 	}
 
 	public function test_get_label_order_meta_data_multiple_labels_regular_json() {
-		$labels_data = $this->multiple_labels_data;
-		$labels_data[ 0 ][ 'package_name' ] = 'box';
-		$labels_data[ 0 ][ 'product_names' ] = array( 'product' );
+		$labels_data                     = $this->multiple_labels_data;
+		$labels_data[0]['package_name']  = 'box';
+		$labels_data[0]['product_names'] = array( 'product' );
 		update_post_meta( $this->order_id, 'wc_connect_labels', json_encode( $labels_data ) );
 
 		$settings_store = $this->get_settings_store();
-		$actual = $settings_store->get_label_order_meta_data( $this->order_id );
+		$actual         = $settings_store->get_label_order_meta_data( $this->order_id );
 
 		$this->assertEquals( $actual, $labels_data );
 	}
@@ -145,19 +145,19 @@ class WP_Test_WC_Connect_Service_Settings_Store extends WC_Unit_Test_Case {
 		update_post_meta( $this->order_id, 'wc_connect_labels', $json );
 
 		$settings_store = $this->get_settings_store();
-		$actual = $settings_store->get_label_order_meta_data( $this->order_id );
+		$actual         = $settings_store->get_label_order_meta_data( $this->order_id );
 
 		$this->assertEquals( $actual, $this->multiple_labels_data );
 	}
 
 	public function test_get_label_order_meta_data_multiple_labels_unescaped_json() {
-		//create a json and ensure that quotes are unescaped
+		// create a json and ensure that quotes are unescaped
 		$json = json_encode( $this->multiple_labels_data );
 		$json = str_replace( '\"', '"', $json );
 		update_post_meta( $this->order_id, 'wc_connect_labels', $json );
 
 		$settings_store = $this->get_settings_store();
-		$actual = $settings_store->get_label_order_meta_data( $this->order_id );
+		$actual         = $settings_store->get_label_order_meta_data( $this->order_id );
 
 		$this->assertEquals( $actual, $this->multiple_labels_data );
 	}
@@ -166,7 +166,7 @@ class WP_Test_WC_Connect_Service_Settings_Store extends WC_Unit_Test_Case {
 		update_post_meta( $this->order_id, 'wc_connect_labels', $this->multiple_labels_data );
 
 		$settings_store = $this->get_settings_store();
-		$actual = $settings_store->get_label_order_meta_data( $this->order_id );
+		$actual         = $settings_store->get_label_order_meta_data( $this->order_id );
 
 		$this->assertEquals( $actual, $this->multiple_labels_data );
 	}
@@ -176,7 +176,7 @@ class WP_Test_WC_Connect_Service_Settings_Store extends WC_Unit_Test_Case {
 		$expected = array();
 
 		$settings_store = $this->get_settings_store();
-		$actual = $settings_store->get_label_order_meta_data( $this->order_id );
+		$actual         = $settings_store->get_label_order_meta_data( $this->order_id );
 
 		$this->assertEquals( $actual, $expected );
 	}

--- a/tests/php/test_class-wc-connect-shipping-label.php
+++ b/tests/php/test_class-wc-connect-shipping-label.php
@@ -4,20 +4,20 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 
 	protected $wc_connect_packages = array(
 		array(
-			'id' => 'weight_0_.',
-			'box_id' => '"',
-			'length' => 10,
-			'width' => 10,
-			'height' => 10,
-			'weight' => 0.25625,
-			'items' => array(
-				array (
+			'id'         => 'weight_0_.',
+			'box_id'     => '"',
+			'length'     => 10,
+			'width'      => 10,
+			'height'     => 10,
+			'weight'     => 0.25625,
+			'items'      => array(
+				array(
 					'product_id' => 128,
-					'length' => 3,
-					'width' => 3,
-					'height' => 2.5,
-					'weight' => 0.15625,
-					'quantity' => 1,
+					'length'     => 3,
+					'width'      => 3,
+					'height'     => 2.5,
+					'weight'     => 0.15625,
+					'quantity'   => 1,
 				),
 			),
 			'service_id' => 'pri',
@@ -26,47 +26,47 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 
 	protected $wc_connect_packages_multiple = array(
 		array(
-			'id' => 'weight_0_.',
-			'box_id' => '"',
-			'length' => 10,
-			'width' => 10,
-			'height' => 10,
-			'weight' => 0.25625,
-			'items' => array(
-				array (
+			'id'         => 'weight_0_.',
+			'box_id'     => '"',
+			'length'     => 10,
+			'width'      => 10,
+			'height'     => 10,
+			'weight'     => 0.25625,
+			'items'      => array(
+				array(
 					'product_id' => 128,
-					'length' => 3,
-					'width' => 3,
-					'height' => 2.5,
-					'weight' => 0.15625,
-					'quantity' => 1,
+					'length'     => 3,
+					'width'      => 3,
+					'height'     => 2.5,
+					'weight'     => 0.15625,
+					'quantity'   => 1,
 				),
 			),
 			'service_id' => 'pri',
 		),
 		array(
-			'id' => 'weight_1_.',
-			'box_id' => '"',
-			'length' => 10,
-			'width' => 10,
-			'height' => 10,
-			'weight' => 0.25625,
-			'items' => array(
-				array (
+			'id'         => 'weight_1_.',
+			'box_id'     => '"',
+			'length'     => 10,
+			'width'      => 10,
+			'height'     => 10,
+			'weight'     => 0.25625,
+			'items'      => array(
+				array(
 					'product_id' => 128,
-					'length' => 3,
-					'width' => 3,
-					'height' => 2.5,
-					'weight' => 0.15625,
-					'quantity' => 1,
+					'length'     => 3,
+					'width'      => 3,
+					'height'     => 2.5,
+					'weight'     => 0.15625,
+					'quantity'   => 1,
 				),
-				array (
+				array(
 					'product_id' => 129,
-					'length' => 3,
-					'width' => 3,
-					'height' => 2.5,
-					'weight' => 0.15625,
-					'quantity' => 1,
+					'length'     => 3,
+					'width'      => 3,
+					'height'     => 2.5,
+					'weight'     => 0.15625,
+					'quantity'   => 1,
 				),
 			),
 			'service_id' => 'pri',
@@ -75,73 +75,77 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 
 	protected $expected_selected_packages = array(
 		'weight_0_.' => array(
-			'id' => 'weight_0_.',
-			'box_id' => '"',
-			'length' => 10,
-			'width' => 10,
-			'height' => 10,
-			'weight' => 0.25625,
-			'items' => array ( array(
-				'product_id' => 128,
-				'value' => 0,
-				'length' => 3,
-				'width' => 3,
-				'height' => 2.5,
-				'weight' => 0.15625,
-				'quantity' => 1,
-				'name' => '#128 - [Deleted product]',
-			) ),
+			'id'         => 'weight_0_.',
+			'box_id'     => '"',
+			'length'     => 10,
+			'width'      => 10,
+			'height'     => 10,
+			'weight'     => 0.25625,
+			'items'      => array(
+				array(
+					'product_id' => 128,
+					'value'      => 0,
+					'length'     => 3,
+					'width'      => 3,
+					'height'     => 2.5,
+					'weight'     => 0.15625,
+					'quantity'   => 1,
+					'name'       => '#128 - [Deleted product]',
+				),
+			),
 			'service_id' => 'pri',
 		),
 	);
 
 	protected $expected_selected_packages_multiple = array(
 		'weight_0_.' => array(
-			'id' => 'weight_0_.',
-			'box_id' => '"',
-			'length' => 10,
-			'width' => 10,
-			'height' => 10,
-			'weight' => 0.25625,
-			'items' => array ( array(
-				'product_id' => 128,
-				'value' => 0,
-				'length' => 3,
-				'width' => 3,
-				'height' => 2.5,
-				'weight' => 0.15625,
-				'quantity' => 1,
-				'name' => '#128 - [Deleted product]',
-			) ),
+			'id'         => 'weight_0_.',
+			'box_id'     => '"',
+			'length'     => 10,
+			'width'      => 10,
+			'height'     => 10,
+			'weight'     => 0.25625,
+			'items'      => array(
+				array(
+					'product_id' => 128,
+					'value'      => 0,
+					'length'     => 3,
+					'width'      => 3,
+					'height'     => 2.5,
+					'weight'     => 0.15625,
+					'quantity'   => 1,
+					'name'       => '#128 - [Deleted product]',
+				),
+			),
 			'service_id' => 'pri',
 		),
 		'weight_1_.' => array(
-			'id' => 'weight_1_.',
-			'box_id' => '"',
-			'length' => 10,
-			'width' => 10,
-			'height' => 10,
-			'weight' => 0.25625,
-			'items' => array (
+			'id'         => 'weight_1_.',
+			'box_id'     => '"',
+			'length'     => 10,
+			'width'      => 10,
+			'height'     => 10,
+			'weight'     => 0.25625,
+			'items'      => array(
 				array(
 					'product_id' => 128,
-					'value' => 0,
-					'length' => 3,
-					'width' => 3,
-					'height' => 2.5,
-					'weight' => 0.15625,
-					'quantity' => 1,
-					'name' => '#128 - [Deleted product]',
+					'value'      => 0,
+					'length'     => 3,
+					'width'      => 3,
+					'height'     => 2.5,
+					'weight'     => 0.15625,
+					'quantity'   => 1,
+					'name'       => '#128 - [Deleted product]',
 				),
-				array (
+				array(
 					'product_id' => 129,
-					'value' => 0,
-					'length' => 3,
-					'width' => 3,
-					'height' => 2.5,
-					'weight' => 0.15625,
-					'quantity' => 1,
-					'name' => '#129 - [Deleted product]',
+					'value'      => 0,
+					'length'     => 3,
+					'width'      => 3,
+					'height'     => 2.5,
+					'weight'     => 0.15625,
+					'quantity'   => 1,
+					'name'       => '#129 - [Deleted product]',
 				),
 			),
 			'service_id' => 'pri',
@@ -149,16 +153,16 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 	);
 
 	public static function setupBeforeClass() {
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-compatibility.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-shipping-label.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-service-settings-store.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client-live.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-service-schemas-store.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-payment-methods-store.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-account-settings.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-package-settings.php' );
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-continents.php' );
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-compatibility.php';
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-shipping-label.php';
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-service-settings-store.php';
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client.php';
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client-live.php';
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-service-schemas-store.php';
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-payment-methods-store.php';
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-account-settings.php';
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-package-settings.php';
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-continents.php';
 
 		WC_Connect_Compatibility::set_version( '3.0.0' );
 	}
@@ -223,12 +227,12 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		);
 
 		$shipping_label = $this->get_shipping_label();
-		$actual = $shipping_label->get_selected_rates( $mock_order );
+		$actual         = $shipping_label->get_selected_rates( $mock_order );
 		$this->assertEquals( $actual, $expected );
 	}
 
 	public function test_get_selected_rates_unescaped_json() {
-		//create a json and ensure that quotes are unescaped
+		// create a json and ensure that quotes are unescaped
 		$json = json_encode( $this->wc_connect_packages );
 		$json = str_replace( '"box_id":"\""', '"box_id":"""', $json );
 
@@ -246,7 +250,7 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		);
 
 		$shipping_label = $this->get_shipping_label();
-		$actual = $shipping_label->get_selected_rates( $mock_order );
+		$actual         = $shipping_label->get_selected_rates( $mock_order );
 		$this->assertEquals( $actual, $expected );
 	}
 
@@ -265,7 +269,7 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		);
 
 		$shipping_label = $this->get_shipping_label();
-		$actual = $shipping_label->get_selected_rates( $mock_order );
+		$actual         = $shipping_label->get_selected_rates( $mock_order );
 		$this->assertEquals( $actual, $expected );
 	}
 
@@ -284,7 +288,7 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		);
 
 		$shipping_label = $this->get_shipping_label();
-		$actual = $shipping_label->get_selected_rates( $mock_order );
+		$actual         = $shipping_label->get_selected_rates( $mock_order );
 		$this->assertEquals( $actual, $expected );
 	}
 
@@ -301,12 +305,12 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		$mock_order->expects( $this->any() )->method( 'get_shipping_methods' )->will( $this->returnValue( $shipping_method ) );
 
 		$shipping_label = $this->get_shipping_label();
-		$actual = $shipping_label->get_selected_packages( $mock_order );
+		$actual         = $shipping_label->get_selected_packages( $mock_order );
 		$this->assertEquals( $actual, $this->expected_selected_packages );
 	}
 
 	public function test_get_selected_packages_unescaped_json() {
-		//create a json and ensure that quotes are unescaped
+		// create a json and ensure that quotes are unescaped
 		$json = json_encode( $this->wc_connect_packages );
 		$json = str_replace( '"box_id":"\""', '"box_id":"""', $json );
 
@@ -320,7 +324,7 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		$mock_order->expects( $this->any() )->method( 'get_shipping_methods' )->will( $this->returnValue( $shipping_method ) );
 
 		$shipping_label = $this->get_shipping_label();
-		$actual = $shipping_label->get_selected_packages( $mock_order );
+		$actual         = $shipping_label->get_selected_packages( $mock_order );
 		$this->assertEquals( $actual, $this->expected_selected_packages );
 	}
 
@@ -335,7 +339,7 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		$mock_order->expects( $this->any() )->method( 'get_shipping_methods' )->will( $this->returnValue( $shipping_method ) );
 
 		$shipping_label = $this->get_shipping_label();
-		$actual = $shipping_label->get_selected_packages( $mock_order );
+		$actual         = $shipping_label->get_selected_packages( $mock_order );
 		$this->assertEquals( $actual, $this->expected_selected_packages );
 	}
 
@@ -350,7 +354,7 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		$mock_order->expects( $this->any() )->method( 'get_shipping_methods' )->will( $this->returnValue( $shipping_method ) );
 
 		$shipping_label = $this->get_shipping_label();
-		$actual = $shipping_label->get_selected_packages( $mock_order );
+		$actual         = $shipping_label->get_selected_packages( $mock_order );
 		$this->assertEquals( $actual, $this->expected_selected_packages );
 	}
 
@@ -379,7 +383,7 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		$mock_order->expects( $this->any() )->method( 'get_shipping_methods' )->will( $this->returnValue( $shipping_method ) );
 
 		$shipping_label = $this->get_shipping_label();
-		$actual = $shipping_label->get_selected_packages( $mock_order );
+		$actual         = $shipping_label->get_selected_packages( $mock_order );
 		$this->assertEquals( $actual, $expected );
 	}
 
@@ -401,12 +405,12 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		);
 
 		$shipping_label = $this->get_shipping_label();
-		$actual = $shipping_label->get_selected_rates( $mock_order );
+		$actual         = $shipping_label->get_selected_rates( $mock_order );
 		$this->assertEquals( $actual, $expected );
 	}
 
 	public function test_get_selected_rates_multiple_packages_unescaped_json() {
-		//create a json and ensure that quotes are unescaped
+		// create a json and ensure that quotes are unescaped
 		$json = json_encode( $this->wc_connect_packages_multiple );
 		$json = str_replace( '"box_id":"\""', '"box_id":"""', $json );
 
@@ -425,7 +429,7 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		);
 
 		$shipping_label = $this->get_shipping_label();
-		$actual = $shipping_label->get_selected_rates( $mock_order );
+		$actual         = $shipping_label->get_selected_rates( $mock_order );
 		$this->assertEquals( $actual, $expected );
 	}
 
@@ -445,7 +449,7 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		);
 
 		$shipping_label = $this->get_shipping_label();
-		$actual = $shipping_label->get_selected_rates( $mock_order );
+		$actual         = $shipping_label->get_selected_rates( $mock_order );
 		$this->assertEquals( $actual, $expected );
 	}
 
@@ -465,7 +469,7 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		);
 
 		$shipping_label = $this->get_shipping_label();
-		$actual = $shipping_label->get_selected_rates( $mock_order );
+		$actual         = $shipping_label->get_selected_rates( $mock_order );
 		$this->assertEquals( $actual, $expected );
 	}
 
@@ -482,12 +486,12 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		$mock_order->expects( $this->any() )->method( 'get_shipping_methods' )->will( $this->returnValue( $shipping_method ) );
 
 		$shipping_label = $this->get_shipping_label();
-		$actual = $shipping_label->get_selected_packages( $mock_order );
+		$actual         = $shipping_label->get_selected_packages( $mock_order );
 		$this->assertEquals( $actual, $this->expected_selected_packages_multiple );
 	}
 
 	public function test_get_selected_packages_multiple_packages_unescaped_json() {
-		//create a json and ensure that quotes are unescaped
+		// create a json and ensure that quotes are unescaped
 		$json = json_encode( $this->wc_connect_packages_multiple );
 		$json = str_replace( '"box_id":"\""', '"box_id":"""', $json );
 
@@ -501,7 +505,7 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		$mock_order->expects( $this->any() )->method( 'get_shipping_methods' )->will( $this->returnValue( $shipping_method ) );
 
 		$shipping_label = $this->get_shipping_label();
-		$actual = $shipping_label->get_selected_packages( $mock_order );
+		$actual         = $shipping_label->get_selected_packages( $mock_order );
 		$this->assertEquals( $actual, $this->expected_selected_packages_multiple );
 	}
 
@@ -516,7 +520,7 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		$mock_order->expects( $this->any() )->method( 'get_shipping_methods' )->will( $this->returnValue( $shipping_method ) );
 
 		$shipping_label = $this->get_shipping_label();
-		$actual = $shipping_label->get_selected_packages( $mock_order );
+		$actual         = $shipping_label->get_selected_packages( $mock_order );
 		$this->assertEquals( $actual, $this->expected_selected_packages_multiple );
 	}
 
@@ -531,7 +535,7 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		$mock_order->expects( $this->any() )->method( 'get_shipping_methods' )->will( $this->returnValue( $shipping_method ) );
 
 		$shipping_label = $this->get_shipping_label();
-		$actual = $shipping_label->get_selected_packages( $mock_order );
+		$actual         = $shipping_label->get_selected_packages( $mock_order );
 		$this->assertEquals( $actual, $this->expected_selected_packages_multiple );
 	}
 }

--- a/tests/php/test_class-wc-connect-shipping-method.php
+++ b/tests/php/test_class-wc-connect-shipping-method.php
@@ -2,85 +2,112 @@
 
 class WP_Test_WC_Connect_Shipping_Method extends WP_UnitTestCase {
 
-	static function setUpBeforeClass()	{
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-shipping-method.php' );
+	static function setUpBeforeClass() {
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-shipping-method.php';
 	}
 
 	public function is_valid_package_destination_provider() {
 
 		return array(
-			'empty city' => array( array(
-				'destination' => array(
-					'city'     => '',
-					'country'  => 'US',
-					'state'    => 'UT',
-					'postcode' => '84068',
-				)
-			), true ),
-			'empty country' => array( array(
-				'destination' => array(
-					'city'     => 'Park City',
-					'country'  => '',
-					'state'    => 'UT',
-					'postcode' => '84068',
-				)
-			), false ),
-			'empty state' => array( array(
-				'destination' => array(
-					'city'     => 'Park City',
-					'country'  => 'US',
-					'state'    => '',
-					'postcode' => '84068',
-				)
-			), false ),
-			'invalid empty postcode' => array( array(
-				'destination' => array(
-					'city'     => 'Park City',
-					'country'  => 'US',
-					'state'    => 'UT',
-					'postcode' => '',
-				)
-			), false ),
-			'invalid postcode' => array( array(
-				'destination' => array(
-					'city'     => 'Park City',
-					'country'  => 'US',
-					'state'    => 'UT',
-					'postcode' => 'EC4V 6JA',
-				)
-			), false ),
-			'invalid state' => array( array(
-				'destination' => array(
-					'city'     => 'Park City',
-					'country'  => 'US',
-					'state'    => 'XX',
-					'postcode' => '84068',
-				)
-			), false ),
-			'valid destination with postcode' => array( array(
-				'destination' => array(
-					'city'     => 'Park City',
-					'country'  => 'US',
-					'state'    => 'UT',
-					'postcode' => '84068',
-				)
-			), true ),
-			'valid destination without postcode' => array( array(
-				'destination' => array(
-					'city'     => 'Kowloon City',
-					'country'  => 'HK',
-					'state'    => 'KOWLOON',
-					'postcode' => '',
-				)
-			), true ),
-			'valid destination without state or postcode' => array( array(
-				'destination' => array(
-					'city'     => 'Oranjestad',
-					'country'  => 'AW',
-					'state'    => '',
-					'postcode' => '',
-				)
-			), true ),
+			'empty city'                                  => array(
+				array(
+					'destination' => array(
+						'city'     => '',
+						'country'  => 'US',
+						'state'    => 'UT',
+						'postcode' => '84068',
+					),
+				),
+				true,
+			),
+			'empty country'                               => array(
+				array(
+					'destination' => array(
+						'city'     => 'Park City',
+						'country'  => '',
+						'state'    => 'UT',
+						'postcode' => '84068',
+					),
+				),
+				false,
+			),
+			'empty state'                                 => array(
+				array(
+					'destination' => array(
+						'city'     => 'Park City',
+						'country'  => 'US',
+						'state'    => '',
+						'postcode' => '84068',
+					),
+				),
+				false,
+			),
+			'invalid empty postcode'                      => array(
+				array(
+					'destination' => array(
+						'city'     => 'Park City',
+						'country'  => 'US',
+						'state'    => 'UT',
+						'postcode' => '',
+					),
+				),
+				false,
+			),
+			'invalid postcode'                            => array(
+				array(
+					'destination' => array(
+						'city'     => 'Park City',
+						'country'  => 'US',
+						'state'    => 'UT',
+						'postcode' => 'EC4V 6JA',
+					),
+				),
+				false,
+			),
+			'invalid state'                               => array(
+				array(
+					'destination' => array(
+						'city'     => 'Park City',
+						'country'  => 'US',
+						'state'    => 'XX',
+						'postcode' => '84068',
+					),
+				),
+				false,
+			),
+			'valid destination with postcode'             => array(
+				array(
+					'destination' => array(
+						'city'     => 'Park City',
+						'country'  => 'US',
+						'state'    => 'UT',
+						'postcode' => '84068',
+					),
+				),
+				true,
+			),
+			'valid destination without postcode'          => array(
+				array(
+					'destination' => array(
+						'city'     => 'Kowloon City',
+						'country'  => 'HK',
+						'state'    => 'KOWLOON',
+						'postcode' => '',
+					),
+				),
+				true,
+			),
+			'valid destination without state or postcode' => array(
+				array(
+					'destination' => array(
+						'city'     => 'Oranjestad',
+						'country'  => 'AW',
+						'state'    => '',
+						'postcode' => '',
+					),
+				),
+				true,
+			),
 		);
 
 	}

--- a/tests/php/test_class_wc-connect-nux.php
+++ b/tests/php/test_class_wc-connect-nux.php
@@ -3,7 +3,7 @@
 class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 
 	public static function setupBeforeClass() {
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-nux.php' );
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-nux.php';
 	}
 
 	public function test_get_banner_type_to_display_dev_jp() {
@@ -15,7 +15,8 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 					'can_accept_tos'                  => false,
 					'should_display_after_cxn_banner' => false,
 				)
-			), false
+			),
+			false
 		);
 
 		$this->assertEquals(
@@ -26,7 +27,8 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 					'can_accept_tos'                  => null, // irrelevant here, TOS is accepted (DEV)
 					'should_display_after_cxn_banner' => false,
 				)
-			), false
+			),
+			false
 		);
 
 		$this->assertEquals(
@@ -37,7 +39,8 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 					'can_accept_tos'                  => null, // irrelevant here, TOS will be accepted in "after" banner
 					'should_display_after_cxn_banner' => true,
 				)
-			), 'after_jetpack_connection'
+			),
+			'after_jetpack_connection'
 		);
 
 		$this->assertEquals(
@@ -48,7 +51,8 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 					'can_accept_tos'                  => false,
 					'should_display_after_cxn_banner' => true,
 				)
-			), 'after_jetpack_connection'
+			),
+			'after_jetpack_connection'
 		);
 
 		$this->assertEquals(
@@ -59,100 +63,156 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 					'can_accept_tos'                  => true,
 					'should_display_after_cxn_banner' => false,
 				)
-			), 'tos_only_banner'
+			),
+			'tos_only_banner'
 		);
 	}
 
 	public function test_get_banner_type_to_display_no_jp_cxn_without_tos_acceptance() {
 		// before going through connection
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
-			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_NOT_INSTALLED,
-			'tos_accepted'                           => false,
-			'can_accept_tos'                         => false, // no master user, not DEV
-			'should_display_after_cxn_banner'        => false,
-		) ), 'before_jetpack_connection' );
+		$this->assertEquals(
+			WC_Connect_Nux::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_NOT_INSTALLED,
+					'tos_accepted'                    => false,
+					'can_accept_tos'                  => false, // no master user, not DEV
+					'should_display_after_cxn_banner' => false,
+				)
+			),
+			'before_jetpack_connection'
+		);
 
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
-			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_INSTALLED_NOT_ACTIVATED,
-			'tos_accepted'                           => false,
-			'can_accept_tos'                         => false, // no master user, not DEV
-			'should_display_after_cxn_banner'        => false,
-		) ), 'before_jetpack_connection' );
+		$this->assertEquals(
+			WC_Connect_Nux::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_INSTALLED_NOT_ACTIVATED,
+					'tos_accepted'                    => false,
+					'can_accept_tos'                  => false, // no master user, not DEV
+					'should_display_after_cxn_banner' => false,
+				)
+			),
+			'before_jetpack_connection'
+		);
 
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
-			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_ACTIVATED_NOT_CONNECTED,
-			'tos_accepted'                           => false,
-			'can_accept_tos'                         => false, // no master user, not DEV
-			'should_display_after_cxn_banner'        => false,
-		) ), 'before_jetpack_connection' );
+		$this->assertEquals(
+			WC_Connect_Nux::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_ACTIVATED_NOT_CONNECTED,
+					'tos_accepted'                    => false,
+					'can_accept_tos'                  => false, // no master user, not DEV
+					'should_display_after_cxn_banner' => false,
+				)
+			),
+			'before_jetpack_connection'
+		);
 
 		// after going through connection, TOS was never accepted
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
-			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
-			'tos_accepted'                           => false,
-			'can_accept_tos'                         => null, // irrelevant here, TOS will be accepted in "after" banner
-			'should_display_after_cxn_banner'        => true,
-		) ), 'after_jetpack_connection' );
+		$this->assertEquals(
+			WC_Connect_Nux::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_CONNECTED,
+					'tos_accepted'                    => false,
+					'can_accept_tos'                  => null, // irrelevant here, TOS will be accepted in "after" banner
+					'should_display_after_cxn_banner' => true,
+				)
+			),
+			'after_jetpack_connection'
+		);
 	}
 
 	public function test_get_banner_type_to_display_no_jp_cxn_with_tos_acceptance() {
 		// before going through connection
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
-			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_NOT_INSTALLED,
-			'tos_accepted'                           => true,
-			'can_accept_tos'                         => true,
-			'should_display_after_cxn_banner'        => false,
-		) ), 'before_jetpack_connection' );
+		$this->assertEquals(
+			WC_Connect_Nux::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_NOT_INSTALLED,
+					'tos_accepted'                    => true,
+					'can_accept_tos'                  => true,
+					'should_display_after_cxn_banner' => false,
+				)
+			),
+			'before_jetpack_connection'
+		);
 
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
-			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_INSTALLED_NOT_ACTIVATED,
-			'tos_accepted'                           => true,
-			'can_accept_tos'                         => true,
-			'should_display_after_cxn_banner'        => false,
-		) ), 'before_jetpack_connection' );
+		$this->assertEquals(
+			WC_Connect_Nux::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_INSTALLED_NOT_ACTIVATED,
+					'tos_accepted'                    => true,
+					'can_accept_tos'                  => true,
+					'should_display_after_cxn_banner' => false,
+				)
+			),
+			'before_jetpack_connection'
+		);
 
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
-			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_ACTIVATED_NOT_CONNECTED,
-			'tos_accepted'                           => true,
-			'can_accept_tos'                         => true,
-			'should_display_after_cxn_banner'        => false,
-		) ), 'before_jetpack_connection' );
+		$this->assertEquals(
+			WC_Connect_Nux::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_ACTIVATED_NOT_CONNECTED,
+					'tos_accepted'                    => true,
+					'can_accept_tos'                  => true,
+					'should_display_after_cxn_banner' => false,
+				)
+			),
+			'before_jetpack_connection'
+		);
 
 		// after going through connection, TOS was already previously accepted
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
-			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
-			'tos_accepted'                           => true,
-			'can_accept_tos'                         => true,
-			'should_display_after_cxn_banner'        => true,
-		) ), 'after_jetpack_connection' );
+		$this->assertEquals(
+			WC_Connect_Nux::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_CONNECTED,
+					'tos_accepted'                    => true,
+					'can_accept_tos'                  => true,
+					'should_display_after_cxn_banner' => true,
+				)
+			),
+			'after_jetpack_connection'
+		);
 	}
 
 	public function test_get_banner_type_to_display_with_jp_cxn_without_tos_acceptance() {
 		// Jetpack is already connected, TOS was not yet accepted
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
-			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
-			'tos_accepted'                           => false,
-			'can_accept_tos'                         => true,
-			'should_display_after_cxn_banner'        => false,
-		) ), 'tos_only_banner' );
+		$this->assertEquals(
+			WC_Connect_Nux::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_CONNECTED,
+					'tos_accepted'                    => false,
+					'can_accept_tos'                  => true,
+					'should_display_after_cxn_banner' => false,
+				)
+			),
+			'tos_only_banner'
+		);
 
 		// Regression test for changing order of "tos accepted" and "should display after cxn banner"
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
-			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
-			'tos_accepted'                           => false,
-			'can_accept_tos'                         => true,
-			'should_display_after_cxn_banner'        => true,
-		) ), 'after_jetpack_connection' );
+		$this->assertEquals(
+			WC_Connect_Nux::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_CONNECTED,
+					'tos_accepted'                    => false,
+					'can_accept_tos'                  => true,
+					'should_display_after_cxn_banner' => true,
+				)
+			),
+			'after_jetpack_connection'
+		);
 	}
 
 	public function test_get_banner_type_to_display_with_jp_cxn_with_tos_acceptance() {
 		// Jetpack is already connected, TOS is already accepted
 		// did not show before connection banner
-		$this->assertEquals( WC_Connect_Nux::get_banner_type_to_display( array(
-			'jetpack_connection_status'              => WC_Connect_Nux::JETPACK_CONNECTED,
-			'tos_accepted'                           => true,
-			'can_accept_tos'                         => true,
-			'should_display_after_cxn_banner'        => false,
-		) ), false );
+		$this->assertEquals(
+			WC_Connect_Nux::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_CONNECTED,
+					'tos_accepted'                    => true,
+					'can_accept_tos'                  => true,
+					'should_display_after_cxn_banner' => false,
+				)
+			),
+			false
+		);
 	}
 }

--- a/tests/php/test_wc-connect-services-validator.php
+++ b/tests/php/test_wc-connect-services-validator.php
@@ -17,25 +17,25 @@ class WP_Test_WC_Connect_Service_Schemas_Validator extends WC_Unit_Test_Case {
 		return (object) array(
 			'shipping' => array(
 				(object) array(
-					'id' => 'usps',
+					'id'                 => 'usps',
 					'method_description' => 'Obtains rates dynamically from the USPS API during cart/checkout.',
-					'method_title' => 'USPS (WooCommerce Shipping)',
-					'form_layout' => array(),
-					'service_settings' => (object) array(
-						'type' => 'object',
-						'required' => array(),
+					'method_title'       => 'USPS (WooCommerce Shipping)',
+					'form_layout'        => array(),
+					'service_settings'   => (object) array(
+						'type'       => 'object',
+						'required'   => array(),
 						'properties' => (object) array(
 							'title' => (object) array(
-								'type' => 'string',
-								'title' => 'Method Title',
+								'type'        => 'string',
+								'title'       => 'Method Title',
 								'description' => 'This controls the title which the user sees during checkout.',
-								'default' => 'USPS'
-							)
-						)
-					)
-				)
+								'default'     => 'USPS',
+							),
+						),
+					),
+				),
 			),
-			'boxes' => new stdClass()
+			'boxes'    => new stdClass(),
 		);
 
 	}
@@ -64,11 +64,11 @@ class WP_Test_WC_Connect_Service_Schemas_Validator extends WC_Unit_Test_Case {
 	public function validate_services_errors_provider() {
 
 		// service should reference an object
-		$service_not_ref_object = self::get_golden_services();
+		$service_not_ref_object              = self::get_golden_services();
 		$service_not_ref_object->shipping[0] = array();
 
 		// service type should reference an array
-		$service_type_array = self::get_golden_services();
+		$service_type_array           = self::get_golden_services();
 		$service_type_array->shipping = new stdClass();
 
 		// service should have an id
@@ -76,7 +76,7 @@ class WP_Test_WC_Connect_Service_Schemas_Validator extends WC_Unit_Test_Case {
 		unset( $service_id_required->shipping[0]->id );
 
 		// service id should be a string
-		$service_id_string = self::get_golden_services();
+		$service_id_string                  = self::get_golden_services();
 		$service_id_string->shipping[0]->id = 99;
 
 		// service should have method description
@@ -84,7 +84,7 @@ class WP_Test_WC_Connect_Service_Schemas_Validator extends WC_Unit_Test_Case {
 		unset( $service_method_description->shipping[0]->method_description );
 
 		// service method description should be a string
-		$service_method_string = self::get_golden_services();
+		$service_method_string                                  = self::get_golden_services();
 		$service_method_string->shipping[0]->method_description = 99;
 
 		// service should have method title
@@ -92,7 +92,7 @@ class WP_Test_WC_Connect_Service_Schemas_Validator extends WC_Unit_Test_Case {
 		unset( $service_title_required->shipping[0]->method_title );
 
 		// service method title should be a string
-		$service_title_string = self::get_golden_services();
+		$service_title_string                            = self::get_golden_services();
 		$service_title_string->shipping[0]->method_title = 99;
 
 		// service should have service settings
@@ -108,7 +108,7 @@ class WP_Test_WC_Connect_Service_Schemas_Validator extends WC_Unit_Test_Case {
 		unset( $service_settings_type_required->shipping[0]->service_settings->type );
 
 		// service settings type should be a string
-		$service_settings_type_string = self::get_golden_services();
+		$service_settings_type_string                                      = self::get_golden_services();
 		$service_settings_type_string->shipping[0]->service_settings->type = 99;
 
 		// service settings should have required
@@ -136,25 +136,25 @@ class WP_Test_WC_Connect_Service_Schemas_Validator extends WC_Unit_Test_Case {
 		unset( $service_settings_boxes_required->boxes );
 
 		return array(
-			'services should be an object' => array( array(), 'outermost_container_not_object' ),
-			'service type should reference an array' => array( $service_type_array, 'service_type_not_ref_array' ),
-			'service should reference an object' => array( $service_not_ref_object, 'service_not_ref_object' ),
-			'service should have an id' => array( $service_id_required, 'required_service_property_missing' ),
-			'service id should be a string' => array( $service_id_string, 'required_service_property_wrong_type' ),
-			'service should have method description' => array( $service_method_description, 'required_service_property_missing' ),
+			'services should be an object'                 => array( array(), 'outermost_container_not_object' ),
+			'service type should reference an array'       => array( $service_type_array, 'service_type_not_ref_array' ),
+			'service should reference an object'           => array( $service_not_ref_object, 'service_not_ref_object' ),
+			'service should have an id'                    => array( $service_id_required, 'required_service_property_missing' ),
+			'service id should be a string'                => array( $service_id_string, 'required_service_property_wrong_type' ),
+			'service should have method description'       => array( $service_method_description, 'required_service_property_missing' ),
 			'service method description should be a string' => array( $service_method_string, 'required_service_property_wrong_type' ),
-			'service should have method title' => array( $service_title_required, 'required_service_property_missing' ),
-			'service method title should be a string' => array( $service_title_string, 'required_service_property_wrong_type' ),
-			'service should have service settings' => array( $service_settings_required, 'required_service_property_missing' ),
-			'service should have form layout' => array( $form_layout_required, 'required_service_property_missing' ),
-			'service settings should have type' => array( $service_settings_type_required, 'service_settings_missing_required_property' ),
-			'service settings type should be a string' => array( $service_settings_type_string, 'service_settings_property_wrong_type' ),
-			'service settings should have required' => array( $service_settings_required_required, 'service_settings_missing_required_property' ),
+			'service should have method title'             => array( $service_title_required, 'required_service_property_missing' ),
+			'service method title should be a string'      => array( $service_title_string, 'required_service_property_wrong_type' ),
+			'service should have service settings'         => array( $service_settings_required, 'required_service_property_missing' ),
+			'service should have form layout'              => array( $form_layout_required, 'required_service_property_missing' ),
+			'service settings should have type'            => array( $service_settings_type_required, 'service_settings_missing_required_property' ),
+			'service settings type should be a string'     => array( $service_settings_type_string, 'service_settings_property_wrong_type' ),
+			'service settings should have required'        => array( $service_settings_required_required, 'service_settings_missing_required_property' ),
 			'service settings required should be an array' => array( $service_settings_required_array, 'service_settings_property_wrong_type' ),
-			'service settings should have properties' => array( $service_settings_properties_required, 'service_settings_missing_required_property' ),
+			'service settings should have properties'      => array( $service_settings_properties_required, 'service_settings_missing_required_property' ),
 			'service settings properties should be an object' => array( $service_settings_properties_object, 'service_settings_property_wrong_type' ),
 			'service settings properties should have title' => array( $service_settings_title_required, 'service_properties_missing_required_property' ),
-			'boxes should be an object' => array( $service_settings_boxes_required, 'boxes_not_object' ),
+			'boxes should be an object'                    => array( $service_settings_boxes_required, 'boxes_not_object' ),
 		);
 
 	}

--- a/tests/php/test_woocommerce-connect-client.php
+++ b/tests/php/test_woocommerce-connect-client.php
@@ -68,7 +68,7 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 
 	public function mockLoaderAndActiveShippingMethods() {
 		$service_data = array(
-			'test_method_that_is_from_wc_connect'
+			'test_method_that_is_from_wc_connect',
 		);
 
 		$store = $this->getMockBuilder( 'WC_Connect_Service_Schemas_Store' )
@@ -79,7 +79,6 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 		$store->expects( $this->any() )
 			->method( 'get_all_shipping_method_ids' )
 			->will( $this->returnValue( $service_data ) );
-
 
 		return $this->mockLoader( $store );
 	}
@@ -203,7 +202,7 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 			->getMock();
 
 		$service_data = array(
-			'method_id' => 'test_method'
+			'method_id' => 'test_method',
 		);
 
 		$store->expects( $this->any() )

--- a/tests/php/test_woocommerce-connect-tracks.php
+++ b/tests/php/test_woocommerce-connect-tracks.php
@@ -6,7 +6,7 @@ abstract class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 	protected $logger;
 
 	public static function setupBeforeClass() {
-		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-tracks.php' );
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-tracks.php';
 	}
 
 	public function setUp() {
@@ -28,7 +28,7 @@ class WP_Test_WC_Connect_Tracks_No_Jetpack extends WP_Test_WC_Connect_Tracks {
 			->with(
 				$this->stringContains( 'Error' ),
 				$this->anything()
-		);
+			);
 		$record = $this->tracks->opted_out();
 		$this->assertNull( $record );
 	}
@@ -39,7 +39,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 
 	public static function setupBeforeClass() {
 		parent::setupBeforeClass();
-		require_once( dirname( __FILE__ ) . '/mocks/jetpack.php' );
+		require_once dirname( __FILE__ ) . '/mocks/jetpack.php';
 	}
 
 	public function test_record_user_event() {
@@ -130,7 +130,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
 		// rather then the less precise for all versions
 		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
-			$this->logger->expects( $this->exactly(2) )
+			$this->logger->expects( $this->exactly( 2 ) )
 				->method( 'log' )
 				->withConsecutive(
 					array(
@@ -143,14 +143,14 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 					)
 				);
 		} else {
-			$this->logger->expects( $this->at(0) )
+			$this->logger->expects( $this->at( 0 ) )
 				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_saved_service_settings' ),
 					$this->anything()
 				);
 
-			$this->logger->expects( $this->at(1) )
+			$this->logger->expects( $this->at( 1 ) )
 				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_saved_usps_settings' ),
@@ -168,7 +168,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
 		// rather then the less precise for all versions
 		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
-			$this->logger->expects( $this->exactly(2) )
+			$this->logger->expects( $this->exactly( 2 ) )
 				->method( 'log' )
 				->withConsecutive(
 					array(
@@ -181,14 +181,14 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 					)
 				);
 		} else {
-			$this->logger->expects( $this->at(0) )
+			$this->logger->expects( $this->at( 0 ) )
 				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_method_added' ),
 					$this->anything()
 				);
 
-			$this->logger->expects( $this->at(1) )
+			$this->logger->expects( $this->at( 1 ) )
 				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_usps_added' ),
@@ -206,7 +206,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
 		// rather then the less precise for all versions
 		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
-			$this->logger->expects( $this->exactly(2) )
+			$this->logger->expects( $this->exactly( 2 ) )
 				->method( 'log' )
 				->withConsecutive(
 					array(
@@ -219,14 +219,14 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 					)
 				);
 		} else {
-			$this->logger->expects( $this->at(0) )
+			$this->logger->expects( $this->at( 0 ) )
 				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_method_deleted' ),
 					$this->anything()
 				);
 
-			$this->logger->expects( $this->at(1) )
+			$this->logger->expects( $this->at( 1 ) )
 				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_canada_post_deleted' ),
@@ -244,7 +244,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
 		// rather then the less precise for all versions
 		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
-			$this->logger->expects( $this->exactly(2) )
+			$this->logger->expects( $this->exactly( 2 ) )
 				->method( 'log' )
 				->withConsecutive(
 					array(
@@ -257,14 +257,14 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 					)
 				);
 		} else {
-			$this->logger->expects( $this->at(0) )
+			$this->logger->expects( $this->at( 0 ) )
 				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_method_enabled' ),
 					$this->anything()
 				);
 
-			$this->logger->expects( $this->at(1) )
+			$this->logger->expects( $this->at( 1 ) )
 				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_usps_enabled' ),
@@ -282,7 +282,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
 		// rather then the less precise for all versions
 		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
-			$this->logger->expects( $this->exactly(2) )
+			$this->logger->expects( $this->exactly( 2 ) )
 				->method( 'log' )
 				->withConsecutive(
 					array(
@@ -295,14 +295,14 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 					)
 				);
 		} else {
-			$this->logger->expects( $this->at(0) )
+			$this->logger->expects( $this->at( 0 ) )
 				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_method_disabled' ),
 					$this->anything()
 				);
 
-			$this->logger->expects( $this->at(1) )
+			$this->logger->expects( $this->at( 1 ) )
 				->method( 'log' )
 				->with(
 					$this->stringContains( 'woocommerceconnect_shipping_zone_usps_disabled' ),

--- a/tests/php/test_woocommerce-services-compatibility.php
+++ b/tests/php/test_woocommerce-services-compatibility.php
@@ -1,11 +1,11 @@
 <?php
 
-if( ! class_exists( 'WC_Connect_Compatibility' ) ) {
-	require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-compatibility.php' );
+if ( ! class_exists( 'WC_Connect_Compatibility' ) ) {
+	require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-compatibility.php';
 }
 
 class WP_Test_WC_Services_Compatibility extends WC_Unit_Test_Case {
-	public function  test_compatibility_selection() {
+	public function test_compatibility_selection() {
 		WC_Connect_Compatibility::set_version( '3.0.1' );
 		$this->assertEquals( 'WC_Connect_Compatibility_WC30', get_class( WC_Connect_Compatibility::instance() ) );
 
@@ -24,21 +24,21 @@ class WP_Test_WC_Services_Compatibility extends WC_Unit_Test_Case {
 	}
 
 	public function test_get_order_id() {
-		$compat = WC_Connect_Compatibility::instance();
-		$order = WC_Helper_Order::create_order();
+		$compat     = WC_Connect_Compatibility::instance();
+		$order      = WC_Helper_Order::create_order();
 		$next_order = WC_Helper_Order::create_order();
-		$id = $compat->get_order_id( $order );
+		$id         = $compat->get_order_id( $order );
 		$this->assertEquals( self::get_id( $order ), $id );
 		$this->assertNotEquals( self::get_id( $order ), self::get_id( $next_order ) );
 	}
 
 	public function test_get_item_product() {
-		$compat = WC_Connect_Compatibility::instance();
-		$product = WC_Helper_Product::create_simple_product();
- 		$order = WC_Helper_Order::create_order();
- 		$items = $order->get_items();
+		$compat      = WC_Connect_Compatibility::instance();
+		$product     = WC_Helper_Product::create_simple_product();
+		$order       = WC_Helper_Order::create_order();
+		$items       = $order->get_items();
 		$item_values = array_values( $items );
-		$item = $item_values[ 0 ];
+		$item        = $item_values[0];
 
 		$result = $compat->get_item_product( $order, $item );
 
@@ -54,43 +54,43 @@ class WP_Test_WC_Services_Compatibility extends WC_Unit_Test_Case {
 	}
 
 	public function test_get_formatted_variation() {
-		$compat = WC_Connect_Compatibility::instance();
-		$product = WC_Helper_Product::create_variation_product();
+		$compat     = WC_Connect_Compatibility::instance();
+		$product    = WC_Helper_Product::create_variation_product();
 		$variations = $product->get_available_variations();
-		$variation = new WC_Product_Variation( $variations[0]['variation_id'] );
+		$variation  = new WC_Product_Variation( $variations[0]['variation_id'] );
 		$this->assertTrue( is_string( $compat->get_formatted_variation( $variation ) ) );
 		$this->assertRegExp( '/^\<dl class="variation"/', $compat->get_formatted_variation( $variation ) );
 	}
 
 	public function test_get_product_id() {
-		$compat = WC_Connect_Compatibility::instance();
+		$compat  = WC_Connect_Compatibility::instance();
 		$product = WC_Helper_Product::create_variation_product();
-		$id = $compat->get_product_id( $product );
+		$id      = $compat->get_product_id( $product );
 		$this->assertEquals( self::get_id( $product ), $id );
 	}
 
 	public function test_get_parent_product_id() {
-		$compat = WC_Connect_Compatibility::instance();
-		$product = WC_Helper_Product::create_variation_product();
-		$variations = $product->get_available_variations();
-		$variation = new WC_Product_Variation( $variations[0]['variation_id'] );
-		$parent_id = $compat->get_parent_product_id( $product );
+		$compat       = WC_Connect_Compatibility::instance();
+		$product      = WC_Helper_Product::create_variation_product();
+		$variations   = $product->get_available_variations();
+		$variation    = new WC_Product_Variation( $variations[0]['variation_id'] );
+		$parent_id    = $compat->get_parent_product_id( $product );
 		$variation_id = $compat->get_parent_product_id( $variation );
 		$this->assertEquals( self::get_id( $product ), $parent_id );
 		$this->assertEquals( self::get_id( $product ), $variation_id );
 	}
 
 	public function get_product_name_from_order() {
-		$compat = WC_Connect_Compatibility::instance();
-		$order = WC_Helper_Order::create_order();
+		$compat   = WC_Connect_Compatibility::instance();
+		$order    = WC_Helper_Order::create_order();
 		$order_id = self::get_id( $order );
 
 		// The order is auto-populated with a product. Delete that product from the database, but not from the order
-		$items = $order->get_items();
-		$item_values = array_values( $items );
-		$item = $item_values[ 0 ];
-		$product = $compat->get_item_product( $order, $item );
-		$product_id = self::get_id( $product );
+		$items        = $order->get_items();
+		$item_values  = array_values( $items );
+		$item         = $item_values[0];
+		$product      = $compat->get_item_product( $order, $item );
+		$product_id   = self::get_id( $product );
 		$product_name = $product->get_title();
 		WC_Helper_Product::delete_product( $product_id );
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -34,10 +34,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-require_once( plugin_basename( 'classes/class-wc-connect-extension-compatibility.php' ) );
-require_once( plugin_basename( 'classes/class-wc-connect-functions.php' ) );
-require_once( plugin_basename( 'classes/class-wc-connect-jetpack.php' ) );
-require_once( plugin_basename( 'classes/class-wc-connect-options.php' ) );
+require_once __DIR__ . '/classes/class-wc-connect-extension-compatibility.php';
+require_once __DIR__ . '/classes/class-wc-connect-functions.php';
+require_once __DIR__ . '/classes/class-wc-connect-jetpack.php';
+require_once __DIR__ . '/classes/class-wc-connect-options.php';
 
 if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
@@ -48,7 +48,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 	define( 'WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH', 32 );
 
 	if ( ! defined( 'WOOCOMMERCE_CONNECT_SERVER_API_VERSION ' ) ) {
-		define( 'WOOCOMMERCE_CONNECT_SERVER_API_VERSION', '5');
+		define( 'WOOCOMMERCE_CONNECT_SERVER_API_VERSION', '5' );
 	}
 
 	// Check for CI environment variable to trigger test mode.
@@ -204,11 +204,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		protected static $wcs_version;
 
-		static function plugin_deactivation() {
+		public static function plugin_deactivation() {
 			wp_clear_scheduled_hook( 'wc_connect_fetch_service_schemas' );
 		}
 
-		static function plugin_uninstall() {
+		public static function plugin_uninstall() {
 			WC_Connect_Options::delete_all_options();
 		}
 
@@ -217,10 +217,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 *
 		 * @return string
 		 */
-		static function get_wcs_version() {
+		public static function get_wcs_version() {
 			if ( null === self::$wcs_version ) {
-				$plugin_data = get_file_data( __FILE__, array( 'Version' => 'Version' ) );
-				self::$wcs_version = $plugin_data[ 'Version' ];
+				$plugin_data       = get_file_data( __FILE__, array( 'Version' => 'Version' ) );
+				self::$wcs_version = $plugin_data['Version'];
 			}
 			return self::$wcs_version;
 		}
@@ -230,7 +230,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 *
 		 * @return string
 		 */
-		static function get_wc_connect_base_url() {
+		private static function get_wc_connect_base_url() {
 			return trailingslashit( defined( 'WOOCOMMERCE_CONNECT_DEV_SERVER_URL' ) ? WOOCOMMERCE_CONNECT_DEV_SERVER_URL : plugins_url( 'dist/', __FILE__ ) );
 		}
 
@@ -239,7 +239,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 *
 		 * @return string
 		 */
-		static function get_wcs_admin_script_url() {
+		public static function get_wcs_admin_script_url() {
 			return self::get_wc_connect_base_url() . 'woocommerce-services-' . self::get_wcs_version() . '.js';
 		}
 
@@ -248,7 +248,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 *
 		 * @return string
 		 */
-		static function get_wcs_admin_style_url() {
+		public static function get_wcs_admin_style_url() {
 			if ( ! defined( 'WOOCOMMERCE_CONNECT_DEV_SERVER_URL' ) ) {
 				return self::get_wc_connect_base_url() . 'woocommerce-services-' . self::get_wcs_version() . '.css';
 			} else {
@@ -256,8 +256,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 		}
 
-		function wpcom_static_url($file) {
-			$i = hexdec( substr( md5( $file ), -1 ) ) % 2;
+		function wpcom_static_url( $file ) {
+			$i   = hexdec( substr( md5( $file ), -1 ) ) % 2;
 			$url = 'http://s' . $i . '.wp.com' . $file;
 			return set_url_scheme( $url );
 		}
@@ -492,13 +492,16 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->load_textdomain();
 
 			if ( ! class_exists( 'WooCommerce' ) ) {
-				add_action( 'admin_notices', function() {
-					/* translators: %s WC download URL link. */
-					echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'WooCommerce Shipping & Tax requires the WooCommerce plugin to be installed and active. You can download %s here.', 'woocommerce-services' ), '<a href="https://wordpress.org/plugins/woocommerce/" target="_blank">WooCommerce</a>' ) . '</strong></p></div>';
-				} );
+				add_action(
+					'admin_notices',
+					function() {
+						/* translators: %s WC download URL link. */
+						echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'WooCommerce Shipping & Tax requires the WooCommerce plugin to be installed and active. You can download %s here.', 'woocommerce-services' ), '<a href="https://wordpress.org/plugins/woocommerce/" target="_blank">WooCommerce</a>' ) . '</strong></p></div>';
+					}
+				);
 				return;
 			}
-			add_action( 'before_woocommerce_init', array( $this, 'pre_wc_init') );
+			add_action( 'before_woocommerce_init', array( $this, 'pre_wc_init' ) );
 		}
 
 		/**
@@ -512,7 +515,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$tos_accepted = WC_Connect_Options::get_option( 'tos_accepted' );
 
 			// Prevent presenting users with TOS they've already
-			// accepted in the core WC Setup Wizard or on WP.com
+			// accepted in the core WC Setup Wizard or on WP.com.
 			if ( ! $tos_accepted &&
 				( get_option( 'woocommerce_setup_jetpack_opted_in' ) || WC_Connect_Jetpack::is_atomic_site() )
 			) {
@@ -525,12 +528,12 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'admin_init', array( $this, 'admin_enqueue_scripts' ) );
 			add_action( 'admin_init', array( $this->nux, 'set_up_nux_notices' ) );
 
-			// Plugin should be enabled if dev mode or connected + TOS
-			$jetpack_status = $this->nux->get_jetpack_install_status();
+			// Plugin should be enabled if dev mode or connected + TOS.
+			$jetpack_status       = $this->nux->get_jetpack_install_status();
 			$is_jetpack_connected = WC_Connect_Nux::JETPACK_CONNECTED === $jetpack_status;
-			$is_jetpack_dev_mode = WC_Connect_Nux::JETPACK_DEV === $jetpack_status;
+			$is_jetpack_dev_mode  = WC_Connect_Nux::JETPACK_DEV === $jetpack_status;
 
-			if (  ! $is_jetpack_connected && ! $is_jetpack_dev_mode ) {
+			if ( ! $is_jetpack_connected && ! $is_jetpack_dev_mode ) {
 				return;
 			}
 
@@ -568,8 +571,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		public function save_defaults_to_shipping_method( $instance_id, $service_id, $zone_id ) {
 			$shipping_method = WC_Shipping_Zones::get_shipping_method( $instance_id );
-			$schema   = $shipping_method->get_service_schema();
-			$defaults = (object) $this->get_service_schema_defaults( $schema->service_settings );
+			$schema          = $shipping_method->get_service_schema();
+			$defaults        = (object) $this->get_service_schema_defaults( $schema->service_settings );
 			WC_Connect_Options::update_shipping_method_option( 'form_settings', $defaults, $service_id, $instance_id );
 		}
 
@@ -579,11 +582,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				return;
 			}
 
-			$zone = WC_Shipping_Zones::get_zone( $zone_id );
+			$zone        = WC_Shipping_Zones::get_zone( $zone_id );
 			$instance_id = $zone->add_shipping_method( $method->method_id );
 			$zone->save();
 
-			// Dismiss the "add a method to zone" pointer
+			// Dismiss the "add a method to zone" pointer.
 			$this->nux->dismiss_pointer( 'wc_services_add_service_to_zone' );
 		}
 
@@ -595,7 +598,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			} elseif ( 'CAD' === $store_currency ) {
 				$currency_method = 'canada_post';
 			} else {
-				return; // Only set up live rates for USD and CAD
+				return; // Only set up live rates for USD and CAD.
 			}
 
 			if ( get_option( 'woocommerce_setup_intl_live_rates_zone' ) ) {
@@ -606,7 +609,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			if ( get_option( 'woocommerce_setup_domestic_live_rates_zone' ) ) {
 				$store_country = WC()->countries->get_base_country();
 
-				// Find the "domestic" zone (only location must be the base country)
+				// Find the "domestic" zone (only location must be the base country).
 				foreach ( WC_Shipping_Zones::get_zones() as $zone ) {
 					if (
 						1 === count( $zone['zone_locations'] ) &&
@@ -636,38 +639,38 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * Load all plugin dependencies.
 		 */
 		public function load_dependencies() {
-			require_once( plugin_basename( 'classes/class-wc-connect-logger.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-service-schemas-validator.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-taxjar-integration.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-error-notice.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-compatibility.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-shipping-method.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-service-schemas-store.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-service-settings-store.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-payment-methods-store.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-tracks.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-help-view.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-shipping-label.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-nux.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-paypal-ec.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-label-reports.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-privacy.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-account-settings.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-package-settings.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-continents.php' ) );
-			require_once( plugin_basename( 'classes/class-wc-connect-order-presenter.php' ) );
+			require_once __DIR__ . '/classes/class-wc-connect-logger.php';
+			require_once __DIR__ . '/classes/class-wc-connect-service-schemas-validator.php';
+			require_once __DIR__ . '/classes/class-wc-connect-taxjar-integration.php';
+			require_once __DIR__ . '/classes/class-wc-connect-error-notice.php';
+			require_once __DIR__ . '/classes/class-wc-connect-compatibility.php';
+			require_once __DIR__ . '/classes/class-wc-connect-shipping-method.php';
+			require_once __DIR__ . '/classes/class-wc-connect-service-schemas-store.php';
+			require_once __DIR__ . '/classes/class-wc-connect-service-settings-store.php';
+			require_once __DIR__ . '/classes/class-wc-connect-payment-methods-store.php';
+			require_once __DIR__ . '/classes/class-wc-connect-tracks.php';
+			require_once __DIR__ . '/classes/class-wc-connect-help-view.php';
+			require_once __DIR__ . '/classes/class-wc-connect-shipping-label.php';
+			require_once __DIR__ . '/classes/class-wc-connect-nux.php';
+			require_once __DIR__ . '/classes/class-wc-connect-paypal-ec.php';
+			require_once __DIR__ . '/classes/class-wc-connect-label-reports.php';
+			require_once __DIR__ . '/classes/class-wc-connect-privacy.php';
+			require_once __DIR__ . '/classes/class-wc-connect-account-settings.php';
+			require_once __DIR__ . '/classes/class-wc-connect-package-settings.php';
+			require_once __DIR__ . '/classes/class-wc-connect-continents.php';
+			require_once __DIR__ . '/classes/class-wc-connect-order-presenter.php';
 
-			$core_logger           = new WC_Logger();
-			$logger                = new WC_Connect_Logger( $core_logger );
-			$taxes_logger          = new WC_Connect_Logger( $core_logger, 'taxes' );
-			$shipping_logger       = new WC_Connect_Logger( $core_logger, 'shipping' );
+			$core_logger     = new WC_Logger();
+			$logger          = new WC_Connect_Logger( $core_logger );
+			$taxes_logger    = new WC_Connect_Logger( $core_logger, 'taxes' );
+			$shipping_logger = new WC_Connect_Logger( $core_logger, 'shipping' );
 
-			$validator             = new WC_Connect_Service_Schemas_Validator();
+			$validator = new WC_Connect_Service_Schemas_Validator();
 			if ( defined( 'WOOCOMMERCE_SERVICES_LOCAL_TEST_MODE' ) ) {
-				require_once( plugin_basename( 'tests/php/class-wc-connect-api-client-local-test-mock.php' ) );
+				require_once __DIR__ . '/tests/php/class-wc-connect-api-client-local-test-mock.php';
 				$api_client = new WC_Connect_API_Client_Local_Test_Mock( $validator, $this );
 			} else {
-				require_once( plugin_basename( 'classes/class-wc-connect-api-client-live.php' ) );
+				require_once __DIR__ . '/classes/class-wc-connect-api-client-live.php';
 				$api_client = new WC_Connect_API_Client_Live( $validator, $this );
 			}
 			$schemas_store         = new WC_Connect_Service_Schemas_Store( $api_client, $logger );
@@ -702,16 +705,16 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * Load admin-only plugin dependencies.
 		 */
 		public function load_admin_dependencies() {
-			require_once( plugin_basename( 'classes/class-wc-connect-debug-tools.php' ) );
+			require_once __DIR__ . '/classes/class-wc-connect-debug-tools.php';
 			new WC_Connect_Debug_Tools( $this->api_client );
 
-			require_once( plugin_basename( 'classes/class-wc-connect-settings-pages.php' ) );
+			require_once __DIR__ . '/classes/class-wc-connect-settings-pages.php';
 			$settings_pages = new WC_Connect_Settings_Pages( $this->api_client );
 			$this->set_settings_pages( $settings_pages );
 
-			$schema = $this->get_service_schemas_store();
+			$schema   = $this->get_service_schemas_store();
 			$settings = $this->get_service_settings_store();
-			$logger = $this->get_logger();
+			$logger   = $this->get_logger();
 			$this->set_help_view( new WC_Connect_Help_View( $schema, $settings, $logger ) );
 			add_action( 'admin_notices', array( WC_Connect_Error_Notice::instance(), 'render_notice' ) );
 			add_action( 'admin_notices', array( $this, 'render_schema_notices' ) );
@@ -722,7 +725,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 */
 		public function attach_hooks() {
 			$schemas_store = $this->get_service_schemas_store();
-			$schemas = $schemas_store->get_service_schemas();
+			$schemas       = $schemas_store->get_service_schemas();
 
 			if ( $schemas ) {
 				add_filter( 'woocommerce_shipping_methods', array( $this, 'woocommerce_shipping_methods' ) );
@@ -745,7 +748,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			// Changing the postcode, currency, weight or dimension units affect the returned schema from the server.
 			// Make sure to update the service schemas when these options change.
 			// TODO: Add other options that change the schema here, or figure out a way to do it automatically.
-			add_action( 'update_option_woocommerce_store_postcode',  array( $this, 'queue_service_schema_refresh' ) );
+			add_action( 'update_option_woocommerce_store_postcode', array( $this, 'queue_service_schema_refresh' ) );
 			add_action( 'update_option_woocommerce_currency', array( $this, 'queue_service_schema_refresh' ) );
 			add_action( 'update_option_woocommerce_weight_unit', array( $this, 'queue_service_schema_refresh' ) );
 			add_action( 'update_option_woocommerce_dimension_unit', array( $this, 'queue_service_schema_refresh' ) );
@@ -756,11 +759,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_filter( 'woocommerce_hidden_order_itemmeta', array( $this, 'hide_wc_connect_package_meta_data' ) );
 			add_filter( 'is_protected_meta', array( $this, 'hide_wc_connect_order_meta_data' ), 10, 3 );
 			add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 5, 2 );
-			add_filter( 'woocommerce_shipping_fields' , array( $this, 'add_shipping_phone_to_checkout' ) );
+			add_filter( 'woocommerce_shipping_fields', array( $this, 'add_shipping_phone_to_checkout' ) );
 			add_action( 'woocommerce_admin_shipping_fields', array( $this, 'add_shipping_phone_to_order_fields' ) );
 			add_filter( 'woocommerce_get_order_address', array( $this, 'get_shipping_phone_from_order' ), 10, 3 );
 			add_action( 'admin_enqueue_scripts', array( $this->nux, 'show_pointers' ) );
-			add_filter( 'plugin_action_links_' . plugin_basename(__FILE__), array( $this, 'add_plugin_action_links' ) );
+			add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'add_plugin_action_links' ) );
 			add_action( 'enqueue_wc_connect_script', array( $this, 'enqueue_wc_connect_script' ), 10, 2 );
 			add_action( 'admin_init', array( $this, 'load_admin_dependencies' ) );
 			add_filter( 'wc_connect_shipping_service_settings', array( $this, 'shipping_service_settings' ), 10, 3 );
@@ -789,11 +792,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		public function tos_rest_init() {
 			$settings_store = $this->get_service_settings_store();
-			$logger = $this->get_logger();
+			$logger         = $this->get_logger();
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-base-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-base-controller.php';
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-tos-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-tos-controller.php';
 			$rest_tos_controller = new WC_REST_Connect_Tos_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_tos_controller( $rest_tos_controller );
 			$rest_tos_controller->register_routes();
@@ -805,103 +808,103 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * rest_api_init firing, WP_REST_Controller is not yet defined
 		 */
 		public function rest_api_init() {
-			$schemas_store = $this->get_service_schemas_store();
+			$schemas_store  = $this->get_service_schemas_store();
 			$settings_store = $this->get_service_settings_store();
-			$logger = $this->get_logger();
+			$logger         = $this->get_logger();
 
 			if ( ! class_exists( 'WP_REST_Controller' ) ) {
 				$this->logger->debug( 'Error. WP_REST_Controller could not be found', __FUNCTION__ );
 				return;
 			}
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-base-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-base-controller.php';
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-packages-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-packages-controller.php';
 			$rest_packages_controller = new WC_REST_Connect_Packages_Controller( $this->api_client, $settings_store, $logger, $this->service_schemas_store );
 			$this->set_rest_packages_controller( $rest_packages_controller );
 			$rest_packages_controller->register_routes();
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-account-settings-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-account-settings-controller.php';
 			$rest_account_settings_controller = new WC_REST_Connect_Account_Settings_Controller( $this->api_client, $settings_store, $logger, $this->payment_methods_store );
 			$this->set_rest_account_settings_controller( $rest_account_settings_controller );
 			$rest_account_settings_controller->register_routes();
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-services-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-services-controller.php';
 			$rest_services_controller = new WC_REST_Connect_Services_Controller( $this->api_client, $settings_store, $logger, $schemas_store );
 			$this->set_rest_services_controller( $rest_services_controller );
 			$rest_services_controller->register_routes();
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-self-help-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-self-help-controller.php';
 			$rest_self_help_controller = new WC_REST_Connect_Self_Help_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_self_help_controller( $rest_self_help_controller );
 			$rest_self_help_controller->register_routes();
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-label-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-shipping-label-controller.php';
 			$rest_shipping_label_controller = new WC_REST_Connect_Shipping_Label_Controller( $this->api_client, $settings_store, $logger, $this->shipping_label );
 			$this->set_rest_shipping_label_controller( $rest_shipping_label_controller );
 			$rest_shipping_label_controller->register_routes();
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-label-status-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-shipping-label-status-controller.php';
 			$rest_shipping_label_status_controller = new WC_REST_Connect_Shipping_Label_Status_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_shipping_label_status_controller( $rest_shipping_label_status_controller );
 			$rest_shipping_label_status_controller->register_routes();
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-label-refund-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-shipping-label-refund-controller.php';
 			$rest_shipping_label_refund_controller = new WC_REST_Connect_Shipping_Label_Refund_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_shipping_label_refund_controller( $rest_shipping_label_refund_controller );
 			$rest_shipping_label_refund_controller->register_routes();
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-label-preview-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-shipping-label-preview-controller.php';
 			$rest_shipping_label_preview_controller = new WC_REST_Connect_Shipping_Label_Preview_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_shipping_label_preview_controller( $rest_shipping_label_preview_controller );
 			$rest_shipping_label_preview_controller->register_routes();
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-label-print-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-shipping-label-print-controller.php';
 			$rest_shipping_label_print_controller = new WC_REST_Connect_Shipping_Label_Print_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_shipping_label_print_controller( $rest_shipping_label_print_controller );
 			$rest_shipping_label_print_controller->register_routes();
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-rates-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-shipping-rates-controller.php';
 			$rest_shipping_rates_controller = new WC_REST_Connect_Shipping_Rates_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_shipping_rates_controller( $rest_shipping_rates_controller );
 			$rest_shipping_rates_controller->register_routes();
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-address-normalization-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-address-normalization-controller.php';
 			$rest_address_normalization_controller = new WC_REST_Connect_Address_Normalization_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_address_normalization_controller( $rest_address_normalization_controller );
 			$rest_address_normalization_controller->register_routes();
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-assets-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-assets-controller.php';
 			$rest_assets_controller = new WC_REST_Connect_Assets_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_assets_controller( $rest_assets_controller );
 			$rest_assets_controller->register_routes();
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-carrier-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-shipping-carrier-controller.php';
 			$rest_carrier_controller = new WC_REST_Connect_Shipping_Carrier_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_carrier_controller( $rest_carrier_controller );
 			$rest_carrier_controller->register_routes();
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-carriers-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-shipping-carriers-controller.php';
 			$rest_carriers_controller = new WC_REST_Connect_Shipping_Carriers_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_carriers_controller( $rest_carriers_controller );
 			$rest_carriers_controller->register_routes();
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-subscriptions-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-subscriptions-controller.php';
 			$rest_subscriptions_controller = new WC_REST_Connect_Subscriptions_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_subscriptions_controller( $rest_subscriptions_controller );
 			$rest_subscriptions_controller->register_routes();
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-subscription-activate-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-subscription-activate-controller.php';
 			$rest_subscription_activate_controller = new WC_REST_Connect_Subscription_activate_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_subscription_activate_controller( $rest_subscription_activate_controller );
 			$rest_subscription_activate_controller->register_routes();
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-carrier-delete-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-shipping-carrier-delete-controller.php';
 			$rest_carrier_delete_controller = new WC_REST_Connect_Shipping_Carrier_Delete_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_carrier_delete_controller( $rest_carrier_delete_controller );
 			$rest_carrier_delete_controller->register_routes();
 
-			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-carrier-types-controller.php' ) );
+			require_once __DIR__ . '/classes/class-wc-rest-connect-shipping-carrier-types-controller.php';
 			$rest_carrier_types_controller = new WC_REST_Connect_Shipping_Carrier_Types_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_carrier_types_controller( $rest_carrier_types_controller );
 			$rest_carrier_types_controller->register_routes();
@@ -914,11 +917,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * Delete this when the "v3" REST API is included in all the WC versions we support.
 		 */
 		public function wc_api_dev_init() {
-			$rest_server = rest_get_server();
+			$rest_server     = rest_get_server();
 			$existing_routes = $rest_server->get_routes();
 			if ( ! isset( $existing_routes['/wc/v3/data/continents'] ) ) {
-				require_once( plugin_basename( 'classes/wc-api-dev/class-wc-rest-dev-data-controller.php' ) );
-				require_once( plugin_basename( 'classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php' ) );
+				require_once __DIR__ . '/classes/wc-api-dev/class-wc-rest-dev-data-controller.php';
+				require_once __DIR__ . '/classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php';
 				$continents = new WC_REST_Dev_Data_Continents_Controller();
 				$continents->register_routes();
 			}
@@ -961,25 +964,31 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 */
 		public function shipping_service_settings( $settings, $method_id, $instance_id ) {
 			$settings_store = $this->get_service_settings_store();
-			$schemas_store = $this->get_service_schemas_store();
+			$schemas_store  = $this->get_service_schemas_store();
 			$service_schema = $schemas_store->get_service_schema_by_id_or_instance_id( $instance_id ? $instance_id : $method_id );
 			if ( ! $service_schema ) {
-				return array_merge( $settings, array(
-					'formType'   => 'services',
-					'methodId'   => $method_id,
-					'instanceId' => $instance_id,
-				) );
+				return array_merge(
+					$settings,
+					array(
+						'formType'   => 'services',
+						'methodId'   => $method_id,
+						'instanceId' => $instance_id,
+					)
+				);
 			}
 
-			return array_merge( $settings, array(
-				'storeOptions'       => $settings_store->get_store_options(),
-				'formSchema'         => $service_schema->service_settings,
-				'formLayout'         => $service_schema->form_layout,
-				'formData'           => $settings_store->get_service_settings( $method_id, $instance_id ),
-				'formType'           => 'services',
-				'methodId'           => $method_id,
-				'instanceId'         => $instance_id,
-			) );
+			return array_merge(
+				$settings,
+				array(
+					'storeOptions' => $settings_store->get_store_options(),
+					'formSchema'   => $service_schema->service_settings,
+					'formLayout'   => $service_schema->form_layout,
+					'formData'     => $settings_store->get_service_settings( $method_id, $instance_id ),
+					'formType'     => 'services',
+					'methodId'     => $method_id,
+					'instanceId'   => $instance_id,
+				)
+			);
 		}
 
 		/**
@@ -993,10 +1002,14 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				return;
 			}
 
-			do_action( 'enqueue_wc_connect_script', 'wc-connect-service-settings', array(
-				'methodId' => $method_id,
-				'instanceId' => $instance_id,
-			) );
+			do_action(
+				'enqueue_wc_connect_script',
+				'wc-connect-service-settings',
+				array(
+					'methodId'   => $method_id,
+					'instanceId' => $instance_id,
+				)
+			);
 		}
 
 		/**
@@ -1006,10 +1019,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * @return array report tabs with WCS tabs added
 		 */
 		public function reports_tabs( $reports ) {
-			$reports[ 'wcs_labels' ] = array(
-				'title' => __( 'Shipping Labels', 'woocommerce-services' ),
+			$reports['wcs_labels'] = array(
+				'title'   => __( 'Shipping Labels', 'woocommerce-services' ),
 				'reports' => array(
-					'connect_labels'     => array(
+					'connect_labels' => array(
 						'title'       => __( 'Shipping Labels', 'woocommerce-services' ),
 						'description' => '',
 						'hide_title'  => true,
@@ -1031,7 +1044,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function add_tracking_info_to_emails( $order, $sent_to_admin, $plain_text ) {
 			$id = WC_Connect_Compatibility::instance()->get_order_id( $order );
 
-			// Abort if no id was passed, if the order is not marked as 'completed' or if another extension is handling the emailing
+			// Abort if no id was passed, if the order is not marked as 'completed' or if another extension is handling the emailing.
 			if ( ! $id
 				|| ! $order->has_status( 'completed' )
 				|| ! WC_Connect_Extension_Compatibility::should_email_tracking_details( $id ) ) {
@@ -1040,30 +1053,30 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			$labels = $this->service_settings_store->get_label_order_meta_data( $id );
 
-			// Abort if there are no labels
+			// Abort if there are no labels.
 			if ( empty( $labels ) ) {
 				return;
 			}
 
-			$markup = '';
+			$markup     = '';
 			$link_color = get_option( 'woocommerce_email_text_color' );
 
-			// Generate a table row for each label
+			// Generate a table row for each label.
 			foreach ( $labels as $label ) {
-				$carrier = $label['carrier_id'];
+				$carrier         = $label['carrier_id'];
 				$carrier_service = $this->get_service_schemas_store()->get_service_schema_by_id( $carrier );
-				$carrier_label = ( ! $carrier_service || empty( $carrier_service->carrier_name ) ) ? strtoupper( $carrier ) : $carrier_service->carrier_name;
-				$tracking = $label['tracking'];
-				$error = array_key_exists( 'error', $label );
-				$refunded = array_key_exists( 'refund', $label );
+				$carrier_label   = ( ! $carrier_service || empty( $carrier_service->carrier_name ) ) ? strtoupper( $carrier ) : $carrier_service->carrier_name;
+				$tracking        = $label['tracking'];
+				$error           = array_key_exists( 'error', $label );
+				$refunded        = array_key_exists( 'refund', $label );
 
-				// If the label has an error or is refunded, move to the next label
+				// If the label has an error or is refunded, move to the next label.
 				if ( $error || $refunded ) {
 					continue;
 				}
 
 				if ( $plain_text ) {
-					// Should look like '- USPS: 9405536897846173912345' in plain text mode
+					// Should look like '- USPS: 9405536897846173912345' in plain text mode.
 					$markup .= '- ' . $carrier_label . ': ' . $tracking . "\n";
 					continue;
 				}
@@ -1093,7 +1106,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				$markup .= '</tr>';
 			}
 
-			// Abort if all labels are refunded
+			// Abort if all labels are refunded.
 			if ( empty( $markup ) ) {
 				return;
 			}
@@ -1129,13 +1142,13 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function schedule_service_schemas_fetch() {
 
 			$schemas_store = $this->get_service_schemas_store();
-			$schemas = $schemas_store->get_service_schemas();
+			$schemas       = $schemas_store->get_service_schemas();
 
 			if ( ! $schemas ) {
 				$schemas_store->fetch_service_schemas_from_connect_server();
-			} else if ( defined( 'WOOCOMMERCE_CONNECT_FREQUENT_FETCH' ) && WOOCOMMERCE_CONNECT_FREQUENT_FETCH ) {
+			} elseif ( defined( 'WOOCOMMERCE_CONNECT_FREQUENT_FETCH' ) && WOOCOMMERCE_CONNECT_FREQUENT_FETCH ) {
 				$schemas_store->fetch_service_schemas_from_connect_server();
-			} else if ( ! wp_next_scheduled( 'wc_connect_fetch_service_schemas' ) ) {
+			} elseif ( ! wp_next_scheduled( 'wc_connect_fetch_service_schemas' ) ) {
 				wp_schedule_event( time(), 'daily', 'wc_connect_fetch_service_schemas' );
 			}
 
@@ -1198,7 +1211,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		/**
 		 * Registers shipping methods for use in things like the Add Shipping Method dialog
 		 * on the Shipping Zones view
-		 *
 		 */
 		public function woocommerce_load_shipping_methods() {
 			$shipping_service_ids = $this->get_service_schemas_store()->get_all_shipping_method_ids();
@@ -1222,7 +1234,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					return $locale_data;
 				}
 			}
-			// Return empty if we have nothing to return so it doesn't fail when parsed in JS
+			// Return empty if we have nothing to return so it doesn't fail when parsed in JS.
 			return '{}';
 		}
 
@@ -1232,7 +1244,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function admin_enqueue_scripts() {
 			$plugin_version = self::get_wcs_version();
 
-			wp_register_script( 'wc_connect_admin', self::get_wcs_admin_script_url(), array('lodash', 'moment', 'react', 'react-dom'), null, true );
+			wp_register_script( 'wc_connect_admin', self::get_wcs_admin_script_url(), array( 'lodash', 'moment', 'react', 'react-dom' ), null, true ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 			// Dev mode will handle loading the css itself to support HMR.
 			$stylesheet_url = self::get_wcs_admin_style_url();
 			if ( ! empty( $stylesheet_url ) ) {
@@ -1243,15 +1255,19 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				);
 			}
 			wp_register_script( 'wc_services_admin_pointers', $this->wc_connect_base_url . 'woocommerce-services-admin-pointers-' . $plugin_version . '.js', array( 'wp-pointer', 'jquery' ), null );
-			wp_register_style( 'wc_connect_banner', $this->wc_connect_base_url . 'woocommerce-services-banner-' . $plugin_version . '.css', array(), null );
-			wp_register_script( 'wc_connect_banner', $this->wc_connect_base_url . 'woocommerce-services-banner-' . $plugin_version . '.js',  array(), null );
+			wp_register_style( 'wc_connect_banner', $this->wc_connect_base_url . 'woocommerce-services-banner-' . $plugin_version . '.css', array(), null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+			wp_register_script( 'wc_connect_banner', $this->wc_connect_base_url . 'woocommerce-services-banner-' . $plugin_version . '.js', array(), null );
 
 			$i18n_json = $this->get_i18n_json();
 			/** @var array $i18nStrings defined in i18n/strings.php */
-			wp_localize_script( 'wc_connect_admin', 'i18nLocale', array(
-					'json' => $i18n_json,
+			wp_localize_script(
+				'wc_connect_admin',
+				'i18nLocale',
+				array(
+					'json'       => $i18n_json,
 					'localeSlug' => join( '-', explode( '_', get_locale() ) ),
-			) );
+				)
+			);
 			wp_localize_script(
 				'wc_connect_admin',
 				'wcsPluginData',
@@ -1264,13 +1280,15 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function get_active_shipping_services() {
 			global $wpdb;
 			$active_shipping_services = array();
-			$shipping_service_ids = $this->get_service_schemas_store()->get_all_shipping_method_ids();
+			$shipping_service_ids     = $this->get_service_schemas_store()->get_all_shipping_method_ids();
 
 			foreach ( $shipping_service_ids as $shipping_service_id ) {
-				$is_active = $wpdb->get_var( $wpdb->prepare(
-					"SELECT instance_id FROM {$wpdb->prefix}woocommerce_shipping_zone_methods WHERE is_enabled = 1 AND method_id = %s LIMIT 1;",
-					$shipping_service_id
-				) );
+				$is_active = $wpdb->get_var(
+					$wpdb->prepare(
+						"SELECT instance_id FROM {$wpdb->prefix}woocommerce_shipping_zone_methods WHERE is_enabled = 1 AND method_id = %s LIMIT 1;",
+						$shipping_service_id
+					)
+				);
 
 				if ( $is_active ) {
 					$active_shipping_services[] = $shipping_service_id;
@@ -1297,7 +1315,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		public function shipping_zone_method_deleted( $instance_id, $service_id, $zone_id ) {
 			if ( $this->is_wc_connect_shipping_service( $service_id ) ) {
-				WC_Connect_Options::delete_shipping_method_options(  $service_id, $instance_id );
+				WC_Connect_Options::delete_shipping_method_options( $service_id, $instance_id );
 				do_action( 'wc_connect_shipping_zone_method_deleted', $instance_id, $service_id, $zone_id );
 			}
 		}
@@ -1385,7 +1403,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		function hide_wc_connect_order_meta_data( $protected, $meta_key, $meta_type ) {
-			if ( in_array( $meta_key, array( 'wc_connect_labels', 'wc_connect_destination_normalized' ) ) ) {
+			if ( in_array( $meta_key, array( 'wc_connect_labels', 'wc_connect_destination_normalized' ), true ) ) {
 				$protected = true;
 			}
 
@@ -1403,7 +1421,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				'autocomplete' => 'tel',
 			);
 
-			// Use existing settings if the field exists
+			// Use existing settings if the field exists.
 			$field = isset( $fields['shipping_phone'] )
 				? array_merge( $defaults, $fields['shipping_phone'] )
 				: $defaults;
@@ -1415,13 +1433,13 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				$field['validate'][] = 'tel';
 			}
 
-			// Add to the list
+			// Add to the list.
 			$fields['shipping_phone'] = $field;
 			return $fields;
 		}
 
 		function add_shipping_phone_to_order_fields( $fields ) {
-			$fields[ 'phone' ] = array(
+			$fields['phone'] = array(
 				'label' => __( 'Phone', 'woocommerce-services' ),
 			);
 			return $fields;
@@ -1433,9 +1451,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				$shipping_phone = get_post_meta( $order_id, '_shipping_phone', true );
 				if ( ! $shipping_phone ) {
 					$billing_address = $order->get_address( 'billing' );
-					$shipping_phone = $billing_address[ 'phone' ];
+					$shipping_phone  = $billing_address['phone'];
 				}
-				$fields[ 'phone' ] =  $shipping_phone;
+				$fields['phone'] = $shipping_phone;
 			}
 			return $fields;
 		}
@@ -1443,8 +1461,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		function add_plugin_action_links( $links ) {
 			$links[] = sprintf(
 				wp_kses(
+					/* translators: %s Support url */
 					__( '<a href="%s">Support</a>', 'woocommerce-services' ),
-					array(  'a' => array( 'href' => array() ) )
+					array( 'a' => array( 'href' => array() ) )
 				),
 				esc_url( 'https://woocommerce.com/my-account/create-a-ticket/' )
 			);
@@ -1463,16 +1482,18 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			wp_localize_script( 'wc_connect_admin', 'wcConnectData', $payload );
 			wp_enqueue_script( 'wc_connect_admin' );
 
-			$debug_page_uri = esc_url( add_query_arg(
-				array(
-					'page' => 'wc-status',
-					'tab' => 'connect'
-				),
-				admin_url( 'admin.php' )
-			) );
+			$debug_page_uri = esc_url(
+				add_query_arg(
+					array(
+						'page' => 'wc-status',
+						'tab'  => 'connect',
+					),
+					admin_url( 'admin.php' )
+				)
+			);
 
 			?>
-				<div class="wcc-root woocommerce <?php echo esc_attr( $root_view ) ?>" data-args="<?php echo esc_attr( wp_json_encode( $extra_args ) ) ?>">
+				<div class="wcc-root woocommerce <?php echo esc_attr( $root_view ); ?>" data-args="<?php echo esc_attr( wp_json_encode( $extra_args ) ); ?>">
 					<span class="form-troubles" style="opacity: 0">
 						<?php printf( __( 'Section not loading? Visit the <a href="%s">status page</a> for troubleshooting steps.', 'woocommerce-services' ), $debug_page_uri ); ?>
 					</span>
@@ -1492,24 +1513,24 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			);
 			foreach ( $schemas->notices as $notice ) {
 				$dismissible = false;
-				//check if the notice is dismissible
+				// check if the notice is dismissible.
 				if ( property_exists( $notice, 'id' ) && ! empty( $notice->id ) && property_exists( $notice, 'dismissible' ) && $notice->dismissible ) {
-					//check if the notice is being dismissed right now
+					// check if the notice is being dismissed right now.
 					if ( isset( $_GET['wc-connect-dismiss-server-notice'] ) && $_GET['wc-connect-dismiss-server-notice'] === $notice->id ) {
 						set_transient( 'wcc_notice_dismissed_' . $notice->id, true, MONTH_IN_SECONDS );
 						continue;
 					}
-					//check if the notice has already been dismissed
+					// check if the notice has already been dismissed.
 					if ( false !== get_transient( 'wcc_notice_dismissed_' . $notice->id ) ) {
 						continue;
 					}
 
-					$dismissible = true;
+					$dismissible  = true;
 					$link_dismiss = add_query_arg( array( 'wc-connect-dismiss-server-notice' => $notice->id ) );
 				}
 				?>
-				<div class='<?php echo esc_attr( 'notice notice-' . $notice->type ) ?>' style="position: relative;">
-					<?php if ( $dismissible ): ?>
+				<div class='<?php echo esc_attr( 'notice notice-' . $notice->type ); ?>' style="position: relative;">
+					<?php if ( $dismissible ) : ?>
 					<a href="<?php echo esc_url( $link_dismiss ); ?>" style="text-decoration: none;" class="notice-dismiss" title="<?php esc_attr_e( 'Dismiss this notice', 'woocommerce-services' ); ?>"></a>
 					<?php endif; ?>
 					<p><?php echo wp_kses( $notice->message, $allowed_html ); ?></p>


### PR DESCRIPTION
## Description
All the phpcs notices were annoying me. Ran phpcbf over all the php files with:
```sh
vendor/bin/phpcbf classes/* tests/php/ woocommerce-services.php
```

### Steps to reproduce & screenshots/GIFs
Only about 1916 phpcs errors exists as reported by `vendor/bin/phpcs classes/* tests/php/ woocommerce-services.php | wc -l`
vs 4760 that used to be reported.


### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests


