### PR TITLE
Fix/issue 2511

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Only call WC Subscriptions API when "access_token_secret" value is saved in database.
 * Fix - Add name field to fields sent for EasyPost API address verification.
 * Fix - Display company name under origin and destination address when create shipping label.
+* Fix - Add WCC version logic to address name validation functionality.
 
 = 1.25.20 - 2021-11-15 =
 * Fix - Hide "Shipping Label" and "Shipment Tracking" metabox when the label setting is disabled.

--- a/classes/class-wc-rest-connect-address-normalization-controller.php
+++ b/classes/class-wc-rest-connect-address-normalization-controller.php
@@ -19,6 +19,16 @@ class WC_REST_Connect_Address_Normalization_Controller extends WC_REST_Connect_B
 
 		unset( $address['company'], $address['phone'] );
 
+		/**
+		 * We only want to validate the name field if the API
+		 * version is greater than 5. If it's 5 or less
+		 * don't validate the name field.
+		 */
+		if ( WOOCOMMERCE_CONNECT_SERVER_API_VERSION <= 5 ) {
+			$name = $address['name'];
+			unset( $address['name'] );
+		}
+
 		$body     = array(
 			'destination' => $address,
 		);
@@ -40,6 +50,15 @@ class WC_REST_Connect_Address_Normalization_Controller extends WC_REST_Connect_B
 				'success'      => true,
 				'field_errors' => $response->field_errors,
 			);
+		}
+
+		/**
+		 * We only want to validate the name field if the API
+		 * version is greater than 5. If it's 5 or less
+		 * don't validate the name field.
+		 */
+		if ( WOOCOMMERCE_CONNECT_SERVER_API_VERSION <= 5 ) {
+			$response->normalized->name = $name;
 		}
 
 		$response->normalized->company = $company;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
We needed to add logic to ensure the connect server only validates the address name field if using a version of WCS newer than 1.25.20.
### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
Fixes #2511 

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

1. Make sure you are using WCC branch fix/wcs-issue-2511 and that [this constant](https://github.com/Automattic/woocommerce-services/blob/a0b068d3124dc661c48cbdaf29e0f2f7ad8fc125/woocommerce-services.php#L48) is set to 5.
2. Create an order and create a label for that order.
3. Add a blank space to the origin/destination name field and click verify address.
4. The address should be verified automatically if the address is valid.
5. Change [this constant](https://github.com/Automattic/woocommerce-services/blob/a0b068d3124dc661c48cbdaf29e0f2f7ad8fc125/woocommerce-services.php#L48) to 6.
6. Change WCS to version 1.25.21 (I just hardcoded the passed version [here](https://github.com/Automattic/woocommerce-connect-server/blob/8e5aebed5932f8d09aa6a1dadc276690a066b620/lib/shipping/handler.js#L198))
7. Now try to create a shipping label for the order.
8. Add a blank space to the origin/destination name field and click verify address.
9. An error should be returned.
10. Add a name to the origin/destination name field and click verify address.
11. The address should be verified automatically if the address is valid.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

