### PR TITLE
feat: spinner icon on service data fetch

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,12 +8,6 @@
 * Tweak   - Update the shipping label status endpoint to accept and return multiple ids.
 * Tweak	- Display spinner icon during service data refresh.
 
-= 1.25.10 - 2021-xx-xx =
-* Add   - Run phpcbf as a pre-commit rule.
-* Fix   - Fix PHPUnit tests. Rename `test_` to `test-` to match our phpcs rules. Remove travis and move to github action.
-* Tweak - Updated .nvmrc to use 10.16.0
-* Tweak   - Update the shipping label status endpoint to accept and return multiple ids.
-
 = 1.25.10 - 2021-03-24 =
 * Add   - Add an endpoint for shipping label creation eligibility and share code for store eligibility.
 * Fix   - Shipping validation notice shown when no address entered.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,8 @@
 
 = 1.25.10 - 2021-xx-xx =
 * Tweak - Removes deprecated Jetpack constant JETPACK_MASTER_USER
-* Fix	  - Ensure status page is displayed on new WC navigation menu.
+* Fix	- Ensure status page is displayed on new WC navigation menu.
+* Tweak	- Display spinner icon during service data refresh.
 * Add   - Add an endpoint for shipping label creation eligibility and share code for store eligibility.
 * Add   - Run phpcbf as a pre-commit rule.
 * Fix   - Fix PHPUnit tests. Rename `test_` to `test-` to match our phpcs rules. Remove travis and move to github action.

--- a/client/apps/plugin-status/indicator.js
+++ b/client/apps/plugin-status/indicator.js
@@ -15,6 +15,10 @@ import FormLegend from 'components/forms/form-legend';
 const Indicator = ( { title, subtitle, state, message, children } ) => {
 	let icon, className;
 	switch ( state ) {
+		case 'fetching':
+			className = 'is-fetching';
+			icon = 'sync';
+			break;
 		case 'success':
 			className = 'is-success';
 			icon = 'checkmark-circle';

--- a/client/apps/plugin-status/state/actions.js
+++ b/client/apps/plugin-status/state/actions.js
@@ -36,7 +36,7 @@ const saveSettings = () => ( dispatch, getState ) => {
 };
 
 export const refreshServiceData = () => (dispatch) => {
-	api.post(api.url.refreshServiceData())
+	return api.post(api.url.refreshServiceData())
 		.then(response => {
 			const {success, ...data} = response;
 			dispatch({

--- a/client/apps/plugin-status/style.scss
+++ b/client/apps/plugin-status/style.scss
@@ -14,6 +14,16 @@
 		margin: 0 0 4px 4px;
 	}
 
+	&.is-fetching .plugin-status__indicator-icon-and-message {
+		fill: var( --color-neutral-dark );
+
+		.gridicon {
+			fill: var( --color-neutral-dark );
+			animation: 3s linear infinite;
+			animation-name: rotate-spinner;
+		}
+	}
+
 	&.is-success .plugin-status__indicator-icon-and-message {
 		fill: var( --color-success );
 

--- a/client/apps/plugin-status/woocommerce-services-indicator.js
+++ b/client/apps/plugin-status/woocommerce-services-indicator.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, {useCallback} from 'react'
+import React, { useCallback, useState } from 'react'
 import { connect } from 'react-redux'
 import { localize } from 'i18n-calypso'
 
@@ -13,10 +13,13 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation'
 import { refreshServiceData } from './state/actions';
 
 const WooCommerceServicesIndicator = ({ translate, moment, status, onRefreshClick }) => {
+	const [isFetchingData, setIsFetchingData] = useState(false);
 	const handleRefreshClick = useCallback((event) => {
 		event.preventDefault();
-		onRefreshClick();
-	}, [onRefreshClick]);
+
+		setIsFetchingData(true);
+		onRefreshClick().finally(() => setIsFetchingData(false))
+	}, [onRefreshClick, setIsFetchingData]);
 
 	const currentTimestamp = Date.now() / 1000
 	let indicatorState, indicatorMessage
@@ -35,6 +38,10 @@ const WooCommerceServicesIndicator = ({ translate, moment, status, onRefreshClic
 	} else {
 		indicatorState = 'success'
 		indicatorMessage = translate('Service data is up-to-date')
+	}
+
+	if( isFetchingData ) {
+		indicatorState = 'fetching';
 	}
 
 	return (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

I thought it would be nice to display a spinner icon on the status page when the data is refreshing in the background. Otherwise there's no feedback of the action that the user has taken.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

- Go to the status page
- Click refresh
- During the refresh, a spinner icon is displayed

![2021-03-18 14 46 33](https://user-images.githubusercontent.com/273592/111687992-f7904b00-87f8-11eb-8383-156c6e6cdd05.gif)


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

