### PR TITLE
Replace EllipsisMenu with WP component DropdownMenu

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -43,7 +43,7 @@
 			text-shadow: none !important;
 		}
 		//wp-admin styles override the disabled button with !important, so need to do the same here
-		
+
 		&.is-busy {
 			background-size: 120px 100% !important;
 			background-image: linear-gradient(
@@ -311,16 +311,6 @@
 				text-shadow: 0 -1px 1px #006799, 1px 0 1px #006799, 0 1px 1px #006799, -1px 0 1px #006799;
 			}
 		}
-	}
-}
-
-// Adding here so it will not have the .wp-core-ui.wp-admin .wcc-root prefix
-.shipping-label__item-menu-reprint-expired.popover__menu-item {
-	cursor: pointer;
-	background: transparent;
-	color: $muriel-gray-100;
-	.gridicon {
-		color: $muriel-gray-100;
 	}
 }
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item-in-progress.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item-in-progress.js
@@ -19,7 +19,7 @@ class LabelItemInProgress extends LabelItem {
 
 		return (
 			<div className="shipping-label__item">
-				<p className="shipping-label__item-detail">
+				<div className="shipping-label__item-detail">
 					{ translate( '%(service)s label (#%(labelIndex)d)', {
 						args: {
 							service: serviceName,
@@ -28,7 +28,7 @@ class LabelItemInProgress extends LabelItem {
 					} ) }
 					<br />
 					{ translate( 'Purchasing…' ) }
-				</p>
+				</div>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -8,13 +8,17 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
-import { Tooltip } from '@wordpress/components';
+import Gridicon from 'gridicons';
+
+/**
+ * WordPress dependencies
+ */
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import EllipsisMenu from 'components/ellipsis-menu';
-import PopoverMenuItem from 'components/popover/menu-item';
 import RefundDialog from './label-refund-modal';
 import ReprintDialog from './label-reprint-modal';
 import DetailsDialog from './label-details-modal';
@@ -24,32 +28,20 @@ import {
 	openReprintDialog,
 	openDetailsDialog,
 } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
-import Gridicon from "gridicons";
 
 export class LabelItem extends Component {
 	renderRefund = ( labelId, expired, carrierId, trackingId ) => {
 		const { orderId, siteId, translate } = this.props;
-		let toolTipMessage = '';
+		let info     = '';
 		let disabled = false;
 
 		if ( expired ) {
-			toolTipMessage = translate( 'Labels older than 30 days cannot be refunded.' );
-			disabled       = true;
-		} 
-		else if ( 'usps' === carrierId && ! trackingId ) {
-			toolTipMessage = translate( 'USPS labels without tracking are not eligible for refund.' );
-			disabled       = true
+			info     = translate( 'Labels older than 30 days cannot be refunded.' );
+			disabled = true;
 		}
-
-		if ( disabled ) {
-			return (
-				<Tooltip position="top left" text={ toolTipMessage }>
-					<button className="popover__menu-item shipping-label__item-menu-reprint-expired" role="menuitem" tabIndex="-1">
-						<Gridicon icon="refund" size={ 18 }/>
-						<span> { translate( 'Request refund' ) } </span>
-					</button>
-				</Tooltip>
-			);
+		else if ( 'usps' === carrierId && ! trackingId ) {
+			info     = translate( 'USPS labels without tracking are not eligible for refund.' );
+			disabled = true
 		}
 
 		const openDialog = () => {
@@ -57,24 +49,23 @@ export class LabelItem extends Component {
 		};
 
 		return (
-			<PopoverMenuItem onClick={ openDialog } icon="refund">
+			<MenuItem
+				disabled={ disabled }
+				icon={ <Gridicon icon="refund" /> }
+				info={ info }
+				onClick={ openDialog }
+			>
 				{ translate( 'Request refund' ) }
-			</PopoverMenuItem>
+			</MenuItem>
 		);
 	};
 
 	renderReprint = ( labelId, expired ) => {
 		const { orderId, siteId, translate } = this.props;
+		let info = '';
 
 		if ( expired ) {
-			return (
-				<Tooltip position="top left" text={ translate('Label images older than 180 days are deleted by our technology partners for general security and data privacy concerns.') }>
-					<button className="popover__menu-item shipping-label__item-menu-reprint-expired" role="menuitem" tabIndex="-1">
-						<Gridicon icon="print" size={ 18 }/>
-						<span> { translate( 'Reprint' ) } </span>
-					</button>
-				</Tooltip>
-			);
+			info = translate( 'Label images older than 180 days are deleted by our technology partners for general security and data privacy concerns.' );
 		}
 
 		const openDialog = () => {
@@ -82,9 +73,14 @@ export class LabelItem extends Component {
 		};
 
 		return (
-			<PopoverMenuItem onClick={ openDialog } icon="print">
+			<MenuItem
+				disabled={ expired }
+				icon={ <Gridicon icon="print" /> }
+				info={ info }
+				onClick={ openDialog }
+			>
 				{ translate( 'Reprint shipping label' ) }
-			</PopoverMenuItem>
+			</MenuItem>
 		);
 	};
 
@@ -96,9 +92,9 @@ export class LabelItem extends Component {
 		};
 
 		return (
-			<PopoverMenuItem onClick={ openDialog } icon="info-outline">
+			<MenuItem onClick={ openDialog } icon={ <Gridicon icon="info-outline" /> }>
 				{ translate( 'View details' ) }
-			</PopoverMenuItem>
+			</MenuItem>
 		);
 	};
 
@@ -120,9 +116,9 @@ export class LabelItem extends Component {
 		};
 
 		return (
-			<PopoverMenuItem onClick={ onClickOpenPage } icon="external">
+			<MenuItem onClick={ onClickOpenPage } icon={ <Gridicon icon="external" /> }>
 				{ translate( 'Schedule a pickup' ) }
-			</PopoverMenuItem>
+			</MenuItem>
 		);
 	};
 
@@ -138,9 +134,9 @@ export class LabelItem extends Component {
 		}
 
 		return (
-			<PopoverMenuItem onClick={ printCommercialInvoice } icon="print">
+			<MenuItem onClick={ printCommercialInvoice } icon={ <Gridicon icon="print" /> }>
 				{ translate( 'Print customs form' ) }
-			</PopoverMenuItem>
+			</MenuItem>
 		);
 	}
 
@@ -192,7 +188,7 @@ export class LabelItem extends Component {
 
 		return (
 			<div className="shipping-label__item">
-				<p className="shipping-label__item-detail">
+				<div className="shipping-label__item-detail">
 					{ translate( '%(service)s label (#%(labelIndex)d)', {
 						args: {
 							service: serviceName,
@@ -202,13 +198,19 @@ export class LabelItem extends Component {
 					{ showDetails && (
 						<span>
 							{ ( ! isModal && (
-								<EllipsisMenu position="bottom left">
-									{ this.renderLabelDetails( labelId ) }
-									{ this.renderPickup( carrierId ) }
-									{ this.renderRefund( labelId, refundExpired, carrierId, tracking ) }
-									{ this.renderReprint( labelId, expired ) }
-									{ this.renderCommercialInvoiceLink( commercialInvoiceUrl ) }
-								</EllipsisMenu>
+								<DropdownMenu className="shipping-label__item-dropdown-menu" icon={ <Gridicon icon="ellipsis" /> } label={ translate( 'Toggle menu' ) } popoverProps={ { position: 'bottom left' } }>
+									{ () => (
+										<Fragment>
+											<MenuGroup>
+												{ this.renderLabelDetails( labelId ) }
+												{ this.renderPickup( carrierId ) }
+												{ this.renderRefund( labelId, refundExpired, carrierId, tracking ) }
+												{ this.renderReprint( labelId, expired ) }
+												{ this.renderCommercialInvoiceLink( commercialInvoiceUrl ) }
+											</MenuGroup>
+										</Fragment>
+									) }
+								</DropdownMenu>
 							) ) }
 							<DetailsDialog
 								siteId={ siteId }
@@ -231,7 +233,7 @@ export class LabelItem extends Component {
 							<ReprintDialog siteId={ siteId } orderId={ orderId } labelId={ labelId } />
 						</span>
 					) }
-				</p>
+				</div>
 				{ showDetails && (
 					<p className="shipping-label__item-tracking">
 						{ translate( 'Tracking #: {{trackingLink/}}', {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
@@ -46,7 +46,9 @@
 	}
 
 	.shipping-label__item-detail {
+		line-height: 1.5;
 		margin-bottom: 6px;
+		text-align: left;
 
 		a {
 			vertical-align: text-top;

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
@@ -24,10 +24,6 @@
 		margin-top: 16px;
 	}
 
-	.ellipsis-menu__toggle {
-		padding: 0;
-	}
-
 	.shipping-label__item-detail, .shipping-label__item-actions {
 		display: flex;
 		justify-content: space-between;

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
@@ -61,6 +61,21 @@
 		}
 	}
 
+	.shipping-label__item-dropdown-menu {
+		.components-dropdown-menu__toggle {
+			height: 30px;
+			min-width: 26px;
+		}
+
+		.components-menu-item__button .gridicon {
+			height: 20px;
+			margin-left: 2px;
+			margin-right: 10px;
+			order: -10;
+			width: 20px;
+		}
+	}
+
 	.shipping-label__purchase-error {
 		color: var( --color-error );
 		cursor: help;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## To-dos

Although the implementation is done, this PR is posted as a draft as tests have to be updated before it is submitted for review.

## Description
<!-- Explain the motivation for making this change -->

Replace the `EllipsisMenu` component with `DropdownMenu` from `@wordpress/components`.

Since `EllipsisMenu` was only used in one place, instead of creating a new component wrapping `DropdownMenu` I opted for using `DropdownMenu` directly.

### Important changes

#### Keyboard navigation!

Thanks to using the component from `@wordpress/components`, the menu got full keyboard navigation support. Previously there was none.

#### Toggle animation is no longer there

In the current version of WCS&T (1.25.9), when the menu toggle is clicked, the ellipsis icon is animated: it rotates 90º with a slight bounce [(demo in Calypso docs)](https://wpcalypso.wordpress.com/devdocs/design/ellipsis-menu).

The version in this PR does not include that.

#### Tooltips replaced by `info` text

Although it might be possible to use tooltips on the menu items, I opted for DropdownMenu's supported feature of displaying a description text under the menu item label. This is very friendly for keyboard navigation: disabled menu items are skipped when using keyboard nav, therefore not allowing a "focus" state, which in turn leads to a lack of conditions under which the tooltip should be displayed.

It might be possible to work around this if necessary however the main reason why I wanted to point this out is that using the info text might cause some clutter when multiple items have it:

![After - potential clutter](https://user-images.githubusercontent.com/1759681/111828590-d5c3c080-88eb-11eb-8c11-f9c1abdd50f2.png)

Another workaround might be to change the wording of these messages.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Part of #2333.

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

#### Before

**Mouse pointer hovering over an active item**

![Before](https://user-images.githubusercontent.com/1759681/111828654-e7a56380-88eb-11eb-85cf-cb67a4883e2a.png)

**Mouse pointer hovering over a disabled item**

![Before - mouse hover over disabled item](https://user-images.githubusercontent.com/1759681/111828718-0146ab00-88ec-11eb-8efd-19902d310aa9.png)

#### After

**Mouse pointer hovering over an active item**

![After](https://user-images.githubusercontent.com/1759681/111828674-effd9e80-88eb-11eb-871e-1c56c8efbd5d.png)

**Mouse pointer hovering over a disabled item**

![After - mouse hover over disabled item](https://user-images.githubusercontent.com/1759681/111828681-f2f88f00-88eb-11eb-97fd-b8d0e137f976.png)

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added

