### PR TITLE
Do not fail on `npm run update-deps` if npm-shrinkwrap.json is missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "release": "node tasks/release.js",
     "i18n": "cross-env NODE_ENV=i18n DISABLE_FEATURES=wpcom-user-bootstrap CALYPSO_CLIENT=true webpack && node tasks/i18n",
     "i18njson": "node tasks/i18njson",
-    "update-deps": "rm npm-shrinkwrap.json && rm -rf node_modules && npm install && npm shrinkwrap",
+    "update-deps": "rm -f npm-shrinkwrap.json && rm -rf node_modules && npm install && npm shrinkwrap",
     "build": "echo yes | npm run release && cp release/woocommerce-services.zip ./",
 	"up": "docker-compose up --build --force-recreate -d && ./bin/docker-setup.sh",
 	"down": "docker-compose down",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

This is a tiny change that will allow the `npm run update-deps` script to proceed if `npm-shrinkwrap.json` is missing.

Previously if you ran `npm run update-deps` and something failed, you could end up with a missing `npm-shrinkwrap.json`. If you then retried `npm run update-deps`, the script would fail because `rm npm-shrinkwrap.json && ...` would fail.

Replacing `rm` with `rm -f` resolves this. 