### PR TITLE
Fixed label purchase modal section cutoff issue. - Fix/issue 2527

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.24 - 2022-xx-xx =
+* Fix - Label purchase modal sections getting cut off.
+
 = 1.25.23 - 2022-02-10 =
 * Tweak - Make "Name" field optional if "Company" field is not empty.
 * Fix   - Added "Delete California tax rates" tool.

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -24,7 +24,7 @@
 
 	.components-modal__content {
 		background: $studio-gray-0;
-		height: 100%;
+		height: auto;
 	}
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
The label purchase modal was cutting off the bottom sections when the sections were expanded. This fix adjusted the CSS so this no longer happens.
### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
Fixes #2527
### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

1. Follow the steps to reproduce [here](https://github.com/Automattic/woocommerce-services/issues/2527).
2. When all sections are open, you should still be able to scroll all the way to the bottom of the modal and access the last section.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

