### PR TITLE
Replace Calypso Fieldset with internal Fieldset

### DIFF
--- a/client/components/forms/form-fieldset/index.js
+++ b/client/components/forms/form-fieldset/index.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import classnames from 'classnames';
+
+const FormFieldset = ( { className, children, ...otherProps } ) => (
+	<fieldset { ...otherProps } className={ classnames( className, 'form-fieldset' ) }>
+		{ children }
+	</fieldset>
+);
+
+export default FormFieldset;

--- a/client/components/forms/form-fieldset/style.scss
+++ b/client/components/forms/form-fieldset/style.scss
@@ -1,0 +1,4 @@
+.form-fieldset {
+	clear: both;
+	margin-bottom: 20px;
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Replace the Calypso `FormFieldset` component with an internal `FormFieldset` component. There was not a comparable WordPress component to replace with and the component itself is very simple so it was easy to move over to our internal components. This component is simply a wrapper `fieldset` HTML tag for form fields and is primarily used by other components (TextField, NumberField, WeightField, etc). 

I placed the replacement component within the top level `client/components` directory based on some recent discussions on how best to organize our internal components. I kept the naming the same to simplify the code changes required. Due to having the same name, the Webpack config `resolve.modules` array order is hitting this new internal component rather than the Calypso component.

### Related issue(s)

Related to #2333 

### Steps to reproduce & screenshots/GIFs

This component is used on most of the plugin's pages, but below are the main pages and areas to confirm:

1. The Status page, each item within the settings group cards is wrapped in a FormFieldset.
2. The Settings page, each item in the Shipping Labels card is wrapped in a FormFieldset.
3. Within Settings, the connect carrier forms and add package forms use FormFieldset. 
4. The Label Purchase modal, each form field in the modal is wrapped in a FormFieldset.

Since the component is identical to Calypso's, I confirmed it was using the new internal component by adding a class name to the component and confirm that class name was added in all the relevant places.

Some examples of the FormFieldset:

![LabelPurchase-Fieldset](https://user-images.githubusercontent.com/68524302/109351170-cdc1b500-7846-11eb-851f-4fb8b10d758a.png)
![Settings-Fieldset](https://user-images.githubusercontent.com/68524302/109351171-cdc1b500-7846-11eb-834b-8f2e6af1320f.png)
![Status-Fieldset](https://user-images.githubusercontent.com/68524302/109351172-cdc1b500-7846-11eb-8a4e-c0696746932f.png)
 

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added

