### PR TITLE
Missing Quebec Sales Tax (QST) TaxJar API workaround - Fix/issue 1654

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.26 - 2022-xx-xx =
+* Fix - TaxJar does not calculate Quebec Sales Tax when shipping from Canadian address.
+
 = 1.25.25 - 2022-03-29 =
 * Fix   - TaxJar does not get the tax if the cart has non-taxable on the first item.
 * Tweak - Use regex to check on WC Rest API route for WooCommerce Blocks compatibility.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -956,6 +956,45 @@ class WC_Connect_TaxJar_Integration {
 			'plugin'       => 'woo',
 		);
 
+		/**
+		 * Change the API request body so that provincial sales tax (PST) is added
+		 * in cases where TaxJar does not combine it with general sales tax (GST)
+		 * based on from/to address alone. This is a limitation of their API.
+		 * They said they would be working on adding specific cases like
+		 * this in the future.
+		 *
+		 * As a temporary workaround, TaxJar suggested we remove the from address
+		 * parameters and use the nexus_addresses[] parameter instead in cases that
+		 * require it. This ensures that the PST is added in cases where it needs to be.
+		 *
+		 * In this case, when shipping from an address Canada to Quebec,
+		 * PST should be charged in addition to GST. The combined tax is
+		 * referred to as Québec sales tax (QST).
+		 */
+		if ( true === apply_filters( 'woocommerce_apply_taxjar_nexus_addresses_workaround', true ) && 'CA' === $body['to_country'] && 'QC' === $body['to_state'] && 'CA' === $body['from_country'] ) {
+			$params_to_unset = array(
+				'from_country',
+				'from_state',
+				'from_zip',
+				'from_city',
+				'from_street',
+			);
+
+			foreach ( $params_to_unset as $param ) {
+				unset( $body[ $param ] );
+			}
+
+			$body['nexus_addresses'] = array(
+				array(
+					'street'  => $body['to_street'],
+					'city'    => $body['to_city'],
+					'state'   => $body['to_state'],
+					'country' => $body['to_country'],
+					'zip'     => $body['to_zip'],
+				),
+			);
+		}
+
 		// Filter the line items to find the taxable items and use empty array if line items is NULL.
 		$taxable_line_items = array();
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
The TaxJar API doesn't correctly calculate the Quebec Sales Tax when shipping from a Canadian address to an address in Quebec. The workaround is to remove the "from_" parameters from the request and pass the `nexus_addresses[]` parameter instead when shipping from a Canadian address.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Fixes #1654 

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
1. Set store address to `1223 Woo Street, Vancouver, BC, Canada, V5V 2P3`
2. Make sure automated taxes is enabled
3. Add a product to cart, go to checkout and set the following address `1223 Woo Street, Quebec City, QC, Canada, G1R 3X2`
4. Go to `/wp-admin/admin.php?page=wc-settings&tab=tax&section=standard` 
5. You should see the tax rate that was added. The Rate % should be 14.9750 for Quebec.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

