### PR TITLE
refactor: rename tax name for US

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 1.25.12 - 2021-xx-xx =
+* Tweak - Rename automatic tax names for US.
 * Fix   - UPS account connection form retry on invalid submission.
 * Fix   - Fix PHP 5.6 compatibility issue.
 * Tweak - Update plugin author name.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1048,15 +1048,13 @@ class WC_Connect_TaxJar_Integration {
 		// prevents from saving a "state" column value for GB
 		$to_state = 'GB' === $location['to_country'] ? '' : $location['to_state'];
 
-		// For the US, we're going to modify the name of the tax rate to simplify the reporting and distinguish between the tax rates at the counties level.
-		// I would love to do this for other locations, but it looks like that would create issues.
-		// For example, for the UK it would continuously rename the rate name with an updated `state` "piece", each time a request is made
-		$tax_rate_name = self::generate_tax_rate_name( $taxjar_response, $location['to_country'], $to_state );
-
 		$tax_rate = array(
 			'tax_rate_country'  => $location['to_country'],
 			'tax_rate_state'    => $to_state,
-			'tax_rate_name'     => sprintf( '%s Tax', $tax_rate_name ),
+			// For the US, we're going to modify the name of the tax rate to simplify the reporting and distinguish between the tax rates at the counties level.
+			// I would love to do this for other locations, but it looks like that would create issues.
+			// For example, for the UK it would continuously rename the rate name with an updated `state` "piece", each time a request is made
+			'tax_rate_name'     => sprintf( '%s Tax', self::generate_tax_rate_name( $taxjar_response, $location['to_country'], $to_state ) ),
 			'tax_rate_priority' => 1,
 			'tax_rate_compound' => false,
 			'tax_rate_shipping' => $freight_taxable,

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -876,7 +876,7 @@ class WC_Connect_TaxJar_Integration {
 	 * Direct from the TaxJar plugin, without Nexus check.
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L247
 	 *
-	 * @return array
+	 * @return array|boolean
 	 */
 	public function calculate_tax( $options = array() ) {
 		$this->_log( ':::: TaxJar Plugin requested ::::' );

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -51,9 +51,9 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	/**
-	 * @param $taxjar_response
-	 * @param string          $to_country
-	 * @param string          $to_state
+	 * @param mixed  $taxjar_response
+	 * @param string $to_country
+	 * @param string $to_state
 	 *
 	 * @return string
 	 */

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -831,7 +831,7 @@ class WC_Connect_TaxJar_Integration {
 	 * Direct from the TaxJar plugin, without Nexus check.
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L247
 	 *
-	 * @return void
+	 * @return array
 	 */
 	public function calculate_tax( $options = array() ) {
 		$this->_log( ':::: TaxJar Plugin requested ::::' );
@@ -909,27 +909,32 @@ class WC_Connect_TaxJar_Integration {
 
 		$response = $this->smartcalcs_cache_request( wp_json_encode( $body ) );
 
-		if ( isset( $response ) ) {
-			// Log the response
-			$this->_log( 'Received: ' . $response['body'] );
+		// if no response, no need to keep going - bail early
+		if ( ! isset( $response ) ) {
+			$this->_log( 'Received: none.' );
 
-			// Decode Response
-			$taxjar_response = json_decode( $response['body'] );
-			$taxjar_response = $taxjar_response->tax;
+			return $taxes;
+		}
 
-			// Update Properties based on Response
-			$taxes['freight_taxable'] = (int) $taxjar_response->freight_taxable;
-			$taxes['has_nexus']       = (int) $taxjar_response->has_nexus;
-			$taxes['tax_rate']        = $taxjar_response->rate;
+		// Log the response
+		$this->_log( 'Received: ' . $response['body'] );
 
-			if ( ! empty( $taxjar_response->breakdown ) ) {
-				if ( ! empty( $taxjar_response->breakdown->line_items ) ) {
-					$line_items = array();
-					foreach ( $taxjar_response->breakdown->line_items as $line_item ) {
-						$line_items[ $line_item->id ] = $line_item;
-					}
-					$taxes['line_items'] = $line_items;
+		// Decode Response
+		$taxjar_response = json_decode( $response['body'] );
+		$taxjar_response = $taxjar_response->tax;
+
+		// Update Properties based on Response
+		$taxes['freight_taxable'] = (int) $taxjar_response->freight_taxable;
+		$taxes['has_nexus']       = (int) $taxjar_response->has_nexus;
+		$taxes['tax_rate']        = $taxjar_response->rate;
+
+		if ( ! empty( $taxjar_response->breakdown ) ) {
+			if ( ! empty( $taxjar_response->breakdown->line_items ) ) {
+				$line_items = array();
+				foreach ( $taxjar_response->breakdown->line_items as $line_item ) {
+					$line_items[ $line_item->id ] = $line_item;
 				}
+				$taxes['line_items'] = $line_items;
 			}
 		}
 
@@ -944,10 +949,6 @@ class WC_Connect_TaxJar_Integration {
 				'to_zip'     => $to_zip,
 				'to_city'    => $to_city,
 			);
-
-			if ( 'GB' === $to_country ) {
-				$location['to_state'] = '';
-			}
 
 			// Add line item tax rates
 			foreach ( $taxes['line_items'] as $line_item_key => $line_item ) {
@@ -965,6 +966,7 @@ class WC_Connect_TaxJar_Integration {
 
 				if ( $line_item->combined_tax_rate ) {
 					$taxes['rate_ids'][ $line_item_key ] = $this->create_or_update_tax_rate(
+						$taxjar_response,
 						$location,
 						$line_item->combined_tax_rate * 100,
 						$tax_class,
@@ -976,6 +978,7 @@ class WC_Connect_TaxJar_Integration {
 			// Add shipping tax rate
 			if ( $taxes['tax_rate'] ) {
 				$taxes['rate_ids']['shipping'] = $this->create_or_update_tax_rate(
+					$taxjar_response,
 					$location,
 					$taxes['tax_rate'] * 100,
 					'',
@@ -993,13 +996,55 @@ class WC_Connect_TaxJar_Integration {
 	 * Unchanged from the TaxJar plugin.
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/9d8e725/includes/class-wc-taxjar-integration.php#L396
 	 *
-	 * @return void
+	 * @return int
 	 */
-	public function create_or_update_tax_rate( $location, $rate, $tax_class = '', $freight_taxable = 1 ) {
+	public function create_or_update_tax_rate( $taxjar_response, $location, $rate, $tax_class = '', $freight_taxable = 1 ) {
+		// all the states in GB have the same tax rate
+		// prevents from saving a "state" column value for GB
+		$to_state = 'GB' === $location['to_country'] ? '' : $location['to_state'];
+
+		$tax_rate_name = $to_state;
+		// For the US, we're going to modify the name of the tax rate to simplify the reporting and distinguish between the tax rates at the counties level.
+		// I would love to do this for other locations, but it looks like that would create issues.
+		// For example, for the UK it would continuously rename the rate name with an updated `state` "piece", each time a request is made
+		if ( 'US' === $location['to_country'] ) {
+			// for a list of possible attributes in the `jurisdictions` attribute, see:
+			// https://developers.taxjar.com/api/reference/#post-calculate-sales-tax-for-an-order
+			$jurisdiction_pieces = array_merge(
+				[
+					'city'    => '',
+					'county'  => '',
+					'state'   => $to_state,
+					'country' => $location['to_country'],
+				],
+				(array) $taxjar_response->jurisdictions
+			);
+
+			// sometimes TaxJar returns a string with the value 'FALSE' for `state`.
+			if ( rest_is_boolean( $to_state ) ) {
+				$jurisdiction_pieces['state'] = '';
+			}
+
+			$tax_rate_name = join(
+				'-',
+				array_filter(
+					[
+						// the `$jurisdiction_pieces` is not really sorted
+						// so let's sort it with COUNTRY-STATE-COUNTY-CITY
+						// `array_filter` will take care of filtering out the "falsy" entries
+						$jurisdiction_pieces['country'],
+						$jurisdiction_pieces['state'],
+						$jurisdiction_pieces['county'],
+						$jurisdiction_pieces['city'],
+					]
+				)
+			);
+		}
+
 		$tax_rate = array(
 			'tax_rate_country'  => $location['to_country'],
-			'tax_rate_state'    => $location['to_state'],
-			'tax_rate_name'     => sprintf( '%s Tax', $location['to_state'] ),
+			'tax_rate_state'    => $to_state,
+			'tax_rate_name'     => sprintf( '%s Tax', $tax_rate_name ),
 			'tax_rate_priority' => 1,
 			'tax_rate_compound' => false,
 			'tax_rate_shipping' => $freight_taxable,
@@ -1010,7 +1055,7 @@ class WC_Connect_TaxJar_Integration {
 		$wc_rate = WC_Tax::find_rates(
 			array(
 				'country'   => $location['to_country'],
-				'state'     => $location['to_state'],
+				'state'     => $to_state,
 				'postcode'  => $location['to_zip'],
 				'city'      => $location['to_city'],
 				'tax_class' => $tax_class,

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -57,7 +57,7 @@ class WC_Connect_TaxJar_Integration {
 	 *
 	 * @return string
 	 */
-	private static function generate_tax_rate_name( $taxjar_response, $to_country, $to_state ): mixed {
+	private static function generate_tax_rate_name( $taxjar_response, $to_country, $to_state ) {
 		if ( 'US' !== $to_country ) {
 			return $to_state;
 		}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Renames the "Tax name" column, so that people can more easily identify the tax rates by the counties for reports.
This change is only valid for the US (I didn't want to break it for other countries). Although I feel like it might be useful to extend this format for all countries 🤷 

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Fix: https://github.com/Automattic/woocommerce-services/issues/2226

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

- I recommend deleting all your existing tax rates before this - or maybe only keep the ones you want to see changing
- Change your store to be based in MN (just as an example for nexus)
- Place 2 orders on your store to both these addresses:
  - 1000 Nicollet Mall, Minneapolis, MN 55403
  - 2105 London Rd, Duluth, MN 55812
- Go to WooCommerce > Settings > Tax > Standard rates, you should see updated values: https://d.pr/i/aSdMzN
- Go to Analytics > Taxes, you should see updated values in the report (might take a bit after an order is placed due to internal caching)

Before: https://d.pr/i/psnvuh
After: https://d.pr/i/lg7S6a

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

