### PR TITLE
Fix country drop down showing currency name

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.19 - 2021-xx-xx =
+* Fix   - Country drop down list no longer showing currency name.
+
 = 1.25.18 - 2021-08-16 =
 * Add   - Added "Automated Taxes" health item on status page.
 * Fix   - Show error when missing required destination phone for international shipments.

--- a/classes/class-wc-connect-continents.php
+++ b/classes/class-wc-connect-continents.php
@@ -59,7 +59,7 @@ class WC_Connect_Continents {
 						)
 					);
 
-					$country = array_merge( $country, $country_data );
+					$country = array_merge( $country_data, $country );
 				}
 
 				$local_states = array();

--- a/readme.txt
+++ b/readme.txt
@@ -76,6 +76,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 1.25.19 - 2021-xx-xx =
+* Fix   - Country drop down list no longer showing currency name.
+
 = 1.25.18 - 2021-08-16 =
 * Add   - Added "Automated Taxes" health item on status page.
 * Fix   - Show error when missing required destination phone for international shipments.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
It was discovered that the shipping label purchase modal was showing a currency name instead of the country name when using the latest WooCommerce version. This was the result of the changes in https://github.com/woocommerce/woocommerce/pull/30216 where some locale info keys were added. The culprit was the addition of the name key to the locale info which was then overwriting the country name key when we did an array merge. 

I went with what seemed like the cleanest fix by just changing the order of the arrays in the merge so that the country information will always override the locale (essentially currency) information in case they share a key. This allowed the country name to remain in the name key and shows the proper country name in the drop down.


### Related issue(s)
Fixes #2477 

### Steps to reproduce & screenshots/GIFs

1. Setup local site with latest version of WCShip and WC 5.7.1.
2. Create a new order and attempt to purchase a label for the order.
3. Note that the country fields inside the Origin address and Destination address both contain the correct country names now.
4. Set Destination address to an international address. Note that Origin country field on customs form is filled in with the correct country name.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

