### PR TITLE
Add helpful messaging and a way for merchants to download backed-up tax rates - Add/issue 2311

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,9 +2,10 @@
 
 + 1.26.3 - 2022-xx-xx =
 * Add   - Add filter to override TaxJar result.
+* Add   - Add list of tax rate backup files for merchants to click and download.
 
 = 1.26.2 - 2022-07-04 =
-* Fix   - Change the wp-calypso commit to fix NPM Error when run `npm run prepare`. 
+* Fix   - Change the wp-calypso commit to fix NPM Error when run `npm run prepare`.
 * Fix   - E2E Tests: npm ci, update puppeteer to v2
 * Fix   - JS Tests: npm ci
 * Tweak - Replace colors npm package with chalk

--- a/classes/class-wc-connect-functions.php
+++ b/classes/class-wc-connect-functions.php
@@ -262,5 +262,29 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 
 			return (bool) $backed_up;
 		}
+
+		/**
+		 * Search the uploads directory and return all backed up
+		 * tax rate files.
+		 *
+		 * @return array|false
+		 */
+		public static function get_backed_up_tax_rate_files() {
+			$upload_dir  = wp_upload_dir();
+			$pattern     = $upload_dir['basedir'] . '/taxjar-wc_tax_rates-*.csv';
+			$found_files = glob( $pattern );
+
+			if ( empty( $found_files ) ) {
+				return false;
+			}
+
+			$files = [];
+			foreach ( $found_files as $file ) {
+				$filename           = basename( $file );
+				$files[ $filename ] = $upload_dir['baseurl'] . '/' . $filename;
+			}
+
+			return $files;
+		}
 	}
 }

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -282,15 +282,16 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 		 */
 		protected function get_form_data() {
 			return array(
-				'health_items'    => $this->get_health_items(),
-				'services'        => $this->get_services_items(),
-				'logging_enabled' => $this->logger->is_logging_enabled(),
-				'debug_enabled'   => $this->logger->is_debug_enabled(),
-				'logs'            => array(
+				'health_items'     => $this->get_health_items(),
+				'services'         => $this->get_services_items(),
+				'logging_enabled'  => $this->logger->is_logging_enabled(),
+				'debug_enabled'    => $this->logger->is_debug_enabled(),
+				'logs'             => array(
 					'shipping' => $this->get_debug_log_data( 'shipping' ),
 					'taxes'    => $this->get_debug_log_data( 'taxes' ),
 					'other'    => $this->get_debug_log_data(),
 				),
+				'tax_rate_backups' => WC_Connect_Functions::get_backed_up_tax_rate_files(),
 			);
 		}
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -173,11 +173,20 @@ class WC_Connect_TaxJar_Integration {
 	 * @return array
 	 */
 	public function add_tax_settings( $tax_settings ) {
-		$enabled = $this->is_enabled();
+		$enabled                = $this->is_enabled();
+		$backedup_tax_rates_url = admin_url( '/admin.php?page=wc-status&tab=connect#tax-rate-backups' );
 
-		$powered_by_wct_notice       = '<p>' . __( 'Powered by WooCommerce Tax. If automated taxes are enabled, you\'ll need to enter prices exclusive of tax.', 'woocommerce-services' ) . '</p>';
+		$powered_by_wct_notice = '<p>' . __( 'Powered by WooCommerce Tax. If automated taxes are enabled, you\'ll need to enter prices exclusive of tax.', 'woocommerce-services' ) . '</p>';
+
+		if ( ! empty( WC_Connect_Functions::get_backed_up_tax_rate_files() ) ) {
+			$powered_by_wct_notice .= '<p>' . sprintf( __( 'You\'re previous tax rates were backed up and can be downloaded %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . $backedup_tax_rates_url . '">', '</a>' ) . '</p>';
+		}
+
 		$desctructive_action_notice  = '<p>' . __( 'Enabling this option overrides any tax rates you have manually added.', 'woocommerce-services' ) . '</p>';
-		$tax_nexus_notice            = '<p>' . $this->get_tax_tooltip() . '</p>';
+		$desctructive_action_notice .= '<p>' . sprintf( __( 'You\'re existing tax rates will be backed-up to a CSV that you can download %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . $backedup_tax_rates_url . '">', '</a>' ) . '</p>';
+
+		$tax_nexus_notice = '<p>' . $this->get_tax_tooltip() . '</p>';
+
 		$automated_taxes_description = join(
 			'',
 			$enabled ? [

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -179,7 +179,7 @@ class WC_Connect_TaxJar_Integration {
 		$powered_by_wct_notice = '<p>' . __( 'Powered by WooCommerce Tax. If automated taxes are enabled, you\'ll need to enter prices exclusive of tax.', 'woocommerce-services' ) . '</p>';
 
 		if ( ! empty( WC_Connect_Functions::get_backed_up_tax_rate_files() ) ) {
-			$powered_by_wct_notice .= '<p>' . sprintf( __( 'Your previous tax rates were backed up and can be downloaded %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . $backedup_tax_rates_url . '">', '</a>' ) . '</p>';
+			$powered_by_wct_notice .= '<p>' . sprintf( __( 'Your previous tax rates were backed up and can be downloaded %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . esc_url( $backedup_tax_rates_url ) . '">', '</a>' ) . '</p>';
 		}
 
 		$desctructive_action_notice  = '<p>' . __( 'Enabling this option overrides any tax rates you have manually added.', 'woocommerce-services' ) . '</p>';

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -179,11 +179,11 @@ class WC_Connect_TaxJar_Integration {
 		$powered_by_wct_notice = '<p>' . __( 'Powered by WooCommerce Tax. If automated taxes are enabled, you\'ll need to enter prices exclusive of tax.', 'woocommerce-services' ) . '</p>';
 
 		if ( ! empty( WC_Connect_Functions::get_backed_up_tax_rate_files() ) ) {
-			$powered_by_wct_notice .= '<p>' . sprintf( __( 'You\'re previous tax rates were backed up and can be downloaded %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . $backedup_tax_rates_url . '">', '</a>' ) . '</p>';
+			$powered_by_wct_notice .= '<p>' . sprintf( __( 'Your previous tax rates were backed up and can be downloaded %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . $backedup_tax_rates_url . '">', '</a>' ) . '</p>';
 		}
 
 		$desctructive_action_notice  = '<p>' . __( 'Enabling this option overrides any tax rates you have manually added.', 'woocommerce-services' ) . '</p>';
-		$desctructive_action_notice .= '<p>' . sprintf( __( 'You\'re existing tax rates will be backed-up to a CSV that you can download %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . $backedup_tax_rates_url . '">', '</a>' ) . '</p>';
+		$desctructive_action_notice .= '<p>' . sprintf( __( 'Your existing tax rates will be backed-up to a CSV that you can download %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . $backedup_tax_rates_url . '">', '</a>' ) . '</p>';
 
 		$tax_nexus_notice = '<p>' . $this->get_tax_tooltip() . '</p>';
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -183,7 +183,7 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		$desctructive_action_notice  = '<p>' . __( 'Enabling this option overrides any tax rates you have manually added.', 'woocommerce-services' ) . '</p>';
-		$desctructive_action_notice .= '<p>' . sprintf( __( 'Your existing tax rates will be backed-up to a CSV that you can download %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . $backedup_tax_rates_url . '">', '</a>' ) . '</p>';
+		$desctructive_action_notice .= '<p>' . sprintf( __( 'Your existing tax rates will be backed-up to a CSV that you can download %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . esc_url( $backedup_tax_rates_url ) . '">', '</a>' ) . '</p>';
 
 		$tax_nexus_notice = '<p>' . $this->get_tax_tooltip() . '</p>';
 

--- a/client/apps/plugin-status/view.js
+++ b/client/apps/plugin-status/view.js
@@ -22,7 +22,7 @@ import {
 	toggleDebugging,
 } from './state/actions';
 
-const StatusView = ( { onLoggingToggle, onDebuggingToggle, isLoggingEnabled, isDebuggingEnabled, translate } ) => {
+const StatusView = ( { onLoggingToggle, onDebuggingToggle, isLoggingEnabled, isDebuggingEnabled, taxRateBackups, translate } ) => {
 	return (
 		<div>
 			<GlobalNotices id="notices" notices={ notices.list } />
@@ -57,6 +57,33 @@ const StatusView = ( { onLoggingToggle, onDebuggingToggle, isLoggingEnabled, isD
 					logKey="other"
 					title={ translate( 'Other Log' ) } />
 			</SettingsGroupCard>
+
+			{ taxRateBackups ? <SettingsGroupCard heading={ translate( 'Tax Rates' ) }>
+				<FormFieldset>
+					<FormLegend id="tax-rate-backups">{ translate( 'Download Backed-up Tax Rates' ) }</FormLegend>
+					<p className="plugin-status__help-description">
+						{ translate( 'Simply click a file below to download it, then import it into the {{taxRatesA}}tax rates table{{/taxRatesA}}.', {
+							components: {
+								taxRatesA:
+									<a href="/wp-admin/admin.php?page=wc-settings&tab=tax&section=standard" />,
+							},
+						} ) }
+
+						<br />
+
+						<br />
+
+						<ul>
+							{ Object.keys( taxRateBackups ).map( ( filename, i ) => {
+								return ( <li key={ i }>
+									<a href={ taxRateBackups[ filename ] }>{ filename }</a>
+								</li> );
+							} ) }
+						</ul>
+					</p>
+				</FormFieldset>
+			</SettingsGroupCard> : '' }
+
 			<SettingsGroupCard heading={ translate( 'Support' ) }>
 				<FormFieldset>
 					<FormLegend>{ translate( 'Need help?' ) }</FormLegend>
@@ -84,6 +111,7 @@ const StatusView = ( { onLoggingToggle, onDebuggingToggle, isLoggingEnabled, isD
 const mapStateToProps = ( state ) => ( {
 	isLoggingEnabled: Boolean( state.status.logging_enabled ),
 	isDebuggingEnabled: Boolean( state.status.debug_enabled ),
+	taxRateBackups: state.status.tax_rate_backups,
 } );
 
 const mapDispatchToProps = {

--- a/client/apps/plugin-status/view.js
+++ b/client/apps/plugin-status/view.js
@@ -62,7 +62,7 @@ const StatusView = ( { onLoggingToggle, onDebuggingToggle, isLoggingEnabled, isD
 				<FormFieldset>
 					<FormLegend id="tax-rate-backups">{ translate( 'Download Backed-up Tax Rates' ) }</FormLegend>
 					<p className="plugin-status__help-description">
-						{ translate( 'Simply click a file below to download it, then import it into the {{taxRatesA}}tax rates table{{/taxRatesA}}.', {
+						{ translate( 'Click a file below to download it, then import it into the {{taxRatesA}}tax rates table{{/taxRatesA}}.', {
 							components: {
 								taxRatesA:
 									<a href="/wp-admin/admin.php?page=wc-settings&tab=tax&section=standard" />,

--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@ Tags: shipping, stamps, usps, woocommerce, taxes, payment, dhl, labels
 Requires at least: 4.6
 Requires PHP: 5.3
 Tested up to: 6.0.2
+WC tested up to: 7.0.0
 Stable tag: 1.26.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -9,7 +9,7 @@
  * Domain Path: /i18n/languages/
  * Version: 1.26.2
  * WC requires at least: 3.5.5
- * WC tested up to: 6.6.1
+ * WC tested up to: 6.7.0
  *
  * Copyright (c) 2017-2022 Automattic
  *

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -9,7 +9,7 @@
  * Domain Path: /i18n/languages/
  * Version: 1.26.3
  * WC requires at least: 3.5.5
- * WC tested up to: 6.7.0
+ * WC tested up to: 7.0
  *
  * Copyright (c) 2017-2022 Automattic
  *


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
When enabling automated tax rates, existing tax rates are backed up into a CSV file and stored in the uploads folder so merchants can import backed-up rates if they choose to disable automated taxes. This works but is currently not intuitive, especially for merchants that haven't accessed their site files before. This PR creates a section with a list of backup links in the WC > Status > WC Shipping & Tax admin page and adds messaging so merchants know how to get their backups so they can more easily download and import their previous tax rates.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
Fixes #2311 

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

1. Checkout this branch
2. Enable taxes in the WC General settings
3. Add a few tax rates [here](http://localhost:8050/wp-admin/admin.php?page=wc-settings&tab=tax&section=standard) and save
4. Go to http://localhost:8050/wp-admin/admin.php?page=wc-settings&tab=tax
5. You should see the following message before you enable automated taxes:

![tax-settings-messaging-auto-taxes-disabled](https://user-images.githubusercontent.com/11618203/180149999-8d7ff82a-bb82-4f44-b01b-37b5ba8407d7.png)

6. Enable automated taxes and save.
7. You should now see the following message:

![tax-settings-messaging-auto-taxes-enabled](https://user-images.githubusercontent.com/11618203/180150002-7ee13cc3-2306-49a5-a96d-f7a302a67846.png)

8. Click the link in the message to be taken to the backed up tax rates section of the WC Shipping & Tax admin page.
9. You should see the following section with a link to your newly backed-up tax rates.

![wcs-connect-tab-tax-rate-backup-downloads](https://user-images.githubusercontent.com/11618203/180150007-5e0c95f6-aa7e-4bfe-87f2-6df651ac3ed6.png)

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

