### PR TITLE
Fix/wc connect server issue 1812 - To make name field optional if company field is not empty

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,10 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 1.25.21 - 2021-xx-xx =
-* Fix - Only call WC Subscriptions API when "access_token_secret" value is saved in database.
-* Fix - Add name field to fields sent for EasyPost API address verification.
-* Fix - Display company name under origin and destination address when create shipping label.
+* Fix   - Only call WC Subscriptions API when "access_token_secret" value is saved in database.
+* Fix   - Add name field to fields sent for EasyPost API address verification.
+* Fix   - Display company name under origin and destination address when create shipping label.
+* Tweak - Make "Name" field optional if "Company" field is not empty.
 
 = 1.25.20 - 2021-11-15 =
 * Fix - Hide "Shipping Label" and "Shipment Tracking" metabox when the label setting is disabled.

--- a/classes/class-wc-rest-connect-address-normalization-controller.php
+++ b/classes/class-wc-rest-connect-address-normalization-controller.php
@@ -14,10 +14,11 @@ class WC_REST_Connect_Address_Normalization_Controller extends WC_REST_Connect_B
 	public function post( $request ) {
 		$data    = $request->get_json_params();
 		$address = $data['address'];
+		$name    = $address['name'];
 		$company = $address['company'];
 		$phone   = $address['phone'];
 
-		unset( $address['company'], $address['phone'] );
+		unset( $address['phone'] );
 
 		$body     = array(
 			'destination' => $address,
@@ -42,9 +43,8 @@ class WC_REST_Connect_Address_Normalization_Controller extends WC_REST_Connect_B
 			);
 		}
 
-		$response->normalized->company = $company;
-		$response->normalized->phone   = $phone;
-		$is_trivial_normalization      = isset( $response->is_trivial_normalization ) ? $response->is_trivial_normalization : false;
+		$response->normalized->phone = $phone;
+		$is_trivial_normalization    = isset( $response->is_trivial_normalization ) ? $response->is_trivial_normalization : false;
 
 		return array(
 			'success'                  => true,

--- a/classes/class-wc-rest-connect-address-normalization-controller.php
+++ b/classes/class-wc-rest-connect-address-normalization-controller.php
@@ -14,8 +14,6 @@ class WC_REST_Connect_Address_Normalization_Controller extends WC_REST_Connect_B
 	public function post( $request ) {
 		$data    = $request->get_json_params();
 		$address = $data['address'];
-		$name    = $address['name'];
-		$company = $address['company'];
 		$phone   = $address['phone'];
 
 		unset( $address['phone'] );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -223,14 +223,19 @@ export const isCustomsFormRequired = createSelector(
  */
  export const getRawAddressErrors = ( appState, addressData, siteId, fieldsToValidate ) => {
 	const { values } = addressData;
-	const { phone, postcode, state, country } = getAddressValues( addressData );
-	const requiredFields = [ 'name', 'address', 'city', 'postcode', 'country' ];
+	const { name, company, phone, postcode, state, country } = getAddressValues( addressData );
+	const requiredFields = [ 'address', 'city', 'postcode', 'country' ];
 	const errors = {};
 	requiredFields.forEach( field => {
 		if ( ! values[ field ] ) {
 			errors[ field ] = translate( 'This field is required' );
 		}
 	} );
+
+	if ( ! name && ! company ) {
+		errors.name = translate( 'This field is required if Company field empty' );
+		errors.company = translate( 'This field is required if Name field empty' );
+	}
 
 	if (
 		includes( ACCEPTED_USPS_ORIGIN_COUNTRIES, country ) &&

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -233,8 +233,8 @@ export const isCustomsFormRequired = createSelector(
 	} );
 
 	if ( ! name && ! company ) {
-		errors.name = translate( 'This field is required if Company field empty' );
-		errors.company = translate( 'This field is required if Name field empty' );
+		errors.name = translate( 'Either Name or Company field is required' );
+		errors.company = translate( 'Either Name or Company field is required' );
 	}
 
 	if (

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/selectors.js
@@ -557,7 +557,7 @@ describe( 'Shipping label selectors', () => {
 		[ 'country', '', true ],
 		[ 'country', 'Wonderland', false ],
 		[ 'phone', '', false ],
-		[ 'name', '', true ],
+		[ 'name', '', false ],
 		[ 'state', '', true ],
 
 		// States are selected in a dropdown and individual values are not validated
@@ -597,6 +597,24 @@ describe( 'Shipping label form validation', () => {
 		}
 	};
 	const appState = {};
+
+	it ( 'with no name entered and no company entered, return error', () => {
+		const fieldsToValidate = { destinationPhone: false };
+		const addressDataWithEmptyNameAndCompany = Object.assign( {}, addressData);
+		addressDataWithEmptyNameAndCompany.values.name = '';
+		addressDataWithEmptyNameAndCompany.values.company = '';
+		const errors = getRawAddressErrors( appState, addressDataWithEmptyNameAndCompany, siteId, fieldsToValidate );
+		expect( errors ).to.be.an( 'Object' ).and.to.have.property( 'name' );
+	} );
+
+	it ( 'with no company entered and no name entered, return error', () => {
+		const fieldsToValidate = { destinationPhone: false };
+		const addressDataWithEmptyNameAndCompany = Object.assign( {}, addressData);
+		addressDataWithEmptyNameAndCompany.values.name = '';
+		addressDataWithEmptyNameAndCompany.values.company = '';
+		const errors = getRawAddressErrors( appState, addressDataWithEmptyNameAndCompany, siteId, fieldsToValidate );
+		expect( errors ).to.be.an( 'Object' ).and.to.have.property( 'company' );
+	} );
 
 	it ( 'with no destination phone entered and destination phone required, return error', () => {
 		const fieldsToValidate = { destinationPhone: true };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
This PR is related to this [WC Connect Server PR #1895](https://github.com/Automattic/woocommerce-connect-server/pull/1895) . 
The intention for this PR is to make the name optional if the company's name is present.
This will allow clients to offer a better user experience for companies by allowing them to create shipping labels using the company's name only.

<!-- Explain the motivation for making this change -->

### Related issue(s)
Enhancement on [WC Connect Server Issue #1812](https://github.com/Automattic/woocommerce-connect-server/issues/1812)
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
1. Try to bump the version to 1.25.23 manually.
2. Create a new order.
3. Try to create a shipping label from order edit page in admin area.
4. When editing the address, leave the **Name** and **Company** field empty. It will show an error like in this screenshot :
![screenshot-localhost_8050-2021 11 26-19_16_54](https://user-images.githubusercontent.com/631098/143579938-de132951-6646-4f74-8c3f-681c7ba70739.png)
5. Input the name or company field and the error will not be displayed.
6. Try to purchase the label and make sure the label has all entered information.
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

