### PR TITLE
Fix extra requests to /services

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 1.25.13 - 2021-xx-xx =
+* Fix - Prevent new sites from retrying failed connections.
 * Fix - Data encoding when entities are part of order meta.
 * Tweak - Update WC version support in headers.
 * Fix - Plugin deletion when WooCommerce core is not present.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,12 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 1.25.13 - 2021-xx-xx =
+* Fix - Data encoding when entities are part of order meta.
+* Tweak - Update WC version support in headers.
 * Fix - Plugin deletion when WooCommerce core is not present.
 * Tweak - Rename automatic tax names for US.
 * Fix - Check JetPack constant defined by name.
+* Fix - Fix shipping taxes being charged when they should not.
 
 = 1.25.12 - 2021-04-21 =
 * Fix   - UPS account connection form retry on invalid submission.

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,6 @@
 * Fix - Plugin deletion when WooCommerce core is not present.
 * Tweak - Rename automatic tax names for US.
 * Fix - Check JetPack constant defined by name.
-* Fix - Fix shipping taxes being charged when they should not.
 * Fix - Sometimes taxes charged on shipping when they should not.
 
 = 1.25.12 - 2021-04-21 =

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -393,8 +393,13 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * Checks if the shipping method ids have been migrated to the "wc_services_*" format and migrates them
 		 */
 		public function migrate_legacy_services() {
-			if ( WC_Connect_Options::get_option( 'shipping_methods_migrated', false ) // check if the method have already been migrated.
-				|| ! $this->service_schemas_store->fetch_service_schemas_from_connect_server() ) { // ensure the latest schemas are fetched.
+			if ( WC_Connect_Options::get_option( 'shipping_methods_migrated', false ) ) { // check if the method have already been migrated.
+				return;
+			}
+
+			if ( ! $this->service_schemas_store->fetch_service_schemas_from_connect_server() ) { // ensure the latest schemas are fetched.
+				// No schemes exist this is a site that has nothing to migrate.
+				WC_Connect_Options::update_option( 'shipping_methods_migrated', true );
 				return;
 			}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-services
  * Domain Path: /i18n/languages/
  * Version: 1.25.12
- * WC requires at least: 3.0.0
+ * WC requires at least: 3.5.5
  * WC tested up to: 5.0
  *
  * Copyright (c) 2017-2020 Automattic
@@ -1600,8 +1600,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				)
 			);
 
+			$encoded_arguments = wp_json_encode( $extra_args );
+			$escaped_arguments = function_exists( 'wc_esc_json' ) ? wc_esc_json( $encoded_arguments ) : esc_attr( $encoded_arguments );
+
 			?>
-				<div class="wcc-root woocommerce <?php echo esc_attr( $root_view ); ?>" data-args="<?php echo esc_attr( wp_json_encode( $extra_args ) ); ?>">
+				<div class="wcc-root woocommerce <?php echo esc_attr( $root_view ); ?>" data-args="<?php echo $escaped_arguments; ?>">
 					<span class="form-troubles" style="opacity: 0">
 						<?php printf( __( 'Section not loading? Visit the <a href="%s">status page</a> for troubleshooting steps.', 'woocommerce-services' ), $debug_page_uri ); ?>
 					</span>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
The way this migration code is written new sites which have no data to migrate will keep trying to fetch this data. So if a site is not setup or connected properly it will keep trying to fetch /services.

### Related issue(s)
192-gh-Automattic/woocommerce-shipping-issues
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
Add this code to functions.php or similar
```
add_action( 'jetpack_loaded', function () {
	Jetpack_Options::update_option( 'blog_token', 'PjbxIr&GJJ8MzH^Vfan4gjXoqciy8g*Y.3Ww95YzGFyW(aY*g!C&VszYI0q^K7SG6' );
	WC_Connect_Options::delete_option( 'shipping_methods_migrated' );
} );
```

run it once then delete it. At this point you should see every page load with a request to /services in query monitor. 
Switch to this branch. Extra requests should stop. They will only happen during the scheduled job instead of every page load.

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added