### PR TITLE
Replace Calypso External-link component with WordPress component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -11,7 +11,6 @@
 @import 'components/card/style';
 @import 'components/dialog/style';
 @import 'components/ellipsis-menu/style';
-@import 'components/external-link/style';
 @import 'components/foldable-card/style';
 @import 'components/forms/form-button/style';
 @import 'components/forms/form-currency-input/style';

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -253,6 +253,8 @@
 @import "~@wordpress/base-styles/variables";
 @import "~@wordpress/base-styles/z-index";
 @import '~@wordpress/components/src/tooltip/style.scss';
+@import '~@wordpress/components/src/external-link/style.scss';
+@import '~@wordpress/components/src/visually-hidden/style.scss';
 
 #woocommerce-order-label .inside {
 	margin: 0;

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
@@ -97,7 +97,7 @@
 }
 
 .address-step__unverifiable-info {
-	.external-link {
+	.components-external-link {
 		float: left;
 		clear: both;
 	}

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/unverified.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/unverified.js
@@ -8,11 +8,11 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import url from 'url';
 import { invokeMap } from 'lodash';
+import { ExternalLink } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import ExternalLink from 'components/external-link';
 import FormButton from 'components/forms/form-button';
 import Notice from 'components/notice';
 import AddressSummary from './summary';
@@ -112,12 +112,12 @@ const UnverifiedAddress = ( {
 						) }
 					</p>
 					{ uspsUrl && (
-						<ExternalLink icon={ true } href={ uspsUrl } target="_blank">
-							{ translate( 'Verify with USPS' ) }
+						<ExternalLink href={ uspsUrl } target="_blank">
+							{ translate( 'Verify with USPS ' ) }
 						</ExternalLink>
 					) }
-					<ExternalLink icon={ true } href={ googleMapsUrl } target="_blank">
-						{ translate( 'View on Google Maps' ) }
+					<ExternalLink href={ googleMapsUrl } target="_blank">
+						{ translate( 'View on Google Maps ' ) }
 					</ExternalLink>
 				</div>
 			</div>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/unverified.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/unverified.js
@@ -112,12 +112,12 @@ const UnverifiedAddress = ( {
 						) }
 					</p>
 					{ uspsUrl && (
-						<ExternalLink href={ uspsUrl } target="_blank">
-							{ translate( 'Verify with USPS ' ) }
+						<ExternalLink href={ uspsUrl }>
+							{ translate( 'Verify with USPS' ) }
 						</ExternalLink>
 					) }
-					<ExternalLink href={ googleMapsUrl } target="_blank">
-						{ translate( 'View on Google Maps ' ) }
+					<ExternalLink href={ googleMapsUrl }>
+						{ translate( 'View on Google Maps' ) }
 					</ExternalLink>
 				</div>
 			</div>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/item-row-header.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/item-row-header.js
@@ -18,7 +18,6 @@ export const TariffCodeTitle = localize( ( { translate } ) => (
 		{ translate( 'HS Tariff number' ) } (
 		<ExternalLink
 			href="https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29"
-			target="_blank"
 		>
 			{ translate( 'more info' ) }
 		</ExternalLink>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/item-row-header.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/item-row-header.js
@@ -5,12 +5,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { Tooltip } from '@wordpress/components';
+import { ExternalLink, Tooltip } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import ExternalLink from 'components/external-link';
 import { getShippingLabel } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 import Gridicon from "gridicons";
 
@@ -18,7 +17,6 @@ export const TariffCodeTitle = localize( ( { translate } ) => (
 	<span>
 		{ translate( 'HS Tariff number' ) } (
 		<ExternalLink
-			icon
 			href="https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29"
 			target="_blank"
 		>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/package-row.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/package-row.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { map, uniq } from 'lodash';
+import { ExternalLink } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -29,7 +30,6 @@ import {
 	isLoaded,
 	getFormErrors,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
-import ExternalLink from 'components/external-link';
 
 const PackageRow = props => {
 	const {
@@ -118,7 +118,7 @@ const PackageRow = props => {
 				title={
 					<span>
 						{ translate( 'ITN' ) } (
-						<ExternalLink icon href="https://pe.usps.com/text/imm/immc5_010.htm" target="_blank">
+						<ExternalLink href="https://pe.usps.com/text/imm/immc5_010.htm" target="_blank">
 							{ translate( 'more info' ) }
 						</ExternalLink>
 						)

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/package-row.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/package-row.js
@@ -118,7 +118,7 @@ const PackageRow = props => {
 				title={
 					<span>
 						{ translate( 'ITN' ) } (
-						<ExternalLink href="https://pe.usps.com/text/imm/immc5_010.htm" target="_blank">
+						<ExternalLink href="https://pe.usps.com/text/imm/immc5_010.htm">
 							{ translate( 'more info' ) }
 						</ExternalLink>
 						)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
Replace Calypso External-link component with WordPress External-link component.

### Related issue(s)

Part of #2333

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
The following links have been replaced:

Purchasing labels, verification address links:

|<img width="551" alt="AddressVerificationLinks" src="https://user-images.githubusercontent.com/8002881/110496498-243ab900-80bb-11eb-942a-0c8bbc1fc815.png">|
|-|

Purchasing labels, customs form, more info links:
|<img width="1085" alt="CustomsFormLinks" src="https://user-images.githubusercontent.com/8002881/110496662-551aee00-80bb-11eb-8f2b-6d0409a8d6be.png">|
|-|


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added

