### PR TITLE
Support new data format from connect server for multiple usage tracking events

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/list-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/list-item.js
@@ -55,9 +55,13 @@ const SubscriptionsUsageListItem = ( props ) => {
 		submitActivation();
 	}
 
-	const usage_count = data.usage_count ? data.usage_count : 0 ;
-	const usage = data.usage_limit ? `${ usage_count }/${ data.usage_limit }` : '';
-	const isUsageOverLimit = data.usage_count && data.usage_limit && data.usage_count > data.usage_limit;
+	const usage = [];
+	let isUsageOverLimit = false;
+
+	data.usage_data.forEach( ( usageEvent, index ) => {
+		usage.push( <div key={ index }>{ usageEvent.label }: { usageEvent.count }/{ usageEvent.limit }</div> );
+		isUsageOverLimit = isUsageOverLimit || usageEvent.count > usageEvent.limit;
+	} );
 
 	return (
 		<div className= "subscriptions-usage__list-item" >
@@ -113,8 +117,11 @@ SubscriptionsUsageListItem.propTypes = {
 	data: PropTypes.shape( {
 		product_name: PropTypes.string.isRequired,
 		is_active: PropTypes.bool.isRequired,
-		usage_limit: PropTypes.number,
-		usage_count: PropTypes.number,
+		usage_data: PropTypes.arrayOf( PropTypes.shape( {
+			limit: PropTypes.number,
+			count: PropTypes.number,
+			label: PropTypes.string,
+		} ) )
 	} ).isRequired,
 };
 

--- a/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/test/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/subscriptions-usage/test/index.js
@@ -53,8 +53,13 @@ const subscriptions = [
 		sites_active:1,
 		maxed:false,
 		product_status:"publish",
-		usage_limit:1000,
-		usage_count:250,
+		usage_data: [
+			{
+				limit: 1000,
+				count: 250,
+				label: 'Rate Request',
+			}
+		],
 		is_active: true,
 	},
 	{
@@ -79,8 +84,18 @@ const subscriptions = [
 		sites_active:0,
 		maxed:false,
 		product_status:"publish",
-		usage_limit:50,
-		usage_count:8,
+		usage_data: [
+			{
+				limit: 500,
+				count: 888,
+				label: 'Rate Request',
+			},
+			{
+				limit: 50,
+				count: 8,
+				label: 'Label Purchase',
+			}
+		],
 		is_active:false,
 	},
 
@@ -99,7 +114,6 @@ describe( 'Subscriptions Usage', () => {
 
 	it('should render a list of subscriptions usage info', () => {
 		const wrapper = mount(
-			
 			<Wrapper>
 				<SubscriptionsUsage subscriptions={ subscriptions } />
 			</Wrapper>
@@ -114,20 +128,20 @@ describe( 'Subscriptions Usage', () => {
 		expect(upsLabelsListItem.find('span[children="UPS rates"]')).toHaveLength(1);
 
 		// Expect subscription usage.
-		expect(dhlExpressRatesListItem.find('span[children="250/1000"]')).toHaveLength(1);
-		expect(upsLabelsListItem.find('span[children="8/50"]')).toHaveLength(1);
-		
+		expect(dhlExpressRatesListItem.find('.subscriptions-usage__list-item-usage-numbers div')).toHaveLength(1);
+		expect(upsLabelsListItem.find('.subscriptions-usage__list-item-usage-numbers div')).toHaveLength(2);
+
+		expect(dhlExpressRatesListItem.find('.is-over-limit')).toHaveLength(0);
+		expect(upsLabelsListItem.find('.is-over-limit')).toHaveLength(1);
 		// Expect button manage.
 		const dhlExpressmanageButton = dhlExpressRatesListItem.find('a[href="https://woocommerce.com/my-account/my-subscriptions/"]');
 		expect(dhlExpressmanageButton.text()).toBe('Manage');
 		// Expect button activate.
 		expect(upsLabelsListItem.find('button').text()).toBe('Activate');
-	
 	});
 
 	it('should call the API to activate the subscription when clicking on the button', async () => {
 		const wrapper = mount(
-			
 			<Wrapper>
 				<SubscriptionsUsage subscriptions={ subscriptions } />
 			</Wrapper>


### PR DESCRIPTION
## Description
Updated to use new format for usage events from connect server.
See connect server PR https://github.com/Automattic/woocommerce-connect-server/pull/1721 
for testing details.

### Related issue(s)
https://github.com/Automattic/woocommerce-connect-server/issues/1695


### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

