### PR TITLE
Fix PHP 5 compatibility issues

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Tweak - Update the shipping label status endpoint to accept and return multiple ids.
 * Tweak	- Display spinner icon during service data refresh.
 * Add	- Adds Dockerized E2E tests with GitHub Action integration.
+* Fix   - Fix PHP 5.6 compatibility issue.
 
 = 1.25.10 - 2021-03-24 =
 * Add   - Add an endpoint for shipping label creation eligibility and share code for store eligibility.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.12 - 2021-xx-xx =
+* Fix   - Fix PHP 5.6 compatibility issue.
+
 = 1.25.11 - 2021-04-06 =
 * Fix	- Ensure status page is displayed on new WC navigation menu.
 * Add   - Run phpcbf as a pre-commit rule.
@@ -8,7 +11,6 @@
 * Tweak - Update the shipping label status endpoint to accept and return multiple ids.
 * Tweak	- Display spinner icon during service data refresh.
 * Add	- Adds Dockerized E2E tests with GitHub Action integration.
-* Fix   - Fix PHP 5.6 compatibility issue.
 * Fix   - Handle DHL live rates notice creation and deletion errors.
 
 = 1.25.10 - 2021-03-24 =

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -320,7 +320,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		 * @param WC_Order $order The order to check for shipping label creation eligibility.
 		 * @return bool Whether the given order is eligible for shipping label creation.
 		 */
-		public function is_order_eligible_for_shipping_label_creation( WC_Order $order ): bool {
+		public function is_order_eligible_for_shipping_label_creation( WC_Order $order ) {
 			// Set up a dictionary from product ID to quantity in the order, which will be updated by refunds and existing labels later.
 			$quantities_by_product_id = array();
 			foreach ( $order->get_items() as $item ) {
@@ -366,7 +366,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		 *
 		 * @return bool Whether the WC store is eligible for shipping label creation.
 		 */
-		public function is_store_eligible_for_shipping_label_creation(): bool {
+		public function is_store_eligible_for_shipping_label_creation() {
 			$base_currency = get_woocommerce_currency();
 			if ( ! $this->is_supported_currency( $base_currency ) ) {
 				return false;
@@ -386,7 +386,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		 * @param string $country_code Country code of the WC store.
 		 * @return bool Whether the given country code is supported for shipping labels.
 		 */
-		private function is_supported_country( string $country_code ): bool {
+		private function is_supported_country( $country_code ) {
 			return in_array( $country_code, $this->supported_countries, true );
 		}
 
@@ -396,7 +396,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		 * @param string $currency_code Currency code of the WC store.
 		 * @return bool Whether the given country code is supported for shipping labels.
 		 */
-		private function is_supported_currency( string $currency_code ): bool {
+		private function is_supported_currency( $currency_code ) {
 			return in_array( $currency_code, $this->supported_currencies, true );
 		}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
We had received a report of a syntax error for some PHP 7 syntax (return type and string parameter type in functions). To meet the requirement of PHP 5.6 compatibility, I removed this additional syntax. To confirm there were not additional issues, I ran the [PHPCompatibility tool](https://github.com/PHPCompatibility/PHPCompatibility) to look for further issues and address them all at once.

### Related issue(s)
Fixes #2401 

### Steps to reproduce & screenshots/GIFs
1. Set up a site using PHP 5.6 and older version of WC (I used 4.1 to test: https://wordpress.org/plugins/woocommerce/advanced/)
2. Find a shippable order ID.
3. Make a GET request to your store API endpoint: connect/label/<order_id>/creation_eligibility
4. Confirm syntax error.
5. Update to this branch and request again.
6. Confirm no syntax error.


![PHP56-errors](https://user-images.githubusercontent.com/68524302/113022874-14127880-9153-11eb-8a0a-6ad2c513cd91.png)

![PHP56-noerrors](https://user-images.githubusercontent.com/68524302/113022900-1c6ab380-9153-11eb-9a0e-5b670628db6d.png)

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

