### PR TITLE
Add/issue 2572 - Add an option to use last package.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,10 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.2.0 - 2023-xx-xx =
+* Add   - Add option to let user pick whether to save the last package or not.
+
 = 2.1.1 - 2023-01-02 =
 * Fix   - Save the selected package box and do not skip the package step.
-* Add   - Add option to let user pick whether to save the last package or not.
 
 = 2.1.0 - 2022-11-30 =
 * Tweak - Catch malformed zipcode and display WC notice.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 2.1.1 - 2022-xx-xx =
 * Fix   - Save the selected package box and do not skip the package step.
+* Add   - Add option to let user pick whether to save the last package or not.
 
 = 2.1.0 - 2022-11-30 =
 * Tweak - Catch malformed zipcode and display WC notice.

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -63,8 +63,8 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				$result['email_receipts'] = true;
 			}
 
-			if ( ! isset( $result['save_last_package'] ) ) {
-				$result['save_last_package'] = true;
+			if ( ! isset( $result['use_last_package'] ) ) {
+				$result['use_last_package'] = true;
 			}
 
 			return $result;

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -63,6 +63,10 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				$result['email_receipts'] = true;
 			}
 
+			if ( ! isset( $result['save_last_package'] ) ) {
+				$result['save_last_package'] = true;
+			}
+
 			return $result;
 		}
 

--- a/client/extensions/woocommerce/woocommerce-services/state/label-settings/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/label-settings/selectors.js
@@ -74,9 +74,9 @@ export const getEmailReceipts = ( state, siteId = getSelectedSiteId( state ) ) =
 	return data && data.email_receipts;
 };
 
