### PR TITLE
fix: shipping metabox user permissions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,9 @@
 = 1.25.14 - 2020-XX-XX =
 * Fix   - Issue with printing blank label in Safari.
 * Fix   - Update DHL Express pickup link.
+* Fix   - Ensure shipping label metabox is displayed to users with the correct capabilities.
+* Add   - Added `wcship_user_can_manage_labels` filter to check permissions to print shipping labels.
+* Add   - Added `wcship_manage_labels` capability to check permissions to print shipping labels.
 
 = 1.25.13 - 2021-05-20 =
 * Fix   - Prevent new sites from retrying failed connections.

--- a/classes/class-wc-connect-functions.php
+++ b/classes/class-wc-connect-functions.php
@@ -83,5 +83,17 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 
 			return false;
 		}
+
+		/**
+		 * Checks whether the current user has permissions to manage shipping labels.
+		 *
+		 * @return boolean
+		 */
+		public static function user_can_manage_labels() {
+			/**
+			 * @since 1.25.14
+			 */
+			return apply_filters( 'wcship_user_can_manage_labels', current_user_can( 'manage_woocommerce' ) || current_user_can( 'wcship_manage_labels' ) );
+		}
 	}
 }

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -431,6 +431,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		}
 
 		private function calculate_should_show_meta_box() {
+			// not all users have the permission to manage shipping labels.
+			// if a request is made to the JS backend and the user doesn't have permission, an error would be displayed.
+			if ( ! WC_Connect_Functions::user_can_manage_labels() ) {
+				return false;
+			}
+
 			$order = wc_get_order();
 
 			if ( ! $order ) {

--- a/classes/class-wc-rest-connect-address-normalization-controller.php
+++ b/classes/class-wc-rest-connect-address-normalization-controller.php
@@ -62,7 +62,7 @@ class WC_REST_Connect_Address_Normalization_Controller extends WC_REST_Connect_B
 		$data = $request->get_json_params();
 
 		if ( 'origin' === $data['type'] ) {
-			return current_user_can( 'manage_woocommerce' ); // Only an admin can normalize the origin address
+			return WC_Connect_Functions::user_can_manage_labels(); // Only an admin can normalize the origin address
 		}
 
 		return true; // non-authenticated service for the 'destination' address

--- a/classes/class-wc-rest-connect-base-controller.php
+++ b/classes/class-wc-rest-connect-base-controller.php
@@ -149,7 +149,7 @@ abstract class WC_REST_Connect_Base_Controller extends WP_REST_Controller {
 	 * Validate the requester's permissions
 	 */
 	public function check_permission( $request ) {
-		return current_user_can( 'manage_woocommerce' );
+		return WC_Connect_Functions::user_can_manage_labels();
 	}
 
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Little tiny itty bitty fix to check the user's permission to display the metabox to print shipping labels.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

closes https://github.com/Automattic/woocommerce-services/issues/2433

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

**Without the fix**
- Download a plugin to manage user capabilities, like https://wordpress.org/plugins/leira-roles/ or https://wordpress.org/plugins/user-role-editor/
- Create a user without the `manage_woocommerce` permission
- Go to an order page with shipping labels
- You get an error
![Screen Shot 2021-06-11 at 12 53 27 PM](https://user-images.githubusercontent.com/273592/121729441-1a5a9480-cab4-11eb-9709-b31193632afd.png)


**With the fix**
- Download a plugin to manage user capabilities, like https://wordpress.org/plugins/leira-roles/ or https://wordpress.org/plugins/user-role-editor/
- Create a user without the `manage_woocommerce` permission
- Go to an order page with shipping labels
- No error is displayed
- No shipping label/shipment tracking metabox is displayed
![Screen Shot 2021-06-11 at 12 57 47 PM](https://user-images.githubusercontent.com/273592/121730003-bbe1e600-cab4-11eb-91ce-7814671748ac.png)

---

- Add a new `wcship_manage_labels` capability
- Assign it to the user
- For the same order, user can now print/refund labels and add custom packages

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

