### PR TITLE
refactor: calypso form-select

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -20,7 +20,6 @@
 @import 'components/forms/form-label/style';
 @import 'components/forms/form-legend/style';
 @import 'components/forms/form-section-heading/style';
-@import 'components/forms/form-select/style';
 @import 'components/forms/form-setting-explanation/style';
 @import 'components/forms/form-text-input/style';
 @import 'components/forms/text-control-with-affixes/style';

--- a/client/apps/print-test-label/view.js
+++ b/client/apps/print-test-label/view.js
@@ -15,7 +15,7 @@ import * as PrintTestLabelActions from './state/actions';
 import ErrorNotice from 'components/error-notice';
 import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
-import FormSelect from 'components/forms/form-select';
+import FormSelect from 'wcs-client/components/forms/form-select';
 import FormLegend from 'components/forms/form-legend';
 import SettingsGroupCard from 'woocommerce/woocommerce-services/components/settings-group-card';
 

--- a/client/components/forms/form-select/index.js
+++ b/client/components/forms/form-select/index.js
@@ -1,0 +1,23 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react'
+import classNames from 'classnames'
+import './styles.scss'
+
+const FormSelect = ({ inputRef, className, isError, ...restProps }) => {
+	return (
+		<select
+			{...restProps}
+			ref={inputRef}
+			className={classNames(className, 'form-select', {
+				'is-error': isError,
+			})}
+		/>
+	)
+}
+
+export default FormSelect

--- a/client/components/forms/form-select/styles.scss
+++ b/client/components/forms/form-select/styles.scss
@@ -1,0 +1,114 @@
+.form-select {
+	background: var( --color-white )
+	url( data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjQzhEN0UxIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg== )
+	no-repeat right 10px center;
+	border-color: var( --color-neutral-100 );
+	border-style: solid;
+	border-radius: 4px;
+	border-width: 1px 1px 2px;
+	color: var( --color-neutral-700 );
+	cursor: pointer;
+	display: inline-block;
+	margin: 0;
+	outline: 0;
+	overflow: hidden;
+	font-size: 16px;
+	font-weight: 400;
+	line-height: 1.4em;
+	text-overflow: ellipsis;
+	text-decoration: none;
+	vertical-align: top;
+	white-space: nowrap;
+	box-sizing: border-box;
+	padding: 7px 32px 9px 14px; // Aligns the text to the 8px baseline grid and adds padding on right to allow for the arrow.
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+
+	&:hover {
+		background-image: url( data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjYThiZWNlIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg== );
+	}
+
+	&:focus {
+		background-image: url( data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiA8dGl0bGU+YXJyb3ctZG93bjwvdGl0bGU+IDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPiA8ZGVmcz48L2RlZnM+IDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHNrZXRjaDp0eXBlPSJNU1BhZ2UiPiA8ZyBpZD0iYXJyb3ctZG93biIgc2tldGNoOnR5cGU9Ik1TQXJ0Ym9hcmRHcm91cCIgZmlsbD0iIzJlNDQ1MyI+IDxwYXRoIGQ9Ik0xNS41LDYgTDE3LDcuNSBMMTAuMjUsMTQuMjUgTDMuNSw3LjUgTDUsNiBMMTAuMjUsMTEuMjUgTDE1LjUsNiBaIiBpZD0iRG93bi1BcnJvdyIgc2tldGNoOnR5cGU9Ik1TU2hhcGVHcm91cCI+PC9wYXRoPiA8L2c+IDwvZz48L3N2Zz4= );
+		border-color: var( --color-primary );
+		box-shadow: 0 0 0 2px var( --color-primary-100 );
+		outline: 0;
+		-moz-outline: none;
+		-moz-user-focus: ignore;
+	}
+
+	&:disabled,
+	&:hover:disabled {
+		background: url( data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjZTllZmYzIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg== )
+		no-repeat right 10px center;
+	}
+
+	// A smaller variant that works well when presented inline with text
+	&.is-compact {
+		min-width: 0;
+		padding: 0 20px 2px 6px;
+		margin: 0 4px;
+		background-position: right 5px center;
+		background-size: 12px 12px;
+	}
+
+	// Make it display:block when it follows a label
+	label &,
+	label + & {
+		display: block;
+		min-width: 200px;
+
+		&.is-compact {
+			display: inline-block;
+			min-width: 0;
+		}
+	}
+
+	// IE: Remove the default arrow
+	&::-ms-expand {
+		display: none;
+	}
+
+	// IE: Remove default background and color styles on focus
+	&::-ms-value {
+		background: none;
+		color: var( --color-neutral-700 );
+	}
+
+	// Firefox: Remove the focus outline, see http://stackoverflow.com/questions/3773430/remove-outline-from-select-box-in-ff/18853002#18853002
+	&:-moz-focusring {
+		color: transparent;
+		text-shadow: 0 0 0 var( --color-neutral-700 );
+	}
+
+	margin-bottom: 1em;
+
+	&.is-error {
+		border-color: var( --color-error );
+	}
+
+	&.is-error:hover {
+		border-color: var( --color-error-dark );
+	}
+
+	&:disabled {
+		color: var( --color-neutral-100 );
+	}
+
+	&:focus {
+		&.is-error {
+			box-shadow: 0 0 0 2px var( --color-error-100 );
+		}
+
+		&.is-error:hover {
+			box-shadow: 0 0 0 2px var( --color-error-200 );
+		}
+	}
+}
+
+// According to CSS tricks, browser support is IE9+
+.form-select:only-of-type,
+.form-select:last-of-type {
+	margin-bottom: 0;
+}

