### PR TITLE
Fix/issue 2475 - WC Subscriptions API to be called when "x-woo-signature" header is added.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.25.20 - 2021-xx-xx =
 * Fix - Hide "Shipping Label" and "Shipment Tracking" metabox when the label setting is disabled.
 * Fix - Update shipping label to only show non-refunded order line items.
+* Fix - Only call WC Subscriptions API when "access_token_secret" value is saved in database.
 
 = 1.25.19 - 2021-10-14 =
 * Add - Notice about tax nexus in settings.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,11 +1,13 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.21 - 2021-xx-xx =
+* Fix - Only call WC Subscriptions API when "access_token_secret" value is saved in database.
+
 = 1.25.20 - 2021-11-15 =
 * Fix - Hide "Shipping Label" and "Shipment Tracking" metabox when the label setting is disabled.
 * Fix - Wrap TaxJar API zipcodes with wc_normalize_postcode() before inserting into the database.
 * Fix - Update shipping label to only show non-refunded order line items.
 * Fix - Added 3 digits currency code on shipping label price for non USD.
-* Fix - Only call WC Subscriptions API when "access_token_secret" value is saved in database.
 
 = 1.25.19 - 2021-10-14 =
 * Add - Notice about tax nexus in settings.

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -91,10 +91,13 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 				$extra_args['carrier_accounts'] = $carriers_response->carriers;
 			}
 
-			$subscriptions_usage_response = $this->api_client->get_wccom_subscriptions();
+			// check the helper auth before calling wccom subscription api.
+			if ( ! is_wp_error( WC_Connect_Functions::get_wc_helper_auth_info() ) ) {
+				$subscriptions_usage_response = $this->api_client->get_wccom_subscriptions();
 
-			if ( ! is_wp_error( $subscriptions_usage_response ) && ! empty( $subscriptions_usage_response->subscriptions ) ) {
-				$extra_args['subscriptions'] = $subscriptions_usage_response->subscriptions;
+				if ( ! is_wp_error( $subscriptions_usage_response ) && ! empty( $subscriptions_usage_response->subscriptions ) ) {
+					$extra_args['subscriptions'] = $subscriptions_usage_response->subscriptions;
+				}
 			}
 
 			if ( isset( $_GET['from_order'] ) ) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description

To make sure the WC Subscriptions API is called when "x-woo-signature" value is added in the header. 

### Related issue(s)

Fixes : #2475 

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

1. Install query monitor plugins.
2. Go to `/wp-admin/admin.php?page=wc-addons&section=helper`.
3. Make sure the site is not connected to WooCommerce.com.
4. Click WooCommerce >> Settings >> Shipping.
5. Click on "WooCommerce Shipping" option.
6. Observe that "HTTP API Calls" error is not triggered.
![screenshot-localhost_8050-2021 11 10-17_48_31](https://user-images.githubusercontent.com/631098/141099961-95955a6c-20bd-4387-ac61-f323ac75544a.png)


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

