### PR TITLE
release: 1.25.10

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -76,6 +76,11 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 1.25.10 - 2021-xx-xx =
+* Add   - Add an endpoint for shipping label creation eligibility and share code for store eligibility.
+* Fix   - Shipping validation notice shown when no address entered.
+* Tweak - Stop retrying to fetch /services when authentication fails on connect server.
+
 = 1.25.9 - 2021-03-17 =
 * Add   - WC Admin notice about DHL live rates.
 * Add	- Live rates section in settings page.


### PR DESCRIPTION
## Release PR for 1.25.10
### Changes in this release
- https://github.com/Automattic/woocommerce-services/pull/2379 :  Use a script to find latest 3 minor versions for WooCommerce for test.
- https://github.com/Automattic/woocommerce-services/pull/2334 :  Add an endpoint for shipping label creation eligibility for Woo mobile.
- https://github.com/Automattic/woocommerce-services/pull/2394 :  Do not retry fetching services on auth failure.
- https://github.com/Automattic/woocommerce-services/pull/2391 :  Fix Shipping validation notice shown when no address entered.

This release branch is branched from latest `master`.

### Test notes
- Test label purchase.
- Test settings screen.
- Test status screen.
- Test living rates (USPS/DHL).
- Test account registration.

### Changelog
* Add   - Add an endpoint for shipping label creation eligibility and share code for store eligibility.
* Fix   - Shipping validation notice shown when no address entered.
* Tweak - Stop retrying to fetch /services when authentication fails on connect server.

## Build File
Built from this branch using `php woorelease.phar simulate --product_version=1.25.10 https://github.com/Automattic/woocommerce-services/tree/release/1.25.10`

[woocommerce-services.zip](https://github.com/Automattic/woocommerce-services/files/6192173/woocommerce-services.zip)
