### PR TITLE
Extract WC_Connect_TaxJar_Integration::backup_existing_tax_rates() for re-usability - Fix/issue 2523

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.23 - 2022-xx-xx =
+* Fix - Extract WC_Connect_TaxJar_Integration::backup_existing_tax_rates() for re-usability.
+
 = 1.25.22 - 2022-02-02 =
 * Fix   - TaxJar does not get the tax if the cart has non-taxable item.
 * Tweak - Bump WP tested version to 5.9 and WC tested version to 6.1.

--- a/classes/class-wc-connect-functions.php
+++ b/classes/class-wc-connect-functions.php
@@ -95,5 +95,126 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 			 */
 			return apply_filters( 'wcship_user_can_manage_labels', current_user_can( 'manage_woocommerce' ) || current_user_can( 'wcship_manage_labels' ) );
 		}
+
+		/**
+		 * Exports existing tax rates to a CSV and clears the table.
+		 *
+		 * Ported from TaxJar's plugin.
+		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/42cd4cd0/taxjar-woocommerce.php#L75
+		 */
+		public static function backup_existing_tax_rates() {
+			global $wpdb;
+
+			// Export Tax Rates
+			$rates = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT * FROM {$wpdb->prefix}woocommerce_tax_rates
+			ORDER BY tax_rate_order
+			LIMIT %d, %d
+			",
+					0,
+					10000
+				)
+			);
+
+			ob_start();
+			$header =
+				__( 'Country Code', 'woocommerce' ) . ',' .
+				__( 'State Code', 'woocommerce' ) . ',' .
+				__( 'ZIP/Postcode', 'woocommerce' ) . ',' .
+				__( 'City', 'woocommerce' ) . ',' .
+				__( 'Rate %', 'woocommerce' ) . ',' .
+				__( 'Tax Name', 'woocommerce' ) . ',' .
+				__( 'Priority', 'woocommerce' ) . ',' .
+				__( 'Compound', 'woocommerce' ) . ',' .
+				__( 'Shipping', 'woocommerce' ) . ',' .
+				__( 'Tax Class', 'woocommerce' ) . "\n";
+
+			echo $header;
+
+			foreach ( $rates as $rate ) {
+				if ( $rate->tax_rate_country ) {
+					echo esc_attr( $rate->tax_rate_country );
+				} else {
+					echo '*';
+				}
+
+				echo ',';
+
+				if ( $rate->tax_rate_state ) {
+					echo esc_attr( $rate->tax_rate_state );
+				} else {
+					echo '*';
+				}
+
+				echo ',';
+
+				$locations = $wpdb->get_col( $wpdb->prepare( "SELECT location_code FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE location_type='postcode' AND tax_rate_id = %d ORDER BY location_code", $rate->tax_rate_id ) );
+
+				if ( $locations ) {
+					echo esc_attr( implode( '; ', $locations ) );
+				} else {
+					echo '*';
+				}
+
+				echo ',';
+
+				$locations = $wpdb->get_col( $wpdb->prepare( "SELECT location_code FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE location_type='city' AND tax_rate_id = %d ORDER BY location_code", $rate->tax_rate_id ) );
+				if ( $locations ) {
+					echo esc_attr( implode( '; ', $locations ) );
+				} else {
+					echo '*';
+				}
+
+				echo ',';
+
+				if ( $rate->tax_rate ) {
+					echo esc_attr( $rate->tax_rate );
+				} else {
+					echo '0';
+				}
+
+				echo ',';
+
+				if ( $rate->tax_rate_name ) {
+					echo esc_attr( $rate->tax_rate_name );
+				} else {
+					echo '*';
+				}
+
+				echo ',';
+
+				if ( $rate->tax_rate_priority ) {
+					echo esc_attr( $rate->tax_rate_priority );
+				} else {
+					echo '1';
+				}
+
+				echo ',';
+
+				if ( $rate->tax_rate_compound ) {
+					echo esc_attr( $rate->tax_rate_compound );
+				} else {
+					echo '0';
+				}
+
+				echo ',';
+
+				if ( $rate->tax_rate_shipping ) {
+					echo esc_attr( $rate->tax_rate_shipping );
+				} else {
+					echo '0';
+				}
+
+				echo ',';
+
+				echo "\n";
+			} // End foreach().
+
+			$csv = ob_get_contents();
+			ob_end_clean();
+			$upload_dir = wp_upload_dir();
+			file_put_contents( $upload_dir['basedir'] . '/taxjar-wc_tax_rates-' . date( 'm-d-Y' ) . '-' . time() . '.csv', $csv );
+		}
 	}
 }

--- a/classes/class-wc-connect-functions.php
+++ b/classes/class-wc-connect-functions.php
@@ -101,6 +101,8 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 		 *
 		 * Ported from TaxJar's plugin.
 		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/42cd4cd0/taxjar-woocommerce.php#L75
+		 *
+		 * @return boolean
 		 */
 		public static function backup_existing_tax_rates() {
 			global $wpdb;
@@ -214,7 +216,9 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 			$csv = ob_get_contents();
 			ob_end_clean();
 			$upload_dir = wp_upload_dir();
-			file_put_contents( $upload_dir['basedir'] . '/taxjar-wc_tax_rates-' . date( 'm-d-Y' ) . '-' . time() . '.csv', $csv );
+			$backed_up  = file_put_contents( $upload_dir['basedir'] . '/taxjar-wc_tax_rates-' . date( 'm-d-Y' ) . '-' . time() . '.csv', $csv );
+
+			return (bool) $backed_up;
 		}
 	}
 }

