### PR TITLE
Fix/issue 2578 - Make sure the packaging step is not skipped

### DIFF
--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -13,6 +13,7 @@ jobs:
           submodules: recursive
       - name: Switch to PHP 7.4
         run: |
+          sudo apt install php7.4
           sudo a2enmod php7.4
           sudo update-alternatives --set php /usr/bin/php7.4
           sudo update-alternatives --set phar /usr/bin/phar7.4

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -13,7 +13,6 @@ jobs:
           submodules: recursive
       - name: Switch to PHP 7.4
         run: |
-          sudo php -v
           sudo update-alternatives --set php /usr/bin/php7.4
           sudo update-alternatives --set phar /usr/bin/phar7.4
           sudo update-alternatives --set phar.phar /usr/bin/phar.phar7.4

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -13,6 +13,7 @@ jobs:
           submodules: recursive
       - name: Switch to PHP 7.4
         run: |
+          sudo a2enmod php7.4
           sudo update-alternatives --set php /usr/bin/php7.4
           sudo update-alternatives --set phar /usr/bin/phar7.4
           sudo update-alternatives --set phar.phar /usr/bin/phar.phar7.4

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -5,22 +5,22 @@ on: [pull_request, workflow_dispatch]
 jobs:
   php_lint:
     name: PHP Syntax Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout latest WCS
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Switch to PHP 8.1
+      - name: Switch to PHP 7.4
         run: |
-          sudo update-alternatives --set php /usr/bin/php8.1
-          sudo update-alternatives --set phar /usr/bin/phar8.1
-          sudo update-alternatives --set phar.phar /usr/bin/phar.phar8.1
+          sudo update-alternatives --set php /usr/bin/php7.4
+          sudo update-alternatives --set phar /usr/bin/phar7.4
+          sudo update-alternatives --set phar.phar /usr/bin/phar.phar7.4
       - name: Lint
         run: find . -type f -name "*.php" -exec php -l {} \;
   find_latest_versions:
     name: Find supported wordpress and woocommerce versions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       wc-versions: ${{ steps.get_wc_versions_for_matrix.outputs.wc-versions }}
       wp-versions: ${{ steps.get_wp_versions_for_matrix.outputs.wp-versions }}
@@ -36,7 +36,7 @@ jobs:
   php_build_and_test:
     name: PHP Unit Test (WP, WC)
     needs: find_latest_versions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       mariadb:
         image: mariadb:latest
@@ -57,11 +57,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Switch to PHP 8.1
+      - name: Switch to PHP 7.4
         run: |
-          sudo update-alternatives --set php /usr/bin/php8.1
-          sudo update-alternatives --set phar /usr/bin/phar8.1
-          sudo update-alternatives --set phar.phar /usr/bin/phar.phar8.1
+          sudo update-alternatives --set php /usr/bin/php7.4
+          sudo update-alternatives --set phar /usr/bin/phar7.4
+          sudo update-alternatives --set phar.phar /usr/bin/phar.phar7.4
       - name: Install composer
         run: |
           ./bin/composer-installer.sh

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -13,7 +13,6 @@ jobs:
           submodules: recursive
       - name: Switch to PHP 7.4
         run: |
-          sudo cd /usr/bin && ls
           sudo update-alternatives --set php /usr/bin/php7.4
           sudo update-alternatives --set phar /usr/bin/phar7.4
           sudo update-alternatives --set phar.phar /usr/bin/phar.phar7.4

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -13,9 +13,10 @@ jobs:
           submodules: recursive
       - name: Switch to PHP 7.4
         run: |
-          sudo update-alternatives --set php /usr/bin/php8.0
-          sudo update-alternatives --set phar /usr/bin/phar8.0
-          sudo update-alternatives --set phar.phar /usr/bin/phar.phar8.0
+          sudo php -v
+          sudo update-alternatives --set php /usr/bin/php7.4
+          sudo update-alternatives --set phar /usr/bin/phar7.4
+          sudo update-alternatives --set phar.phar /usr/bin/phar.phar7.4
       - name: Lint
         run: find . -type f -name "*.php" -exec php -l {} \;
   find_latest_versions:

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -13,6 +13,7 @@ jobs:
           submodules: recursive
       - name: Switch to PHP 7.4
         run: |
+          sudo cd /usr/bin && ls
           sudo update-alternatives --set php /usr/bin/php7.4
           sudo update-alternatives --set phar /usr/bin/phar7.4
           sudo update-alternatives --set phar.phar /usr/bin/phar.phar7.4

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -13,9 +13,9 @@ jobs:
           submodules: recursive
       - name: Switch to PHP 7.4
         run: |
-          sudo update-alternatives --set php /usr/bin/php7.4
-          sudo update-alternatives --set phar /usr/bin/phar7.4
-          sudo update-alternatives --set phar.phar /usr/bin/phar.phar7.4
+          sudo update-alternatives --set php /usr/bin/php8.0
+          sudo update-alternatives --set phar /usr/bin/phar8.0
+          sudo update-alternatives --set phar.phar /usr/bin/phar.phar8.0
       - name: Lint
         run: find . -type f -name "*.php" -exec php -l {} \;
   find_latest_versions:

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -5,22 +5,22 @@ on: [pull_request, workflow_dispatch]
 jobs:
   php_lint:
     name: PHP Syntax Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout latest WCS
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Switch to PHP 7.4
+      - name: Switch to PHP 8.1
         run: |
