### PR TITLE
Bump testing matrix to support latest woocommerce 5.1.0

### DIFF
--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         wp-version: [5.4.4, 5.5.3, latest]
-        wc-version: [4.8.0, 4.9.2, 5.0.0]
+        wc-version: [4.9.2, 5.0.0, 5.1.0]
     steps:
       - name: Checkout latest WCS
         uses: actions/checkout@v2


### PR DESCRIPTION
### Description
Support latest woocommerce 5.1.0 in our CI pipeline.

### Related issue(s)
N/A

### Steps to reproduce & screenshots/GIFs
Make sure pipeline passes.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added

