### PR TITLE
Only display shipping validation errors on cart or checkout page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Add   - Run phpcbf as a pre-commit rule.
 * Fix   - Fix PHPUnit tests. Rename `test_` to `test-` to match our phpcs rules. Remove travis and move to github action.
 * Tweak - Updated .nvmrc to use 10.16.0
+* Fix   - Only display shipping validation errors on the cart or checkout pages.
 
 = 1.25.8 - 2021-03-02 =
 * Tweak - Add support for new Jetpack 9.5 data connection.

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -399,10 +399,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			);
 
 			if ( ! $this->is_valid_package_destination( $package ) ) {
-				foreach ( $this->package_validation_errors->errors as $code => $messages ) {
-					$data = $this->package_validation_errors->get_error_data( $code );
-					foreach ( $messages as $message ) {
-						wc_add_notice( $message, 'error', $data );
+				if ( is_cart() || is_checkout() ) {
+					foreach ( $this->package_validation_errors->errors as $code => $messages ) {
+						$data = $this->package_validation_errors->get_error_data( $code );
+						foreach ( $messages as $message ) {
+							wc_add_notice( $message, 'error', $data );
+						}
 					}
 				}
 				return;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
After a recent update, users had reported getting an error when adding products to their cart. It appears these errors were coming from the shipping validation process and being added as notices to the page. This PR looks to address that issue by only adding the errors as notices when on the Cart or Checkout page. This seemed to be the least disruptive approach for addressing this issue.

![AddToCart-ValidationError](https://user-images.githubusercontent.com/68524302/110543236-0dff1e00-80f8-11eb-98b9-b15ff8fc64b4.png)

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
Fixes #2362 

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
1. With WCS&T set up on this branch and shipping zones/methods set up.
2. Use an Incognito window or clear cache to simulate a customer that does not have any shipping information entered/cached yet.
2. Visit a product's single page (I was unable to reproduce from a listing page).
3. Add the product to the Cart.
4. No error should be displayed.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

