### PR TITLE
fix: encoding of html entities

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 1.25.13 - 2021-xx-xx =
+* Fix - Data encoding when entities are part of order meta.
 * Tweak - Rename automatic tax names for US.
 * Fix - Check JetPack constant defined by name.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.25.13 - 2021-xx-xx =
 * Fix - Data encoding when entities are part of order meta.
+* Tweak - Update WC version support in headers.
 * Fix - Plugin deletion when WooCommerce core is not present.
 * Tweak - Rename automatic tax names for US.
 * Fix - Check JetPack constant defined by name.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1600,8 +1600,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				)
 			);
 
+			$encoded_arguments = wp_json_encode( $extra_args );
+			$escaped_arguments = function_exists( 'wc_esc_json' ) ? wc_esc_json( $encoded_arguments ) : esc_attr( $encoded_arguments );
+
 			?>
-				<div class="wcc-root woocommerce <?php echo esc_attr( $root_view ); ?>" data-args="<?php echo wc_esc_json( wp_json_encode( $extra_args ) ); ?>">
+				<div class="wcc-root woocommerce <?php echo esc_attr( $root_view ); ?>" data-args="<?php echo $escaped_arguments; ?>">
 					<span class="form-troubles" style="opacity: 0">
 						<?php printf( __( 'Section not loading? Visit the <a href="%s">status page</a> for troubleshooting steps.', 'woocommerce-services' ), $debug_page_uri ); ?>
 					</span>

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1600,11 +1600,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				)
 			);
 
-			$encoded_arguments = wp_json_encode( $extra_args );
-			$escaped_arguments = function_exists( 'wc_esc_json' ) ? wc_esc_json( $encoded_arguments ) : esc_attr( $encoded_arguments );
-
 			?>
-				<div class="wcc-root woocommerce <?php echo esc_attr( $root_view ); ?>" data-args="<?php echo $escaped_arguments; ?>">
+				<div class="wcc-root woocommerce <?php echo esc_attr( $root_view ); ?>" data-args="<?php echo wc_esc_json( wp_json_encode( $extra_args ) ); ?>">
 					<span class="form-troubles" style="opacity: 0">
 						<?php printf( __( 'Section not loading? Visit the <a href="%s">status page</a> for troubleshooting steps.', 'woocommerce-services' ), $debug_page_uri ); ?>
 					</span>

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-services
  * Domain Path: /i18n/languages/
  * Version: 1.25.12
- * WC requires at least: 5.0.0
+ * WC requires at least: 3.5.5
  * WC tested up to: 5.0
  *
  * Copyright (c) 2017-2020 Automattic

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1596,8 +1596,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				)
 			);
 
+			$encoded_arguments = wp_json_encode( $extra_args );
+			$escaped_arguments = function_exists( 'wc_esc_json' ) ? wc_esc_json( $encoded_arguments ) : esc_attr( $encoded_arguments );
+
 			?>
-				<div class="wcc-root woocommerce <?php echo esc_attr( $root_view ); ?>" data-args="<?php echo esc_attr( wp_json_encode( $extra_args ) ); ?>">
+				<div class="wcc-root woocommerce <?php echo esc_attr( $root_view ); ?>" data-args="<?php echo $escaped_arguments; ?>">
 					<span class="form-troubles" style="opacity: 0">
 						<?php printf( __( 'Section not loading? Visit the <a href="%s">status page</a> for troubleshooting steps.', 'woocommerce-services' ), $debug_page_uri ); ?>
 					</span>

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-services
  * Domain Path: /i18n/languages/
  * Version: 1.25.12
- * WC requires at least: 3.0.0
+ * WC requires at least: 5.0.0
  * WC tested up to: 5.0
  *
  * Copyright (c) 2017-2020 Automattic


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Plugin breaks on order page when HTML entities are not properly encoded.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Fixes https://github.com/Automattic/woocommerce-services/issues/2420

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

- Go to order page
- Add item metadata with encoded entities (e.g.: `&quot;`): https://d.pr/i/HEXQQO
- Page breaks: https://d.pr/i/vXgwc5
- Checkout this branch
- Page does not break

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

