### PR TITLE
Fix/issue 2473 - Display company if the field is filled.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Wrap TaxJar API zipcodes with wc_normalize_postcode() before inserting into the database.
 * Fix - Update shipping label to only show non-refunded order line items.
 * Fix - Added 3 digits currency code on shipping label price for non USD.
+* Fix - Display company name under origin and destination address when create shipping label.
 
 = 1.25.19 - 2021-10-14 =
 * Add - Notice about tax nexus in settings.

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/summary.js
@@ -45,6 +45,7 @@ const AddressSummary = ( {
 		);
 	};
 
+	const displayCompany = ( '' !== getValue( 'company' ) ) ? ( <p>{ getValue( 'company' ) }</p> ) : '';
 	const displayState = getValue( 'state' );
 	const cityStateAndPostcode = filter( [
 		getValue( 'city' ),
@@ -59,6 +60,7 @@ const AddressSummary = ( {
 	return (
 		<div className="address-step__summary">
 			<p>{ getValue( 'name' ) }</p>
+			{ displayCompany }
 			<p>
 				{ getValue( 'address' ) } { getValue( 'address_2' ) }
 			</p>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
Display the company information in the shipping label step if the "Company" field is filled by the user.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
Fixes #2473 

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
1. Attempt to print a shipping label.
2. Edit the origin or destination address.
<img width="1225" alt="68747470733a2f2f642e70722f692f486d774269742b" src="https://user-images.githubusercontent.com/631098/141266129-95e5aff6-444c-425e-a968-dbcda935208b.png">

3. Click "Verify Address" button.
4. Notice the company name is displayed :
![screenshot-localhost_8050-2021 11 11-15_44_56](https://user-images.githubusercontent.com/631098/141266663-bffbf7f1-f27f-435e-9ba8-8fef2f157b91.png)
5. Confirm that the actual label itself includes the company name:
<img width="744" alt="68747470733a2f2f642e70722f692f634f46334e452b" src="https://user-images.githubusercontent.com/631098/141266867-ee72cf2a-c620-43c2-bdd7-8c6cf020237c.png">

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

