### PR TITLE
Fix/issue 2547 - make sure TaxJar request array is set.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.28 - 2022-xx-xx =
+* Fix   - Notice: Undefined index: 'from_country' when validating TaxJar request.
+
 = 1.25.27 - 2022-05-03 =
 * Fix   - Cart with non-taxable product still calculate the tax.
 * Tweak - Validate the TaxJar request before calling the api and cache 404 and 400 TaxJar response error for 5 minutes.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1184,7 +1184,7 @@ class WC_Connect_TaxJar_Integration {
 			return false;
 		}
 
-		if ( 'US' === $json['from_country'] && ! WC_Validation::is_postcode( $json['from_zip'], $json['from_country'] ) ) {
+		if ( ! empty( $json['from_country'] ) && ! empty( $json['from_zip'] ) && 'US' === $json['from_country'] && ! WC_Validation::is_postcode( $json['from_zip'], $json['from_country'] ) ) {
 			$this->_error( 'API request is stopped. Country store is set to US but the zip code has incorrect format.' );
 
 			return false;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Add a conditional in `validate_taxjar_request()` to make sure that the request array is not empty.
<!-- Explain the motivation for making this change -->

### Related issue(s)

Closes #2547 
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
1. Set the store country with "Canada".
2. Set the tax to be automatic.
3. Add any product to the cart.
4. Set the shipping address to "Quebec, Canada".
5. When the tax is calculated in checkout page, go to the log file. Make sure there is no error like this : `Notice: Undefined index: from_country`
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

