### PR TITLE
Update WP version used by E2E tests to 5.7.2

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -7,7 +7,7 @@ jobs:
     name: Build Container and Run E2E Tests
     runs-on: ubuntu-18.04
     env:
-      WP_VERSION: 5.6
+      WP_VERSION: 5.7.2
       TRAVIS_MARIADB_VERSION: 10.5.5
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

E2E tests are currently failing. Updating WP version used by the tests to 5.7.2 resolves the issue.