--- a/client/extensions/woocommerce/woocommerce-services/components/dropdown/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/dropdown/index.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import FormFieldset from 'components/forms/form-fieldset';
-import FormSelect from 'components/forms/form-select';
+import FormSelect from 'wcs-client/components/forms/form-select';
 import FormLegend from 'components/forms/form-legend';
 import FieldError from '../field-error';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -20,7 +20,7 @@ import Button from 'components/button';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
-import FormSelect from 'components/forms/form-select';
+import FormSelect from 'wcs-client/components/forms/form-select';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import PaymentMethod, { getPaymentMethodTitle } from './label-payment-method';

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/edit-package.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/edit-package.js
@@ -16,7 +16,7 @@ import { TextControl } from '@wordpress/components';
 import FormDimensionsInput from 'woocommerce/components/form-dimensions-input';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
-import FormSelect from 'components/forms/form-select';
+import FormSelect from 'wcs-client/components/forms/form-select';
 import FieldError from '../../components/field-error';
 import inputFilters from './input-filters';
 import TextControlWithAffixes from 'components/forms/text-control-with-affixes';

--- a/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/entry.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/entry.js
@@ -13,7 +13,7 @@ import { snakeCase } from 'lodash';
  * Internal dependencies
  */
 import Checkbox from 'woocommerce/woocommerce-services/components/checkbox';
-import FormSelect from 'components/forms/form-select';
+import FormSelect from 'wcs-client/components/forms/form-select';
 import NumberInput from 'woocommerce/woocommerce-services/components/number-field/number-input';
 
 const ShippingServiceEntry = props => {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/package-select.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/package-select.js
@@ -15,7 +15,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import FormSelect from 'components/forms/form-select';
+import FormSelect from 'wcs-client/components/forms/form-select';
 import getBoxDimensions from 'woocommerce/woocommerce-services/lib/utils/get-box-dimensions';
 import PackageDialog from '../../../packages/package-dialog.js';
 import FormLegend from 'components/forms/form-legend';

--- a/tests/client/jest.config.js
+++ b/tests/client/jest.config.js
@@ -3,6 +3,7 @@
 module.exports = {
 	moduleNameMapper: {
 		'^config$': '<rootDir>/wp-calypso/server/config/index.js',
+		"^wcs-client/(.*)$": "<rootDir>/client/$1"
 	},
 	transform: {
 		'^.+\\.jsx?$': '<rootDir>/tests/test/helpers/assets/babel-transform.js',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -242,6 +242,7 @@ module.exports = {
 		symlinks: false,
 		alias: {
 			'react-dom': '@hot-loader/react-dom',
+			'wcs-client': path.resolve( __dirname, 'client' ),
 		},
 	},
 	node: {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Replacing the `form-select` component from Calypso.
I copied the styles and the body from Calypso, making it a functional component.
Unfortunately, the `@wordpress/components` component doesn't allow `optgroup` children.
I have a PR open for that: https://github.com/WordPress/gutenberg/pull/29540
Moreover, the Calypso styles are targeting _all_ `select` elements, causing some visual artifacts when using the `SelectControl` from `@wordpress/components`: https://d.pr/i/iYhj0G
In the meantime, the team agreed to just copy the styles/component to get rid of the Calypso submodule.

Original: https://github.com/Automattic/wp-calypso/blob/df4ddfdc94438b6d31b686d6415e08a567570944/client/components/forms/form-select/index.jsx

You might think the Calypso styles are all in here: https://github.com/Automattic/wp-calypso/blob/df4ddfdc94438b6d31b686d6415e08a567570944/client/components/forms/form-select/style.scss
But you'd be wrong, there's more from here: https://github.com/Automattic/wp-calypso/blob/df4ddfdc94438b6d31b686d6415e08a567570944/assets/stylesheets/shared/_forms.scss

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Part of https://github.com/Automattic/woocommerce-services/issues/2333

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

This component is used in many places.
A few examples:
- Account connection page: https://d.pr/i/9stEFr
- WCS settings: https://d.pr/i/2lvK6c
- Label creation: https://d.pr/i/2jzaxG | https://d.pr/i/MbjoRm | https://d.pr/i/PE1Aq2 | https://d.pr/i/Uy3eai
- Settings page (currently broken, but https://github.com/Automattic/woocommerce-services/pull/2369 fixes it)

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added

