### PR TITLE
Add phpcbf to our pre-commit hooks using lint-staged

### DIFF
--- a/bin/wc-phpcbf
+++ b/bin/wc-phpcbf
@@ -1,0 +1,17 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * vendor/bin/phpcbf exit with code 1 even after all errors are fixed. This is a work around until
+ * our phpcbf is upgraded to https://github.com/squizlabs/PHP_CodeSniffer/issues/3057#issuecomment-681158506.
+ */
+use PHP_CodeSniffer\Runner;
+
+include_once __DIR__.'/../vendor/squizlabs/php_codesniffer/autoload.php';
+
+$runner   = new Runner();
+$exitCode = $runner->runPHPCBF();
+if ($exitCode === 1) {
+    $exitCode = 0;
+}
+exit($exitCode);

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Tweak - Refresh on status page does not reload page.
 * Fix   - UPS invoice number allows numbers and letters.
 * Add 	- Tracks shipping services used at checkout.
+* Add   - Run phpcbf as a pre-commit rule.
 
 = 1.25.8 - 2021-03-02 =
 * Tweak - Add support for new Jetpack 9.5 data connection.

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -2,4 +2,7 @@ module.exports = {
 	'*.js': [
 		'npm run eslint:fix',
 	],
+	'*.php': [
+		'bin/wc-phpcbf',
+	],
 };


### PR DESCRIPTION
## Description
Add phpcbf in our pre-commit hooks so that it automatically cleans up PHP linting errors based on our phpcs rules.

### Related issue(s)
Closes https://github.com/Automattic/woocommerce-services/issues/2352

### Steps to reproduce & screenshots/GIFs
1. checkout this branch
2. run `composer install`
3. Make a change on `woocommerce-services.php` line 45, from 
`define( 'WOOCOMMERCE_CONNECT_MINIMUM_JETPACK_VERSION', '7.5' ); `
to 
`define('WOOCOMMERCE_CONNECT_MINIMUM_JETPACK_VERSION','8.5');`
4. `git add woocommerce-services.php` and `git commit`
5. You should see the linting run through and the style is fixed
![image](https://user-images.githubusercontent.com/572862/110043502-bd0cb580-7d04-11eb-9ed4-541d13786cd1.png)
6. Exit commit window with `:q!`

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