-          sudo update-alternatives --set php /usr/bin/php7.4
-          sudo update-alternatives --set phar /usr/bin/phar7.4
-          sudo update-alternatives --set phar.phar /usr/bin/phar.phar7.4
+          sudo update-alternatives --set php /usr/bin/php8.1
+          sudo update-alternatives --set phar /usr/bin/phar8.1
+          sudo update-alternatives --set phar.phar /usr/bin/phar.phar8.1
       - name: Lint
         run: find . -type f -name "*.php" -exec php -l {} \;
   find_latest_versions:
     name: Find supported wordpress and woocommerce versions
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       wc-versions: ${{ steps.get_wc_versions_for_matrix.outputs.wc-versions }}
       wp-versions: ${{ steps.get_wp_versions_for_matrix.outputs.wp-versions }}
@@ -36,7 +36,7 @@ jobs:
   php_build_and_test:
     name: PHP Unit Test (WP, WC)
     needs: find_latest_versions
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     services:
       mariadb:
         image: mariadb:latest
@@ -57,11 +57,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Switch to PHP 7.4
+      - name: Switch to PHP 8.1
         run: |
-          sudo update-alternatives --set php /usr/bin/php7.4
-          sudo update-alternatives --set phar /usr/bin/phar7.4
-          sudo update-alternatives --set phar.phar /usr/bin/phar.phar7.4
+          sudo update-alternatives --set php /usr/bin/php8.1
+          sudo update-alternatives --set phar /usr/bin/phar8.1
+          sudo update-alternatives --set phar.phar /usr/bin/phar.phar8.1
       - name: Install composer
         run: |
           ./bin/composer-installer.sh

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
   php_lint:
     name: PHP Syntax Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout latest WCS
         uses: actions/checkout@v2
@@ -20,7 +20,7 @@ jobs:
         run: find . -type f -name "*.php" -exec php -l {} \;
   find_latest_versions:
     name: Find supported wordpress and woocommerce versions
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       wc-versions: ${{ steps.get_wc_versions_for_matrix.outputs.wc-versions }}
       wp-versions: ${{ steps.get_wp_versions_for_matrix.outputs.wp-versions }}
@@ -36,7 +36,7 @@ jobs:
   php_build_and_test:
     name: PHP Unit Test (WP, WC)
     needs: find_latest_versions
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     services:
       mariadb:
         image: mariadb:latest

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
   php_lint:
     name: PHP Syntax Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout latest WCS
         uses: actions/checkout@v2
@@ -13,8 +13,6 @@ jobs:
           submodules: recursive
       - name: Switch to PHP 7.4
         run: |
-          sudo apt install php7.4
-          sudo a2enmod php7.4
           sudo update-alternatives --set php /usr/bin/php7.4
           sudo update-alternatives --set phar /usr/bin/phar7.4
           sudo update-alternatives --set phar.phar /usr/bin/phar.phar7.4
@@ -22,7 +20,7 @@ jobs:
         run: find . -type f -name "*.php" -exec php -l {} \;
   find_latest_versions:
     name: Find supported wordpress and woocommerce versions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       wc-versions: ${{ steps.get_wc_versions_for_matrix.outputs.wc-versions }}
       wp-versions: ${{ steps.get_wp_versions_for_matrix.outputs.wp-versions }}
@@ -38,7 +36,7 @@ jobs:
   php_build_and_test:
     name: PHP Unit Test (WP, WC)
     needs: find_latest_versions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       mariadb:
         image: mariadb:latest

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.1.1 - 2022-xx-xx =
+* Fix   - Save the selected package box and do not skip the package step.
+
 = 2.1.0 - 2022-11-30 =
 * Tweak - Catch malformed zipcode and display WC notice.
 

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -434,9 +434,8 @@ export const removeIgnoreValidation = ( orderId, siteId, group ) => {
 
 const checkPackagesStep = ( orderId, siteId, dispatch, getState ) => {
 	const { expanded } = getShippingLabel( getState(), orderId, siteId ).form[ 'packages' ];
-	if ( true !== expanded ) {
+	if ( !expanded ) {
 		dispatch( toggleStep( orderId, siteId, 'packages' ) );
-		return;
 	}
 };
 

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -347,12 +347,7 @@ export const openPrintingFlow = ( orderId, siteId ) => ( dispatch, getState ) =>
 
 	waitForAllPromises( promisesQueue ).then( () =>
 		tryGetLabelRates( orderId, siteId, dispatch, getState )
-	).then( () => {
-		const { packageId, boxId } = getDefaultBoxSelection( orderId, siteId, getState ) || {};
-		if ( packageId !== undefined && boxId !== undefined ) {
-			dispatch( setPackageType (orderId, siteId, packageId, boxId ) );
-		}
-	} );
+	);
 
 	dispatch( { type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW, orderId, siteId } );
 };
