### PR TITLE
Replaces deprecated Jetpack constant JETPACK_MASTER_USER

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,6 @@
 *** WooCommerce Shipping & Tax Changelog ***
+= 1.25.10 - 2021-xx-xx =
+* Tweak - Removes deprecated Jetpack constant JETPACK_MASTER_USER
 
 = 1.25.9 - 2021-xx-xx =
 * Tweak - Cleanup stripe functionality.

--- a/classes/class-wc-connect-jetpack.php
+++ b/classes/class-wc-connect-jetpack.php
@@ -155,39 +155,43 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 
 		/**
 		 * Determines if the current user is connected to Jetpack
+		 *
 		 * @return bool Whether or nor the current user is connected to Jetpack
 		 */
 		public static function is_current_user_connected() {
+			if ( class_exists( '\Automattic\Jetpack\Connection\Manager' ) && method_exists( '\Automattic\Jetpack\Connection\Manager', 'is_user_connected' ) ) {
+				$connection = new Manager();
+
+				return $connection->is_user_connected();
+			}
+
 			if ( defined( JETPACK_MASTER_USER ) ) {
-				$user_token = WC_Connect_Jetpack::get_master_user_access_token( JETPACK_MASTER_USER );
+				$user_token = self::get_master_user_access_token( JETPACK_MASTER_USER );
 
 				return ( isset( $user_token->external_user_id ) && get_current_user_id() === $user_token->external_user_id );
-			} else {
-				if ( class_exists( '\Automattic\Jetpack\Connection\Manager' ) && method_exists( '\Automattic\Jetpack\Connection\Manager', 'is_user_connected' ) ) {
-					$connection = new Manager();
-
-					return $connection->is_user_connected();
-				}
 			}
+
 			return false;
 		}
 
 		/**
 		 * Determines if Jetpack is connected
+		 *
 		 * @return bool Whether or nor Jetpack is connected
 		 */
 		public static function is_connected() {
+			if ( class_exists( '\Automattic\Jetpack\Connection\Manager' ) && method_exists( '\Automattic\Jetpack\Connection\Manager', 'is_connected' ) ) {
+				$connection = new Manager();
+
+				return $connection->is_connected();
+			}
+
 			if ( defined( JETPACK_MASTER_USER ) ) {
-				$user_token = WC_Connect_Jetpack::get_master_user_access_token( JETPACK_MASTER_USER );
+				$user_token = self::get_master_user_access_token( JETPACK_MASTER_USER );
 
 				return isset( $user_token->external_user_id );
-			} else {
-				if ( class_exists( '\Automattic\Jetpack\Connection\Manager' ) && method_exists( '\Automattic\Jetpack\Connection\Manager', 'is_connected' ) ) {
-					$connection = new Manager();
-
-					return $connection->is_connected();
-				}
 			}
+
 			return false;
 		}
 	}

--- a/classes/class-wc-connect-jetpack.php
+++ b/classes/class-wc-connect-jetpack.php
@@ -152,5 +152,43 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 			}
 			return false;
 		}
+
+		/**
+		 * Determines if the current user is connected to Jetpack
+		 * @return bool Whether or nor the current user is connected to Jetpack
+		 */
+		public static function is_current_user_connected() {
+			if ( defined( JETPACK_MASTER_USER ) ) {
+				$user_token = WC_Connect_Jetpack::get_master_user_access_token( JETPACK_MASTER_USER );
+
+				return ( isset( $user_token->external_user_id ) && get_current_user_id() === $user_token->external_user_id );
+			} else {
+				if ( class_exists( '\Automattic\Jetpack\Connection\Manager' ) && method_exists( '\Automattic\Jetpack\Connection\Manager', 'is_user_connected' ) ) {
+					$connection = new Manager();
+
+					return $connection->is_user_connected();
+				}
+			}
+			return false;
+		}
+
+		/**
+		 * Determines if Jetpack is connected
+		 * @return bool Whether or nor Jetpack is connected
+		 */
+		public static function is_connected() {
+			if ( defined( JETPACK_MASTER_USER ) ) {
+				$user_token = WC_Connect_Jetpack::get_master_user_access_token( JETPACK_MASTER_USER );
+
+				return isset( $user_token->external_user_id );
+			} else {
+				if ( class_exists( '\Automattic\Jetpack\Connection\Manager' ) && method_exists( '\Automattic\Jetpack\Connection\Manager', 'is_connected' ) ) {
+					$connection = new Manager();
+
+					return $connection->is_connected();
+				}
+			}
+			return false;
+		}
 	}
 }

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -237,11 +237,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				return true;
 			}
 
-			$user_token = WC_Connect_Jetpack::get_master_user_access_token( JETPACK_MASTER_USER );
-			$can_accept = (
-				isset( $user_token->external_user_id ) &&
-				get_current_user_id() === $user_token->external_user_id
-			);
+			$can_accept = WC_Connect_Jetpack::is_current_user_connected();
 
 			return $can_accept;
 		}
@@ -312,8 +308,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 
 			// installed, activated, dev mode off
 			// check if connected
-			$user_token = WC_Connect_Jetpack::get_master_user_access_token( JETPACK_MASTER_USER );
-			if ( ! isset( $user_token->external_user_id ) ) { // always an int
+			if ( ! WC_Connect_Jetpack::is_connected() ) {
 				return self::JETPACK_ACTIVATED_NOT_CONNECTED;
 			}
 


### PR DESCRIPTION
## Description
Instead of using the deprecated `JETPACK_MASTER_USER` constant, the Jetpack class now uses proper method from the Jetpack manager to get the status of the connection
### Related issue(s)

Closes https://github.com/Automattic/woocommerce-shipping-issues/issues/185

### Steps to reproduce & screenshots/GIFs

1. Create a new test site with latest WooCommerce.
2. Install latest Jetpack version v9.6.
3. Install this plugin and connect the site to Jetpack. The connection should be made without incidents.

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added