### PR TITLE
feat: add notice about tax nexus in settings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.19 - 2021-xx-xx =
+* Add - Notice about tax nexus in settings.
+
 = 1.25.18 - 2021-08-16 =
 * Add   - Added "Automated Taxes" health item on status page.
 * Fix   - Show error when missing required destination phone for international shipments.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -174,11 +174,21 @@ class WC_Connect_TaxJar_Integration {
 	public function add_tax_settings( $tax_settings ) {
 		$enabled = $this->is_enabled();
 
-		$automated_taxes = array(
+		$powered_by_wct_notice       = '<p>' . __( 'Powered by WooCommerce Tax. If automated taxes are enabled, you\'ll need to enter prices exclusive of tax.', 'woocommerce-services' ) . '</p>';
+		$desctructive_action_notice  = '<p>' . __( 'Enabling this option overrides any tax rates you have manually added.', 'woocommerce-services' ) . '</p>';
+		$tax_nexus_notice            = '<p>' . $this->get_tax_tooltip() . '</p>';
+		$automated_taxes_description = join(
+			'',
+			$enabled ? [
+				$powered_by_wct_notice,
+				$tax_nexus_notice,
+			] : [ $desctructive_action_notice, $tax_nexus_notice ]
+		);
+		$automated_taxes             = array(
 			'title'    => __( 'Automated taxes', 'woocommerce-services' ),
 			'id'       => self::OPTION_NAME, // TODO: save in `wc_connect_options`?
 			'desc_tip' => $this->get_tax_tooltip(),
-			'desc'     => $enabled ? '<p>' . __( 'Powered by WooCommerce Tax. If automated taxes are enabled, you\'ll need to enter prices exclusive of tax.', 'woocommerce-services' ) . '</p>' : '',
+			'desc'     => $automated_taxes_description,
 			'default'  => 'no',
 			'type'     => 'select',
 			'class'    => 'wc-enhanced-select',


### PR DESCRIPTION
## Description
I'd like to elevate the notice about the tax nexus in the settings.
It seems that it might not be clear to merchants that taxes are calculated for a single nexus.

With the setting disabled:
![Screen Shot 2021-10-06 at 6 11 41 PM](https://user-images.githubusercontent.com/273592/136296472-bdd9dddd-8ecd-4e24-9e3e-572997e596c4.png)

With the setting enabled:
![Screen Shot 2021-10-06 at 6 10 52 PM](https://user-images.githubusercontent.com/273592/136296495-1e5bf6b5-efde-4a27-a0dc-5250069b1446.png)

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

- Go to http://localhost:8050/wp-admin/admin.php?page=wc-settings&tab=tax
- The plugin now has the notice about the tax nexus elevated next to the setting.

The link goes to the WC docs, but I'm not sure where the anchor went.
The information is already presented in the tooltip, I'm just "elevating" it so that it becomes more visible.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added

