### PR TITLE
Remove extra brackets in develop

### DIFF
--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -116,8 +116,8 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			// Lastly, do the WooCommerce Shipping & Tax health check
 			// Check that we have schema
 			// Check that we are able to talk to the WooCommerce Shipping & Tax server
-			$schemas              = $this->service_schemas_store->get_service_schemas();
-			$last_fetch_timestamp = $this->service_schemas_store->get_last_fetch_timestamp();
+			$schemas                              = $this->service_schemas_store->get_service_schemas();
+			$last_fetch_timestamp                 = $this->service_schemas_store->get_last_fetch_timestamp();
 			$health_items['woocommerce_services'] = array(
 				'timestamp'           => $last_fetch_timestamp,
 				'has_service_schemas' => ! is_null( $schemas ),

--- a/classes/class-wc-rest-connect-service-data-refresh-controller.php
+++ b/classes/class-wc-rest-connect-service-data-refresh-controller.php
@@ -23,18 +23,24 @@ class WC_REST_Connect_Service_Data_Refresh_Controller extends WC_REST_Connect_Ba
 	public function post() {
 		$result = $this->services_schemas_store->fetch_service_schemas_from_connect_server();
 		if ( $result === false ) {
-			return new WP_REST_Response( [
-				'success' => false,
-			], 500 );
+			return new WP_REST_Response(
+				[
+					'success' => false,
+				],
+				500
+			);
 		}
 
 		$schemas = $this->services_schemas_store->get_service_schemas();
 
-		return new WP_REST_Response( [
-			'success'             => true,
-			'timestamp'           => $this->services_schemas_store->get_last_fetch_timestamp(),
-			'has_service_schemas' => ! is_null( $schemas ),
-		], 200 );
+		return new WP_REST_Response(
+			[
+				'success'             => true,
+				'timestamp'           => $this->services_schemas_store->get_last_fetch_timestamp(),
+				'has_service_schemas' => ! is_null( $schemas ),
+			],
+			200
+		);
 	}
 
 }

--- a/tests/php/test_class-wc-connect-shipping-method.php
+++ b/tests/php/test_class-wc-connect-shipping-method.php
@@ -2,7 +2,7 @@
 
 class WP_Test_WC_Connect_Shipping_Method extends WP_UnitTestCase {
 
-	static function setUpBeforeClass()	{
+	static function setUpBeforeClass() {
 		require_once __DIR__ . '/../../classes/class-wc-connect-shipping-method.php';
 		require_once __DIR__ . '/../../classes/class-wc-connect-cart-validation.php';
 	}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -843,7 +843,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->set_rest_self_help_controller( $rest_self_help_controller );
 			$rest_self_help_controller->register_routes();
 
-			require_once __DIR__ . 'classes/class-wc-rest-connect-service-data-refresh-controller.php' ) );
+			require_once __DIR__ . 'classes/class-wc-rest-connect-service-data-refresh-controller.php';
 			$rest_service_data_refresh_controller = new WC_REST_Connect_Service_Data_Refresh_Controller( $this->api_client, $settings_store, $logger );
 			$rest_service_data_refresh_controller->set_service_schemas_store( $this->get_service_schemas_store() );
 			$rest_service_data_refresh_controller->register_routes();

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -843,7 +843,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->set_rest_self_help_controller( $rest_self_help_controller );
 			$rest_self_help_controller->register_routes();
 
-			require_once __DIR__ . 'classes/class-wc-rest-connect-service-data-refresh-controller.php';
+			require_once __DIR__ . '/classes/class-wc-rest-connect-service-data-refresh-controller.php';
 			$rest_service_data_refresh_controller = new WC_REST_Connect_Service_Data_Refresh_Controller( $this->api_client, $settings_store, $logger );
 			$rest_service_data_refresh_controller->set_service_schemas_store( $this->get_service_schemas_store() );
 			$rest_service_data_refresh_controller->register_routes();


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Remove the extra brackets on the `require_once` line for `classes/class-wc-rest-connect-service-data-refresh-controller.php`. Also ran `vendor/bin/phpcbf classes/* tests/php/ woocommerce-services.php` for phpcs linting so that [this PR](https://github.com/Automattic/woocommerce-services/pull/2322)'s effort is kept.

### Related issue(s)
Closes https://github.com/Automattic/woocommerce-services/issues/2349

### Steps to reproduce & screenshots/GIFs
1. First commit is to remove the bracket
2. Second commit is `vendor/bin/phpcbf classes/* tests/php/ woocommerce-services.php`
3. Run PHPUnit and tests should pass.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added

