### PR TITLE
Fix shipping tax when multiple tax classes are used

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - Plugin deletion when WooCommerce core is not present.
 * Tweak - Rename automatic tax names for US.
 * Fix - Check JetPack constant defined by name.
+* Fix - Sometimes taxes charged on shipping when they should not.
 
 = 1.25.12 - 2021-04-21 =
 * Fix   - UPS account connection form retry on invalid submission.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1018,15 +1018,13 @@ class WC_Connect_TaxJar_Integration {
 			}
 
 			// Add shipping tax rate
-			if ( $taxes['tax_rate'] ) {
-				$taxes['rate_ids']['shipping'] = $this->create_or_update_tax_rate(
-					$taxjar_response,
-					$location,
-					$taxes['tax_rate'] * 100,
-					'',
-					$taxes['freight_taxable']
-				);
-			}
+			$taxes['rate_ids']['shipping'] = $this->create_or_update_tax_rate(
+				$taxjar_response,
+				$location,
+				$taxes['tax_rate'] * 100,
+				'',
+				$taxes['freight_taxable']
+			);
 		} // End if().
 
 		return $taxes;


### PR DESCRIPTION
## Description
We store rates return from tax jar in the woocommerce tax tables. Sometimes non-taxable items will charge taxes on shipping because this table is not updated if the tax rate returned by taxjar is 0.0. Really we're backporting a bugfix from the taxjar plugin https://github.com/taxjar/taxjar-woocommerce-plugin/blob/master/includes/class-taxjar-tax-calculation.php#L393

### Related issue(s)
#2020 

### Steps to reproduce & screenshots/GIFs

Create a taxable and non-taxable product.
Set store location and customer location to NY or any state that requires collecting taxes on shipping charges.
Add taxable product to cart and observe taxes for product and shipping.
Remove taxable product
add non-taxable product to cart and verify that no taxes are charged.
Without this fix shipping taxes would still be charged.

### Checklist

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

