### PR TITLE
Replace calypso's spinner

### DIFF
--- a/client/components/spinner/README.md
+++ b/client/components/spinner/README.md
@@ -1,0 +1,27 @@
+Spinner
+=======
+
+Spinner is a React component for rendering a loading indicator.
+
+__Please exercise caution in deciding to use a spinner in your component.__ A lone spinner is a poor user-experience and conveys little context to what the user should expect from the page. Refer to [the _Reactivity and Loading States_ guide](https://github.com/Automattic/wp-calypso/blob/master/docs/reactivity.md) for more information on building fast interfaces and making the most of data already available to use.
+
+## Usage
+
+```jsx
+import React from 'react';
+import Spinner from 'components/spinner';
+
+export default class extends React.Component {
+	render() {
+		return <Spinner />;
+	}
+}
+```
+
+## Props
+
+The following props can be passed to the Spinner component:
+
+| PROPERTY     | TYPE     | REQUIRED | DEFAULT | DESCRIPTION |
+| ------------ | -------- | -------- | ------- | ----------- |
+| **size**     | *number* | no       | `20`    | The width and height of the spinner, in pixels. |

--- a/client/components/spinner/docs/example.jsx
+++ b/client/components/spinner/docs/example.jsx
@@ -1,0 +1,34 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Spinner from 'components/spinner';
+
+export default class extends React.PureComponent {
+	static displayName = 'Spinner';
+
+	render() {
+		return (
+			<div>
+				<p>
+					<strong>Please exercise caution in deciding to use a spinner in your component.</strong> A
+					lone spinner is a poor user-experience and conveys little context to what the user should
+					expect from the page. Refer to{' '}
+					<a href="/devdocs/docs/reactivity.md">
+						the <em>Reactivity and Loading States</em> guide
+					</a>{' '}
+					for more information on building fast interfaces and making the most of data already
+					available to use.
+				</p>
+				<Spinner />
+			</div>
+		);
+	}
+}

--- a/client/components/spinner/index.jsx
+++ b/client/components/spinner/index.jsx
@@ -1,0 +1,43 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import classNames from 'classnames';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export default class Spinner extends PureComponent {
+	static propTypes = {
+		className: PropTypes.string,
+		size: PropTypes.number,
+	};
+
+	static defaultProps = {
+		size: 20,
+	};
+
+	render() {
+		const className = classNames( 'spinner', this.props.className );
+
+		const style = {
+			width: this.props.size,
+			height: this.props.size,
+			fontSize: this.props.size, // allows border-width to be specified in em units
+		};
+
+		return (
+			<div className={ className }>
+				<div className="spinner__outer" style={ style }>
+					<div className="spinner__inner" />
+				</div>
+			</div>
+		);
+	}
+}

--- a/client/components/spinner/style.scss
+++ b/client/components/spinner/style.scss
@@ -1,0 +1,31 @@
+@keyframes rotate-spinner {
+	100% {
+		transform: rotate( 360deg );
+	}
+}
+
+.spinner {
+	display: flex;
+	align-items: center;
+}
+
+.spinner__outer, .spinner__inner {
+	margin: auto;
+	box-sizing: border-box;
+  border: 0.1em solid transparent;
+	border-radius: 50%;
+	animation: 3s linear infinite;
+	animation-name: rotate-spinner;
+}
+
+.spinner__outer {
+	border-top-color: var( --color-accent );
+}
+
+.spinner__inner {
+	width: 100%;
+  height: 100%;
+	border-top-color: var( --color-accent );
+  border-right-color: var( --color-accent );
+  opacity: 0.4;
+}

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/step-container.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/step-container.js
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import Spinner from 'components/spinner';
+import Spinner from 'wcs-client/components/spinner';
 import FoldableCard from 'wcs-client/components/foldable-card';
 
 const StepContainer = ( {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/step-container.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/step-container.js
@@ -12,6 +12,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import Spinner from 'components/spinner';
 import FoldableCard from 'wcs-client/components/foldable-card';
 
 const StepContainer = ( {
@@ -36,23 +37,23 @@ const StepContainer = ( {
 		if ( isError ) {
 			return 'notice-outline';
 		}
-		if ( isProgress ) {
-			return 'sync';
-		}
 		return '';
 	};
 	const className = classNames( {
 		'is-success': isSuccess,
 		'is-warning': isWarning,
 		'is-error': isError,
-		'label-purchase-modal__step-spinner': isProgress
 	} );
 
 	summary = (
 		<span className={ className }>
 			<span>{ summary }</span>
 			<div className="label-purchase-modal__step-status">
-			<Gridicon icon={ getIcon() } className={ className } size={ 18 } />
+				{ isProgress ? (
+					<Spinner size={ 18 } />
+				) : (
+					<Gridicon icon={ getIcon() } className={ className } size={ 18 } />
+				) }
 			</div>
 		</span>
 	);

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/step-container.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/step-container.js
@@ -12,7 +12,6 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import Spinner from 'components/spinner';
 import FoldableCard from 'wcs-client/components/foldable-card';
 
 const StepContainer = ( {
@@ -37,23 +36,23 @@ const StepContainer = ( {
 		if ( isError ) {
 			return 'notice-outline';
 		}
+		if ( isProgress ) {
+			return 'sync';
+		}
 		return '';
 	};
 	const className = classNames( {
 		'is-success': isSuccess,
 		'is-warning': isWarning,
 		'is-error': isError,
+		'label-purchase-modal__step-spinner': isProgress
 	} );
 
 	summary = (
 		<span className={ className }>
 			<span>{ summary }</span>
 			<div className="label-purchase-modal__step-status">
-				{ isProgress ? (
-					<Spinner size={ 18 } />
-				) : (
-					<Gridicon icon={ getIcon() } className={ className } size={ 18 } />
-				) }
+			<Gridicon icon={ getIcon() } className={ className } size={ 18 } />
 			</div>
 		</span>
 	);

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -77,11 +77,6 @@
 	.gridicon.is-warning {
 		color: var( --color-warning );
 	}
-	.gridicon.label-purchase-modal__step-spinner {
-		fill: var( --color-neutral-dark );
-		animation: 3s linear infinite;
-		animation-name: rotate-spinner;
-	}
 
 	.is-error:not( .notice ) {
 		color: var( --color-error );
@@ -228,4 +223,3 @@
 .label-purchase-modal__shipping-summary-section {
 	padding-bottom: 15px;
 }
-

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -77,6 +77,11 @@
 	.gridicon.is-warning {
 		color: var( --color-warning );
 	}
+	.gridicon.label-purchase-modal__step-spinner {
+		fill: var( --color-neutral-dark );
+		animation: 3s linear infinite;
+		animation-name: rotate-spinner;
+	}
 
 	.is-error:not( .notice ) {
 		color: var( --color-error );
@@ -223,3 +228,4 @@
 .label-purchase-modal__shipping-summary-section {
 	padding-bottom: 15px;
 }
+


### PR DESCRIPTION
## Description
Removes `<Spinner>` and use existing `Gridicon` with CSS animation.

### Related issue(s)
Relates to https://github.com/Automattic/woocommerce-services/issues/2333.

### Considerations
We don't have the <Spinner> components from WC https://woocommerce.github.io/woocommerce-admin/#/components/ in our `'woocommerce/components/`. We could add `@woocommerce/components` but I would rather wait until we decide which component (WC/WP/our own) to use.

We I tried using WP `<Spinner>` https://developer.wordpress.org/block-editor/reference-guides/components/spinner/ but couldn't get it to show. 

Using existing `GridIcon` + CSS reduces component dependency and we already use [a similar technique here](https://github.com/Automattic/woocommerce-services/pull/2392). 

I decided to use GridIcon + CSS.

### Steps to reproduce & screenshots/GIFs
1. Go purchase a label
2. Go through each step. As it loads, you should see a spinner similar to the following:
[spinner.webm](https://user-images.githubusercontent.com/572862/202322622-a8bbb12f-41b2-4e43-aca4-a52a403916c8.webm)


### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added

