### PR TITLE
Catch malformed zipcode and display a WC notice - Tweak/issue 2586

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.1.0 - 2022-xx-xx =
+* Tweak - Catch malformed zipcode and display WC notice.
+
 = 2.0.0 - 2022-11-16 =
 * Add   - High-Performance Order Storage compatibility.
 * Add   - Add list of tax rate backup files for merchants to click and download.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -377,7 +377,8 @@ class WC_Connect_TaxJar_Integration {
 		// ignore error messages caused by customer input
 		$state_zip_mismatch = false !== strpos( $formatted_message, 'to_zip' ) && false !== strpos( $formatted_message, 'is not used within to_state' );
 		$invalid_postcode   = false !== strpos( $formatted_message, 'isn\'t a valid postal code for' );
-		if ( ! is_admin() && ( $state_zip_mismatch || $invalid_postcode ) ) {
+		$malformed_postcode = false !== strpos( $formatted_message, 'zip code has incorrect format' );
+		if ( ! is_admin() && ( $state_zip_mismatch || $invalid_postcode || $malformed_postcode ) ) {
 			$fields              = WC()->countries->get_address_fields();
 			$postcode_field_name = __( 'ZIP/Postal code', 'woocommerce-services' );
 			if ( isset( $fields['billing_postcode'] ) && isset( $fields['billing_postcode']['label'] ) ) {
@@ -386,6 +387,8 @@ class WC_Connect_TaxJar_Integration {
 
 			if ( $state_zip_mismatch ) {
 				$message = sprintf( _x( '%s does not match the selected state.', '%s - ZIP/Postal code checkout field label', 'woocommerce-services' ), $postcode_field_name );
+			} elseif ( $malformed_postcode ) {
+				$message = sprintf( _x( '%s is not formatted correctly.', '%s - ZIP/Postal code checkout field label', 'woocommerce-services' ), $postcode_field_name );
 			} else {
 				$message = sprintf( _x( 'Invalid %s entered.', '%s - ZIP/Postal code checkout field label', 'woocommerce-services' ), $postcode_field_name );
 			}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1078,6 +1078,10 @@ class WC_Connect_TaxJar_Integration {
 
 		// Decode Response
 		$taxjar_response = json_decode( $response['body'] );
+		if ( empty( $taxjar_response->tax ) ) {
+			return false;
+		}
+
 		$taxjar_response = $this->maybe_override_taxjar_tax( $taxjar_response->tax, $body );
 
 		// Update Properties based on Response

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: woocommerce, automattic, woothemes, allendav, kellychoffman, jkudi
 Tags: shipping, stamps, usps, woocommerce, taxes, payment, dhl, labels
 Requires PHP: 5.6
 Requires at least: 4.6
-Tested up to: 6.0.3
+Tested up to: 6.1.1
 WC requires at least: 3.6
-WC tested up to: 7.0.0
+WC tested up to: 7.1.0
 Stable tag: 2.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -9,9 +9,9 @@
  * Domain Path: /i18n/languages/
  * Version: 2.0.0
  * Requires at least: 4.6
- * Tested up to: 6.0
+ * Tested up to: 6.1
  * WC requires at least: 3.6
- * WC tested up to: 7.0
+ * WC tested up to: 7.1
  *
  * Copyright (c) 2017-2022 Automattic
  *


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
TaxJar returns a variety of zipcode related error messages. One of these messages related to an incorrectly formatted zipcode was slipping through the cracks and allowing customers to checkout with $0 in tax. This PR tweaks the zipcode error catching functionality to handle this case as well and prevent customers from checking out with a malformed zipcode.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
Fixes #2586 

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
1. Checkout this branch of WC Services.
2. Go to `/wp-admin/admin.php?page=wc-settings&tab=general` and check `Enable tax rates and calculations` and save changes.
3. Go to `/wp-admin/admin.php?page=wc-settings&tab=tax` and enable automated taxes.
4. Add a taxable product to cart and navigate to checkout.
5. Set the billing address to a California address.
6. Change the zipcode to `88330-0000`.
7. You should see the following notice and should not be able to place the order.

![screenshot-localhost_8050-2022 11 18-11_00_00](https://user-images.githubusercontent.com/11618203/202675089-da332768-8266-45db-b0aa-478f13a9736a.png)

8. Change the zipcode to `883300000`.
9. You should see the following notice and should not be able to place the order.

![screenshot-localhost_8050-2022 11 18-11_01_10](https://user-images.githubusercontent.com/11618203/202675305-36a18e85-d675-42e0-82c6-409f76fd05a3.png)


### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added

