### PR TITLE
Do not retry fetching services on auth failure

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Shipping & Tax Changelog ***
 = 1.25.10 - 2021-xx-xx =
 * Add   - Add an endpoint for shipping label creation eligibility and share code for store eligibility.
+* Tweak - Stop retrying to fetch /services when authentication fails on connect server.
 
 = 1.25.9 - 2021-03-17 =
 * Add   - WC Admin notice about DHL live rates.

--- a/classes/class-wc-connect-api-client-live.php
+++ b/classes/class-wc-connect-api-client-live.php
@@ -77,7 +77,7 @@ if ( ! class_exists( 'WC_Connect_API_Client_Live' ) ) {
 			$response      = wp_remote_request( $url, $args );
 			$response_code = wp_remote_retrieve_response_code( $response );
 
-			// If the received response is not JSON, return the raw response
+			// If the received response is not JSON, return the raw response.
 			$content_type = wp_remote_retrieve_header( $response, 'content-type' );
 			if ( false === strpos( $content_type, 'application/json' ) ) {
 				if ( 200 != $response_code ) {
@@ -86,6 +86,9 @@ if ( ! class_exists( 'WC_Connect_API_Client_Live' ) ) {
 						sprintf(
 							__( 'Error: The WooCommerce Shipping & Tax server returned HTTP code: %d', 'woocommerce-services' ),
 							$response_code
+						),
+						array(
+							'response_status_code' => $response_code,
 						)
 					);
 				}
@@ -104,13 +107,18 @@ if ( ! class_exists( 'WC_Connect_API_Client_Live' ) ) {
 						sprintf(
 							__( 'Error: The WooCommerce Shipping & Tax server returned ( %d ) and an empty response body.', 'woocommerce-services' ),
 							$response_code
+						),
+						array(
+							'response_status_code' => $response_code,
 						)
 					);
 				}
 
 				$error   = property_exists( $response_body, 'error' ) ? $response_body->error : '';
 				$message = property_exists( $response_body, 'message' ) ? $response_body->message : '';
-				$data    = property_exists( $response_body, 'data' ) ? $response_body->data : '';
+				$data    = property_exists( $response_body, 'data' ) ? (array) $response_body->data : array();
+
+				$data['response_status_code'] = $response_code;
 
 				return new WP_Error(
 					'wcc_server_error_response',

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -28,6 +28,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 						'last_heartbeat',
 						'origin_address',
 						'last_rate_request',
+						'services_last_result_code',
 					);
 				case 'shipping_method':
 					return array(

--- a/classes/class-wc-connect-service-schemas-store.php
+++ b/classes/class-wc-connect-service-schemas-store.php
@@ -26,9 +26,14 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 			$response_body = $this->api_client->get_service_schemas();
 
 			if ( is_wp_error( $response_body ) ) {
+				$error_data = $response_body->get_error_data();
+				if ( isset( $error_data['response_status_code'] ) ) {
+					$this->update_last_fetch_result_code( $error_data['response_status_code'] );
+				}
 				$this->logger->log( $response_body, __FUNCTION__ );
 				return false;
 			}
+			$this->update_last_fetch_result_code( '200' );
 
 			$this->logger->log( 'Successfully loaded service schemas from server response.', __FUNCTION__ );
 			$this->update_last_fetch_timestamp();
@@ -58,6 +63,17 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 
 		protected function update_last_fetch_timestamp() {
 			WC_Connect_Options::update_option( 'services_last_update', time() );
+		}
+
+		public function get_last_fetch_result_code() {
+			return WC_Connect_Options::get_option( 'services_last_result_code' );
+		}
+
+		/**
+		 * @param int $result_status_code
+		 */
+		protected function update_last_fetch_result_code( $result_status_code ) {
+			WC_Connect_Options::update_option( 'services_last_result_code', $result_status_code );
 		}
 
 		protected function maybe_update_heartbeat() {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1233,10 +1233,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * Hook fetching the available services from the connect server
 		 */
 		public function schedule_service_schemas_fetch() {
-			$schemas_store = $this->get_service_schemas_store();
-			$schemas       = $schemas_store->get_service_schemas();
+			$schemas_store     = $this->get_service_schemas_store();
+			$schemas           = $schemas_store->get_service_schemas();
+			$last_fetch_result = $schemas_store->get_last_fetch_result_code();
 
-			if ( ! $schemas ) {
+			if ( ! $schemas && '401' !== $last_fetch_result ) { // Don't retry auth failures wait for next scheduled time.
 				$schemas_store->fetch_service_schemas_from_connect_server();
 			} elseif ( defined( 'WOOCOMMERCE_CONNECT_FREQUENT_FETCH' ) && WOOCOMMERCE_CONNECT_FREQUENT_FETCH ) {
 				$schemas_store->fetch_service_schemas_from_connect_server();


### PR DESCRIPTION
closes https://github.com/Automattic/woocommerce-shipping-issues/issues/192

## Description
Many extra requests are being sent to the connect server with changes in 1.25.9. Most of these are from stores which are not authenticated. This happens because a store with an invalid blog token we keep trying to fetch services even though it fails each time.
 
### Related issue(s)
https://github.com/Automattic/woocommerce-shipping-issues/issues/192

### Steps to reproduce & screenshots/GIFs
Ensure your site is connected to production connect server. 
Change your blog token to an invalid one. This code should do it
```php
add_action( 'jetpack_loaded', function () {
	Jetpack_Options::update_option( 'blog_token', 'PjbxIr&GJJ8MzH^Vfan4gjXoqciy8g*Y.3Ww95YzGFyW(aY*g!C&VszYI0q^K7SG6' );
} );
```
If you using master you will see a 401 request on each page load to `/services` with this branch it should only happen one time.

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

