### PR TITLE
Add tool to automatically delete all tax rates for California in the database. - Fix/issue 218

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.23 - 2022-xx-xx =
+* Fix - Added "Delete California tax rates" tool.
+
 = 1.25.22 - 2022-02-02 =
 * Fix   - TaxJar does not get the tax if the cart has non-taxable item.
 * Tweak - Bump WP tested version to 5.9 and WC tested version to 6.1.

--- a/classes/class-wc-connect-debug-tools.php
+++ b/classes/class-wc-connect-debug-tools.php
@@ -30,7 +30,7 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 				$tools['delete_ca_taxes'] = array(
 					'name'     => __( 'Delete California tax rates', 'woocommerce-services' ),
 					'button'   => __( 'Delete CA tax rates', 'woocommerce-services' ),
-					'desc'     => sprintf( '<strong class="red">%1$s</strong> %2$s <a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#jan-2022-ca-notice" target="_blank">%3$s</a>', __( 'Note:', 'woocommerce-services' ), __( 'This option will delete ALL of your "CA" tax rates, use with caution. This action cannot be reversed.', 'woocommerce-services' ), __( 'Additional information.', 'woocommerce-services' ) ),
+					'desc'     => sprintf( '<strong class="red">%1$s</strong> %2$s <a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#jan-2022-ca-notice" target="_blank">%3$s</a>', __( 'Note:', 'woocommerce-services' ), __( 'This option will delete ALL of your "CA" tax rates where the tax name ends with " Tax", use with caution. This action cannot be reversed.', 'woocommerce-services' ), __( 'Additional information.', 'woocommerce-services' ) ),
 					'callback' => array( $this, 'delete_california_tax_rates' ),
 				);
 			}

--- a/classes/class-wc-connect-debug-tools.php
+++ b/classes/class-wc-connect-debug-tools.php
@@ -30,7 +30,7 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 				$tools['delete_ca_taxes'] = array(
 					'name'     => __( 'Delete California tax rates', 'woocommerce-services' ),
 					'button'   => __( 'Delete CA tax rates', 'woocommerce-services' ),
-					'desc'     => sprintf( '<strong class="red">%1$s</strong> %2$s <a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#jan-2022-ca-notice" target="_blank">%3$s</a>', __( 'Note:', 'woocommerce-services' ), __( 'This option will delete ALL of your "CA" tax rates where the tax name ends with " Tax" (case insensitive), use with caution. This action cannot be reversed.', 'woocommerce-services' ), __( 'Additional information.', 'woocommerce-services' ) ),
+					'desc'     => sprintf( '<strong class="red">%1$s</strong> %2$s %3$s %4$s <a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#jan-2022-ca-notice" target="_blank">%5$s</a>', __( 'Note:', 'woocommerce-services' ), __( 'This option will delete ALL of your "CA" tax rates where the tax name ends with " Tax" (case insensitive).', 'woocommerce-services' ), '<br>', __( 'A backup CSV of all existing tax rates will be made before the deletion process runs.', 'woocommerce-services' ), __( 'Additional information.', 'woocommerce-services' ) ),
 					'callback' => array( $this, 'delete_california_tax_rates' ),
 				);
 			}
@@ -48,8 +48,9 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 		}
 
 		/**
-		 * Loop through the tax rates in the database and delete
-		 * rates where:
+		 * Back up all existing tax rates from the database in a CSV file.         *
+		 * Then, if successfully backed up, loop through the tax rates
+		 * in the database and delete rates where:
 		 * tax_rate_country = 'US' and
 		 * tax_rate_state = 'CA' and
 		 * tax_rate_name LIKE '% Tax'
@@ -57,6 +58,16 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 		 * @return void
 		 */
 		function delete_california_tax_rates() {
+			$backed_up = WC_Connect_Functions::backup_existing_tax_rates();
+
+			if ( ! $backed_up ) {
+				echo '<div class="error inline"><p>';
+				echo __( 'ERROR: The "CA" tax rate deletion process was cancelled because the existing tax rates could not be backed up.', 'woocommerce-services' );
+				echo '</p></div>';
+
+				return;
+			}
+
 			global $wpdb;
 
 			$found_ca_rates = $wpdb->get_results(
@@ -95,6 +106,5 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 			echo sprintf( __( 'Successfully deleted %1$d rows from the database.', 'woocommerce-services' ), $deleted_count );
 			echo '</p></div>';
 		}
-
 	}
 }

