### PR TITLE
Tweak/issue 2530 - Use regex to check the REST API route

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 1.25.25 - 2022-xx-xx =
-* Fix - TaxJar does not get the tax if the cart has non-taxable on the first item.
+* Fix   - TaxJar does not get the tax if the cart has non-taxable on the first item.
+* Tweak - Use regex to check on WC Rest API route for WooCommerce Blocks compatibility.
 
 = 1.25.24 - 2022-03-17 =
 * Fix - Empty document is opened when Firefox is set to open PDF file using another program.

--- a/classes/class-wc-connect-functions.php
+++ b/classes/class-wc-connect-functions.php
@@ -52,10 +52,12 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 				return false;
 			}
 			$rest_route = $GLOBALS['wp']->query_vars['rest_route'];
-			return (
-				false !== strpos( $rest_route, 'wc/store/cart' ) ||
-				false !== strpos( $rest_route, 'wc/store/checkout' )
-			);
+
+			// Use regex to check any route that has "wc/store" with any of these text : "cart", "checkout", or "batch"
+			// Example : wc/store/v3/batch
+			preg_match( '/wc\/store\/v[0-9]{1,}\/(batch|cart|checkout)/', $rest_route, $route_matches, PREG_OFFSET_CAPTURE );
+
+			return ( ! empty( $route_matches ) );
 		}
 
 		/**


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
WooCommerce Blocks seems changing the REST API route in cart and checkout page. 
It was changed from `/wc/store/cart` to `/wc/store/v1/batch`. I propose to use regex so it would be more flexible if they change the route version ( from v1 to v2 for example ) in the future.
<!-- Explain the motivation for making this change -->

### Related issue(s)
Closes #2530 
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
1. Install [WooCommerce Blocks](https://woocommerce.com/products/woocommerce-gutenberg-products-block/?aff=10486&cid=1131038).
2. Change the shortcode on cart and checkout page to use WC Blocks.
3. Add an item to the cart
4. Update the quantity to 2
5. Notice that the shipping method is still displayed.
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

