### PR TITLE
Fix/issue 2514 - TaxJar does not get the tax if the cart has non-taxable item.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,12 +1,14 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.22 - 2022-xx-xx =
+* Fix - TaxJar does not get the tax if the cart has non-taxable item.
+
 = 1.25.21 - 2022-01-26 =
 * Fix - Use 'native' pdf support feature for Firefox version 94 or later.
 * Fix - Only call WC Subscriptions API when "access_token_secret" value is saved in database.
 * Fix - Add name field to fields sent for EasyPost API address verification.
 * Fix - Display company name under origin and destination address when create shipping label.
 * Fix - Don't override general "Enable Tax" setting with WC Services Automated Taxes setting.
-* Fix - TaxJar does not get the tax if the cart has non-taxable item.
 
 = 1.25.20 - 2021-11-15 =
 * Fix - Hide "Shipping Label" and "Shipment Tracking" metabox when the label setting is disabled.

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - Add name field to fields sent for EasyPost API address verification.
 * Fix - Display company name under origin and destination address when create shipping label.
 * Fix - Don't override general "Enable Tax" setting with WC Services Automated Taxes setting.
+* Fix - TaxJar does not get the tax if the cart has non-taxable item.
 
 = 1.25.20 - 2021-11-15 =
 * Fix - Hide "Shipping Label" and "Shipment Tracking" metabox when the label setting is disabled.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -956,11 +956,23 @@ class WC_Connect_TaxJar_Integration {
 			'plugin'       => 'woo',
 		);
 
-		// Either `amount` or `line_items` parameters are required to perform tax calculations.
+		// Filter the line items to find the taxable items and use empty array if line items is NULL.
 		if ( empty( $line_items ) ) {
+			$taxable_line_items = array();
+		} else {
+			$taxable_line_items = array_filter(
+				$line_items,
+				function( $line_item ) {
+					return ( isset( $line_item['product_tax_code'] ) && '99999' !== $line_item['product_tax_code'] ) ? true : false;
+				}
+			);
+		}
+
+		// Either `amount` or `line_items` parameters are required to perform tax calculations.
+		if ( empty( $taxable_line_items ) ) {
 			$body['amount'] = 0.0;
 		} else {
-			$body['line_items'] = $line_items;
+			$body['line_items'] = $taxable_line_items;
 		}
 
 		$response = $this->smartcalcs_cache_request( wp_json_encode( $body ) );


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
Remove the line item that has product tax code : 99999 when getting a tax value from TaxJar. Line item with product tax code is blocking the plugin to get a tax information from TaxJar.

### Related issue(s)
Fixes #2514 
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
1. Create a product and set it to be taxed only on shipping.
2. Create a second product for any amount like $10 and set its taxes so it isn't taxed.
3. Add the non-tax product to the cart and enter an address that should be charged taxes.
4. Add the second product to the cart and notice that the taxes are now not 0.
![screenshot-localhost_8050-2022 01 11-19_29_21](https://user-images.githubusercontent.com/631098/148943310-0d402318-209e-4463-9041-6ded09e27ce5.png)
![screenshot-localhost_8050-2022 01 11-19_29_54](https://user-images.githubusercontent.com/631098/148943294-214fa8cd-b9c5-48f7-8919-c183e31817e1.png)
![screenshot-localhost_8050-2022 01 11-19_30_39](https://user-images.githubusercontent.com/631098/148943343-49359c7c-8a5a-4314-a3c8-c59680674316.png)


<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

