### PR TITLE
Fix/issue 2543 - Cache the 400 and 404 error for TaxJar API and validate the TaxJar request

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.27 - 2022-xx-xx =
+* Tweak - Validate the TaxJar request before calling the api and cache 404 and 400 TaxJar response error for 5 minutes.
+
 = 1.25.26 - 2022-04-19 =
 * Fix   - Display error on cart block and checkout block from WC Blocks plugin.
 * Fix   - TaxJar does not calculate Quebec Sales Tax when shipping from Canadian address.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1237,8 +1237,7 @@ class WC_Connect_TaxJar_Integration {
 
 		if ( in_array( $response_code, $save_error_codes ) ) {
 			$this->_log( 'Retrieved the error from the cache.' );
-			$this->_log( 'Error retrieving the tax rates. Received (' . $response['response']['code'] . '): ' . $response['body'] );
-
+			$this->_error( 'Error retrieving the tax rates. Received (' . $response['response']['code'] . '): ' . $response['body'] );
 			return false;
 		}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
Create a function for pre-request validation of TaxJar API calls. And cache the response for 5 minutes if the TaxJar response is 400 or 404.

### Related issue(s)
Closes #2543 
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
1. Enable the Automated taxes from `/wp-admin/admin.php?page=wc-settings&tab=tax`
![image](https://user-images.githubusercontent.com/631098/164212450-3540bf89-dbb6-456c-9588-7ebbd96723e7.png)

2. Add any product into the cart.
3. Go to checkout page and add the address like this : 
![image](https://user-images.githubusercontent.com/631098/164214553-fbd86b7d-8414-471d-b43d-82bf62f78e5e.png)

4. Refresh the page again so it will try to call the TaxJar api again.
5. Go to WooCommerce >> Status page and click "WooCommerce Shipping & Tax" tab. And the TaxJar log will have something like this :
```
xx-xx-2022 @ xx:xx:xx - Retrieved the error from the cache. (WCS Tax)
xx-xx-2022 @ xx:xx:xx - Error retrieving the tax rates. Received (400): {"status":400,"error":"Bad Request","detail":"to_zip 90215 is not used within to_state CA"} (WCS Tax)
```
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

