### PR TITLE
feat: add tool to clear transient cache

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 1.25.29 - 2022-xx-xx =
+* Add - Tool to clear cached Tax server responses from the transients.
+
 = 1.25.28 - 2022-05-12 =
 * Fix   - Notice: Undefined index: 'from_country' when validating TaxJar request.
 

--- a/classes/class-wc-connect-debug-tools.php
+++ b/classes/class-wc-connect-debug-tools.php
@@ -35,6 +35,18 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 				);
 			}
 
+			/**
+			 * Only show when object cache is disabled - the tool doesn't work when object cache is enabled.
+			 */
+			if ( ! wp_using_ext_object_cache() ) {
+				$tools['delete_cached_tax_server_responses'] = array(
+					'name'     => __( 'Delete WooCommerce Tax cached tax rate responses', 'woocommerce-services' ),
+					'button'   => __( 'Delete cached Tax transients', 'woocommerce-services' ),
+					'desc'     => __( 'Deletes the all the transients in your database that represent cached Tax Rates responses', 'woocommerce-services' ),
+					'callback' => array( $this, 'delete_cached_tax_server_responses' ),
+				);
+			}
+
 			return $tools;
 		}
 
@@ -104,6 +116,25 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 
 			echo '<div class="updated inline"><p>';
 			echo sprintf( __( 'Successfully deleted %1$d rows from the database.', 'woocommerce-services' ), $deleted_count );
+			echo '</p></div>';
+		}
+
+		/**
+		 * Deletes the all the transients in the database that represent cached Tax Rates responses.
+		 *
+		 * @return void
+		 */
+		function delete_cached_tax_server_responses() {
+			global $wpdb;
+
+			$deleted_count = absint(
+				$wpdb->query(
+					"DELETE FROM {$wpdb->options} WHERE option_name LIKE '%tj\_tax\_%';"
+				)
+			);
+
+			echo '<div class="updated inline"><p>';
+			echo sprintf( __( 'Successfully deleted %1$d transients from the database.', 'woocommerce-services' ), $deleted_count );
 			echo '</p></div>';
 		}
 	}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

When working on clients' website, it can be useful to clear the DB transient data cache for Tax responses.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

- Go to WooCommerce > Status > Tools
- Run the "Delete WooCommerce Tax cached tax rate responses" tool
- You should receive a success message:
 
![Screen Shot 2022-05-19 at 6 56 16 PM](https://user-images.githubusercontent.com/273592/169422712-91ef8d11-6b46-465e-b426-657a3b1d2ba8.png)


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

