### PR TITLE
Fix condition to display DHL live rates notice.

### DIFF
--- a/classes/class-wc-connect-note-dhl-live-rates-available.php
+++ b/classes/class-wc-connect-note-dhl-live-rates-available.php
@@ -21,9 +21,9 @@ class WC_Connect_Note_DHL_Live_Rates_Available {
 	 */
 	public static function init( WC_Connect_Service_Schemas_Store $schemas ) {
 		// If store has DHL Express live rates.
-		$has_wc_services_dlh_express = in_array( 'wc_services_dhlexpress', $schemas->get_all_shipping_method_ids(), true );
+		$has_wc_services_dhl_express = in_array( 'wc_services_dhlexpress', $schemas->get_all_shipping_method_ids(), true );
 
-		if ( ! ! $has_wc_services_dlh_express ) {
+		if ( ! ! $has_wc_services_dhl_express ) {
 			self::possibly_add_note();
 		}
 	}

--- a/classes/class-wc-connect-note-dhl-live-rates-available.php
+++ b/classes/class-wc-connect-note-dhl-live-rates-available.php
@@ -23,7 +23,7 @@ class WC_Connect_Note_DHL_Live_Rates_Available {
 		// If store has DHL Express live rates.
 		$has_wc_services_dhl_express = in_array( 'wc_services_dhlexpress', $schemas->get_all_shipping_method_ids(), true );
 
-		if ( ! ! $has_wc_services_dhl_express ) {
+		if ( $has_wc_services_dhl_express ) {
 			self::possibly_add_note();
 		}
 	}

--- a/classes/class-wc-connect-note-dhl-live-rates-available.php
+++ b/classes/class-wc-connect-note-dhl-live-rates-available.php
@@ -21,7 +21,7 @@ class WC_Connect_Note_DHL_Live_Rates_Available {
 	 */
 	public static function init( WC_Connect_Service_Schemas_Store $schemas ) {
 		// If store has DHL Express live rates.
-		$has_dlh_express = $schemas->get_service_schema_by_id( 'dhlexpress' );
+		$has_dlh_express = in_array( 'wc_services_dhlexpress', $schemas->get_all_shipping_method_ids(), true );
 
 		if ( ! ! $has_dlh_express ) {
 			self::possibly_add_note();

--- a/classes/class-wc-connect-note-dhl-live-rates-available.php
+++ b/classes/class-wc-connect-note-dhl-live-rates-available.php
@@ -21,9 +21,9 @@ class WC_Connect_Note_DHL_Live_Rates_Available {
 	 */
 	public static function init( WC_Connect_Service_Schemas_Store $schemas ) {
 		// If store has DHL Express live rates.
-		$has_dlh_express = in_array( 'wc_services_dhlexpress', $schemas->get_all_shipping_method_ids(), true );
+		$has_wc_services_dlh_express = in_array( 'wc_services_dhlexpress', $schemas->get_all_shipping_method_ids(), true );
 
-		if ( ! ! $has_dlh_express ) {
+		if ( ! ! $has_wc_services_dlh_express ) {
 			self::possibly_add_note();
 		}
 	}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
Change condition to display DHL notice, same as [on the live rates card](https://github.com/Automattic/woocommerce-services/blob/378862c4df16230c89ae2cbbe9ad7423cd667da0/client/extensions/woocommerce/woocommerce-services/views/live-rates-carriers-list/carriers-list.js#L72).

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

1. Activate the plugin on a new JN site
2. Check the notice is not displayed
3. Activate the flag for DHL live rates
4. Check the notice is displayed

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added

