### PR TITLE
Use a script to find latest 3 minor versions for WooCommerce for test

### DIFF
--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Get the 3 latest WC minor versions
         id: get_wc_versions_for_matrix
         run: |
-          git ls-remote --tags --refs git@github.com:woocommerce/woocommerce.git | sed 's/.*refs\/tags\///'
+          git ls-remote --tags --refs https://github.com/woocommerce/woocommerce.git | sed 's/.*refs\/tags\///'
           php ./bin/wc-latest-version.php
   php_build_and_test:
     name: PHP Unit Test (WP, WC)

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -18,8 +18,20 @@ jobs:
           sudo update-alternatives --set phar.phar /usr/bin/phar.phar7.4
       - name: Lint
         run: find . -type f -name "*.php" -exec php -l {} \;
+  find_wc_latest_versions:
+    name: Find supported woocommerce versions
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.get_wc_versions_for_matrix.outputs.wc-versions }}
+    steps:
+      - name: Get the 3 latest WC minor versions
+        id: get_wc_versions_for_matrix
+        run: |
+          git ls-remote --tags --refs git@github.com:woocommerce/woocommerce.git | sed 's/.*refs\/tags\///'
+          php ./bin/wc-latest-version.php
   php_build_and_test:
     name: PHP Unit Test (WP, WC)
+    needs: find_wc_latest_versions
     runs-on: ubuntu-latest
     services:
       mariadb:
@@ -35,13 +47,8 @@ jobs:
     strategy:
       matrix:
         wp-version: [5.4.4, 5.5.3, latest]
-        wc-version: ${{ steps.get-wc-versions-for-matrix.outputs.wc-versions }}
+        wc-version: ${{ find_wc_latest_versions.output.matrix }}
     steps:
-      - name: Get the 3 latest WC minor versions
-        id: get-wc-versions-for-matrix
-        run: |
-          git ls-remote --tags --refs git@github.com:woocommerce/woocommerce.git | sed 's/.*refs\/tags\///'
-          php ./bin/wc-latest-version.php
       - name: Checkout latest WCS
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -24,6 +24,8 @@ jobs:
     outputs:
       matrix: ${{ steps.get_wc_versions_for_matrix.outputs.wc-versions }}
     steps:
+      - name: Checkout latest WCS
+        uses: actions/checkout@v2
       - name: Get the 3 latest WC minor versions
         id: get_wc_versions_for_matrix
         run: |

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -21,6 +21,8 @@ jobs:
   find_wc_latest_versions:
     name: Find supported woocommerce versions
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.get_wc_versions_for_matrix }}
     steps:
       - name: Checkout latest WCS
         uses: actions/checkout@v2

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -28,8 +28,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get the 3 latest WC minor versions
         id: get_wc_versions_for_matrix
-        run: |
-          git ls-remote --tags --refs https://github.com/woocommerce/woocommerce.git | sed 's/.*refs\/tags\///' | php ./bin/wc-latest-version.php
+        run: git ls-remote --tags --refs https://github.com/woocommerce/woocommerce.git | sed 's/.*refs\/tags\///' | php ./bin/wc-latest-version.php
   php_build_and_test:
     name: PHP Unit Test (WP, WC)
     needs: find_wc_latest_versions

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -21,8 +21,6 @@ jobs:
   find_wc_latest_versions:
     name: Find supported woocommerce versions
     runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.get_wc_versions_for_matrix.outputs.wc-versions }}
     steps:
       - name: Checkout latest WCS
         uses: actions/checkout@v2

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         wp-version: [5.4.4, 5.5.3, latest]
-        wc-version: ${{ format({0}, needs.find_wc_latest_versions.outputs.matrix) }}
+        wc-version: ${{ fromJSON(needs.find_wc_latest_versions.outputs.matrix) }}
     steps:
       - name: Checkout latest WCS
         uses: actions/checkout@v2

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -29,8 +29,7 @@ jobs:
       - name: Get the 3 latest WC minor versions
         id: get_wc_versions_for_matrix
         run: |
