### PR TITLE
Change API version back to 5.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - Add name field to fields sent for EasyPost API address verification.
 * Fix - Display company name under origin and destination address when create shipping label.
 * Fix - Don't override general "Enable Tax" setting with WC Services Automated Taxes setting.
+* Fix - Change WOOCOMMERCE_CONNECT_SERVER_API_VERSION back to 5.
 
 = 1.25.20 - 2021-11-15 =
 * Fix - Hide "Shipping Label" and "Shipment Tracking" metabox when the label setting is disabled.

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,7 +6,6 @@
 * Fix - Add name field to fields sent for EasyPost API address verification.
 * Fix - Display company name under origin and destination address when create shipping label.
 * Fix - Don't override general "Enable Tax" setting with WC Services Automated Taxes setting.
-* Fix - Change WOOCOMMERCE_CONNECT_SERVER_API_VERSION back to 5.
 
 = 1.25.20 - 2021-11-15 =
 * Fix - Hide "Shipping Label" and "Shipment Tracking" metabox when the label setting is disabled.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -44,7 +44,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 	define( 'WOOCOMMERCE_CONNECT_MINIMUM_JETPACK_VERSION', '7.5' );
 	define( 'WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH', 32 );
 
-	if ( ! defined( 'WOOCOMMERCE_CONNECT_SERVER_API_VERSION ' ) ) {
+	if ( ! defined( 'WOOCOMMERCE_CONNECT_SERVER_API_VERSION' ) ) {
 		define( 'WOOCOMMERCE_CONNECT_SERVER_API_VERSION', '5' );
 	}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -45,7 +45,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 	define( 'WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH', 32 );
 
 	if ( ! defined( 'WOOCOMMERCE_CONNECT_SERVER_API_VERSION ' ) ) {
-		define( 'WOOCOMMERCE_CONNECT_SERVER_API_VERSION', '6' );
+		define( 'WOOCOMMERCE_CONNECT_SERVER_API_VERSION', '5' );
 	}
 
 	// Check for CI environment variable to trigger test mode.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
We needed to add logic to ensure the connect server only validates the address name field if using a version of WCS newer than 1.25.20.
### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
Fixes #2511 

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

1. Make sure you are using WCC branch fix/wcs-issue-2511.
2. Change WCS to version 1.25.21 (I just hardcoded the passed version [here](https://github.com/Automattic/woocommerce-connect-server/blob/8e5aebed5932f8d09aa6a1dadc276690a066b620/lib/shipping/handler.js#L198))
3. Now try to create a shipping label for the order.
4. Add a blank space to the origin/destination name field and click verify address.
5. An error should be returned.
6. Add a name to the origin/destination name field and click verify address.
7. The address should be verified automatically if the address is valid.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

