### PR TITLE
Update the shipping label status API to fetch multiple ones

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Add   - Run phpcbf as a pre-commit rule.
 * Fix   - Fix PHPUnit tests. Rename `test_` to `test-` to match our phpcs rules. Remove travis and move to github action.
 * Tweak - Updated .nvmrc to use 10.16.0
+* Add   - Update the shipping label status endpoint to accept multiple ids.
 
 = 1.25.9 - 2021-03-17 =
 * Add   - WC Admin notice about DHL live rates.

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,7 @@
 * Add   - Run phpcbf as a pre-commit rule.
 * Fix   - Fix PHPUnit tests. Rename `test_` to `test-` to match our phpcs rules. Remove travis and move to github action.
 * Tweak - Updated .nvmrc to use 10.16.0
-* Add   - Update the shipping label status endpoint to accept multiple ids.
+* Tweak   - Update the shipping label status endpoint to accept and return multiple ids.
 
 = 1.25.9 - 2021-03-17 =
 * Add   - WC Admin notice about DHL live rates.

--- a/client/extensions/woocommerce/woocommerce-services/api/url.js
+++ b/client/extensions/woocommerce/woocommerce-services/api/url.js
@@ -4,6 +4,7 @@ export const packages = 'connect/packages';
 export const orderLabels = ( orderId ) => `connect/label/${ orderId }`;
 export const getLabelRates = ( orderId ) => `connect/label/${ orderId }/rates`;
 export const labelStatus = ( orderId, labelId ) => `connect/label/${ orderId }/${ labelId }`;
+export const labelsStatus = ( orderId, labelIds ) => `connect/label/${ orderId }/${ labelIds.join() }`;
 export const labelRefund = ( orderId, labelId ) => `connect/label/${ orderId }/${ labelId }/refund`;
 export const labelsPrint = () => 'connect/label/print';
 export const labelTestPrint = () => 'connect/label/preview';

--- a/client/extensions/woocommerce/woocommerce-services/api/url.js
+++ b/client/extensions/woocommerce/woocommerce-services/api/url.js
@@ -3,7 +3,6 @@ export const accountSettings = 'connect/account/settings';
 export const packages = 'connect/packages';
 export const orderLabels = ( orderId ) => `connect/label/${ orderId }`;
 export const getLabelRates = ( orderId ) => `connect/label/${ orderId }/rates`;
-export const labelStatus = ( orderId, labelId ) => `connect/label/${ orderId }/${ labelId }`;
 export const labelsStatus = ( orderId, labelIds ) => `connect/label/${ orderId }/${ labelIds.join() }`;
 export const labelRefund = ( orderId, labelId ) => `connect/label/${ orderId }/${ labelId }/refund`;
 export const labelsPrint = () => 'connect/label/print';

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -1118,7 +1118,8 @@ export const fetchLabelsStatus = ( orderId, siteId ) => ( dispatch, getState ) =
 		type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_STATUS_RETRIEVAL_IN_PROGRESS,
 		orderId
 	});
-	const labelRequests = api
+
+	api
 		.get( siteId, api.url.labelsStatus( orderId, shippingLabel.labels.map( label => label.label_id ) ) )
 		.then( response => {
 			const labelsData = response.labels;
@@ -1138,15 +1139,11 @@ export const fetchLabelsStatus = ( orderId, siteId ) => ( dispatch, getState ) =
 				labelsData: null,
 				error,
 			} );
-			throw error;
-		} );
 
-	// Handle error with a single notice
-	labelRequests.catch( error => {
-		dispatch(
-			NoticeActions.errorNotice( `Failed to retrieve shipping label refund status: ${ error }` )
-		);
-	} );
+			dispatch(
+				NoticeActions.errorNotice( `Failed to retrieve shipping label refund status: ${ error }` )
+			);
+		} );
 };
 
 export const closeRefundDialog = ( orderId, siteId ) => {

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -1195,44 +1195,27 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_CLOSE_REFUND_DIALOG ] = state => {
 	};
 };
 
-reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_STATUS_RETRIEVAL_IN_PROGRESS ] = ( state, { labelId } ) => {
-	const labelIndex = findIndex( state.labels, { label_id: labelId } );
-	const labelData = {
-		...state.labels[ labelIndex ],
+reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_STATUS_RETRIEVAL_IN_PROGRESS ] = state => {
+	return {
+		...state,
 		statusRetrivalInProgress: true,
 	};
-
-	const newState = {
-		...state,
-		labels: [ ...state.labels ],
-	};
-	newState.labels[ labelIndex ] = labelData;
-	return newState;
 };
 
 reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_STATUS_RESPONSE ] = (
 	state,
-	{ labelId, response, error }
+	{ labelsData, error }
 ) => {
 	if ( error ) {
-		response = {};
+		labelsData = {};
 	}
 
-	const labelIndex = findIndex( state.labels, { label_id: labelId } );
-	const labelData = {
-		...state.labels[ labelIndex ],
-		...response,
-		statusUpdated: true,
+	return {
+		...state,
+		labels: labelsData,
+		refreshedLabelStatus: true,
 		statusRetrivalInProgress: false,
 	};
-
-	const newState = {
-		...state,
-		labels: [ ...state.labels ],
-		refreshedLabelStatus: true,
-	};
-	newState.labels[ labelIndex ] = labelData;
-	return newState;
 };
 
 reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_REFUND_REQUEST ] = state => {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
The purchase label endpoint is asynchronous (the sync behavior is [discouraged](https://href.li/?1227-gh-Automattic/woocommerce-connect-server), and the web client uses the status endpoint for each created label individually after the purchase.
With the mobile apps consuming the API, there are some new constraints regarding the network availability, and the round-trip delays, so this PR is updating the `label status` endpoint to accept multiple label_ids at the same time, and updates the web client to use it instead, and following the list of changes:
1. Update the endpoint to accept multiple ids: 6bd250a
2. Update the labels polling after a purchase to use the new endpoint: 3c3ae4f.
3. Update the logic of fetching labels to use the new endpoint: 369e0b8

Relevant discussion: p91TBi-4K3-p2

### Related issue(s)
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
https://github.com/woocommerce/woocommerce-android/issues/3698

### Steps to reproduce & screenshots/GIFs
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
- Manually test the label status endpoint, and confirm that the response has a `labels` array, containing the data of the passed ids.
- Make shipping label purchases, and confirm that there is no regression.
- Confirm that there is no regression when loading an order that has shipping labels. 

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added