### PR TITLE
Fix/issue 2480 - Use 'native' pdf support feature for Firefox version 94 or later.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.21 - 2021-xx-xx =
+* Fix - Use 'native' pdf support feature for Firefox version 94 or later.
+
 = 1.25.20 - 2021-11-15 =
 * Fix - Hide "Shipping Label" and "Shipment Tracking" metabox when the label setting is disabled.
 * Fix - Wrap TaxJar API zipcodes with wc_normalize_postcode() before inserting into the database.

--- a/client/extensions/woocommerce/woocommerce-services/lib/utils/pdf-support.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/utils/pdf-support.js
@@ -26,9 +26,14 @@ export default memoize( () => {
 	}
 
 	if ( includes( navigator.userAgent, 'Firefox' ) ) {
-		// Firefox has a long-lived bug (https://bugzilla.mozilla.org/show_bug.cgi?id=911444),
-		// it's not reliable to consider its PDF reader "native"
-		return 'addon';
+		// Use native for Firefox with version > 94
+		if ( parseFloat( navigator.userAgent.split('Firefox/')[1] ) >= 94 ) {
+			return 'native';
+		
+		// Use 'addon' for Firefox with version < 94 as it is still not fully tested and might have a long-lived bug (https://bugzilla.mozilla.org/show_bug.cgi?id=911444),
+		} else {
+			return 'addon';
+		}
 	}
 
 	if ( includes( navigator.userAgent, 'Safari' ) && !includes( navigator.userAgent, 'Chrome' )) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Originally, the plugin need to use blob in Firefox because there is some concern with the browser's PDF reader reliability based on [this comment](https://github.com/Automattic/woocommerce-services/blob/c39f7c7cbb506830beb399d0e326f19d30620100/client/extensions/woocommerce/woocommerce-services/lib/utils/pdf-support.js#L29-L30). **It seems Firefox is not stable enough to do direct printing for PDF file because of this [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=911444).**

However, I did some testing by changing this [code](https://github.com/Automattic/woocommerce-services/blob/c39f7c7cbb506830beb399d0e326f19d30620100/client/extensions/woocommerce/woocommerce-services/lib/utils/pdf-support.js#L31) into `return 'native';` and try to print the label using **Firefox (version 94)** native PDF reader.
**The result** : I can print the PDF label without any issue.
**Screenshot** : https://paste.pics/8e10a4a6fc880f66c221bb775473c96a

This PR is to change the PDF support for Firefox ver. 94 to use `native` instead of `addon`.
### Related issue(s)

Fixes #2480 
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

1. Start with a store with an order with a shipping label created.
2. Using Firefox, log in to the store as the merchant and go to the relevant order.
3. On the sidebar click on the label's menu and select reprint label.
4. In the modal click Print.
5. This should bring up a printing box like in this [screenshot](https://paste.pics/8e10a4a6fc880f66c221bb775473c96a).
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Another scenario that needs to be tested : 

1. Try to test this PR in different OS : MacOS, Windows, Linux.
2. Try to test this PR in later version of Firefox.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

