### PR TITLE
Add/issue 1625 - Display warning if non-roman character is entered in address fields

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.29 - 2022-xx-xx =
+* Add   - Display warning if non-roman character is entered in address fields.
+
 = 1.25.28 - 2022-05-12 =
 * Fix   - Notice: Undefined index: 'from_country' when validating TaxJar request.
 

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -230,11 +230,23 @@ export const isCustomsFormRequired = createSelector(
 		if ( ! values[ field ] ) {
 			errors[ field ] = translate( 'This field is required' );
 		}
+
+		if ( hasNonAsciiCharacters( values[ field ] ) ) {
+			errors[ field ] = translate( 'This field has non-ASCII character' );
+		}
 	} );
 
 	if ( ! name && ! company ) {
 		errors.name = translate( 'Either Name or Company field is required' );
 		errors.company = translate( 'Either Name or Company field is required' );
+	}
+
+	if ( hasNonAsciiCharacters( name ) ) {
+		errors.name = translate( 'Name field has non-ASCII character' );
+	}
+
+	if ( hasNonAsciiCharacters( company ) ) {
+		errors.company = translate( 'Company field has non-ASCII character' );
 	}
 
 	if (
@@ -278,6 +290,8 @@ export const isCustomsFormRequired = createSelector(
 
 	return errors;
 };
+
+const hasNonAsciiCharacters = str => /[^\u0000-\u007f]/.test(str);
 
 const getAddressErrors = ( addressData, appState, siteId, fieldsToValidate = {} ) => {
 	const {

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -230,23 +230,11 @@ export const isCustomsFormRequired = createSelector(
 		if ( ! values[ field ] ) {
 			errors[ field ] = translate( 'This field is required' );
 		}
-
-		if ( hasNonAsciiCharacters( values[ field ] ) ) {
-			errors[ field ] = translate( 'This field has non-ASCII character' );
-		}
 	} );
 
 	if ( ! name && ! company ) {
 		errors.name = translate( 'Either Name or Company field is required' );
 		errors.company = translate( 'Either Name or Company field is required' );
-	}
-
-	if ( hasNonAsciiCharacters( name ) ) {
-		errors.name = translate( 'Name field has non-ASCII character' );
-	}
-
-	if ( hasNonAsciiCharacters( company ) ) {
-		errors.company = translate( 'Company field has non-ASCII character' );
 	}
 
 	if (
@@ -290,8 +278,6 @@ export const isCustomsFormRequired = createSelector(
 
 	return errors;
 };
-
-const hasNonAsciiCharacters = str => /[^\u0000-\u007f]/.test(str);
 
 const getAddressErrors = ( addressData, appState, siteId, fieldsToValidate = {} ) => {
 	const {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
@@ -89,7 +89,7 @@ const getNormalizationStatus = ( {
 
 const hasNonAsciiCharacters = str => /[^\u0000-\u007f]/.test(str);
 
-const checkAddressCharacters = function ( addressValues ) {
+const checkAddressCharacters = addressValues => {
 	for ( const value in addressValues ) {
 		if ( hasNonAsciiCharacters( addressValues[ value ] ) ) {
 			return false;

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
@@ -45,6 +45,12 @@ const renderSummary = (
 	if ( ! isNormalized ) {
 		return translate( "You've edited the address, please revalidate it for accurate rates" );
 	}
+
+	const addressValues = getAddressValues( addressData );
+
+	if ( ! checkAddressCharacters( addressValues ) ) {
+		return translate( "One of the address data has character(s) that might not be printed as is!" );
+	}
 	const { city, postcode, state, country } = getAddressValues( addressData );
 	// Summary format: "city, state  postcode [, country]"
 	let str = city + ', ';
@@ -72,11 +78,26 @@ const getNormalizationStatus = ( {
 	if ( hasNonEmptyLeaves( errors ) || ( isNormalized && ! normalized ) || ! isNormalized ) {
 		return { isError: true };
 	}
+	if ( ! checkAddressCharacters( values ) ) {
+		return { isWarning: true };
+	}
 	if ( isNormalized ) {
 		return isEqual( values, normalized ) ? { isSuccess: true } : { isWarning: true };
 	}
 	return {};
 };
+
+const hasNonAsciiCharacters = str => /[^\u0000-\u007f]/.test(str);
+
+const checkAddressCharacters = function ( addressValues ) {
+	for ( const value in addressValues ) {
+		if ( hasNonAsciiCharacters( addressValues[ value ] ) ) {
+			return false;
+		}
+	}
+
+	return true;
+}
 
 const AddressStep = props => {
 	const toggleStepHandler = () => props.toggleStep( props.orderId, props.siteId, props.type );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
@@ -49,7 +49,7 @@ const renderSummary = (
 	const addressValues = getAddressValues( addressData );
 
 	if ( ! checkAddressCharacters( addressValues ) ) {
-		return translate( "One of the address data has character(s) that might not be printed as is!" );
+		return translate( "One of the address data has non-roman character(s) that might not be printed properly!" );
 	}
 	const { city, postcode, state, country } = getAddressValues( addressData );
 	// Summary format: "city, state  postcode [, country]"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
USPS has non-roman character issue that changing the non-roman character to question marks ( ? ). The changes in this PR made the plugin will display warning if non-roman character is entered in address fields.
<!-- Explain the motivation for making this change -->

### Related issue(s)
Closes #1625 
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
1. Create an order.
2. Try to attempt creating a label.
3. Input any non-roman character in the name fields.
4. `One of the address data has non-roman character(s) that might not be printed properly!`
Warning will be displayed after "Verify Address" button is clicked : 
![image](https://user-images.githubusercontent.com/631098/168987518-89f8a2a7-55d3-4ec9-9a3b-1668a36a7a36.png)

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