--- a/classes/class-wc-connect-debug-tools.php
+++ b/classes/class-wc-connect-debug-tools.php
@@ -73,8 +73,8 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 			$found_ca_rates = $wpdb->get_results(
 				$wpdb->prepare(
 					"SELECT * FROM {$wpdb->prefix}woocommerce_tax_rates
-			WHERE tax_rate_country = %s AND tax_rate_state = %s AND tax_rate_name LIKE '% Tax'
-			",
+			        WHERE tax_rate_country = %s AND tax_rate_state = %s AND tax_rate_name LIKE '% Tax'
+			        ",
 					'US',
 					'CA'
 				),

--- a/classes/class-wc-connect-debug-tools.php
+++ b/classes/class-wc-connect-debug-tools.php
@@ -30,7 +30,7 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 				$tools['delete_ca_taxes'] = array(
 					'name'     => __( 'Delete California tax rates', 'woocommerce-services' ),
 					'button'   => __( 'Delete CA tax rates', 'woocommerce-services' ),
-					'desc'     => sprintf( '<strong class="red">%1$s</strong> %2$s <a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#jan-2022-ca-notice" target="_blank">%3$s</a>', __( 'Note:', 'woocommerce-services' ), __( 'This option will delete ALL of your "CA" tax rates where the tax name ends with " Tax", use with caution. This action cannot be reversed.', 'woocommerce-services' ), __( 'Additional information.', 'woocommerce-services' ) ),
+					'desc'     => sprintf( '<strong class="red">%1$s</strong> %2$s <a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#jan-2022-ca-notice" target="_blank">%3$s</a>', __( 'Note:', 'woocommerce-services' ), __( 'This option will delete ALL of your "CA" tax rates where the tax name ends with " Tax" (case insensitive), use with caution. This action cannot be reversed.', 'woocommerce-services' ), __( 'Additional information.', 'woocommerce-services' ) ),
 					'callback' => array( $this, 'delete_california_tax_rates' ),
 				);
 			}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
Added a tool to automatically delete all tax rates for California with a Tax Name ending in " Tax" in the database. 

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
Fixes [WC Shipping Issues 218](https://github.com/Automattic/woocommerce-shipping-issues/issues/218)
### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

1. Set the store settings to a California address.
2. Enable Automated Taxes (TaxJar).
3. Add a product to cart and set a California address at checkout.
4. Go to WC Settings > Tax > Standard Taxes.
5. You should see at least one tax rate added for the California address you used at checkout.
6. Insert another CA tax rate manually and do not set a Tax Name for it.
7. Go to  WC Status > Tools and scroll down to the bottom of the list.
8. You should NOT see the following tool:
![delete-ca-taxes](https://user-images.githubusercontent.com/11618203/152365969-289b598e-ee87-480b-90df-d7267cd416f3.png)

9. Go back to WC Settings and change the store address to another address from a different state.
10. Go to  WC Status > Tools and scroll down to the bottom of the list.
11. You should see the following tool:
![delete-ca-taxes](https://user-images.githubusercontent.com/11618203/152365969-289b598e-ee87-480b-90df-d7267cd416f3.png)

12. Click the tool's button.
13. When the page refreshes you should see a notice that says 1 row was deleted from the database.
14. Go to WC Settings > Tax > Standard Taxes.
15. The rate added by TaxJar should be gone and the rate you added manually should still be there.
16. There should also be a new tax rate backup CSV in `/wp-content/uploads/`
16. Test other scenarios with various Tax Name combinations.


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

