### PR TITLE
chore(TaxJar): remove branching on tax calculation

### DIFF
--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -933,10 +933,7 @@ class WC_Connect_TaxJar_Integration {
 			}
 		}
 
-		// Remove taxes if they are set somehow and customer is exempt
-		if ( WC()->customer->is_vat_exempt() ) {
-			$wc_cart_object->remove_taxes();
-		} elseif ( $taxes['has_nexus'] ) {
+		if ( $taxes['has_nexus'] ) {
 			// Use Woo core to find matching rates for taxable address
 			$location = array(
 				'to_country' => $to_country,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

The `$wc_cart_object->remove_taxes();` branch is never going to be reached.
First of all, `wc_cart_object` is not a variable in the scope, so the whole application would break.
Second of all, it will never be reached because of the early return on this line: https://github.com/Automattic/woocommerce-services/blob/develop/classes/class-wc-connect-taxjar-integration.php#L870

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
I didn't add a changelog entry because this little change isn't worth it.