--- a/classes/class-wc-connect-functions.php
+++ b/classes/class-wc-connect-functions.php
@@ -111,8 +111,8 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 			$rates = $wpdb->get_results(
 				$wpdb->prepare(
 					"SELECT * FROM {$wpdb->prefix}woocommerce_tax_rates
-			ORDER BY tax_rate_order
-			LIMIT %d, %d
+			        ORDER BY tax_rate_order
+			        LIMIT %d, %d
 			",
 					0,
 					10000

--- a/classes/class-wc-connect-functions.php
+++ b/classes/class-wc-connect-functions.php
@@ -213,8 +213,7 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 				echo "\n";
 			} // End foreach().
 
-			$csv = ob_get_contents();
-			ob_end_clean();
+			$csv = ob_get_clean();
 			$upload_dir = wp_upload_dir();
 			$backed_up  = file_put_contents( $upload_dir['basedir'] . '/taxjar-wc_tax_rates-' . date( 'm-d-Y' ) . '-' . time() . '.csv', $csv );
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1182,118 +1182,15 @@ class WC_Connect_TaxJar_Integration {
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/42cd4cd0/taxjar-woocommerce.php#L75
 	 */
 	public function backup_existing_tax_rates() {
+
+		// Back up all tax rates to a csv file
+		$backed_up = WC_Connect_Functions::backup_existing_tax_rates();
+
+		if ( ! $backed_up ) {
+			return;
+		}
+
 		global $wpdb;
-
-		// Export Tax Rates
-		$rates = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT * FROM {$wpdb->prefix}woocommerce_tax_rates
-			ORDER BY tax_rate_order
-			LIMIT %d, %d
-			",
-				0,
-				10000
-			)
-		);
-
-		ob_start();
-		$header =
-			__( 'Country Code', 'woocommerce' ) . ',' .
-			__( 'State Code', 'woocommerce' ) . ',' .
-			__( 'ZIP/Postcode', 'woocommerce' ) . ',' .
-			__( 'City', 'woocommerce' ) . ',' .
-			__( 'Rate %', 'woocommerce' ) . ',' .
-			__( 'Tax Name', 'woocommerce' ) . ',' .
-			__( 'Priority', 'woocommerce' ) . ',' .
-			__( 'Compound', 'woocommerce' ) . ',' .
-			__( 'Shipping', 'woocommerce' ) . ',' .
-			__( 'Tax Class', 'woocommerce' ) . "\n";
-
-		echo $header;
-
-		foreach ( $rates as $rate ) {
-			if ( $rate->tax_rate_country ) {
-				echo esc_attr( $rate->tax_rate_country );
-			} else {
-				echo '*';
-			}
-
-			echo ',';
-
-			if ( $rate->tax_rate_state ) {
-				echo esc_attr( $rate->tax_rate_state );
-			} else {
-				echo '*';
-			}
-
-			echo ',';
-
-			$locations = $wpdb->get_col( $wpdb->prepare( "SELECT location_code FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE location_type='postcode' AND tax_rate_id = %d ORDER BY location_code", $rate->tax_rate_id ) );
-
-			if ( $locations ) {
-				echo esc_attr( implode( '; ', $locations ) );
-			} else {
-				echo '*';
-			}
-
-			echo ',';
-
-			$locations = $wpdb->get_col( $wpdb->prepare( "SELECT location_code FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE location_type='city' AND tax_rate_id = %d ORDER BY location_code", $rate->tax_rate_id ) );
-			if ( $locations ) {
-				echo esc_attr( implode( '; ', $locations ) );
-			} else {
-				echo '*';
-			}
-
-			echo ',';
-
-			if ( $rate->tax_rate ) {
-				echo esc_attr( $rate->tax_rate );
-			} else {
-				echo '0';
-			}
-
-			echo ',';
-
-			if ( $rate->tax_rate_name ) {
-				echo esc_attr( $rate->tax_rate_name );
-			} else {
-				echo '*';
-			}
-
-			echo ',';
-
-			if ( $rate->tax_rate_priority ) {
-				echo esc_attr( $rate->tax_rate_priority );
-			} else {
-				echo '1';
-			}
-
-			echo ',';
-
-			if ( $rate->tax_rate_compound ) {
-				echo esc_attr( $rate->tax_rate_compound );
-			} else {
-				echo '0';
-			}
-
-			echo ',';
-
-			if ( $rate->tax_rate_shipping ) {
-				echo esc_attr( $rate->tax_rate_shipping );
-			} else {
-				echo '0';
-			}
-
-			echo ',';
-
-			echo "\n";
-		} // End foreach().
-
-		$csv = ob_get_contents();
-		ob_end_clean();
-		$upload_dir = wp_upload_dir();
-		file_put_contents( $upload_dir['basedir'] . '/taxjar-wc_tax_rates-' . date( 'm-d-Y' ) . '-' . time() . '.csv', $csv );
 
 		// Delete all tax rates
 		$wpdb->query( 'TRUNCATE ' . $wpdb->prefix . 'woocommerce_tax_rates' );


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
Extracted the `WC_Connect_TaxJar_Integration::backup_existing_tax_rates()` to the `WC_Connect_Functions` class as a static method so it can be used in other classes as well.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
Fixes #2523 
### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
1. Add a few tax rates under WC > Settings > Tax > Standard Rates
2. Go to WC > Settings > Tax > Tax options and enable Automated Taxes
3. The tax rates you entered in step 1 should be backed up in a CSV file under `/wc-content/uploads/`
4. WC > Settings > Tax > Standard Rates should show be cleared of all previously entered tax rates.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