-export const getSaveLastPackage = ( state, siteId = getSelectedSiteId( state ) ) => {
+export const getUseLastPackage = ( state, siteId = getSelectedSiteId( state ) ) => {
 	const data = getLabelSettingsFormData( state, siteId );
-	return data && data.save_last_package;
+	return data && data.use_last_package;
 };
 
 export const userCanManagePayments = ( state, siteId = getSelectedSiteId( state ) ) => {

--- a/client/extensions/woocommerce/woocommerce-services/state/label-settings/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/label-settings/selectors.js
@@ -74,6 +74,11 @@ export const getEmailReceipts = ( state, siteId = getSelectedSiteId( state ) ) =
 	return data && data.email_receipts;
 };
 
+export const getSaveLastPackage = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const data = getLabelSettingsFormData( state, siteId );
+	return data && data.save_last_package;
+};
+
 export const userCanManagePayments = ( state, siteId = getSelectedSiteId( state ) ) => {
 	const meta = getLabelSettingsFormMeta( state, siteId );
 	return meta && meta.can_manage_payments;

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -349,7 +349,6 @@ export const openPrintingFlow = ( orderId, siteId ) => ( dispatch, getState ) =>
 	waitForAllPromises( promisesQueue ).then( () =>
 		tryGetLabelRates( orderId, siteId, dispatch, getState )
 	).then( () => {
-		//compatibility - only add the email_receipt if the plugin and the server support it
 		const useLastPackage = getUseLastPackage( getState(), siteId );
 		if ( false === useLastPackage ) {
 			return;

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -46,6 +46,7 @@ import { saveOrder } from 'woocommerce/state/sites/orders/actions';
 import { getAllPackageDefinitions } from 'woocommerce/woocommerce-services/state/packages/selectors';
 import {
 	getEmailReceipts,
+	getUseLastPackage,
 	getLabelSettingsUserMeta,
  } from 'woocommerce/woocommerce-services/state/label-settings/selectors';
 import getAddressValues from 'woocommerce/woocommerce-services/lib/utils/get-address-values';
@@ -348,6 +349,12 @@ export const openPrintingFlow = ( orderId, siteId ) => ( dispatch, getState ) =>
 	waitForAllPromises( promisesQueue ).then( () =>
 		tryGetLabelRates( orderId, siteId, dispatch, getState )
 	).then( () => {
+		//compatibility - only add the email_receipt if the plugin and the server support it
+		const useLastPackage = getUseLastPackage( getState(), siteId );
+		if ( false === useLastPackage ) {
+			return;
+		}
+
 		const { packageId, boxId } = getDefaultBoxSelection( orderId, siteId, getState ) || {};
 		if ( packageId !== undefined && boxId !== undefined ) {
 			dispatch( setPackageType (orderId, siteId, packageId, boxId ) );

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -33,7 +33,7 @@ import {
 	areSettingsFetching,
 	areSettingsLoaded,
 	getEmailReceipts,
-	getSaveLastPackage,
+	getUseLastPackage,
 	getLabelSettingsStoreOptions,
 	getMasterUserInfo,
 	getPaperSize,
@@ -346,16 +346,16 @@ class ShippingLabels extends Component {
 
 	renderSavePackageSection = () => {
 		const {
-			saveLastPackage,
+			useLastPackage,
 			translate,
 			canEditSettings,
 			canEditPayments,
 		} = this.props;
 
-		if ( ! isBoolean( saveLastPackage ) ) {
+		if ( ! isBoolean( useLastPackage ) ) {
 			return null;
 		}
-		const onChange = () => this.props.setValue( 'save_last_package', ! saveLastPackage );
+		const onChange = () => this.props.setValue( 'use_last_package', ! useLastPackage );
 		return (
 			<FormFieldSet>
 				<FormLabel className="label-settings__cards-label">
@@ -364,7 +364,7 @@ class ShippingLabels extends Component {
 				<CheckboxControl
 					className="form-label label-settings__credit-card-description"
 					label = { translate( 'Save the package selection from previous transaction.' ) }
-					checked={ saveLastPackage }
+					checked={ useLastPackage }
 					onChange={ onChange }
 					disabled={ ! canEditPayments && ! canEditSettings }
 				/>
@@ -436,7 +436,7 @@ export default connect(
 			canEditSettings:
 				userCanManagePayments( state, siteId ) || userCanEditSettings( state, siteId ),
 			emailReceipts: getEmailReceipts( state, siteId ),
-			saveLastPackage: getSaveLastPackage( state, siteId ),
+			useLastPackage: getUseLastPackage( state, siteId ),
 			...getMasterUserInfo( state, siteId ),
 		};
 	},

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -355,7 +355,9 @@ class ShippingLabels extends Component {
 		if ( ! isBoolean( useLastPackage ) ) {
 			return null;
 		}
+
 		const onChange = () => this.props.setValue( 'use_last_package', ! useLastPackage );
+
 		return (
 			<FormFieldSet>
 				<FormLabel className="label-settings__cards-label">
@@ -363,7 +365,7 @@ class ShippingLabels extends Component {
 				</FormLabel>
 				<CheckboxControl
 					className="form-label label-settings__credit-card-description"
-					label = { translate( 'Save the package selection from previous transaction.' ) }
+					label={ translate( 'Save the package selection from previous transaction.' ) }
 					checked={ useLastPackage }
 					onChange={ onChange }
 					disabled={ ! canEditPayments && ! canEditSettings }

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -33,6 +33,7 @@ import {
 	areSettingsFetching,
 	areSettingsLoaded,
 	getEmailReceipts,
+	getSaveLastPackage,
 	getLabelSettingsStoreOptions,
 	getMasterUserInfo,
 	getPaperSize,
@@ -343,6 +344,34 @@ class ShippingLabels extends Component {
 		);
 	};
 
+	renderSavePackageSection = () => {
+		const {
+			saveLastPackage,
+			translate,
+			canEditSettings,
+			canEditPayments,
+		} = this.props;
+
+		if ( ! isBoolean( saveLastPackage ) ) {
+			return null;
+		}
+		const onChange = () => this.props.setValue( 'save_last_package', ! saveLastPackage );
+		return (
+			<FormFieldSet>
+				<FormLabel className="label-settings__cards-label">
+					{ translate( 'Package Selection' ) }
+				</FormLabel>
+				<CheckboxControl
+					className="form-label label-settings__credit-card-description"
+					label = { translate( 'Save the package selection from previous transaction.' ) }
+					checked={ saveLastPackage }
+					onChange={ onChange }
+					disabled={ ! canEditPayments && ! canEditSettings }
+				/>
+			</FormFieldSet>
+		);
+	};
+
 	renderContent = () => {
 		const { canEditSettings, isLoading, paperSize, storeOptions, translate } = this.props;
 
@@ -377,6 +406,7 @@ class ShippingLabels extends Component {
 					{ this.renderPaymentsSection() }
 				</FormFieldSet>
 				{ this.renderEmailReceiptsSection() }
+				{ this.renderSavePackageSection() }
 			</div>
 		);
 	};
@@ -406,6 +436,7 @@ export default connect(
 			canEditSettings:
 				userCanManagePayments( state, siteId ) || userCanEditSettings( state, siteId ),
 			emailReceipts: getEmailReceipts( state, siteId ),
+			saveLastPackage: getSaveLastPackage( state, siteId ),
 			...getMasterUserInfo( state, siteId ),
 		};
 	},

--- a/readme.txt
+++ b/readme.txt
@@ -78,9 +78,11 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 2.2.0 - 2023-xx-xx =
+* Add   - Add option to let user pick whether to save the last package or not.
+
 = 2.1.1 - 2023-01-02 =
 * Fix   - Save the selected package box and do not skip the package step.
-* Add   - Add option to let user pick whether to save the last package or not.
 
 = 2.1.0 - 2022-11-30 =
 * Tweak - Catch malformed zipcode and display WC notice.

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,7 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 = 2.1.1 - 2022-xx-xx =
 * Fix   - Save the selected package box and do not skip the package step.
+* Add   - Add option to let user pick whether to save the last package or not.
 
 = 2.1.0 - 2022-11-30 =
 * Tweak - Catch malformed zipcode and display WC notice.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Adding an option in **WooCommerce > Settings > Shipping > WooCommerce Shipping** for the user to use saved last package : 
![image](https://user-images.githubusercontent.com/631098/209760735-9807deee-e9aa-4b2d-be2a-1c4cbcbc15b8.png)

 If the user Untick the checkbox, the next printing label process will not use the saved last package.
<!-- Explain the motivation for making this change -->

### Related issue(s)
Fixes #2572 
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
1. Go to **WooCommerce > Settings > Shipping > WooCommerce Shipping**.
2. Untick the **package selection** checkbox.
3. Create a new order
4. Process the shipping label.
5. Notice the Packaging tabs will show an error like the screenshot below : 
![image](https://user-images.githubusercontent.com/631098/209760959-718157b1-8660-4e63-b043-bad3f8ef956f.png)

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

