### PR TITLE
feat: add live rates carriers list section

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 * Tweak - Removes deprecated Jetpack constant JETPACK_MASTER_USER
 
 = 1.25.9 - 2021-xx-xx =
+* Add	- Live rates section in settings page.
 * Tweak - Cleanup stripe functionality.
 * Tweak - Display better errors on checkout page when address fields are missing / invalid.
 * Tweak - Refresh on status page does not reload page.

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -4,9 +4,9 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 
 	class WC_Connect_Settings_Pages {
 		/**
-		 * @array
+		 * @var WC_Connect_Service_Schemas_Store
 		 */
-		protected $fieldsets;
+		protected $service_schemas_store;
 
 		/**
 		 * @var WC_Connect_Continents
@@ -19,11 +19,12 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 		 */
 		protected $api_client;
 
-		public function __construct( WC_Connect_API_Client $api_client ) {
-			$this->id         = 'connect';
-			$this->label      = _x( 'WooCommerce Shipping', 'The WooCommerce Shipping & Tax brandname', 'woocommerce-services' );
-			$this->continents = new WC_Connect_Continents();
-			$this->api_client = $api_client;
+		public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Service_Schemas_Store $service_schemas_store ) {
+			$this->id                    = 'connect';
+			$this->label                 = _x( 'WooCommerce Shipping', 'The WooCommerce Shipping & Tax brandname', 'woocommerce-services' );
+			$this->continents            = new WC_Connect_Continents();
+			$this->api_client            = $api_client;
+			$this->service_schemas_store = $service_schemas_store;
 
 			add_filter( 'woocommerce_get_sections_shipping', array( $this, 'get_sections' ), 30 );
 			add_action( 'woocommerce_settings_shipping', array( $this, 'output_settings_screen' ), 5 );
@@ -80,10 +81,13 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 				<?php
 			}
 
-			$extra_args        = array();
+			$extra_args = array(
+				'live_rates_types' => $this->service_schemas_store->get_all_shipping_method_ids(),
+			);
+
 			$carriers_response = $this->api_client->get_carrier_accounts();
 			if ( ! is_wp_error( $carriers_response ) && $carriers_response ) {
-				$extra_args['carriers'] = $carriers_response->carriers;
+				$extra_args['carrier_accounts'] = $carriers_response->carriers;
 			}
 
 			$subscriptions_usage_response = $this->api_client->get_wccom_subscriptions();

--- a/client/apps/shipping-settings/index.js
+++ b/client/apps/shipping-settings/index.js
@@ -18,7 +18,7 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import { middleware as rawWpcomApiMiddleware } from 'state/data-layer/wpcom-api-middleware';
 import { combineReducers } from 'state/utils';
 
-export default ( { order_id: orderId, order_href: orderHref, carrier: carrier, continents, carriers, subscriptions } ) => ( {
+export default ( { order_id: orderId, order_href: orderHref, carrier, continents, carrier_accounts: carrierAccounts, live_rates_types: liveRatesTypes, subscriptions } ) => ( {
 	getReducer() {
 		return combineReducers( {
 			extensions: combineReducers( {
@@ -74,5 +74,5 @@ export default ( { order_id: orderId, order_href: orderHref, carrier: carrier, c
 		return [ rawWpcomApiMiddleware( mergeHandlers( wcsUiDataLayer, actionList ) ) ];
 	},
 
-	View: () => <ViewWrapper orderId={ orderId } orderHref={ orderHref } carrier={ carrier } carriers={ carriers } subscriptions = { subscriptions } />,
+	View: () => <ViewWrapper orderId={ orderId } orderHref={ orderHref } carrier={ carrier } carrierAccounts={ carrierAccounts } liveRatesTypes={ liveRatesTypes } subscriptions={ subscriptions } />,
 } );

--- a/client/apps/shipping-settings/view-wrapper.js
+++ b/client/apps/shipping-settings/view-wrapper.js
@@ -16,6 +16,7 @@ import LabelSettings from '../../extensions/woocommerce/woocommerce-services/vie
 import notices from 'notices';
 import Packages from '../../extensions/woocommerce/woocommerce-services/views/packages';
 import CarrierAccounts from '../../extensions/woocommerce/woocommerce-services/views/carrier-accounts';
+import LiveRatesCarriersList from '../../extensions/woocommerce/woocommerce-services/views/live-rates-carriers-list';
 import SubscriptionsUsage from '../../extensions/woocommerce/woocommerce-services/views/subscriptions-usage';
 import UpsSettingsForm from '../../extensions/woocommerce/woocommerce-services/views/carrier-accounts/ups-settings-form';
 import DynamicCarrierAccountSettings from '../../extensions/woocommerce/woocommerce-services/views/carrier-accounts/dynamic-settings';
@@ -61,7 +62,7 @@ class LabelSettingsWrapper extends Component {
 	};
 
 	render() {
-		const { carrier, carriers, subscriptions, isSaving, translate } = this.props;
+		const { carrier, carrierAccounts, liveRatesTypes, subscriptions, isSaving, translate } = this.props;
 
 		if ( ! carrier ) {
 			return (
@@ -69,7 +70,8 @@ class LabelSettingsWrapper extends Component {
 					<GlobalNotices id="notices" notices={ notices.list } />
 					<LabelSettings onChange={ this.onChange } />
 					<Packages onChange={ this.onChange } />
-					<CarrierAccounts carriers={ carriers } />
+					<LiveRatesCarriersList carrierIds={ liveRatesTypes } />
+					<CarrierAccounts accounts={ carrierAccounts } />
 					<SubscriptionsUsage subscriptions={ subscriptions } />
 					<Button primary onClick={ this.onSaveChanges } busy={ isSaving } disabled={ isSaving }>
 						{ translate( 'Save changes' ) }

--- a/client/extensions/woocommerce/woocommerce-services/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/style.scss
@@ -6,6 +6,7 @@
 @import 'components/text/style';
 @import 'views/label-settings/style';
 @import 'views/carrier-accounts/style';
+@import 'views/live-rates-carriers-list/style';
 @import 'views/subscriptions-usage/style';
 @import 'views/packages/style';
 @import 'views/service-settings/settings-form/style';

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/index.js
@@ -15,8 +15,8 @@ import Card from 'components/card';
 import ExtendedHeader from 'woocommerce/components/extended-header';
 import CarrierAccountListItem from './list-item';
 
-const CarrierAccounts = ({ translate, carriers = [] }) => {
-	if ( carriers.length === 0 ) {
+const CarrierAccounts = ({ translate, accounts = [] }) => {
+	if ( accounts.length === 0 ) {
 		return null;
 	}
 
@@ -30,20 +30,20 @@ const CarrierAccounts = ({ translate, carriers = [] }) => {
 				<div className="carrier-accounts__header">
 					<div className="carrier-accounts__header-icon" />
 					<div className="carrier-accounts__header-name">{ translate( 'Name' ) }</div>
-					{ some( carriers, 'account' ) && (
+					{ some( accounts, 'account' ) && (
 						<div className="carrier-accounts__header-credentials">{ translate( 'Credentials' ) }</div>
 					) }
 
 					<div className="carrier-accounts__header-actions" />
 				</div>
-				{ carriers.map( ( carrier, index ) => <CarrierAccountListItem key={index} data={carrier} /> ) }
+				{ accounts.map( ( account, index ) => <CarrierAccountListItem key={index} accountData={account} /> ) }
 			</Card>
 		</div>
 	);
 }
 
 CarrierAccounts.propTypes = {
-	carriers: PropTypes.arrayOf(
+	accounts: PropTypes.arrayOf(
 		PropTypes.shape( {
 			id: PropTypes.string,
 			carrier: PropTypes.string.isRequired,

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/list-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/list-item.js
@@ -22,11 +22,11 @@ import { errorNotice as errorNoticeAction, successNotice as successNoticeAction 
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 const CarrierAccountListItem = ( props ) => {
-	const { data, translate, errorNotice, successNotice, siteId } = props;
+	const { accountData, translate, errorNotice, successNotice, siteId } = props;
 
 	const [isDisconnectDialogVisible, setIsDisconnectDialogVisible] = React.useState(false);
 	const [isSaving, setIsSaving] = React.useState(false);
-	const [carrierId, setCarrierId] = React.useState(data.id);
+	const [carrierId, setCarrierId] = React.useState(accountData.id);
 
 	const handleShowDisconnectDialogConfirmation = React.useCallback(() => {
 		setIsDisconnectDialogVisible(true);
@@ -88,13 +88,13 @@ const CarrierAccountListItem = ( props ) => {
 	return (
 		<div className="carrier-accounts__list-item">
 			<div className="carrier-accounts__list-item-carrier-icon">
-				<CarrierIcon carrier={ carrierTypeIconMap[data.type] } size={ 18 } />
+				<CarrierIcon carrier={ carrierTypeIconMap[accountData.type] } size={ 18 } />
 			</div>
 			<div className="carrier-accounts__list-item-name">
-				<span>{ data.carrier }</span>
+				<span>{ accountData.carrier }</span>
 			</div>
 			<div className="carrier-accounts__list-item-credentials">
-				<span>{ carrierId ? data.account : null }</span>
+				<span>{ carrierId ? accountData.account : null }</span>
 			</div>
 			<div className="carrier-accounts__list-item-actions">
 				{ carrierId ? (
@@ -104,7 +104,7 @@ const CarrierAccountListItem = ( props ) => {
 				) : (
 					<a
 						href={
-							`admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings&carrier=${data.type}`
+							`admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings&carrier=${accountData.type}`
 						}
 						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 						className="button is-compact"
@@ -122,7 +122,7 @@ const CarrierAccountListItem = ( props ) => {
 				<div className="carrier-accounts__settings-cancel-dialog-header">
 					<h2 className="carrier-accounts__settings-cancel-dialog-title">
 						{ translate( 'Disconnect your %(carrier_name)s account', {
-							args: { carrier_name: data.carrier },
+							args: { carrier_name: accountData.carrier },
 						} ) }
 					</h2>
 					<button
@@ -134,7 +134,7 @@ const CarrierAccountListItem = ( props ) => {
 				</div>
 				<p className="carrier-accounts__settings-cancel-dialog-description">
 					{ translate( 'This will remove the connection with %(carrier_name)s. All of your %(carrier_name)s account information will be deleted and you won’t see %(carrier_name)s rates.', {
-						args: { carrier_name: data.carrier },
+						args: { carrier_name: accountData.carrier },
 					} ) }
 				</p>
 			</Dialog>
@@ -146,7 +146,7 @@ CarrierAccountListItem.propTypes = {
 	errorNotice: PropTypes.func.isRequired,
 	successNotice: PropTypes.func.isRequired,
 	siteId: PropTypes.number.isRequired,
-	data: PropTypes.shape( {
+	accountData: PropTypes.shape( {
 		id: PropTypes.string,
 		carrier: PropTypes.string.isRequired,
 		account: PropTypes.string,

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/index.js
@@ -38,7 +38,7 @@ describe( 'Carrier Accounts', () => {
 	it('should render a list of provided accounts', () => {
 		const wrapper = mount(
 			<Wrapper>
-				<CarrierAccounts carriers={[
+				<CarrierAccounts accounts={[
 					{
 						carrier: 'DHL Express',
 						type: 'DhlExpressAccount',
@@ -71,7 +71,7 @@ describe( 'Carrier Accounts', () => {
 	it('should render connected accounts', () => {
 		const wrapper = mount(
 			<Wrapper>
-				<CarrierAccounts carriers={[
+				<CarrierAccounts accounts={[
 					{
 						carrier: 'UPS',
 						type: 'UpsAccount',
@@ -103,7 +103,7 @@ describe( 'Carrier Accounts', () => {
 	it('should display a dialog to disconnect an account', async() => {
 		const wrapper = mount(
 			<Wrapper>
-				<CarrierAccounts carriers={[
+				<CarrierAccounts accounts={[
 					{
 						carrier: 'UPS',
 						type: 'UpsAccount',

--- a/client/extensions/woocommerce/woocommerce-services/views/live-rates-carriers-list/carriers-list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/live-rates-carriers-list/carriers-list.js
@@ -12,28 +12,28 @@ import Card from 'components/card'
 import CarrierIcon from '../../components/carrier-icon'
 import Gridicon from 'gridicons'
 
-const Actions = localize(({ translate }) => {
+const Actions = localize( ( { translate } ) => {
 	return (
 		<>
 			{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */}
-			<a className="button is-compact" href="admin.php?page=wc-settings&tab=shipping&section">{translate('Add to shipping zones')}</a>
+			<a className="button is-compact" href="admin.php?page=wc-settings&tab=shipping&section">{ translate( 'Add to shipping zones' ) }</a>
 			<Tooltip
 				position="top left"
-				text={translate('To be displayed at checkout, this carrier must be added as a shipping method to selected shipping zones')}
+				text={ translate( 'To be displayed at checkout, this carrier must be added as a shipping method to selected shipping zones' ) }
 			>
 				<div>
-					<Gridicon icon="help-outline" size={18}/>
+					<Gridicon icon="help-outline" size={ 18 }/>
 				</div>
 			</Tooltip>
 		</>
 	)
 })
 
-const CarrierDiscount = localize(({
+const CarrierDiscount = localize( ( {
 	translate,
 	name,
 	amount
-}) => translate('Up to {{strong}}%(discountAmount)s{{/strong}} off on %(carrierName)s shipping labels', {
+} ) => translate( 'Up to {{strong}}%(discountAmount)s{{/strong}} off on %(carrierName)s shipping labels', {
 	args: {
 		carrierName: name,
 		discountAmount: amount,
@@ -44,51 +44,51 @@ const CarrierDiscount = localize(({
 }))
 
 const carrierItemMap = {
-	'wc_services_usps': ({ translate }) => (
+	'wc_services_usps': ( { translate } ) => (
 		<div className="live-rates-carriers-list__element element-usps">
 			<div className="live-rates-carriers-list__icon">
-				<CarrierIcon carrier="usps" size={18}/>
+				<CarrierIcon carrier="usps" size={ 18 } />
 			</div>
-			<div className="live-rates-carriers-list__carrier">{translate('USPS')}</div>
+			<div className="live-rates-carriers-list__carrier">{ translate( 'USPS' ) }</div>
 			<div className="live-rates-carriers-list__features">
 				<ul>
-					<li>{translate('Ship with the largest delivery network in the United States')}</li>
+					<li>{ translate( 'Ship with the largest delivery network in the United States' ) }</li>
 					<li>
-						<CarrierDiscount name={translate('USPS')} amount="81%"/>
+						<CarrierDiscount name={ translate( 'USPS' ) } amount="81%" />
 					</li>
 					<li>
-						{translate('Live rates for %(carrierName)s at checkout', {
+						{ translate( 'Live rates for %(carrierName)s at checkout', {
 							args: {
-								carrierName: translate('USPS'),
+								carrierName: translate( 'USPS' ),
 							},
 						})}
 					</li>
 				</ul>
 			</div>
-			<div className="live-rates-carriers-list__actions"><Actions/></div>
+			<div className="live-rates-carriers-list__actions"><Actions /></div>
 		</div>
 
 	),
 	'wc_services_dhlexpress': ({ translate }) => (
 		<div className="live-rates-carriers-list__element element-dhlexpress">
 			<div className="live-rates-carriers-list__icon">
-				<CarrierIcon carrier="dhlexpress" size={18}/>
+				<CarrierIcon carrier="dhlexpress" size={ 18 } />
 			</div>
-			<div className="live-rates-carriers-list__carrier">{translate('DHL Express')}</div>
+			<div className="live-rates-carriers-list__carrier">{ translate( 'DHL Express' ) }</div>
 			<div className="live-rates-carriers-list__features">
 				<ul>
-					<li>{translate('Express delivery from the experts in international shipping')}</li>
-					<li><CarrierDiscount name={translate('DHL Express')} amount="74%"/></li>
+					<li>{ translate( 'Express delivery from the experts in international shipping' ) }</li>
+					<li><CarrierDiscount name={ translate( 'DHL Express' ) } amount="74%" /></li>
 					<li>
-						{translate('Live rates for %(carrierName)s at checkout', {
+						{ translate( 'Live rates for %(carrierName)s at checkout', {
 							args: {
-								carrierName: translate('DHL Express'),
+								carrierName: translate( 'DHL Express' ),
 							},
 						})}
 					</li>
 				</ul>
 			</div>
-			<div className="live-rates-carriers-list__actions"><Actions/></div>
+			<div className="live-rates-carriers-list__actions"><Actions /></div>
 		</div>
 	),
 }
@@ -98,22 +98,22 @@ const CarriersList = ({ translate, carrierIds }) => {
 		<Card className="live-rates-carriers-list__wrapper">
 			<div className="live-rates-carriers-list__heading">
 				<div className="live-rates-carriers-list__icon"/>
-				<div className="live-rates-carriers-list__carrier">{translate('Carrier')}</div>
-				<div className="live-rates-carriers-list__features">{translate('Features')}</div>
+				<div className="live-rates-carriers-list__carrier">{ translate( 'Carrier' ) }</div>
+				<div className="live-rates-carriers-list__features">{ translate( 'Features' ) }</div>
 				<div className="live-rates-carriers-list__actions"/>
 			</div>
-			{carrierIds.map(carrierId => {
-				const CarrierView = carrierItemMap[carrierId]
-				if (!CarrierView) {
+			{carrierIds.map( ( carrierId ) => {
+				const CarrierView = carrierItemMap[ carrierId ]
+				if ( ! CarrierView ) {
 					return null
 				}
 
 				return (
-					<CarrierView key={carrierId} translate={translate}/>
+					<CarrierView key={ carrierId } translate={ translate } />
 				)
 			})}
 		</Card>
 	)
 }
 
-export default localize(CarriersList)
+export default localize( CarriersList )

--- a/client/extensions/woocommerce/woocommerce-services/views/live-rates-carriers-list/carriers-list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/live-rates-carriers-list/carriers-list.js
@@ -1,0 +1,119 @@
+/**
+ * External dependencies
+ */
+import React from 'react'
+import { localize } from 'i18n-calypso'
+import { Tooltip } from '@wordpress/components'
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card'
+import CarrierIcon from '../../components/carrier-icon'
+import Gridicon from 'gridicons'
+
+const Actions = localize(({ translate }) => {
+	return (
+		<>
+			{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */}
+			<a className="button is-compact" href="admin.php?page=wc-settings&tab=shipping&section">{translate('Add to shipping zones')}</a>
+			<Tooltip
+				position="top left"
+				text={translate('To be displayed at checkout, this carrier must be added as a shipping method to selected shipping zones')}
+			>
+				<div>
+					<Gridicon icon="help-outline" size={18}/>
+				</div>
+			</Tooltip>
+		</>
+	)
+})
+
+const CarrierDiscount = localize(({
+	translate,
+	name,
+	amount
+}) => translate('Up to {{strong}}%(discountAmount)s{{/strong}} off on %(carrierName)s shipping labels', {
+	args: {
+		carrierName: name,
+		discountAmount: amount,
+	},
+	components: {
+		strong: <strong/>
+	},
+}))
+
+const carrierItemMap = {
+	'wc_services_usps': ({ translate }) => (
+		<div className="live-rates-carriers-list__element element-usps">
+			<div className="live-rates-carriers-list__icon">
+				<CarrierIcon carrier="usps" size={18}/>
+			</div>
+			<div className="live-rates-carriers-list__carrier">{translate('USPS')}</div>
+			<div className="live-rates-carriers-list__features">
+				<ul>
+					<li>{translate('Ship with the largest delivery network in the United States')}</li>
+					<li>
+						<CarrierDiscount name={translate('USPS')} amount="81%"/>
+					</li>
+					<li>
+						{translate('Live rates for %(carrierName)s at checkout', {
+							args: {
+								carrierName: translate('USPS'),
+							},
+						})}
+					</li>
+				</ul>
+			</div>
+			<div className="live-rates-carriers-list__actions"><Actions/></div>
+		</div>
+
+	),
+	'wc_services_dhlexpress': ({ translate }) => (
+		<div className="live-rates-carriers-list__element element-dhlexpress">
+			<div className="live-rates-carriers-list__icon">
+				<CarrierIcon carrier="dhlexpress" size={18}/>
+			</div>
+			<div className="live-rates-carriers-list__carrier">{translate('DHL Express')}</div>
+			<div className="live-rates-carriers-list__features">
+				<ul>
+					<li>{translate('Express delivery from the experts in international shipping')}</li>
+					<li><CarrierDiscount name={translate('DHL Express')} amount="74%"/></li>
+					<li>
+						{translate('Live rates for %(carrierName)s at checkout', {
+							args: {
+								carrierName: translate('DHL Express'),
+							},
+						})}
+					</li>
+				</ul>
+			</div>
+			<div className="live-rates-carriers-list__actions"><Actions/></div>
+		</div>
+	),
+}
+
+const CarriersList = ({ translate, carrierIds }) => {
+	return (
+		<Card className="live-rates-carriers-list__wrapper">
+			<div className="live-rates-carriers-list__heading">
+				<div className="live-rates-carriers-list__icon"/>
+				<div className="live-rates-carriers-list__carrier">{translate('Carrier')}</div>
+				<div className="live-rates-carriers-list__features">{translate('Features')}</div>
+				<div className="live-rates-carriers-list__actions"/>
+			</div>
+			{carrierIds.map(carrierId => {
+				const CarrierView = carrierItemMap[carrierId]
+				if (!CarrierView) {
+					return null
+				}
+
+				return (
+					<CarrierView key={carrierId} translate={translate}/>
+				)
+			})}
+		</Card>
+	)
+}
+
+export default localize(CarriersList)

--- a/client/extensions/woocommerce/woocommerce-services/views/live-rates-carriers-list/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/live-rates-carriers-list/index.js
@@ -10,22 +10,22 @@ import { localize } from 'i18n-calypso'
 import ExtendedHeader from 'woocommerce/components/extended-header'
 import CarriersList from './carriers-list'
 
-const supportedCarrierIds = ['wc_services_usps', 'wc_services_dhlexpress'];
+const supportedCarrierIds = [ 'wc_services_usps', 'wc_services_dhlexpress' ];
 
-const LiveRatesCarriersList = ({ translate, carrierIds }) => {
-	if (carrierIds.some(carrierId => supportedCarrierIds.includes(carrierId)) === false) {
+const LiveRatesCarriersList = ( { translate, carrierIds } ) => {
+	if ( carrierIds.some( ( carrierId ) => supportedCarrierIds.includes( carrierId ) ) === false ) {
 		return null
 	}
 
 	return (
 		<div>
 			<ExtendedHeader
-				label={translate('Live rates at checkout')}
-				description={translate('Show live rates directly on your store - never under or overcharge for shipping again')}
+				label={ translate( 'Live rates at checkout' ) }
+				description={ translate( 'Show live rates directly on your store - never under or overcharge for shipping again' ) }
 			/>
-			<CarriersList carrierIds={carrierIds} />
+			<CarriersList carrierIds={ carrierIds } />
 		</div>
 	)
 }
 
-export default localize(LiveRatesCarriersList)
+export default localize( LiveRatesCarriersList )

--- a/client/extensions/woocommerce/woocommerce-services/views/live-rates-carriers-list/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/live-rates-carriers-list/index.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import React from 'react'
+import { localize } from 'i18n-calypso'
+
+/**
+ * Internal dependencies
+ */
+import ExtendedHeader from 'woocommerce/components/extended-header'
+import CarriersList from './carriers-list'
+
+const supportedCarrierIds = ['wc_services_usps', 'wc_services_dhlexpress'];
+
+const LiveRatesCarriersList = ({ translate, carrierIds }) => {
+	if (carrierIds.some(carrierId => supportedCarrierIds.includes(carrierId)) === false) {
+		return null
+	}
+
+	return (
+		<div>
+			<ExtendedHeader
+				label={translate('Live rates at checkout')}
+				description={translate('Show live rates directly on your store - never under or overcharge for shipping again')}
+			/>
+			<CarriersList carrierIds={carrierIds} />
+		</div>
+	)
+}
+
+export default localize(LiveRatesCarriersList)

--- a/client/extensions/woocommerce/woocommerce-services/views/live-rates-carriers-list/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/live-rates-carriers-list/style.scss
@@ -1,0 +1,75 @@
+.live-rates-carriers-list {
+	.components-popover__content {
+		width: 150px;
+	}
+
+	&__wrapper {
+		padding: 0;
+	}
+
+	&__heading,
+	&__element {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		padding: 12px 24px;
+		font-size: 14px;
+		border-bottom: 1px solid #ccced0;
+		flex-wrap: nowrap;
+
+		> * {
+			margin-right: 12px;
+
+			&:last-child {
+				margin-right: 0;
+			}
+		}
+
+		&:last-child {
+			border-bottom: none;
+		}
+	}
+
+	&__heading {
+		font-weight: 600;
+		background: #f6f6f6;
+	}
+
+	&__element {
+		padding: 24px 24px;
+	}
+
+	&__icon {
+		width: 36px;
+	}
+
+	&__carrier {
+		width: 35%;
+	}
+
+	&__features {
+		width: 30%;
+		flex-grow: 1;
+
+		ul {
+			margin-bottom: 0;
+			margin-left: 1.5em;
+		}
+	}
+
+	&__actions {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		justify-content: flex-end;
+		flex-wrap: nowrap;
+
+		> * {
+			margin-right: 12px;
+
+			&:last-child {
+				margin-right: 0;
+			}
+		}
+	}
+}

--- a/client/extensions/woocommerce/woocommerce-services/views/live-rates-carriers-list/test/live-rates-carriers-list.test.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/live-rates-carriers-list/test/live-rates-carriers-list.test.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { mount } from 'enzyme';
+
+import LiveRatesCarriersList from '..'
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+describe('LiveRatesCarriersList', () => {
+	it('should not render when the list of accounts is empty', () => {
+		const wrapper = mount(<LiveRatesCarriersList carrierIds={[]} />);
+
+		expect(wrapper.html()).toBeFalsy();
+	});
+
+	it('should not render when the list of accounts contains invalid carrier IDs', () => {
+		const wrapper = mount(<LiveRatesCarriersList carrierIds={['wc_services_fedex', 'wc_services_dhlecommerceasia']} />);
+
+		expect(wrapper.html()).toBeFalsy();
+	});
+
+	it('should render the USPS account information', () => {
+		const wrapper = mount(<LiveRatesCarriersList carrierIds={['wc_services_usps']} />);
+
+		expect(wrapper.contains(<div className="live-rates-carriers-list__carrier">USPS</div>)).toBe(true);
+		expect(wrapper.contains(<div className="live-rates-carriers-list__carrier">DHL Express</div>)).toBe(false);
+	});
+
+	it('should render the DHL Express account information', () => {
+		const wrapper = mount(<LiveRatesCarriersList carrierIds={['wc_services_dhlexpress']} />);
+
+		expect(wrapper.contains(<div className="live-rates-carriers-list__carrier">USPS</div>)).toBe(false);
+		expect(wrapper.contains(<div className="live-rates-carriers-list__carrier">DHL Express</div>)).toBe(true);
+	});
+});

--- a/client/extensions/woocommerce/woocommerce-services/views/live-rates-carriers-list/test/live-rates-carriers-list.test.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/live-rates-carriers-list/test/live-rates-carriers-list.test.js
@@ -9,28 +9,28 @@ import LiveRatesCarriersList from '..'
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 describe('LiveRatesCarriersList', () => {
 	it('should not render when the list of accounts is empty', () => {
-		const wrapper = mount(<LiveRatesCarriersList carrierIds={[]} />);
+		const wrapper = mount( <LiveRatesCarriersList carrierIds={ [] } /> );
 
-		expect(wrapper.html()).toBeFalsy();
+		expect( wrapper.html() ).toBeFalsy();
 	});
 
 	it('should not render when the list of accounts contains invalid carrier IDs', () => {
-		const wrapper = mount(<LiveRatesCarriersList carrierIds={['wc_services_fedex', 'wc_services_dhlecommerceasia']} />);
+		const wrapper = mount( <LiveRatesCarriersList carrierIds={ ['wc_services_fedex', 'wc_services_dhlecommerceasia'] } /> );
 
-		expect(wrapper.html()).toBeFalsy();
+		expect( wrapper.html() ).toBeFalsy();
 	});
 
 	it('should render the USPS account information', () => {
-		const wrapper = mount(<LiveRatesCarriersList carrierIds={['wc_services_usps']} />);
+		const wrapper = mount( <LiveRatesCarriersList carrierIds={ ['wc_services_usps'] } /> );
 
-		expect(wrapper.contains(<div className="live-rates-carriers-list__carrier">USPS</div>)).toBe(true);
-		expect(wrapper.contains(<div className="live-rates-carriers-list__carrier">DHL Express</div>)).toBe(false);
+		expect( wrapper.contains( <div className="live-rates-carriers-list__carrier">USPS</div> ) ).toBe( true );
+		expect( wrapper.contains( <div className="live-rates-carriers-list__carrier">DHL Express</div> ) ).toBe( false );
 	});
 
 	it('should render the DHL Express account information', () => {
-		const wrapper = mount(<LiveRatesCarriersList carrierIds={['wc_services_dhlexpress']} />);
+		const wrapper = mount( <LiveRatesCarriersList carrierIds={ ['wc_services_dhlexpress'] } /> );
 
-		expect(wrapper.contains(<div className="live-rates-carriers-list__carrier">USPS</div>)).toBe(false);
-		expect(wrapper.contains(<div className="live-rates-carriers-list__carrier">DHL Express</div>)).toBe(true);
+		expect( wrapper.contains( <div className="live-rates-carriers-list__carrier">USPS</div> ) ).toBe( false );
+		expect( wrapper.contains( <div className="live-rates-carriers-list__carrier">DHL Express</div> ) ).toBe( true );
 	});
 });

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -712,7 +712,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			new WC_Connect_Debug_Tools( $this->api_client );
 
 			require_once __DIR__ . '/classes/class-wc-connect-settings-pages.php';
-			$settings_pages = new WC_Connect_Settings_Pages( $this->api_client );
+			$settings_pages = new WC_Connect_Settings_Pages( $this->api_client, $this->get_service_schemas_store() );
 			$this->set_settings_pages( $settings_pages );
 
 			$schema   = $this->get_service_schemas_store();


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Adding a "Live rates at checkout" section on the settings page.
Some details are on the ticket.

Checked with UX - a few things that are ok for this first phase:
- the tooltip’s width cannot be modified and I also cannot add artificial line breaks - everything needs to go into one line: https://d.pr/i/I29c68
- I tried to keep the alignment of the columns consistent - but on small screens it becomes evident that we’re trying to squeeze a lot of content on a small column: https://d.pr/i/LwYhQB
  - on even smaller screens the whole app is a bit messed up

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Closes https://github.com/Automattic/woocommerce-shipping-issues/issues/188

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

When testing against production (when testing against local/staging you might need to remove `DhlExpressAccount` from the `enabled_carrier_accounts` setting on the connect server).

Brand new site, with no flags:
![Screen Shot 2021-03-12 at 10 09 28 AM](https://user-images.githubusercontent.com/273592/110969998-ed64dd00-831e-11eb-868c-c1bd9eeb83e8.png)

With UPS beta:
![Screen Shot 2021-03-12 at 10 10 02 AM](https://user-images.githubusercontent.com/273592/110970047-f8b80880-831e-11eb-9891-4858bc39e7be.png)

Only grandfathered live rates:
![Screen Shot 2021-03-12 at 10 10 30 AM](https://user-images.githubusercontent.com/273592/110970092-03729d80-831f-11eb-9bf6-80dd6e2920de.png)


UPS beta, grandfathered live rates, DHL Express live rates:
![Screen Shot 2021-03-12 at 10 10 58 AM](https://user-images.githubusercontent.com/273592/110970146-108f8c80-831f-11eb-9afd-f158dc538732.png)


### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

