### PR TITLE
Unset translate() transform on radio buttons in label purchase modal

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@
 * Fix   - Fix PHPUnit tests. Rename `test_` to `test-` to match our phpcs rules. Remove travis and move to github action.
 * Tweak - Updated .nvmrc to use 10.16.0
 * Fix   - Only display shipping validation errors on the cart or checkout pages.
+* Fix   - Revert radio button dot offset in the "Create shipping label" modal.
 
 = 1.25.8 - 2021-03-02 =
 * Tweak - Add support for new Jetpack 9.5 data connection.

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
@@ -66,6 +66,10 @@
 		// See: https://github.com/WordPress/gutenberg/pull/23706
 		border: 4px solid #d52c82;
 		box-sizing: border-box;
+
+		// Unset the translate() transform introduced in Gutenberg.
+		// See: https://github.com/WordPress/gutenberg/pull/27377
+		transform: none;
 	}
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Due to [a change introduced in Gutenberg](https://github.com/WordPress/gutenberg/pull/27377), WCS&T radio button dot is now offset by several px. This commit introduces a `transform: none` CSS rule reverting this behavior.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Fixes #2380, #2321.

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

