### PR TITLE
Fix/issue 2503 - Define WP_TESTS_PHPUNIT_POLYFILLS_PATH in bootstrap.php

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Wrap TaxJar API zipcodes with wc_normalize_postcode() before inserting into the database.
 * Fix - Update shipping label to only show non-refunded order line items.
 * Fix - Added 3 digits currency code on shipping label price for non USD.
+* Fix - Defined WP_TESTS_PHPUNIT_POLYFILLS_PATH in PHPUnit bootstrap.php.
 
 = 1.25.19 - 2021-10-14 =
 * Add - Notice about tax nexus in settings.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,8 @@
 {
     "require-dev": {
         "woocommerce/woocommerce-sniffs": "^0.1.0",
-        "phpunit/phpunit": "6.5.14"
+        "phpunit/phpunit": "6.5.14",
+        "yoast/phpunit-polyfills": "^1.0"
     },
     "scripts": {
 		"test": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d818ac03ab34b8badf57592ac9127a62",
+    "content-hash": "414e6a8c09a9bb4c4335cffc3f6afbe4",
     "packages": [],
     "packages-dev": [
         {
@@ -2105,6 +2105,67 @@
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
             "time": "2020-05-13T23:57:56+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a582ab1d91e86aa450340c4d35631a85314ff9f",
+                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "yoast/yoastcs": "^2.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2021-10-03T08:40:26+00:00"
         }
     ],
     "aliases": [],
@@ -2114,5 +2175,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -8,10 +8,18 @@
  */
 
 /**
+ * Support for the PHPUnit Polyfills library
+ */
+if ( ! defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) ) {
+	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', dirname( __FILE__ ) . '/../../vendor/yoast/phpunit-polyfills/' );
+}
+
+/**
  * Support for:
  * 1. `WC_DEVELOP_DIR` environment variable.
  * 2. Tests checked out to /tmp.
  */
+
 if ( false !== getenv( 'WC_DEVELOP_DIR' ) ) {
 	$wc_root = getenv( 'WC_DEVELOP_DIR' );
 } elseif ( file_exists( '/tmp/woocommerce/tests/legacy/bootstrap.php' ) ) {

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -19,7 +19,6 @@ if ( ! defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) ) {
  * 1. `WC_DEVELOP_DIR` environment variable.
  * 2. Tests checked out to /tmp.
  */
-
 if ( false !== getenv( 'WC_DEVELOP_DIR' ) ) {
 	$wc_root = getenv( 'WC_DEVELOP_DIR' );
 } elseif ( file_exists( '/tmp/woocommerce/tests/legacy/bootstrap.php' ) ) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
PHPUnit tests were no longer working due to a compatibility issue with the WP test suite. This fixes that incompatibility by adding a required constant that defines the path to the PHPUnit Polyfills library.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
Fixes #2503.
### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
PHPUnit tests should no longer show the error described in issue #2503 
### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