@@ -432,14 +427,6 @@ export const removeIgnoreValidation = ( orderId, siteId, group ) => {
 	};
 };
 
-const checkPackagesStep = ( orderId, siteId, dispatch, getState ) => {
-	const { expanded } = getShippingLabel( getState(), orderId, siteId ).form[ 'packages' ];
-	if ( true !== expanded ) {
-		dispatch( toggleStep( orderId, siteId, 'packages' ) );
-		return;
-	}
-};
-
 export const confirmAddressSuggestion = ( orderId, siteId, group ) => ( dispatch, getState ) => {
 	dispatch( {
 		type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_CONFIRM_ADDRESS_SUGGESTION,
@@ -448,12 +435,7 @@ export const confirmAddressSuggestion = ( orderId, siteId, group ) => ( dispatch
 		group,
 	} );
 
-	if ( 'destination' === group ) {
-		checkPackagesStep( orderId, siteId, dispatch, getState );
-		return;
-	}
-	
-	tryGetLabelRates( orderId, siteId, dispatch, getState );	
+	tryGetLabelRates( orderId, siteId, dispatch, getState );
 };
 
 export const submitAddressForNormalization = ( orderId, siteId, group ) => (
@@ -470,12 +452,7 @@ export const submitAddressForNormalization = ( orderId, siteId, group ) => (
 				dispatch( toggleStep( orderId, siteId, group ) );
 			}
 
-			if ( 'destination' === group ) {
-				checkPackagesStep( orderId, siteId, dispatch, getState );
-				return;
-			}
-			
-			tryGetLabelRates( orderId, siteId, dispatch, getState );	
+			tryGetLabelRates( orderId, siteId, dispatch, getState );
 		}
 	};
 

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -347,7 +347,12 @@ export const openPrintingFlow = ( orderId, siteId ) => ( dispatch, getState ) =>
 
 	waitForAllPromises( promisesQueue ).then( () =>
 		tryGetLabelRates( orderId, siteId, dispatch, getState )
-	);
+	).then( () => {
+		const { packageId, boxId } = getDefaultBoxSelection( orderId, siteId, getState ) || {};
+		if ( packageId !== undefined && boxId !== undefined ) {
+			dispatch( setPackageType (orderId, siteId, packageId, boxId ) );
+		}
+	} );
 
 	dispatch( { type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW, orderId, siteId } );
 };
@@ -427,6 +432,14 @@ export const removeIgnoreValidation = ( orderId, siteId, group ) => {
 	};
 };
 
+const checkPackagesStep = ( orderId, siteId, dispatch, getState ) => {
+	const { expanded } = getShippingLabel( getState(), orderId, siteId ).form[ 'packages' ];
+	if ( true !== expanded ) {
+		dispatch( toggleStep( orderId, siteId, 'packages' ) );
+		return;
+	}
+};
+
 export const confirmAddressSuggestion = ( orderId, siteId, group ) => ( dispatch, getState ) => {
 	dispatch( {
 		type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_CONFIRM_ADDRESS_SUGGESTION,
@@ -435,7 +448,12 @@ export const confirmAddressSuggestion = ( orderId, siteId, group ) => ( dispatch
 		group,
 	} );
 
-	tryGetLabelRates( orderId, siteId, dispatch, getState );
+	if ( 'destination' === group ) {
+		checkPackagesStep( orderId, siteId, dispatch, getState );
+		return;
+	}
+	
+	tryGetLabelRates( orderId, siteId, dispatch, getState );	
 };
 
 export const submitAddressForNormalization = ( orderId, siteId, group ) => (
@@ -452,7 +470,12 @@ export const submitAddressForNormalization = ( orderId, siteId, group ) => (
 				dispatch( toggleStep( orderId, siteId, group ) );
 			}
 
-			tryGetLabelRates( orderId, siteId, dispatch, getState );
+			if ( 'destination' === group ) {
+				checkPackagesStep( orderId, siteId, dispatch, getState );
+				return;
+			}
+			
+			tryGetLabelRates( orderId, siteId, dispatch, getState );	
 		}
 	};
 

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 2.1.1 - 2022-xx-xx =
+* Fix   - Save the selected package box and do not skip the package step.
+
 = 2.1.0 - 2022-11-30 =
 * Tweak - Catch malformed zipcode and display WC notice.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
When [#2573](https://github.com/Automattic/woocommerce-services/pull/2573) was merged in, it forces a package to be chosen for every single label purchase. Some stores may need to print large numbers of labels every day all with the same package.

This PR will change that behavior. It will set the package automatically but also will not skip the package step. The reason it is being designed this way in this PR is to prevent the user skip the packages step. So they now the packages that they set before they purchase the label.

### Related issue(s)

Fixes #2578 
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

1. Attempt to create an order with a valid/verified address
2. Notice that the shipping from and destination addresses are automatically validated, and you're offered to select a package
3. Now, create an order with a typo in the address
4. Notice that once you fix the address under Destination Address tab, you will go to Packaging tab instead of directly go to Shipping Rates tab.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

