### PR TITLE
fix: plugin deletion without WC core

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 1.25.13 - 2021-xx-xx =
+* Fix - Plugin deletion when WooCommerce core is not present.
 * Tweak - Rename automatic tax names for US.
 * Fix - Check JetPack constant defined by name.
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -228,6 +228,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			if ( ! class_exists( 'WC_Data_Store' ) ) {
 				return false;
 			}
+
 			try {
 				WC_Data_Store::load( 'admin-note' );
 			} catch ( Exception $e ) {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -225,6 +225,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * @return bool true|false.
 		 */
 		public static function can_add_wc_admin_notice() {
+			if ( ! class_exists( 'WC_Data_Store' ) ) {
+				return false;
+			}
 			try {
 				WC_Data_Store::load( 'admin-note' );
 			} catch ( Exception $e ) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Plugin cannot be deleted when WC core is not present or deactivated.
Looks like the try/catch doesn't catch this.

The logs in the ticket also mention the `wp_woocommerce_shipping_zone_methods` not being present, but it doesn't seem to be an issue.
Pushing a minimal amount of changes.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Fixes https://github.com/Automattic/woocommerce-services/issues/2417

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

I tested this on JN by manually editing the file changed in this PR.

Before:
![2021-04-26 14 26 11](https://user-images.githubusercontent.com/273592/116139228-6932a300-a69b-11eb-98fa-cb33f4e4d7bd.gif)

After:
![2021-04-26 14 24 54](https://user-images.githubusercontent.com/273592/116139260-72237480-a69b-11eb-9e32-2efd9b7e2419.gif)


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

