### PR TITLE
feat: require custom forms for Puerto Rico

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.25.14 - 2020-XX-XX =
 * Fix   - Issue with printing blank label in Safari.
+* Fix   - DHL Express labels - require customs form when shipping to Puerto Rico.
 
 = 1.25.13 - 2021-05-20 =
 * Fix   - Prevent new sites from retrying failed connections.

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -194,25 +194,20 @@ export const isCustomsFormRequired = createSelector(
 		if ( isEmpty( form ) ) {
 			return false;
 		}
-		const origin = getAddressValues( form.origin );
-		const destination = getAddressValues( form.destination );
 
+		const origin = getAddressValues( form.origin );
 		// Special case: Any shipment from/to military addresses must have Customs
 		if ( 'US' === origin.country && includes( US_MILITARY_STATES, origin.state ) ) {
 			return true;
 		}
+
+		const destination = getAddressValues( form.destination );
 		if ( 'US' === destination.country && includes( US_MILITARY_STATES, destination.state ) ) {
 			return true;
 		}
+
 		// No need to have Customs if shipping inside the same territory (for example, from Guam to Guam)
-		if ( origin.country === destination.country ) {
-			return false;
-		}
-		// Shipments between US, Puerto Rico and Virgin Islands don't need Customs, everything else does
-		return (
-			! includes( DOMESTIC_US_TERRITORIES, origin.country ) ||
-			! includes( DOMESTIC_US_TERRITORIES, destination.country )
-		);
+		return origin.country !== destination.country;
 	},
 	( state, orderId, siteId = getSelectedSiteId( state ) ) => [ getForm( state, orderId, siteId ) ]
 );


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

In order to ship an item to Puerto Rico via DHL Express, the user needs to provide a Customs Form.
If the Customs Form information is not provided, the plugin would not return any rates.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Fixes https://github.com/Automattic/woocommerce-services/issues/2430

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

- Create a new product on your site (so that it doesn't have any customs info metadata saved)
- Create an order for the product
- Try and ship it to an address in Puerto Rico (e.g.: `1077 AVE ASHFORD, SAN JUAN, 00907-1128, Puerto Rico`) - make sure to include the phone number
- You should get asked for the customs form information while getting rates (you weren't shown the modal, before)
- You should now get DHL Express labels (you didn't before)

Before - no customs form, no DHL Express rates:
![Screen Shot 2021-06-09 at 4 50 08 PM](https://user-images.githubusercontent.com/273592/121434347-ce3c1280-c942-11eb-9fdc-40a2270a9728.png)

After - customs form, DHL Express rates:
![Screen Shot 2021-06-09 at 4 51 17 PM](https://user-images.githubusercontent.com/273592/121434415-ed3aa480-c942-11eb-977e-157772f6daa7.png)


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

