### PR TITLE
Fix PHP notice on carrier registration page

### DIFF
--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -106,10 +106,10 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 				$extra_args['continents'] = $this->continents->get();
 
 				$carrier_information = array();
-				if ( $extra_args['carriers'] ) {
-					$carrier_information = array_values(
+				if ( ! empty( $extra_args['carrier_accounts'] ) ) {
+					$carrier_information = current(
 						array_filter(
-							$extra_args['carriers'],
+							$extra_args['carrier_accounts'],
 							function( $carrier ) {
 								return $carrier->type === $_GET['carrier'];
 							}
@@ -120,7 +120,7 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 					?>
 					<h2>
 						<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings' ) ); ?>"><?php esc_html_e( 'WooCommerce Shipping & Tax', 'woocommerce-services' ); ?></a> &gt;
-						<span><?php echo esc_html( $carrier_information[0]->carrier ); ?></span>
+						<span><?php echo esc_html( $carrier_information->carrier ); ?></span>
 					</h2>
 					<?php
 				}


### PR DESCRIPTION
## Description
<!-- Explain the motivation for making this change -->

The notice was caused by no array key existence check which is now performed by `empty()`. Also, an invalid key was used.

Replace `array_values()` with `current()` since only the first value is used.

It seems this issue was [caused by this change.](https://github.com/Automattic/woocommerce-services/pull/2375/files#diff-45ab2d6757efe6316bd243c6eb0cf9194e30ddd4c01b98de3ed0e4a9b0aec1a9)

For context on how this looked previously, [this is the PR where the `$carrier_information` variable was introduced](https://github.com/Automattic/woocommerce-services/pull/2265/files#diff-45ab2d6757efe6316bd243c6eb0cf9194e30ddd4c01b98de3ed0e4a9b0aec1a9).

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Fixes #2381.

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

Because of this bug, the following breadcrumbs were not displayed. They should be visible with the changes in this PR.

![Markup on 2021-03-16 at 13:05:01](https://user-images.githubusercontent.com/1759681/111307750-291ee000-865a-11eb-821e-dfeb81e27afb.png)

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added (I didn't add a changelog entry because this fixes an issue with the yet-unreleased feature #2375)

