### PR TITLE
Fix/issue 2537 - Fix the tax of taxable items not being calculated if non-taxable items is on the first item in the cart.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.25.24 - 2022-xx-xx =
 * Fix - Empty document is opened when Firefox is set to open PDF file using another program.
 * Fix - Label purchase modal sections getting cut off.
+* Fix - TaxJar does not get the tax if the cart has non-taxable on the first item.
 
 = 1.25.23 - 2022-02-10 =
 * Tweak - Make "Name" field optional if "Company" field is not empty.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,11 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.25 - 2022-xx-xx =
+* Fix - TaxJar does not get the tax if the cart has non-taxable on the first item.
+
 = 1.25.24 - 2022-03-17 =
 * Fix - Empty document is opened when Firefox is set to open PDF file using another program.
 * Fix - Label purchase modal sections getting cut off.
-* Fix - TaxJar does not get the tax if the cart has non-taxable on the first item.
 
 = 1.25.23 - 2022-02-10 =
 * Tweak - Make "Name" field optional if "Company" field is not empty.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -957,15 +957,14 @@ class WC_Connect_TaxJar_Integration {
 		);
 
 		// Filter the line items to find the taxable items and use empty array if line items is NULL.
-		if ( empty( $line_items ) ) {
-			$taxable_line_items = array();
-		} else {
-			$taxable_line_items = array_filter(
-				$line_items,
-				function( $line_item ) {
-					return ( isset( $line_item['product_tax_code'] ) && '99999' !== $line_item['product_tax_code'] ) ? true : false;
+		$taxable_line_items = array();
+
+		if ( ! empty( $line_items ) ) {
+			foreach ( $line_items as $line_item ) {
+				if ( isset( $line_item['product_tax_code'] ) && '99999' !== $line_item['product_tax_code'] ) {
+					$taxable_line_items[] = $line_item;
 				}
-			);
+			}
 		}
 
 		// Either `amount` or `line_items` parameters are required to perform tax calculations.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
The issue was the taxable items index is not start from zero. To fix this issue, we need to re-indexing the array of taxable items to make sure that the index the array is start from 0. 
<!-- Explain the motivation for making this change -->

### Related issue(s)
Closes #2537 
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
1. Create a product and set it to be taxed.
2. Create a second product for any amount like $10 and set its taxes so it isn't taxed.
3. Add the non-tax product to the cart and enter an address that should be charged taxes.
4. Add the taxable product to the cart and notice that the taxes are now not 0.
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

