### PR TITLE
Fix/2436 tracking x icon

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/tracking-modal/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/tracking-modal/index.js
@@ -24,6 +24,11 @@ import {
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 import ActivityLog from '../../../../app/order/order-activity-log/events';
 
+/**
+ * Style dependencies
+ */
+ import './style.scss';
+
 const TrackingModal = props => {
 	const { loaded, translate } = props;
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/tracking-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/tracking-modal/style.scss
@@ -1,0 +1,14 @@
+.tracking-modal__header {
+    display: flex;
+    flex-direction: row;
+}
+
+.tracking-modal__close-button {
+    align-self: flex-start;
+    padding: 0;
+    border: 0;
+}
+
+.form-section-heading {
+    flex: 1;
+}


### PR DESCRIPTION
## Description
Move the 'x' icon back to top-right using flex box.

### Related issue(s)
Closes https://github.com/Automattic/woocommerce-services/issues/2436

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
1. Create a shipping label. 
2. Click on tracking 
![image](https://user-images.githubusercontent.com/572862/123702090-f15e3180-d81f-11eb-9137-44b4edd0f14a.png)
3. The 'x' icon should be at top right
![image](https://user-images.githubusercontent.com/572862/123703166-40589680-d821-11eb-8995-fd1845651b89.png)

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added

