### PR TITLE
Fix/194 update plugin author

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.25.12 - 2021-xx-xx =
 * Fix   - Fix PHP 5.6 compatibility issue.
+* Tweak - Update plugin author name.
 
 = 1.25.11 - 2021-04-06 =
 * Fix	- Ensure status page is displayed on new WC navigation menu.
@@ -12,7 +13,6 @@
 * Tweak	- Display spinner icon during service data refresh.
 * Add	- Adds Dockerized E2E tests with GitHub Action integration.
 * Fix   - Handle DHL live rates notice creation and deletion errors.
-* Tweak - Update plugin author name.
 
 = 1.25.10 - 2021-03-24 =
 * Add   - Add an endpoint for shipping label creation eligibility and share code for store eligibility.

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Tweak	- Display spinner icon during service data refresh.
 * Add	- Adds Dockerized E2E tests with GitHub Action integration.
 * Fix   - Handle DHL live rates notice creation and deletion errors.
+* Fix   - Update plugin author.
 
 = 1.25.10 - 2021-03-24 =
 * Add   - Add an endpoint for shipping label creation eligibility and share code for store eligibility.

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,7 +9,7 @@
 * Tweak	- Display spinner icon during service data refresh.
 * Add	- Adds Dockerized E2E tests with GitHub Action integration.
 * Fix   - Handle DHL live rates notice creation and deletion errors.
-* Fix   - Update plugin author.
+* Tweak - Update plugin author name.
 
 = 1.25.10 - 2021-03-24 =
 * Add   - Add an endpoint for shipping label creation eligibility and share code for store eligibility.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Shipping & Tax
  * Plugin URI: https://woocommerce.com/
  * Description: Hosted services for WooCommerce: automated tax calculation, shipping label printing, and smoother payment setup.
- * Author: Automattic
+ * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-services
  * Domain Path: /i18n/languages/


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
An HE [posed the question on Slack](p1617974817323500-slack-C7U3Y3VMY), "Why does it say 'by Automattic' rather than 'by WooCommerce' in the system report?"

I initially thought this was a little pedantic (and I probably still do), but checking through the list of Heisenberg/Extendables plugins, I learned that all of them with two exceptions--WooCommerce Shipping & Tax and WooCommerce Distance Rate Shipping--state that their author is WooCommerce, while the latter two state Automattic. 

I really hope this inconsistency hasn't been giving any of our users' sleepless nights, but since it's a one-line change, I created this issue, so that we could put the issue of who truly owns us to bed once and for all.

### Related issue(s)

Closes Automattic/woocommerce-shipping-issues#194

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
1. Print system status report and check the author name next to the plugin.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added