### PR TITLE
fix: broken status page

### DIFF
--- a/client/components/forms/form-label/index.js
+++ b/client/components/forms/form-label/index.js
@@ -9,15 +9,25 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 
-const FormLabel = ( { children, required, optional, translate, className, moment, numberFormat, ...extraProps } ) => {
+const FormLabel = ( { children: childrenProp, required, optional, translate, className, moment, numberFormat, dangerouslySetInnerHTML, ...extraProps } ) => {
+	const children = dangerouslySetInnerHTML ? null : (
+		<>
+			{ childrenProp }
+			{/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */}
+			{ required && ( <small className="form-label__required">{ translate( 'Required' ) }</small> ) }
+			{/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */}
+			{ optional && ( <small className="form-label__optional">{ translate( 'Optional' ) }</small> ) }
+		</>
+	);
+
 	return (
 		<label
 			{ ...extraProps }
+			/* eslint-disable-next-line react/no-danger */
+			dangerouslySetInnerHTML={ dangerouslySetInnerHTML }
 			className={ classnames( className, 'form-label' ) }
 		>
 			{ children }
-			{required && ( <small className="form-label__required">{ translate( 'Required' ) }</small> ) }
-			{optional && ( <small className="form-label__optional">{ translate( 'Optional' ) }</small> )}
 		</label>
 	);
 };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Status page (and a few others?) is broken.
Fixing.

Cannot set both `dangerouslySetInnerHTML` and `children`.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Related to https://github.com/Automattic/woocommerce-services/issues/2333

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added

