### PR TITLE
Update WP to at least 5.6

### DIFF
--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -46,7 +46,7 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     strategy:
       matrix:
-        wp-version: [5.6, 5.7, latest]
+        wp-version: [latest]
         wc-version: ${{ fromJSON(needs.find_wc_latest_versions.outputs.matrix) }}
     steps:
       - name: Checkout latest WCS

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -46,7 +46,7 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     strategy:
       matrix:
-        wp-version: [latest]
+        wp-version: [5.7.3, latest]
         wc-version: ${{ fromJSON(needs.find_wc_latest_versions.outputs.matrix) }}
     steps:
       - name: Checkout latest WCS

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -46,7 +46,7 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     strategy:
       matrix:
-        wp-version: [5.4.4, 5.5.3, latest]
+        wp-version: [5.6, 5.7, latest]
         wc-version: ${{ fromJSON(needs.find_wc_latest_versions.outputs.matrix) }}
     steps:
       - name: Checkout latest WCS

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -46,7 +46,7 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     strategy:
       matrix:
-        wp-version: [5.7.3, latest]
+        wp-version: [5.6.5, 5.7.3, latest]
         wc-version: ${{ fromJSON(needs.find_wc_latest_versions.outputs.matrix) }}
     steps:
       - name: Checkout latest WCS


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Update WP version to 5.6 in the CI matrix. The current L-2 WC version is `['5.6.1','5.7.1','5.8.0']`. WC 5.6.1 requires [at least WP 5.6](https://github.com/woocommerce/woocommerce/blob/5.6.1/woocommerce.php#L11).

Fixes https://github.com/Automattic/woocommerce-services/issues/2492