### PR TITLE
Add DHL Live rates inbox notification

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Shipping & Tax Changelog ***
 = 1.25.10 - 2021-xx-xx =
 * Tweak - Removes deprecated Jetpack constant JETPACK_MASTER_USER
+* Add   - WC Admin notice about DHL live rates.
 
 = 1.25.9 - 2021-xx-xx =
 * Tweak - Cleanup stripe functionality.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,9 @@
 *** WooCommerce Shipping & Tax Changelog ***
 = 1.25.10 - 2021-xx-xx =
 * Tweak - Removes deprecated Jetpack constant JETPACK_MASTER_USER
-* Add   - WC Admin notice about DHL live rates.
 
 = 1.25.9 - 2021-xx-xx =
+* Add   - WC Admin notice about DHL live rates.
 * Tweak - Cleanup stripe functionality.
 * Tweak - Display better errors on checkout page when address fields are missing / invalid.
 * Tweak - Refresh on status page does not reload page.

--- a/classes/class-wc-connect-note-dhl-live-rates-available.php
+++ b/classes/class-wc-connect-note-dhl-live-rates-available.php
@@ -7,54 +7,51 @@
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! class_exists( 'WC_Connect_Note_Dhl_Live_Rates_Available' ) ) {
+/**
+ * Note to inform WooCommerce Shipping users with legacy live rates about DHL live rates.
+ */
+class WC_Connect_Note_DHL_Live_Rates_Available {
+
+	use Automattic\WooCommerce\Admin\Notes\NoteTraits;
 
 	/**
-	 * Note to inform WooCommerce Shipping users with legacy live rates about DHL live rates.
+	 * Name of the note for use in the database.
 	 */
-	class WC_Connect_Note_DHL_Live_Rates_Available {
+	const NOTE_NAME = 'wc-services-dhl-live-rates-available';
 
-		use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+	/**
+	 * Maybe add note to inform WooCommerce Shipping users with legacy live rates about new DHL live rates.
+	 *
+	 * @param WC_Connect_Service_Schemas_Store $schemas   Store schemas.
+	 */
+	public static function init( WC_Connect_Service_Schemas_Store $schemas ) {
+		// If store has DHL Express live rates.
+		$has_dlh_express = $schemas->get_service_schema_by_id( 'dhlexpress' );
 
-		/**
-		 * Name of the note for use in the database.
-		 */
-		const NOTE_NAME = 'wc-services-dhl-live-rates-available';
-
-		/**
-		 * Maybe add note to inform WooCommerce Shipping users with legacy live rates about new DHL live rates.
-		 *
-		 * @param WC_Connect_Service_Schemas_Store $schemas   Store schemas.
-		 */
-		public static function init( WC_Connect_Service_Schemas_Store $schemas ) {
-			// If store has DHL Express live rates.
-			$has_dlh_express = $schemas->get_service_schema_by_id( 'dhlexpress' );
-
-			if ( ! ! $has_dlh_express ) {
-				self::possibly_add_note();
-			}
+		if ( ! ! $has_dlh_express ) {
+			self::possibly_add_note();
 		}
+	}
 
-		/**
-		 * Get the note.
-		 *
-		 * @return Note|null
-		 */
-		public static function get_note() {
-			$note = new Automattic\WooCommerce\Admin\Notes\Note();
+	/**
+	 * Get the note.
+	 *
+	 * @return Note|null
+	 */
+	public static function get_note() {
+		$note = new Automattic\WooCommerce\Admin\Notes\Note();
 
-			$note->set_title( __( 'DHL Express live rates are now available', 'woocommerce-services' ) );
-			$note->set_content( __( 'Add DHL Express as a shipping method to selected shipping zones to display live rates at checkout.', 'woocommerce-services' ) );
-			$note->set_type( Automattic\WooCommerce\Admin\Notes\Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-			$note->set_name( self::NOTE_NAME );
-			$note->set_source( 'woocommerce-services' );
-			$note->add_action(
-				'go-to-shipping-zones',
-				__( 'Go to shipping zones', 'woocommerce-services' ),
-				admin_url( 'admin.php?page=wc-settings&tab=shipping' )
-			);
+		$note->set_title( __( 'DHL Express live rates are now available', 'woocommerce-services' ) );
+		$note->set_content( __( 'Add DHL Express as a shipping method to selected shipping zones to display live rates at checkout.', 'woocommerce-services' ) );
+		$note->set_type( Automattic\WooCommerce\Admin\Notes\Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-services' );
+		$note->add_action(
+			'go-to-shipping-zones',
+			__( 'Go to shipping zones', 'woocommerce-services' ),
+			admin_url( 'admin.php?page=wc-settings&tab=shipping' )
+		);
 
-			return $note;
-		}
+		return $note;
 	}
 }

--- a/classes/class-wc-connect-note-dhl-live-rates-available.php
+++ b/classes/class-wc-connect-note-dhl-live-rates-available.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * WooCommerce Shipping note: DHL live rates available.
+ *
+ * Only for legacy customers that had the feature available.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WC_Connect_Note_Dhl_Live_Rates_Available' ) ) {
+
+	/**
+	 * Note to inform WooCommerce Shipping users with legacy live rates about DHL live rates.
+	 */
+	class WC_Connect_Note_DHL_Live_Rates_Available {
+
+		use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+
+		/**
+		 * Name of the note for use in the database.
+		 */
+		const NOTE_NAME = 'wc-services-dhl-live-rates-available';
+
+		/**
+		 * Maybe add note to inform WooCommerce Shipping users with legacy live rates about new DHL live rates.
+		 *
+		 * @param WC_Connect_Service_Schemas_Store $schemas   Store schemas.
+		 */
+		public static function init( WC_Connect_Service_Schemas_Store $schemas ) {
+			// If store has DHL Express live rates.
+			$has_dlh_express = $schemas->get_service_schema_by_id( 'dhlexpress' );
+
+			if ( ! ! $has_dlh_express ) {
+				self::possibly_add_note();
+			}
+		}
+
+		/**
+		 * Get the note.
+		 *
+		 * @return Note|null
+		 */
+		public static function get_note() {
+			$note = new Automattic\WooCommerce\Admin\Notes\Note();
+
+			$note->set_title( __( 'DHL Express live rates are now available', 'woocommerce-services' ) );
+			$note->set_content( __( 'Add DHL Express as a shipping method to selected shipping zones to display live rates at checkout.', 'woocommerce-services' ) );
+			$note->set_type( Automattic\WooCommerce\Admin\Notes\Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+			$note->set_name( self::NOTE_NAME );
+			$note->set_source( 'woocommerce-services' );
+			$note->add_action(
+				'go-to-shipping-zones',
+				__( 'Go to shipping zones', 'woocommerce-services' ),
+				admin_url( 'admin.php?page=wc-settings&tab=shipping' )
+			);
+
+			return $note;
+		}
+	}
+}

--- a/classes/class-wc-connect-note-dhl-live-rates-available.php
+++ b/classes/class-wc-connect-note-dhl-live-rates-available.php
@@ -5,11 +5,6 @@
  * Only for legacy customers that had the feature available.
  */
 
-defined( 'ABSPATH' ) || exit;
-
-/**
- * Note to inform WooCommerce Shipping users with legacy live rates about DHL live rates.
- */
 class WC_Connect_Note_DHL_Live_Rates_Available {
 
 	use Automattic\WooCommerce\Admin\Notes\NoteTraits;
@@ -36,7 +31,7 @@ class WC_Connect_Note_DHL_Live_Rates_Available {
 	/**
 	 * Get the note.
 	 *
-	 * @return Note|null
+	 * @return Automattic\WooCommerce\Admin\Notes\Note
 	 */
 	public static function get_note() {
 		$note = new Automattic\WooCommerce\Admin\Notes\Note();

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -203,7 +203,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		public static function plugin_deactivation() {
 			wp_clear_scheduled_hook( 'wc_connect_fetch_service_schemas' );
-			self::delete_notices();
 		}
 
 		public static function plugin_uninstall() {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -214,10 +214,20 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * Deletes WC Admin notices.
 		 */
 		public static function delete_notices() {
-			if ( WC()->is_wc_admin_active() ) {
+			if ( self::can_add_wc_admin_notice() ) {
 				require_once __DIR__ . '/classes/class-wc-connect-note-dhl-live-rates-available.php';
 				WC_Connect_Note_DHL_Live_Rates_Available::possibly_delete_note();
 			}
+		}
+		/**
+		 * Checks if WC Admin is active and includes needed classes.
+		 *
+		 * @return bool true|false.
+		 */
+		public static function can_add_wc_admin_notice() {
+			$can_add_notice = WC()->is_wc_admin_active() && trait_exists( 'Automattic\WooCommerce\Admin\Notes\NoteTraits' );
+
+			return $can_add_notice;
 		}
 
 		/**
@@ -733,7 +743,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'admin_notices', array( $this, 'render_schema_notices' ) );
 
 			// Add WC Admin Notices.
-			if ( WC()->is_wc_admin_active() ) {
+			if ( self::can_add_wc_admin_notice() ) {
 				require_once __DIR__ . '/classes/class-wc-connect-note-dhl-live-rates-available.php';
 				WC_Connect_Note_Dhl_Live_Rates_Available::init( $schema );
 			}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -225,9 +225,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * @return bool true|false.
 		 */
 		public static function can_add_wc_admin_notice() {
-			$can_add_notice = WC()->is_wc_admin_active() && trait_exists( 'Automattic\WooCommerce\Admin\Notes\NoteTraits' );
-
-			return $can_add_notice;
+			return trait_exists( 'Automattic\WooCommerce\Admin\Notes\NoteTraits' );
 		}
 
 		/**

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -40,7 +40,6 @@ require_once __DIR__ . '/classes/class-wc-connect-jetpack.php';
 require_once __DIR__ . '/classes/class-wc-connect-options.php';
 
 if ( ! class_exists( 'WC_Connect_Loader' ) ) {
-
 	define( 'WOOCOMMERCE_CONNECT_MINIMUM_WOOCOMMERCE_VERSION', '2.6' );
 	define( 'WOOCOMMERCE_CONNECT_MINIMUM_JETPACK_VERSION', '7.5' );
 	define( 'WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH', 32 );
@@ -204,10 +203,22 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		public static function plugin_deactivation() {
 			wp_clear_scheduled_hook( 'wc_connect_fetch_service_schemas' );
+			self::delete_notices();
 		}
 
 		public static function plugin_uninstall() {
 			WC_Connect_Options::delete_all_options();
+			self::delete_notices();
+		}
+
+		/**
+		 * Deletes WC Admin notices.
+		 */
+		public static function delete_notices() {
+			if ( WC()->is_wc_admin_active() ) {
+				require_once __DIR__ . '/classes/class-wc-connect-note-dhl-live-rates-available.php';
+				WC_Connect_Note_DHL_Live_Rates_Available::possibly_delete_note();
+			}
 		}
 
 		/**
@@ -721,6 +732,12 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->set_help_view( new WC_Connect_Help_View( $schema, $settings, $logger ) );
 			add_action( 'admin_notices', array( WC_Connect_Error_Notice::instance(), 'render_notice' ) );
 			add_action( 'admin_notices', array( $this, 'render_schema_notices' ) );
+
+			// Add WC Admin Notices.
+			if ( WC()->is_wc_admin_active() ) {
+				require_once __DIR__ . '/classes/class-wc-connect-note-dhl-live-rates-available.php';
+				WC_Connect_Note_Dhl_Live_Rates_Available::init( $schema );
+			}
 		}
 
 		/**
@@ -1166,7 +1183,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					case 'dhlexpress':
 						$tracking_url = 'https://www.dhl.com/en/express/tracking.html?AWB=' . $tracking . '&brand=DHL';
 						break;
-
 				}
 
 				$markup .= '<td class="td" scope="col">';
@@ -1209,7 +1225,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * Hook fetching the available services from the connect server
 		 */
 		public function schedule_service_schemas_fetch() {
-
 			$schemas_store = $this->get_service_schemas_store();
 			$schemas       = $schemas_store->get_service_schemas();
 
@@ -1220,7 +1235,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			} elseif ( ! wp_next_scheduled( 'wc_connect_fetch_service_schemas' ) ) {
 				wp_schedule_event( time(), 'daily', 'wc_connect_fetch_service_schemas' );
 			}
-
 		}
 
 		/**
@@ -1242,7 +1256,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			if ( $service_schema ) {
 				$method->set_service_schema( $service_schema );
 			}
-
 		}
 
 		/**


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
This PR adds an inbox notification about DHL live rates for customers that can have DHL live rates.
( = when they have get_service_schema_by_id( 'dhlexpress' ); )

The note is only displayed once, goes away when they dismiss it or action it (Click on 'Go to Shipping Zones')

The note is deleted from the DB when the plugin is uninstalled.

### Related issue(s)
Closes: https://github.com/Automattic/woocommerce-shipping-issues/issues/189

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

1. With WooCommerce and WooCommerce Shipping and Tax active
2. Test on a store without DHL Express live rates available. Check there is no notice.
3. Activate the flag for the store. Refresh the status on the plugin Status page.
4. Check there is a notice like this:
<img width="486" alt="DHLLiveRatesNotice" src="https://user-images.githubusercontent.com/8002881/110958340-39f5eb80-8312-11eb-8f8d-b1d8faa81050.png">
6. Dismiss the notice. Activate-deactivate the plugin, check the notice is not displayed again.

Note: If you want to display the note again, uninstall the plugin or remove it from the DB tables: `wp_wc_admin_notes `and `wp_wc_admin_note_actions`
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests ( I haven't written new PHP tests but I made sure previous tests are still running)

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

