### PR TITLE
fix: UPS registration form submission on invalid data

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Tweak	- Display spinner icon during service data refresh.
 * Add	- Adds Dockerized E2E tests with GitHub Action integration.
 * Fix   - Handle DHL live rates notice creation and deletion errors.
+* Fix   - UPS account connection form retry on invalid submission.
 
 = 1.25.10 - 2021-03-24 =
 * Add   - Add an endpoint for shipping label creation eligibility and share code for store eligibility.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 1.25.12 - 2021-xx-xx =
+* Fix   - UPS account connection form retry on invalid submission.
 * Fix   - Fix PHP 5.6 compatibility issue.
 * Tweak - Update plugin author name.
 
@@ -13,7 +14,6 @@
 * Tweak	- Display spinner icon during service data refresh.
 * Add	- Adds Dockerized E2E tests with GitHub Action integration.
 * Fix   - Handle DHL live rates notice creation and deletion errors.
-* Fix   - UPS account connection form retry on invalid submission.
 
 = 1.25.10 - 2021-03-24 =
 * Add   - Add an endpoint for shipping label creation eligibility and share code for store eligibility.

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/ups-settings-form.test.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/test/ups-settings-form.test.js
@@ -180,8 +180,8 @@ describe( 'UPS Account Registration Form', () => {
 
 
 		await act(async () => {
-			wrapper.find('input[id="enable_ups_invoice_fields"]').simulate('change', { target: { 
-				checked: true 
+			wrapper.find('input[id="enable_ups_invoice_fields"]').simulate('change', { target: {
+				checked: true
 			} } );
 		} );
 
@@ -266,6 +266,190 @@ describe( 'UPS Account Registration Form', () => {
 			title: 'title',
 			type: 'UpsAccount',
 			website: 'http://website.com'
+		} );
+	} );
+
+	it('should submit the form if all the invoice details are entered', async () => {
+		const wrapper = mount(
+			<Wrapper>
+				<UpsSettingsForm />
+			</Wrapper>
+		);
+
+		await act(async () => {
+			wrapper.find('input[id="account_number"]').simulate('change', { target: {
+				value: 'A12345'
+			} } );
+			wrapper.find('input[id="name"]').simulate('change', { target: {
+				value: 'FirstName LastName'
+			} } );
+			wrapper.find('input[id="street1"]').simulate('change', { target: {
+				value: 'Street 1'
+			} } );
+			wrapper.find('input[id="city"]').simulate('change', { target: {
+				value: 'City'
+			} } );
+			wrapper.find('input[id="state"]').simulate('change', { target: {
+				value: 'MN'
+			} } );
+			wrapper.find('input[id="postal_code"]').simulate('change', { target: {
+				value: '55555'
+			} } );
+			wrapper.find('input[id="phone"]').simulate('change', { target: {
+				value: '2065555555'
+			} } );
+			wrapper.find('input[id="email"]').simulate('change', { target: {
+				value: 'email'
+			} } );
+			wrapper.find('input[id="title"]').simulate('change', { target: {
+				value: 'title'
+			} } );
+			wrapper.find('input[id="website"]').simulate('change', { target: {
+				value: 'http://website.com'
+			} } );
+			wrapper.find('input[id="email"]').simulate('change', { target: {
+				value: 'valid-email@email.com'
+			} } );
+			wrapper.find('input[id="enable_ups_invoice_fields"]').simulate('change', { target: {
+				checked: true
+			} } );
+		} );
+
+		// waiting to udpate due to the change on the checkbox data
+		wrapper.update();
+
+		await act(async () => {
+			wrapper.find('input[id="invoice_number"]').simulate('change', { target: {
+					value: '111111111'
+				} } );
+			wrapper.find('input[id="invoice_date"]').simulate('change', { target: {
+					value: '2021-02-29'
+				} } );
+			wrapper.find('input[id="invoice_amount"]').simulate('change', { target: {
+					value: '5.55'
+				} } );
+			wrapper.find('input[id="invoice_currency"]').simulate('change', { target: {
+					value: 'USD'
+				} } );
+			wrapper.find('input[id="invoice_control_id"]').simulate('change', { target: {
+					value: '123456789'
+				} } );
+		} );
+
+		await act(async () => {
+			// Click the register button
+			wrapper.find( 'button.is-primary' ).simulate('click');
+		} );
+
+		expect(apiPostSpy).toHaveBeenCalledWith(1234, 'connect/shipping/carrier', {
+			account_number: 'A12345',
+			city: 'City',
+			country: 'US',
+			email: 'valid-email@email.com',
+			name: 'FirstName LastName',
+			phone: '2065555555',
+			postal_code: '55555',
+			state: 'MN',
+			street1: 'Street 1',
+			title: 'title',
+			type: 'UpsAccount',
+			website: 'http://website.com',
+			invoice_amount: '5.55',
+			invoice_control_id: '123456789',
+			invoice_currency: 'USD',
+			invoice_date: '2021-02-29',
+			invoice_number: '111111111',
+		} );
+	} );
+
+	it('should not submit the invoice details fields when the checkbox is de-checked', async () => {
+		const wrapper = mount(
+			<Wrapper>
+				<UpsSettingsForm />
+			</Wrapper>
+		);
+
+		await act(async () => {
+			wrapper.find('input[id="account_number"]').simulate('change', { target: {
+				value: 'A12345'
+			} } );
+			wrapper.find('input[id="name"]').simulate('change', { target: {
+				value: 'FirstName LastName'
+			} } );
+			wrapper.find('input[id="street1"]').simulate('change', { target: {
+				value: 'Street 1'
+			} } );
+			wrapper.find('input[id="city"]').simulate('change', { target: {
+				value: 'City'
+			} } );
+			wrapper.find('input[id="state"]').simulate('change', { target: {
+				value: 'MN'
+			} } );
+			wrapper.find('input[id="postal_code"]').simulate('change', { target: {
+				value: '55555'
+			} } );
+			wrapper.find('input[id="phone"]').simulate('change', { target: {
+				value: '2065555555'
+			} } );
+			wrapper.find('input[id="email"]').simulate('change', { target: {
+				value: 'email'
+			} } );
+			wrapper.find('input[id="title"]').simulate('change', { target: {
+				value: 'title'
+			} } );
+			wrapper.find('input[id="website"]').simulate('change', { target: {
+				value: 'http://website.com'
+			} } );
+			wrapper.find('input[id="email"]').simulate('change', { target: {
+				value: 'valid-email@email.com'
+			} } );
+			wrapper.find('input[id="enable_ups_invoice_fields"]').simulate('change', { target: {
+				checked: true,
+			} } );
+		} );
+
+		// waiting to udpate due to the change on the checkbox data
+		wrapper.update();
+
+		await act(async () => {
+			wrapper.find('input[id="invoice_number"]').simulate('change', { target: {
+					value: '111111111'
+				} } );
+			wrapper.find('input[id="invoice_date"]').simulate('change', { target: {
+					value: '2021-02-29'
+				} } );
+			wrapper.find('input[id="invoice_amount"]').simulate('change', { target: {
+					value: '5.55'
+				} } );
+			wrapper.find('input[id="invoice_currency"]').simulate('change', { target: {
+					value: 'USD'
+				} } );
+			wrapper.find('input[id="invoice_control_id"]').simulate('change', { target: {
+					value: '123456789'
+				} } );
+			wrapper.find('input[id="enable_ups_invoice_fields"]').simulate('change', { target: {
+					checked: false,
+				} } );
+		} );
+
+		await act(async () => {
+			// Click the register button
+			wrapper.find( 'button.is-primary' ).simulate('click');
+		} );
+
+		expect(apiPostSpy).toHaveBeenCalledWith(1234, 'connect/shipping/carrier', {
+			account_number: 'A12345',
+			city: 'City',
+			country: 'US',
+			email: 'valid-email@email.com',
+			name: 'FirstName LastName',
+			phone: '2065555555',
+			postal_code: '55555',
+			state: 'MN',
+			street1: 'Street 1',
+			title: 'title',
+			type: 'UpsAccount',
+			website: 'http://website.com',
 		} );
 	} );
 } );

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/ups-settings-form.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/ups-settings-form.js
@@ -191,12 +191,12 @@ const UpsSettingsForm = ({ translate, errorNotice, successNotice, countryNames, 
 					type: 'UpsAccount',
 				};
 
-				if( isInvoiceDetailsChecked ) {
-					delete formValues.invoice_number;
-					delete formValues.invoice_date;
-					delete formValues.invoice_amount;
-					delete formValues.invoice_currency;
-					delete formValues.invoice_control_id;
+				if( ! isInvoiceDetailsChecked ) {
+					delete requestBody.invoice_number;
+					delete requestBody.invoice_date;
+					delete requestBody.invoice_amount;
+					delete requestBody.invoice_currency;
+					delete requestBody.invoice_control_id;
 				}
 
 				const result = await api.post( siteId, api.url.shippingCarrier(), requestBody );

--- a/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/ups-settings-form.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/carrier-accounts/ups-settings-form.js
@@ -389,12 +389,14 @@ const UpsSettingsForm = ({ translate, errorNotice, successNotice, countryNames, 
 								<div className="carrier-accounts__settings-two-columns">
 									<TextField
 										id="invoice_number"
+										defaultValue={formValues.invoice_number}
 										title={translate('UPS invoice number')}
 										updateValue={handleFormFieldUpdate}
 										error={typeof formValues.invoice_number === 'string' ? fieldsErrors.invoice_number : undefined}
 									/>
 									<TextField
 										id="invoice_date"
+										defaultValue={formValues.invoice_date}
 										title={translate('UPS invoice date')}
 										updateValue={handleFormFieldUpdate}
 										error={typeof formValues.invoice_date === 'string' ? fieldsErrors.invoice_date : undefined}
@@ -404,12 +406,14 @@ const UpsSettingsForm = ({ translate, errorNotice, successNotice, countryNames, 
 								<div className="carrier-accounts__settings-two-columns">
 									<TextField
 										id="invoice_amount"
+										defaultValue={formValues.invoice_amount}
 										title={translate('UPS invoice amount')}
 										updateValue={handleFormFieldUpdate}
 										error={typeof formValues.invoice_amount === 'string' ? fieldsErrors.invoice_amount : undefined}
 									/>
 									<TextField
 										id="invoice_currency"
+										defaultValue={formValues.invoice_currency}
 										title={translate('UPS invoice currency')}
 										updateValue={handleFormFieldUpdate}
 										error={typeof formValues.invoice_currency === 'string' ? fieldsErrors.invoice_currency : undefined}
@@ -417,6 +421,7 @@ const UpsSettingsForm = ({ translate, errorNotice, successNotice, countryNames, 
 								</div>
 								<TextField
 									id="invoice_control_id"
+									defaultValue={formValues.invoice_control_id}
 									title={translate('UPS invoice control id')}
 									updateValue={handleFormFieldUpdate}
 									error={typeof formValues.invoice_control_id === 'string' ? fieldsErrors.invoice_control_id : undefined}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

I noticed that if the merchant tries to connect their UPS account (with the invoice information) and the submission doesn't go well, the button remains deactivated until all the fields are re-edited.
Fixing.

![2021-04-01 16 26 32](https://user-images.githubusercontent.com/273592/113356772-7365b980-9308-11eb-8453-d3e1981146d4.gif)


### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

- Go register a UPS account
- Enter some jibberish (without checking the "I have been issued an invoice from UPS within the past 90 days" checkbox)
- Submission should fail
- Check the checkbox
- Enter additional jibberish
- Submit again
- Submission should fail, but the "connect" button should be clickable
- On the `develop` branch, the "Connect" button didn't become clickable until both "UPS invoice number" and "UPS invoice date" were edited

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

