### PR TITLE
Replace Calypso FieldLabel with internal FieldLabel

### DIFF
--- a/client/components/forms/form-label/index.js
+++ b/client/components/forms/form-label/index.js
@@ -1,0 +1,48 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { isObject, omit } from 'lodash';
+
+const renderRequiredBadge = translate => (
+	<small className="form-label__required">{ translate( 'Required' ) }</small>
+);
+
+const renderOptionalBadge = translate => (
+	<small className="form-label__optional">{ translate( 'Optional' ) }</small>
+);
+
+const addKeys = elements =>
+	elements.map( ( elem, idx ) => ( isObject( elem ) ? { ...elem, key: idx } : elem ) );
+
+const FormLabel = ( { children, required, optional, translate, className, ...extraProps } ) => {
+	children = React.Children.toArray( children ) || [];
+	if ( required ) {
+		children.push( renderRequiredBadge( translate ) );
+	}
+
+	if ( optional ) {
+		children.push( renderOptionalBadge( translate ) );
+	}
+
+	return (
+		<label
+			{ ...omit( extraProps, 'moment', 'numberFormat' ) }
+			className={ classnames( className, 'form-label' ) }
+		>
+			{ children.length ? addKeys( children ) : null }
+		</label>
+	);
+};
+
+FormLabel.propTypes = {
+	required: PropTypes.bool,
+};
+
+export default localize( FormLabel );

--- a/client/components/forms/form-label/index.js
+++ b/client/components/forms/form-label/index.js
@@ -8,41 +8,24 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { isObject, omit } from 'lodash';
 
-const renderRequiredBadge = translate => (
-	<small className="form-label__required">{ translate( 'Required' ) }</small>
-);
-
-const renderOptionalBadge = translate => (
-	<small className="form-label__optional">{ translate( 'Optional' ) }</small>
-);
-
-const addKeys = elements =>
-	elements.map( ( elem, idx ) => ( isObject( elem ) ? { ...elem, key: idx } : elem ) );
-
-const FormLabel = ( { children, required, optional, translate, className, ...extraProps } ) => {
-	children = React.Children.toArray( children ) || [];
-	if ( required ) {
-		children.push( renderRequiredBadge( translate ) );
-	}
-
-	if ( optional ) {
-		children.push( renderOptionalBadge( translate ) );
-	}
-
+const FormLabel = ( { children, required, optional, translate, className, moment, numberFormat, ...extraProps } ) => {
 	return (
 		<label
-			{ ...omit( extraProps, 'moment', 'numberFormat' ) }
+			{ ...extraProps }
 			className={ classnames( className, 'form-label' ) }
 		>
-			{ children.length ? addKeys( children ) : null }
+			{ children }
+			{required && ( <small className="form-label__required">{ translate( 'Required' ) }</small> ) }
+			{optional && ( <small className="form-label__optional">{ translate( 'Optional' ) }</small> )}
 		</label>
 	);
 };
 
 FormLabel.propTypes = {
 	required: PropTypes.bool,
+	optional: PropTypes.bool,
+	children: PropTypes.node,
 };
 
 export default localize( FormLabel );

--- a/client/components/forms/form-label/style.scss
+++ b/client/components/forms/form-label/style.scss
@@ -1,0 +1,23 @@
+.form-label {
+	display: block;
+	font-size: 14px;
+	font-weight: 600;
+	margin-bottom: 5px;
+
+	.form-label__required {
+		color: var( --color-error );
+		font-weight: normal;
+		margin-left: 6px;
+	}
+
+	.form-label__optional {
+		color: var( --color-neutral-500 );
+		font-weight: normal;
+		margin-left: 6px;
+	}
+}
+
+.form-label input[type='checkbox'] + span,
+.form-label input[type='radio'] + span {
+	font-weight: normal;
+}

--- a/client/components/toggle/index.js
+++ b/client/components/toggle/index.js
@@ -4,6 +4,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { FormToggle } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -11,7 +12,6 @@ import PropTypes from 'prop-types';
 import './style.scss';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
-import { FormToggle } from '@wordpress/components';
 import FieldDescription from '../../extensions/woocommerce/woocommerce-services/components/field-description';
 import sanitizeHTML from 'lib/utils/sanitize-html';
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
Replace the Calypso `FieldLabel` component with an internal `FieldLabel` component. There was not a comparable WordPress component to replace with and the component itself is very simple so it was easy to move over to our internal components. In WordPress components, the field label is often included with the field component, so there may be a few more of these labels removed going forward.

I placed the replacement component within the top level `client/components` directory based on some recent discussions on how best to organize our internal components. I kept the naming the same to simplify the code changes required. Due to having the same name, the Webpack config resolve.modules array order is hitting this new internal component rather than the Calypso component.

### Related issue(s)

Related to #2333 

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

This component is used in multiple areas, primarily with custom form fields (NumberInput, FormTextInputWithAffixes, FormToggle, FormCurrencyInput, etc). Some pages to review in particular:

- Create/Edit package
- Status logs
- Shipping method settings page
- Label purchase modal

Since the component is identical to Calypso's, I confirmed it was using the new internal component by adding a class name to the component and confirm that class name was added in all the relevant places.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added

