### PR TITLE
Fix/issue 2490 - Add 3 digits currency code for non USD order in shipping label price

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.20 - 2021-xx-xx =
+* Fix - Added 3 digits currency code on shipping label price for non USD.
+
 = 1.25.19 - 2021-10-14 =
 * Add - Notice about tax nexus in settings.
 * Fix - Country drop down list no longer showing currency name.

--- a/client/extensions/woocommerce/lib/order-values/index.js
+++ b/client/extensions/woocommerce/lib/order-values/index.js
@@ -104,6 +104,6 @@ export function getOrderTotalTax( order ) {
  * @param {Object} order An order as returned from API
  * @return {String} Currency value
  */
- export function getOrderCurrency( order ) {
+export function getOrderCurrency( order ) {
 	return get( order, 'currency', false );
 }

--- a/client/extensions/woocommerce/lib/order-values/index.js
+++ b/client/extensions/woocommerce/lib/order-values/index.js
@@ -97,3 +97,13 @@ export function getOrderTotalTax( order ) {
 	const fees = getOrderFeeTotalTax( order );
 	return subtotal + shipping + fees;
 }
+
+/**
+ * Get the currency value in order
+ *
+ * @param {Object} order An order as returned from API
+ * @return {String} Currency value
+ */
+ export function getOrderCurrency( order ) {
+	return get( order, 'currency', false );
+}

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
@@ -30,7 +30,10 @@ import {
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 import { getAllPackageDefinitions } from 'woocommerce/woocommerce-services/state/packages/selectors';
 import { getOrderShippingTotal } from 'woocommerce/lib/order-values/totals';
-import { getOrderShippingMethod } from 'woocommerce/lib/order-values';
+import { 
+	getOrderShippingMethod,
+	getOrderCurrency
+} from 'woocommerce/lib/order-values';
 import { getOrder } from 'woocommerce/state/sites/orders/selectors';
 
 
@@ -97,12 +100,15 @@ const getRatesStatus = ( { retrievalInProgress, errors, available, form } ) => {
 };
 
 const showCheckoutShippingInfo = props => {
-	const { shippingMethod, shippingCost, translate } = props;
+	const { shippingMethod, shippingCost, translate, currency } = props;
 
 	// Use a temporary HTML element in order to let the DOM API convert HTML entities into text
 	const shippingMethodDiv = document.createElement( 'div' );
 	shippingMethodDiv.innerHTML = shippingMethod;
 	const decodedShippingMethod = shippingMethodDiv.textContent;
+
+	// Add suffix for non USD.
+	const shippingCostSuffix = ( typeof currency != 'undefined' && 'USD' !== currency ) ? currency : '';
 
 	if ( shippingMethod ) {
 		let shippingInfo;
@@ -117,7 +123,7 @@ const showCheckoutShippingInfo = props => {
 						),
 						shippingCost: (
 							<span className="rates-step__shipping-info-cost">
-								{ formatCurrency( shippingCost, 'USD' ) }
+								{ formatCurrency( shippingCost, currency ) } { shippingCostSuffix }
 							</span>
 						),
 					},
@@ -153,6 +159,7 @@ const RatesStep = props => {
 		errors,
 		ratesTotal,
 		translate,
+		currency,
 	} = props;
 	const summary = ratesSummary( values, available, ratesTotal, form.packages.saved, translate );
 	const toggleStepHandler = () => props.toggleStep( orderId, siteId, 'rates' );
@@ -186,6 +193,7 @@ const RatesStep = props => {
 				id="rates"
 				orderId={ orderId }
 				siteId={ siteId }
+				currency={ currency }
 				showRateNotice={ false }
 				selectedPackages={ form.packages.selected }
 				allPackages={ allPackages }
@@ -223,6 +231,7 @@ const mapStateToProps = ( state, { orderId, siteId } ) => {
 		allPackages: getAllPackageDefinitions( state, siteId ),
 		shippingCost: getOrderShippingTotal( order ),
 		shippingMethod: getOrderShippingMethod( order ),
+		currency: getOrderCurrency( order ),
 	};
 };
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
@@ -33,6 +33,7 @@ const renderRateNotice = translate => {
 
 export const ShippingRates = ( {
 	id,
+	currency,
 	selectedRates, // Store owner selected rates, not customer
 	availableRates,
 	selectedPackages,
@@ -69,6 +70,7 @@ export const ShippingRates = ( {
 						return <ShippingRate
 							id={ id + '_' + pckgId }
 							key={ id + '_' + pckgId + '_' + service_id }
+							currency={ currency }
 							rateObject={ serviceRateObject }
 							signatureRates={ getSignatureServiceRates( pckgId, service_id, availableRates ) }
 							updateValue={ onRateUpdate }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/shipping-rate.js
@@ -89,6 +89,7 @@ class ShippingRate extends Component {
 			},
 			isSelected,
 			updateValue,
+			currency,
 			signatureRates,
 		} = this.props;
 		const { selectedSignature } = this.state;
@@ -119,6 +120,9 @@ class ShippingRate extends Component {
 		}
 
 		const ratePlusSignatureCost = selectedSignature ? rate + selectedSignature.netCost : rate;
+
+		// Add suffix for non USD.
+		const formattedRatePlusSignatureCost = ( typeof currency != 'undefined' && 'USD' !== currency ) ? formatCurrency( ratePlusSignatureCost, 'USD' ) + ' USD' : formatCurrency( ratePlusSignatureCost, 'USD' );
 
 		return(
 			<div className="rates-step__shipping-rate-container">
@@ -157,7 +161,7 @@ class ShippingRate extends Component {
 									</Tooltip>
 									: null
 							}
-							{ formatCurrency( ratePlusSignatureCost, 'USD' ) }
+							{ formattedRatePlusSignatureCost }
 						</div>
 						<div className="rates-step__shipping-rate-delivery-date">{ deliveryDateMessage }</div>
 					</div>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Get the currency information from the order meta and add a conditional to display 3 digits currency code in shipping label price for non USD currency.

### Related issue(s)

Fixes #2490
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: [close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

1. Install WooCommerce Payments and enable the multi-currency feature from this [page](http://localhost:8050/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments).
![screenshot-localhost_8050-2021 11 04-15_54_19](https://user-images.githubusercontent.com/631098/140285337-8d2cf411-657d-4912-bd5e-4d7ba3572869.png)
2. Go to [WooCommerce >> Settings >> Multi-Currency](http://localhost:8050/wp-admin/admin.php?page=wc-settings&tab=wcpay_multi_currency) and set the settings like the screenshot below :
![screenshot-localhost_8050-2021 11 04-15_57_01](https://user-images.githubusercontent.com/631098/140285644-7b0b88af-c300-4b67-90b9-563a54499edc.png)
3. Order any item using EUR currency.
4. Attempt to create the shipping label from order edit page.
5. Notice the 3 digits currency code is added in Shipping label price.
![screenshot-localhost_8050-2021 11 04-16_00_14](https://user-images.githubusercontent.com/631098/140286095-0a349f8f-3486-44fd-8650-40184a551fe2.png)

### Checklist

<!-- All testable code should have tests. -->
- [] unit tests

<!-- An entry in the changelog file is always required -->
- [x] changelog.txt entry added