### PR TITLE
Fix/2409 fix error on checkout without using wcs rates

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.25.12 - 2021-xx-xx =
 * Fix   - Fix PHP 5.6 compatibility issue.
+* Fix   - Removes unnecessary subscription debug error logs.
 
 = 1.25.11 - 2021-04-06 =
 * Fix	- Ensure status page is displayed on new WC navigation menu.
@@ -12,7 +13,6 @@
 * Tweak	- Display spinner icon during service data refresh.
 * Add	- Adds Dockerized E2E tests with GitHub Action integration.
 * Fix   - Handle DHL live rates notice creation and deletion errors.
-* Fix   - Removes unnecessary subscription debug error logs.
 
 = 1.25.10 - 2021-03-24 =
 * Add   - Add an endpoint for shipping label creation eligibility and share code for store eligibility.

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Tweak	- Display spinner icon during service data refresh.
 * Add	- Adds Dockerized E2E tests with GitHub Action integration.
 * Fix   - Handle DHL live rates notice creation and deletion errors.
+* Fix   - Removes unnecessary subscription debug error logs.
 
 = 1.25.10 - 2021-03-24 =
 * Add   - Add an endpoint for shipping label creation eligibility and share code for store eligibility.

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -181,11 +181,6 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 * @return object|WP_Error
 		 */
 		public function track_subscription_event( $services ) {
-			if ( empty( $services ) ) {
-				// Checkout not involved with WCS rates.
-				return $services;
-			}
-
 			return $this->request( 'POST', '/subscriptions/checkout', array( 'services' => $services ) );
 		}
 

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -182,10 +182,8 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 */
 		public function track_subscription_event( $services ) {
 			if ( empty( $services ) ) {
-				return new WP_Error(
-					'nothing_to_ship',
-					__( 'No shipping rate could be calculated. No items in the package are shippable.', 'woocommerce-services' )
-				);
+				// Checkout not involved with WCS rates
+				return $services;
 			}
 
 			return $this->request( 'POST', '/subscriptions/checkout', array( 'services' => $services ) );

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -182,7 +182,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 */
 		public function track_subscription_event( $services ) {
 			if ( empty( $services ) ) {
-				// Checkout not involved with WCS rates
+				// Checkout not involved with WCS rates.
 				return $services;
 			}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1122,6 +1122,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				}
 			}
 
+			if ( empty( $services ) ) {
+				return;
+			}
+
 			$api_client = $this->get_api_client();
 			$response   = $api_client->track_subscription_event( $services );
 			if ( is_wp_error( $response ) ) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
Noticed this issue after a user mentioned this error occurring frequently [here](https://wordpress.org/support/topic/error-track_completed_order/). The user noticed the following error occurring frequently in the logs for their site.

```
Unable to send subscription event: No shipping rate could be calculated. No items in the package are shippable. (track_completed_order)
```

The error looks scary and suggests that something is not working correctly. What is actually happening is that the client-side subscription handler for checkout events has not been able to find any WCS shipping methods involved in a user's checkout and throws an error, because it cannot send any subscription event. The client should not throw an error, as it is perfectly conceivable for a customer on a user's store to complete a checkout without using a WCS shipping method.

### Related issue(s)

Closes #2409 

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
1. Ensure that you have checked out the changes in this PR and the latest version of the Connect Server. Also ensure that debug and logging are both enabled on your site. 
2. Create a shipping zone and enable any shipping method other than any WCS shipping methods on this zone. Do not enable any WCS shipping methods on this zone.
3. Add a product to your cart and complete a checkout using a destination shipping address within the above aforementioned zone.
4. Check the WCS debug log and notice the absence of `Unable to send subscription event` errors.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

