### PR TITLE
Replace Calypso FormToggle with WP component

### DIFF
--- a/client/components/toggle/index.js
+++ b/client/components/toggle/index.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import './style.scss';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
-import FormToggle from 'components/forms/form-toggle/compact';
+import { FormToggle } from '@wordpress/components';
 import FieldDescription from '../../extensions/woocommerce/woocommerce-services/components/field-description';
 import sanitizeHTML from 'lib/utils/sanitize-html';
 

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
@@ -17,7 +17,7 @@ import { isBoolean } from 'lodash';
  */
 import Card from 'components/card';
 import ExtendedHeader from 'woocommerce/components/extended-header';
-import FormToggle from 'components/forms/form-toggle';
+import { FormToggle } from '@wordpress/components';
 import LabelSettings from './label-settings';
 import QueryLabelSettings from 'woocommerce/woocommerce-services/components/query-label-settings';
 import { setFormDataValue, restorePristineSettings } from '../../state/label-settings/actions';

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/style.scss
@@ -109,3 +109,24 @@
 	max-width: 720px;
 	padding: 0;
 }
+
+.components-form-toggle {
+	display: inline-flex;
+	vertical-align: middle;
+
+	.components-form-toggle__track {
+		margin-left: 0;
+	}
+
+	input.components-form-toggle__input[type=checkbox] {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		opacity: 0;
+		margin: 0;
+		z-index: 1;
+		border: none;
+	}
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Replace the Calypso `FormToggle` component with the [Wordpress `FormToggle` Component](https://developer.wordpress.org/block-editor/components/form-toggle/). The props all matched up well so it required minimal changes. There were some styles for all `input[type='checkbox']` that were overriding the component's styles. I just copied the necessary styles over to get the higher specificity and it all looked good.

I didn't replicate the exact look of the previous toggle component, instead opting for a more simplified experience using the Wordpress component look and feel instead.

### Related issue(s)

Related to #2333

### Steps to reproduce & screenshots/GIFs

The form toggle component was used on two screens:

1. WooCommerce Shipping Settings, the top Shipping Labels card.
2. WooCommerce Shipping Status, the Debug toggles.

![FormToggle-Settings](https://user-images.githubusercontent.com/68524302/109211136-d4372a80-777b-11eb-9533-dd4b59a09611.png)
![FormToggle-Status](https://user-images.githubusercontent.com/68524302/109211146-d600ee00-777b-11eb-8e91-26adeddc707f.png)


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added