-          git ls-remote --tags --refs https://github.com/woocommerce/woocommerce.git | sed 's/.*refs\/tags\///'
-          php ./bin/wc-latest-version.php
+          git ls-remote --tags --refs https://github.com/woocommerce/woocommerce.git | sed 's/.*refs\/tags\///' | php ./bin/wc-latest-version.php
   php_build_and_test:
     name: PHP Unit Test (WP, WC)
     needs: find_wc_latest_versions

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         wp-version: [5.4.4, 5.5.3, latest]
-        wc-version: ${{ find_wc_latest_versions.output.matrix }}
+        wc-version: ${{ needs.find_wc_latest_versions.output.matrix }}
     steps:
       - name: Checkout latest WCS
         uses: actions/checkout@v2

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         wp-version: [5.4.4, 5.5.3, latest]
-        wc-version: ${{ fromJSON(needs.find_wc_latest_versions.outputs.matrix) }}
+        wc-version: ${{ format({0}, needs.find_wc_latest_versions.outputs.matrix) }}
     steps:
       - name: Checkout latest WCS
         uses: actions/checkout@v2

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -35,8 +35,13 @@ jobs:
     strategy:
       matrix:
         wp-version: [5.4.4, 5.5.3, latest]
-        wc-version: [4.9.2, 5.0.0, 5.1.0]
+        wc-version: ${{ steps.get-wc-versions-for-matrix.outputs.wc-versions }}
     steps:
+      - name: Get the 3 latest WC minor versions
+        id: get-wc-versions-for-matrix
+        run: |
+          git ls-remote --tags --refs git@github.com:woocommerce/woocommerce.git | sed 's/.*refs\/tags\///'
+          php ./bin/wc-latest-version.php
       - name: Checkout latest WCS
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -22,13 +22,13 @@ jobs:
     name: Find supported woocommerce versions
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.get_wc_versions_for_matrix }}
+      matrix: ${{ steps.get_wc_versions_for_matrix.outputs.wc-versions }}
     steps:
       - name: Checkout latest WCS
         uses: actions/checkout@v2
       - name: Get the 3 latest WC minor versions
         id: get_wc_versions_for_matrix
-        run: git ls-remote --tags --refs https://github.com/woocommerce/woocommerce.git | sed 's/.*refs\/tags\///' | php ./bin/wc-latest-version.php
+        run: echo "::set-output name=wc-versions::$(git ls-remote --tags --refs https://github.com/woocommerce/woocommerce.git | sed 's/.*refs\/tags\///' | php ./bin/wc-latest-version.php)"
   php_build_and_test:
     name: PHP Unit Test (WP, WC)
     needs: find_wc_latest_versions

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         wp-version: [5.4.4, 5.5.3, latest]
-        wc-version: ${{ needs.find_wc_latest_versions.outputs.matrix }}
+        wc-version: ${{ fromJSON(needs.find_wc_latest_versions.outputs.matrix) }}
     steps:
       - name: Checkout latest WCS
         uses: actions/checkout@v2

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         wp-version: [5.4.4, 5.5.3, latest]
-        wc-version: ${{ needs.find_wc_latest_versions.output.matrix }}
+        wc-version: ${{ needs.find_wc_latest_versions.outputs.matrix }}
     steps:
       - name: Checkout latest WCS
         uses: actions/checkout@v2

