### PR TITLE
Replace FormTextInput in TextField component

### DIFF
--- a/assets/stylesheets/_colors.scss
+++ b/assets/stylesheets/_colors.scss
@@ -1,4 +1,6 @@
 :root {
 	--color-link: #984A9C;
+	--color-error: #eb0001;
+	--color-error-rgb: 235, 0, 1;
 }
 

--- a/client/extensions/woocommerce/woocommerce-services/components/text-field/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/text-field/index.js
@@ -5,13 +5,13 @@
  */
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { TextControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormTextInput from 'components/forms/form-text-input';
 import FieldError from '../field-error';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
@@ -26,18 +26,21 @@ const TextField = ( {
 	className,
 	defaultValue
 } ) => {
-	const handleChangeEvent = useCallback(event => updateValue( event.target.value, event ), [updateValue]);
+	const handleChangeEvent = useCallback( newValue => updateValue( newValue, id ), [updateValue]);
+
+	const classes = classNames( 'form-text-input', {
+		'is-error': Boolean( error ),
+	} );
 
 	return (
 		<FormFieldset className={ className }>
-			<FormLabel htmlFor={ id }>{ title }</FormLabel>
-			<FormTextInput
-				id={ id }
+			<TextControl
+				label={ title }
 				name={ id }
 				placeholder={ placeholder }
 				value={ value }
 				onChange={ handleChangeEvent }
-				isError={ Boolean( error ) }
+				className={ classes }
 				defaultValue={ defaultValue }
 			/>
 			{ error && typeof error === 'string' && <FieldError text={ error } /> }

--- a/client/extensions/woocommerce/woocommerce-services/components/text-field/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/components/text-field/style.scss
@@ -1,0 +1,15 @@
+.form-text-input {
+	&.is-error {
+		input { 
+			color: var( --color-error );
+			border-color: var( --color-error );
+		}
+	}
+
+	.components-base-control__label {
+		display: block;
+		font-size: 14px;
+		font-weight: 600;
+		margin-bottom: 5px;	
+	}
+}

--- a/client/extensions/woocommerce/woocommerce-services/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/style.scss
@@ -4,6 +4,7 @@
 @import 'components/info-tooltip/style';
 @import 'components/settings-group-card/style';
 @import 'components/text/style';
+@import 'components/text-field/style';
 @import 'views/label-settings/style';
 @import 'views/carrier-accounts/style';
 @import 'views/subscriptions-usage/style';

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings-form.test.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/dynamic-settings-form.test.js
@@ -79,8 +79,8 @@ describe( 'Carrier Account Dynamic Registration Form', () => {
 			</Wrapper>
 		);
 
-		const accountNumberField = wrapper.find('input[id="account_number"]');
-		const countryField = wrapper.find('input[id="country_code"]');
+		const accountNumberField = wrapper.find('input[name="account_number"]');
+		const countryField = wrapper.find('input[name="country_code"]');
 
 		expect(accountNumberField).toHaveLength(1);
 		expect(countryField).toHaveLength(1);
@@ -129,7 +129,7 @@ describe( 'Carrier Account Dynamic Registration Form', () => {
 		);
 
 		const isResellerField = wrapper.find('input[id="is_reseller"]')
-		const countryField = wrapper.find('input[id="country_code"]')
+		const countryField = wrapper.find('input[name="country_code"]')
 
 		expect(isResellerField).toHaveLength(1);
 		expect(countryField).toHaveLength(1);

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/ups-settings-form.test.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/ups-settings-form.test.js
@@ -63,14 +63,14 @@ describe( 'UPS Account Registration Form', () => {
 		);
 
 		await act(async () => {
-			wrapper.find('input[id="account_number"]').simulate('change', { target: {
+			wrapper.find('input[name="account_number"]').simulate('change', { target: {
 				value: 'A12345'
 			} } );
-			wrapper.find('input[id="name"]').simulate('change', { target: {
+			wrapper.find('input[name="name"]').simulate('change', { target: {
 				value: 'FirstName LastName'
 			} } );
-			wrapper.find('input[id="email"]').simulate('change', { target: {
-				value: 'email@something.com'
+			wrapper.find('input[name="email"]').simulate('change', { target: {
+				value: 'email'
 			} } );
 		} );
 
@@ -90,37 +90,37 @@ describe( 'UPS Account Registration Form', () => {
 		);
 
 		await act(async () => {
-			wrapper.find('input[id="account_number"]').simulate('change', { target: {
+			wrapper.find('input[name="account_number"]').simulate('change', { target: {
 				value: 'A12345'
 			} } );
-			wrapper.find('input[id="name"]').simulate('change', { target: {
+			wrapper.find('input[name="name"]').simulate('change', { target: {
 				value: 'FirstName LastName'
 			} } );
-			wrapper.find('input[id="street1"]').simulate('change', { target: {
+			wrapper.find('input[name="street1"]').simulate('change', { target: {
 				value: 'Street 1'
 			} } );
-			wrapper.find('input[id="city"]').simulate('change', { target: {
+			wrapper.find('input[name="city"]').simulate('change', { target: {
 				value: 'City'
 			} } );
-			wrapper.find('input[id="state"]').simulate('change', { target: {
+			wrapper.find('input[name="state"]').simulate('change', { target: {
 				value: 'MN'
 			} } );
-			wrapper.find('input[id="postal_code"]').simulate('change', { target: {
+			wrapper.find('input[name="postal_code"]').simulate('change', { target: {
 				value: '55555'
 			} } );
-			wrapper.find('input[id="phone"]').simulate('change', { target: {
+			wrapper.find('input[name="phone"]').simulate('change', { target: {
 				value: '2065555555'
 			} } );
-			wrapper.find('input[id="email"]').simulate('change', { target: {
+			wrapper.find('input[name="email"]').simulate('change', { target: {
 				value: 'email'
 			} } );
-			wrapper.find('input[id="title"]').simulate('change', { target: {
+			wrapper.find('input[name="title"]').simulate('change', { target: {
 				value: 'title'
 			} } );
-			wrapper.find('input[id="website"]').simulate('change', { target: {
+			wrapper.find('input[name="website"]').simulate('change', { target: {
 				value: 'http://website.com'
 			} } );
-			wrapper.find('input[id="email"]').simulate('change', { target: {
+			wrapper.find('input[name="email"]').simulate('change', { target: {
 				value: 'invalid-email'
 			} } );
 		} );
@@ -143,37 +143,37 @@ describe( 'UPS Account Registration Form', () => {
 		);
 
 		await act(async () => {
-			wrapper.find('input[id="account_number"]').simulate('change', { target: {
+			wrapper.find('input[name="account_number"]').simulate('change', { target: {
 				value: 'A12345'
 			} } );
-			wrapper.find('input[id="name"]').simulate('change', { target: {
+			wrapper.find('input[name="name"]').simulate('change', { target: {
 				value: 'FirstName LastName'
 			} } );
-			wrapper.find('input[id="street1"]').simulate('change', { target: {
+			wrapper.find('input[name="street1"]').simulate('change', { target: {
 				value: 'Street 1'
 			} } );
-			wrapper.find('input[id="city"]').simulate('change', { target: {
+			wrapper.find('input[name="city"]').simulate('change', { target: {
 				value: 'City'
 			} } );
-			wrapper.find('input[id="state"]').simulate('change', { target: {
+			wrapper.find('input[name="state"]').simulate('change', { target: {
 				value: 'MN'
 			} } );
-			wrapper.find('input[id="postal_code"]').simulate('change', { target: {
+			wrapper.find('input[name="postal_code"]').simulate('change', { target: {
 				value: '55555'
 			} } );
-			wrapper.find('input[id="phone"]').simulate('change', { target: {
+			wrapper.find('input[name="phone"]').simulate('change', { target: {
 				value: '2065555555'
 			} } );
-			wrapper.find('input[id="email"]').simulate('change', { target: {
+			wrapper.find('input[name="email"]').simulate('change', { target: {
 				value: 'email'
 			} } );
-			wrapper.find('input[id="title"]').simulate('change', { target: {
+			wrapper.find('input[name="title"]').simulate('change', { target: {
 				value: 'title'
 			} } );
-			wrapper.find('input[id="website"]').simulate('change', { target: {
+			wrapper.find('input[name="website"]').simulate('change', { target: {
 				value: 'http://website.com'
 			} } );
-			wrapper.find('input[id="email"]').simulate('change', { target: {
+			wrapper.find('input[name="email"]').simulate('change', { target: {
 				value: 'valid-email@email.com'
 			} } );
 		} );

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/ups-settings-form.test.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/ups-settings-form.test.js
@@ -70,7 +70,7 @@ describe( 'UPS Account Registration Form', () => {
 				value: 'FirstName LastName'
 			} } );
 			wrapper.find('input[name="email"]').simulate('change', { target: {
-				value: 'email'
+				value: 'email@something.com'
 			} } );
 		} );
 

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/ups-settings-form.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/ups-settings-form.js
@@ -133,7 +133,7 @@ const StateInput = compose(connect((state, ownProps) => {
 	return {
 		stateNames: getStateNames( state, ownProps.countryValue ),
 	}
-}), localize)(({onUpdate, error, stateNames, translate, value}) => {
+}), localize)(({onDropdownUpdate, onTextFieldUpdate, error, stateNames, translate, value}) => {
 	const statesValuesMap = useMemo(() => {
 		if(!stateNames) return stateNames;
 
@@ -144,10 +144,11 @@ const StateInput = compose(connect((state, ownProps) => {
 		return (
 			<Dropdown
 				id="state"
+				name="state"
 				title={translate('State')}
 				value={value}
 				valuesMap={statesValuesMap}
-				updateValue={onUpdate}
+				updateValue={onDropdownUpdate}
 				error={error}
 			/>
 		);
@@ -156,8 +157,9 @@ const StateInput = compose(connect((state, ownProps) => {
 	return (
 		<TextField
 			id="state"
+			name="state"
 			title={translate('State')}
-			updateValue={onUpdate}
+			updateValue={onTextFieldUpdate}
 			error={error}
 		/>
 	);
@@ -177,6 +179,14 @@ const UpsSettingsForm = ({ translate, errorNotice, successNotice, countryNames, 
 		// using a separate `const` for `id` ensures that on async update of `setFormValues` the synthetic event is not accessed
 		const { id } = event.currentTarget;
 
+		setFormValues(values => ({
+			...values,
+			[id]: value
+		}));
+	}, [setFormValues]);
+
+	const handleFormTextFieldUpdate = useCallback((value, id) => {
+		// using a separate `const` for `id` ensures that on async update of `setFormValues` the synthetic event is not accessed
 		setFormValues(values => ({
 			...values,
 			[id]: value
@@ -272,7 +282,7 @@ const UpsSettingsForm = ({ translate, errorNotice, successNotice, countryNames, 
 						<TextField
 							id="account_number"
 							title={translate('Account number')}
-							updateValue={handleFormFieldUpdate}
+							updateValue={handleFormTextFieldUpdate}
 							error={typeof formValues.account_number === 'string' ? fieldsErrors.account_number : undefined}
 						/>
 					</Card>
@@ -280,26 +290,26 @@ const UpsSettingsForm = ({ translate, errorNotice, successNotice, countryNames, 
 						<TextField
 							id="name"
 							title={translate('Name')}
-							updateValue={handleFormFieldUpdate}
+							updateValue={handleFormTextFieldUpdate}
 							error={typeof formValues.name === 'string' ? fieldsErrors.name : undefined}
 						/>
 						<TextField
 							id="street1"
 							title={translate('Address')}
-							updateValue={handleFormFieldUpdate}
+							updateValue={handleFormTextFieldUpdate}
 							error={typeof formValues.street1 === 'string' ? fieldsErrors.street1 : undefined}
 						/>
 						<div className="carrier-accounts__settings-two-columns">
 							<TextField
 								id="street2"
 								title={translate('Address 2 (optional)')}
-								updateValue={handleFormFieldUpdate}
+								updateValue={handleFormTextFieldUpdate}
 								error={typeof formValues.street2 === 'string' ? fieldsErrors.street2 : undefined}
 							/>
 							<TextField
 								id="city"
 								title={translate('City')}
-								updateValue={handleFormFieldUpdate}
+								updateValue={handleFormTextFieldUpdate}
 								error={typeof formValues.city === 'string' ? fieldsErrors.city : undefined}
 							/>
 						</div>
@@ -307,7 +317,8 @@ const UpsSettingsForm = ({ translate, errorNotice, successNotice, countryNames, 
 							<StateInput
 								countryValue={formValues.country}
 								value={getValue('state')}
-								onUpdate={handleFormFieldUpdate}
+								onDropdownUpdate={handleFormFieldUpdate}
+								onTextFieldUpdate={handleFormTextFieldUpdate}
 								error={typeof formValues.state === 'string' ? fieldsErrors.state : undefined}
 							/>
 
@@ -324,20 +335,20 @@ const UpsSettingsForm = ({ translate, errorNotice, successNotice, countryNames, 
 							<TextField
 								id="postal_code"
 								title={translate('ZIP/Postal code')}
-								updateValue={handleFormFieldUpdate}
+								updateValue={handleFormTextFieldUpdate}
 								error={typeof formValues.postal_code === 'string' ? fieldsErrors.postal_code : undefined}
 							/>
 							<TextField
 								id="phone"
 								title={translate('Phone')}
-								updateValue={handleFormFieldUpdate}
+								updateValue={handleFormTextFieldUpdate}
 								error={typeof formValues.phone === 'string' ? fieldsErrors.phone : undefined}
 							/>
 						</div>
 						<TextField
 							id="email"
 							title={translate('Email')}
-							updateValue={handleFormFieldUpdate}
+							updateValue={handleFormTextFieldUpdate}
 							error={typeof formValues.email === 'string' ? fieldsErrors.email : undefined}
 						/>
 					</Card>
@@ -353,20 +364,20 @@ const UpsSettingsForm = ({ translate, errorNotice, successNotice, countryNames, 
 						<TextField
 							id="company"
 							title={translate('Company name')}
-							updateValue={handleFormFieldUpdate}
+							updateValue={handleFormTextFieldUpdate}
 							error={typeof formValues.company === 'string' ? fieldsErrors.company : undefined}
 						/>
 						<div className="carrier-accounts__settings-two-columns">
 							<TextField
 								id="title"
 								title={translate('Job title')}
-								updateValue={handleFormFieldUpdate}
+								updateValue={handleFormTextFieldUpdate}
 								error={typeof formValues.title === 'string' ? fieldsErrors.title : undefined}
 							/>
 							<TextField
 								id="website"
 								title={translate('Company website')}
-								updateValue={handleFormFieldUpdate}
+								updateValue={handleFormTextFieldUpdate}
 								error={typeof formValues.website === 'string' ? fieldsErrors.website : undefined}
 							/>
 						</div>
@@ -391,13 +402,13 @@ const UpsSettingsForm = ({ translate, errorNotice, successNotice, countryNames, 
 									<TextField
 										id="invoice_number"
 										title={translate('UPS invoice number')}
-										updateValue={handleFormFieldUpdate}
+										updateValue={handleFormTextFieldUpdate}
 										error={typeof formValues.invoice_number === 'string' ? fieldsErrors.invoice_number : undefined}
 									/>
 									<TextField
 										id="invoice_date"
 										title={translate('UPS invoice date')}
-										updateValue={handleFormFieldUpdate}
+										updateValue={handleFormTextFieldUpdate}
 										error={typeof formValues.invoice_date === 'string' ? fieldsErrors.invoice_date : undefined}
 										placeholder={'YYYY-MM-DD'}
 									/>
@@ -406,20 +417,20 @@ const UpsSettingsForm = ({ translate, errorNotice, successNotice, countryNames, 
 									<TextField
 										id="invoice_amount"
 										title={translate('UPS invoice amount')}
-										updateValue={handleFormFieldUpdate}
+										updateValue={handleFormTextFieldUpdate}
 										error={typeof formValues.invoice_amount === 'string' ? fieldsErrors.invoice_amount : undefined}
 									/>
 									<TextField
 										id="invoice_currency"
 										title={translate('UPS invoice currency')}
-										updateValue={handleFormFieldUpdate}
+										updateValue={handleFormTextFieldUpdate}
 										error={typeof formValues.invoice_currency === 'string' ? fieldsErrors.invoice_currency : undefined}
 									/>
 								</div>
 								<TextField
 									id="invoice_control_id"
 									title={translate('UPS invoice control id')}
-									updateValue={handleFormFieldUpdate}
+									updateValue={handleFormTextFieldUpdate}
 									error={typeof formValues.invoice_control_id === 'string' ? fieldsErrors.invoice_control_id : undefined}
 								/>
 							</div>

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
@@ -11,13 +11,12 @@ import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { isBoolean } from 'lodash';
-import { Card } from '@wordpress/components';
+import { Card, FormToggle } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import ExtendedHeader from 'woocommerce/components/extended-header';
-import { FormToggle } from '@wordpress/components';
 import LabelSettings from './label-settings';
 import QueryLabelSettings from 'woocommerce/woocommerce-services/components/query-label-settings';
 import { setFormDataValue, restorePristineSettings } from '../../state/label-settings/actions';

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/style.scss
@@ -75,6 +75,10 @@
 		.form-text-input-with-affixes__prefix {
 			display: none;
 		}
+
+		.components-base-control__label {
+			display: none;
+		}
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- Explain the motivation for making this change -->
As part of the goal to remove Calypso dependencies, this PR replaces the Calypso `FormTextInput` component in our `TextField` component with the WordPress `TextControl` component. There are still other uses of the `FormTextInput` component in other places that will be replaced in a separate PR to keep each PR more manageable and keep this one focused on the `TextField`. 

There were several differences between the components that required reworking a few areas of functionality. The two biggest differences were:
- The `TextControl` component comes with a built in label. This allowed us to remove the `FieldLabel` component from the `TextField`. It also required some additional styles to make sure the label display is carried over successfully.
- The `TextControl` component [does NOT provide the event](https://github.com/WordPress/gutenberg/blob/master/packages/components/src/text-control/index.js), only the new value. This required reworking some event handlers to only expect a value. Some event handlers required an `id` for the change, so this was added as a parameter in addition to the value. 

One other quirk with the `TextControl` component is that if you pass in a HTML id, it will set it on the input, but will not properly set it on the for attribute of the label. Because of this, I opted to not use the HTML id and instead focus on the name attribute. This also allows the WordPress components to self manage the IDs as needed. Throughout my testing, things all seemed to work correctly still and all unit tests passed once the lookup was changed from id to name, but was something I wanted to call out for additional testing.

### Related issue(s)

Related to #2333

### Steps to reproduce & screenshots/GIFs

The TextField component is used in the following areas:
- Dynamic carrier form
- UPS settings form
- Label purchase modal
- Customs fields

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added

