### PR TITLE
Fix/issue 2463 - Strip TaxJar zipcode spaces and dashes before inserting into DB.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 1.25.20 - 2021-xx-xx =
-* Fix - Hide "Shipping Label" and "Shipment Tracking" metabox when the label setting is disabled. 
+* Fix - Hide "Shipping Label" and "Shipment Tracking" metabox when the label setting is disabled.
+* Fix - Wrap TaxJar API zipcodes with wc_normalize_postcode() before inserting into the database.
 
 = 1.25.19 - 2021-10-14 =
 * Add - Notice about tax nexus in settings.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1094,7 +1094,7 @@ class WC_Connect_TaxJar_Integration {
 			$this->_log( ':: Adding New Tax Rate ::' );
 			$this->_log( $tax_rate );
 			$rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
-			WC_Tax::_update_tax_rate_postcodes( $rate_id, wc_clean( $location['to_zip'] ) );
+			WC_Tax::_update_tax_rate_postcodes( $rate_id, wc_normalize_postcode( wc_clean( $location['to_zip'] ) ) );
 			WC_Tax::_update_tax_rate_cities( $rate_id, wc_clean( $location['to_city'] ) );
 		}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
Swedish postcodes contain 3 characters, a space, then 2 more characters. The TaxJar integration class was adding these postcodes to the woocommerce_tax_rate_locations db table as is without running them through the wc_normalize_postcode() function first. This fix runs the postcodes through that function before saving to the db, solving the issue where Swedish tax rate postcodes could not be matched due to inconsistent formatting.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
Fixes #2463.

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
1. Follow the steps to reproduce outlined [here](https://github.com/Automattic/woocommerce-services/issues/2463).
2. The tax rates should now be working at checkout, even if the postcode contains a space.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

