### PR TITLE
Fix/issue 2274 - Fix 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.26.0 - 2022-xx-xx =
 * Add   - Tool to clear cached Tax server responses from the transients.
 * Tweak - Enable shipping tax by default if is Florida interstate shipping.
+* Fix   - "Division by Zero" fatal error on PHP 8.
 
 = 1.25.28 - 2022-05-12 =
 * Fix   - Notice: Undefined index: 'from_country' when validating TaxJar request.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,11 +2,11 @@
 
 = 1.26.1 - 2022-xx-xx =
 * Add   - Display warning if non-roman character is entered in address fields.
+* Fix   - "Division by Zero" fatal error on PHP 8.
 
 = 1.26.0 - 2022-05-27 =
 * Add   - Tool to clear cached Tax server responses from the transients.
 * Tweak - Enable shipping tax by default if is Florida interstate shipping.
-* Fix   - "Division by Zero" fatal error on PHP 8.
 
 = 1.25.28 - 2022-05-12 =
 * Fix   - Notice: Undefined index: 'from_country' when validating TaxJar request.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -756,14 +756,14 @@ class WC_Connect_TaxJar_Integration {
 			if ( is_object( $item ) ) { // Woo 3.0+
 				$id             = $item->get_product_id();
 				$quantity       = $item->get_quantity();
-				$unit_price     = wc_format_decimal( $item->get_subtotal() / $quantity );
+				$unit_price     = empty( $quantity ) ? $item->get_subtotal() : wc_format_decimal( $item->get_subtotal() / $quantity );
 				$discount       = wc_format_decimal( $item->get_subtotal() - $item->get_total() );
 				$tax_class_name = $item->get_tax_class();
 				$tax_status     = $item->get_tax_status();
 			} else { // Woo 2.6
 				$id             = $item['product_id'];
 				$quantity       = $item['qty'];
-				$unit_price     = wc_format_decimal( $item['line_subtotal'] / $quantity );
+				$unit_price     = empty( $quantity ) ? $item['line_subtotal'] : wc_format_decimal( $item['line_subtotal'] / $quantity );
 				$discount       = wc_format_decimal( $item['line_subtotal'] - $item['line_total'] );
 				$tax_class_name = $item['tax_class'];
 				$product        = $order->get_product_from_item( $item );


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Fix "Division by Zero" error on PHP 8. Please test this PR in PHP 8 environment.
<!-- Explain the motivation for making this change -->

### Related issue(s)
Closes #2274
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
1. Go to "WooCommerce->Orders"
2. Click on "Add Order"
3. Click on "Add items" button.
4. Add any of the product with zero quantity.
5. Click on "Create" button.
6. Observe there is no "Fatal Error" is displayed.
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

