### PR TITLE
Detect checkout block REST API call correctly.

### DIFF
--- a/classes/class-wc-connect-functions.php
+++ b/classes/class-wc-connect-functions.php
@@ -43,7 +43,7 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 		}
 
 		/**
-		 * Check if we are currently in Rest API request for the wc/store/cart API call.
+		 * Check if we are currently in Rest API request for the wc/store/cart or wc/store/checkout API call.
 		 *
 		 * @return bool
 		 */
@@ -51,8 +51,8 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 			if ( ! WC()->is_rest_api_request() && empty( $GLOBALS['wp']->query_vars['rest_route'] ) ) {
 				return false;
 			}
-
-			return false !== strpos( $GLOBALS['wp']->query_vars['rest_route'], 'wc/store/cart' );
+			$rest_route = $GLOBALS['wp']->query_vars['rest_route'];
+			return ( false !== strpos( $rest_route, 'wc/store/cart' ) ) || ( false !== strpos( $rest_route, 'wc/store/checkout' ) );
 		}
 
 		/**

--- a/classes/class-wc-connect-functions.php
+++ b/classes/class-wc-connect-functions.php
@@ -52,7 +52,10 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 				return false;
 			}
 			$rest_route = $GLOBALS['wp']->query_vars['rest_route'];
-			return ( false !== strpos( $rest_route, 'wc/store/cart' ) ) || ( false !== strpos( $rest_route, 'wc/store/checkout' ) );
+			return (
+				false !== strpos( $rest_route, 'wc/store/cart' ) ||
+				false !== strpos( $rest_route, 'wc/store/checkout' )
+			);
 		}
 
 		/**


### PR DESCRIPTION
The `wc/store/checkout` was blocked inside the shipping calculation. This PR unblocks it and allows the functions to fetch rates correctly. When the endpoint was blocked the rates were not registered and the cart shipping totals calculation was selecting the default shipping method.

### Related issue(s)
Found during 1.25.9 testing call.
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
From the testing post:
```
When using the following setup:

Cart page housing either the [woocommerce_cart] shortcode or Cart block,
Checkout page using the Checkout block.
Site has WCS&T enabled.
When picking one shipping option with a live rate on the Cart page, and then picking another shipping option with a live rate in the Checkout block, the order will have no shipping costs associated with it.

In addition to that, when I set up the following shipping methods:

Local pickup for $20.
Flat rate for $10.
Regardless of which of the two methods I selected on the Cart page, when I selected the other one on the Checkout page, the order had Local pickup associated with it anyway.
```

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added

