### PR TITLE
Fix/issue 2570 - Always let the user pick the package box

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 + 1.26.3 - 2022-xx-xx =
+* Tweak - Always let the user to pick the package box.
 * Add   - Add filter to override TaxJar result.
 
 = 1.26.2 - 2022-07-04 =

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -347,12 +347,7 @@ export const openPrintingFlow = ( orderId, siteId ) => ( dispatch, getState ) =>
 
 	waitForAllPromises( promisesQueue ).then( () =>
 		tryGetLabelRates( orderId, siteId, dispatch, getState )
-	).then( () => {
-		const { packageId, boxId } = getDefaultBoxSelection( orderId, siteId, getState ) || {};
-		if ( packageId !== undefined && boxId !== undefined ) {
-			dispatch( setPackageType (orderId, siteId, packageId, boxId ) );
-		}
-	} );
+	);
 
 	dispatch( { type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW, orderId, siteId } );
 };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Removing the default box selection function to always let the user pick the package box.
<!-- Explain the motivation for making this change -->

### Related issue(s)

Fixes #2570
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
1. Attempt to create an order with a valid/verified address
2. Notice that the shipping from and destination addresses are automatically validated, and you're offered to select a package
3. Now, create an order with a typo in the address
4. Notice that once you fix the address under Destination Address tab, you wil always need to pick the package box manually.
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

