### PR TITLE
fix: check jetpack constant by name

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.13 - 2021-xx-xx =
+* Fix - Check JetPack constant defined by name.
+
 = 1.25.12 - 2021-04-21 =
 * Fix   - UPS account connection form retry on invalid submission.
 * Fix   - Fix PHP 5.6 compatibility issue.

--- a/classes/class-wc-connect-jetpack.php
+++ b/classes/class-wc-connect-jetpack.php
@@ -165,7 +165,7 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 				return $connection->is_user_connected();
 			}
 
-			if ( defined( JETPACK_MASTER_USER ) ) {
+			if ( defined( 'JETPACK_MASTER_USER' ) ) {
 				$user_token = self::get_master_user_access_token( JETPACK_MASTER_USER );
 
 				return ( isset( $user_token->external_user_id ) && get_current_user_id() === $user_token->external_user_id );
@@ -186,7 +186,7 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 				return $connection->is_connected();
 			}
 
-			if ( defined( JETPACK_MASTER_USER ) ) {
+			if ( defined( 'JETPACK_MASTER_USER' ) ) {
 				$user_token = self::get_master_user_access_token( JETPACK_MASTER_USER );
 
 				return isset( $user_token->external_user_id );

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -297,7 +297,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			}
 
 			// check if Jetpack is activated
-			if ( ! class_exists( '\Automattic\Jetpack\Connection\Manager' ) && ! class_exists( '\Automattic\Jetpack\Connection\Tokens' ) ) {
+			if ( ! is_plugin_active( 'jetpack/jetpack.php' ) ) {
 				return self::JETPACK_INSTALLED_NOT_ACTIVATED;
 			}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

`defined()` in PHP needs the constant's name as `string` for its argument

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

I tested this in JN by downloading the WCS plugin (without activating it), ssh-ing, patching the 2 files with these changes and then going through the WC onboarding.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