--- a/bin/wc-latest-version.php
+++ b/bin/wc-latest-version.php
@@ -27,11 +27,10 @@ function filter_valid_versions() {
  * @return 3 minor versions, in the order of oldest to newest.
  */
 function get_last_three_minor($versions) {
-	$count = 0;
 	$last_minor_version = '';
 	$results = [];
 	foreach ($versions as $index => $version_number) {
-		$current_minor_version = substr($version_number, 0, strrpos($version_number, '.') + 1);
+		$current_minor_version = substr($version_number, 0, strrpos($version_number, '.'));
 
 		if (count($results) >= 3) {
 			break;

--- a/bin/wc-latest-version.php
+++ b/bin/wc-latest-version.php
@@ -42,13 +42,12 @@ function get_last_three_minor($versions) {
 		}
 
 		$last_minor_version = $current_minor_version;
-		$results[] = $version_number;
+		$results[] = "'$version_number'";
 		$count++;
 	}
 
 	return array_reverse($results);
 }
-
 
 // Output 3 latest minor versions in comma separated values, wrapped in [] for github action matrix
 $versions = filter_valid_versions();

--- a/bin/wc-latest-version.php
+++ b/bin/wc-latest-version.php
@@ -53,6 +53,8 @@ function get_last_three_minor($versions) {
 // Output 3 latest minor versions in comma separated values, wrapped in [] for github action matrix
 echo "Processing...\n";
 $versions = filter_valid_versions();
+echo "Version are \n";
+print_r($versions);
 usort($versions, 'version_compare_reverse');
 $results = get_last_three_minor($versions);
 echo '::set-output name=wc-versions::[' . implode(",",$results) . ']' . "\n";

--- a/bin/wc-latest-version.php
+++ b/bin/wc-latest-version.php
@@ -1,0 +1,57 @@
+<?php
+function version_compare_reverse($i, $j) {
+	 return version_compare($i, $j) * -1;
+}
+
+/**
+ * Take input from stdin and adds all valid (ie. x.y.z) versinos to an array.
+ */
+function filter_valid_versions() {
+	$versions = [];
+	$fp = fopen("php://stdin", 'r');
+	$contents = fgets($fp);
+	while ($contents !== false) {
+		$contents = fgets($fp);
+		if (!preg_match('/^\d+\.\d+\.\d+$/', $contents)) {
+			continue;
+		}
+		$versions[] = trim($contents);
+	}
+	return $versions;
+}
+
+/**
+ * Take an array of $versions and return the latest 3 minor versions.
+ *
+ * @param Array $versions The array need to be sorted first.
+ * @return 3 minor versions, in the order of oldest to newest.
+ */
+function get_last_three_minor($versions) {
+	$count = 0;
+	$last_minor_version = '';
+	$results = [];
+	foreach ($versions as $index => $version_number) {
+		$current_minor_version = substr($version_number, 0, strrpos($version_number, '.') + 1);
+
+		if (count($results) >= 3) {
+			break;
+		}
+
+		if ($last_minor_version === $current_minor_version) {
+			continue;
+		}
+
+		$last_minor_version = $current_minor_version;
+		$results[] = $version_number;
+		$count++;
+	}
+
+	return array_reverse($results);
+}
+
+
+// Output 3 latest minor versions in comma separated values, wrapped in [] for github action matrix
+$versions = filter_valid_versions();
+usort($versions, 'version_compare_reverse');
+$results = get_last_three_minor($versions);
+echo '::set-output name=wc-versions::[' . implode(",",$results) . ']';

--- a/bin/wc-latest-version.php
+++ b/bin/wc-latest-version.php
@@ -51,10 +51,7 @@ function get_last_three_minor($versions) {
 
 
 // Output 3 latest minor versions in comma separated values, wrapped in [] for github action matrix
-echo "Processing...\n";
 $versions = filter_valid_versions();
-echo "Version are \n";
-print_r($versions);
 usort($versions, 'version_compare_reverse');
 $results = get_last_three_minor($versions);
-echo '::set-output name=wc-versions::[' . implode(",",$results) . ']' . "\n";
+echo '[' . implode(",",$results) . ']';

--- a/bin/wc-latest-version.php
+++ b/bin/wc-latest-version.php
@@ -51,7 +51,8 @@ function get_last_three_minor($versions) {
 
 
 // Output 3 latest minor versions in comma separated values, wrapped in [] for github action matrix
+echo "Processing...\n";
 $versions = filter_valid_versions();
 usort($versions, 'version_compare_reverse');
 $results = get_last_three_minor($versions);
-echo '::set-output name=wc-versions::[' . implode(",",$results) . ']';
+echo '::set-output name=wc-versions::[' . implode(",",$results) . ']' . "\n";

--- a/bin/wc-latest-version.php
+++ b/bin/wc-latest-version.php
@@ -42,7 +42,6 @@ function get_last_three_minor($versions) {
 
 		$last_minor_version = $current_minor_version;
 		$results[] = "'$version_number'";
-		$count++;
 	}
 
 	return array_reverse($results);


### PR DESCRIPTION
## Description
Automatically find the last 3 minor woocommerce versions to run our Github action matrix tests. This PR is inspired by https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#example-returning-a-json-object. 

### Changes
- Create another job to find the last 3 WC minor version numbers
- Added a php script to output the version numbers out to stdout, ie. `[4.9.2, 5.0.1, 5.1.0]`. 

### Related issue(s)
Closes: https://github.com/Automattic/woocommerce-services/issues/2364

### Steps to reproduce & screenshots/GIFs
1. Scroll to the bottom of the PR, check the actions ran and they passed
2. Click on the "Checks" tab for this PR, make sure it now has a job to find WooCommerce latest 3 minor versions, and it spawns a few other jobs to run the tests on. On the left side, you should see it testing the new WooCommerce 5.1
![image](https://user-images.githubusercontent.com/572862/111348602-f79c1980-8645-11eb-9653-8d7b6720416b.png)

### How to test the script
We want to make sure the script is printing out the last 3 minor versions
1. Go to root of WCS folder
2. run `git ls-remote --tags --refs https://github.com/woocommerce/woocommerce.git | sed 's/.*refs\/tags\///' | php ./bin/wc-latest-version.php` on console
3. You should see `['4.9.2','5.0.0','5.1.0']` on console.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added

