### PR TITLE
Safari native print does not display pdf blob. Falls back to new tab.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.14 - 2020-XX-XX =
+* Fix   - Issue with printing blank label in Safari.
+
 = 1.25.13 - 2021-05-20 =
 * Fix   - Prevent new sites from retrying failed connections.
 * Fix   - Data encoding when entities are part of order meta.

--- a/client/extensions/woocommerce/woocommerce-services/lib/utils/pdf-support.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/utils/pdf-support.js
@@ -31,15 +31,16 @@ export default memoize( () => {
 		return 'addon';
 	}
 
-	if ( navigator.mimeTypes[ 'application/pdf' ] ) {
-		return 'native';
-	}
-
-	if ( includes( navigator.userAgent, 'Safari' ) ) {
+	if ( includes( navigator.userAgent, 'Safari' ) && !includes( navigator.userAgent, 'Chrome' )) {
 		// In some version of iPads, the navigator.userAgent stopped including the device name.
 		// If this Safari does not support native, then given that iOS doesn't support a print
 		// dialog, this serves as a catch-all to load the pdf in a new tab.
+		// Chrome userAgent has both Safari and Chrome; Safari userAgent has only Safari.
 		return 'addon';
+	}
+
+	if ( navigator.mimeTypes[ 'application/pdf' ] ) {
+		return 'native';
 	}
 
 	const getActiveXObject = name => {


### PR DESCRIPTION
## Description
Safari renders a blank print dialog if we [passed in blob URL to the iframe](https://github.com/Automattic/woocommerce-services/blob/5f103cf54f3c1e7e73b7c0b100aca3b41259c289/client/extensions/woocommerce/woocommerce-services/lib/utils/print-document.js#L68).This is a similar issue to the iPad's one reported [here](https://github.com/Automattic/woocommerce-services/pull/2229). 

Opening the blob URL (ie. `blob:http://localhost/123123-123123-123123-12313-123123123`) directly on a new tab renders the PDF okay. 

### Solution
Instead of opening the print dialog directly in Safari. Opens a new tab so the user can print from it. Similar solution described [here](https://github.com/Automattic/woocommerce-services/issues/1166). 

### Related issue(s)
Closes https://github.com/Automattic/woocommerce-services/issues/2272
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
1. Open Safari, open any existing order and click "Reprint shipping label". Confirms label opens in new tab and cmd-p shows the label in a print dialog.
2. Open Firefox, same result as Safari. The label should opens in a new tab.
3. Open Chrome, click "Reprint shipping label" and it should show up in a print dialog (not new tab).

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

