### PR TITLE
Enable shipping tax by default for Florida intrastate shipping - Tweak/issue 2531

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
-= 1.25.29 - 2022-xx-xx =
-* Add - Tool to clear cached Tax server responses from the transients.
+= 1.26.0 - 2022-xx-xx =
+* Add   - Tool to clear cached Tax server responses from the transients.
+* Tweak - Enable shipping tax by default if is Florida interstate shipping.
 
 = 1.25.28 - 2022-05-12 =
 * Fix   - Notice: Undefined index: 'from_country' when validating TaxJar request.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1042,10 +1042,12 @@ class WC_Connect_TaxJar_Integration {
 		if ( $taxes['has_nexus'] ) {
 			// Use Woo core to find matching rates for taxable address
 			$location = array(
-				'to_country' => $to_country,
-				'to_state'   => $to_state,
-				'to_zip'     => $to_zip,
-				'to_city'    => $to_city,
+				'from_country' => $from_country,
+				'from_state'   => $from_state,
+				'to_country'   => $to_country,
+				'to_state'     => $to_state,
+				'to_zip'       => $to_zip,
+				'to_city'      => $to_city,
 			);
 
 			// Add line item tax rates

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1101,6 +1101,28 @@ class WC_Connect_TaxJar_Integration {
 		// prevents from saving a "state" column value for GB
 		$to_state = 'GB' === $location['to_country'] ? '' : $location['to_state'];
 
+		/**
+		 * @see https://github.com/Automattic/woocommerce-services/issues/2531
+		 * @see https://floridarevenue.com/faq/Pages/FAQDetails.aspx?FAQID=1277&IsDlg=1
+		 *
+		 * According to the Florida Department of Revenue, sales tax must be charged on
+		 * shipping costs if the customer does not have an option to avoid paying the
+		 * merchant for shipping costs by either picking up the merchandise themselves
+		 * or arranging for a third party to pick up the merchandise and deliver it to
+		 * them.
+		 *
+		 * Normally TaxJar enables taxes on shipping by default for Florida to
+		 * Florida shipping, but because WooCommerce uses a single account, a nexus
+		 * cannot be added for Florida (or any state) which means the shipping tax
+		 * is not enabled. So, we will enable it here by default and give merchants
+		 * the option to disable it if needed via filter.
+		 *
+		 * @since 1.26.0
+		 */
+		if ( true === apply_filters( 'woocommerce_taxjar_enable_florida_shipping_tax', true ) && 'US' === $location['to_country'] && 'FL' === $location['from_state'] && 'FL' === $location['to_state'] ) {
+			$freight_taxable = 1;
+		}
+
 		$tax_rate = array(
 			'tax_rate_country'  => $location['to_country'],
 			'tax_rate_state'    => $to_state,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
Normally TaxJar enables taxes on shipping by default for Florida to Florida shipping, but because WooCommerce uses a single account, a nexus cannot be added for Florida (or any state) which means the shipping tax is not enabled. So, we will enable it here by default and give merchants the option to disable it if needed via filter.
### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
Fixes #2531 
### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

1. Set your store address to a Florida address:

![store settings](https://user-images.githubusercontent.com/11618203/169785070-13488137-5bd9-4af8-8617-561ce52dedfa.png)

2. Set your tax settings to the following:

![tax settings](https://user-images.githubusercontent.com/11618203/169785057-f8369577-f65a-4012-98a1-b60642c905bd.png)

3. Add a shipping zone for Florida and add a Flat Rate method as shown:

![flat rate settings](https://user-images.githubusercontent.com/11618203/169785074-76a79260-8999-4af8-8403-43b597f5d29c.png)

4. Add a "Beanie with logo" to cart and go to checkout.
5. Set a Florida destination address.
6. You should see the following tax rate and total tax returned:

![tax rate](https://user-images.githubusercontent.com/11618203/169785065-2d8f1fb7-0db3-46a3-86e4-645ef472495d.png)

![checkout view](https://user-images.githubusercontent.com/11618203/169785076-a236cf2d-0b00-444c-ab0d-562c41223e9f.png)


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

