### PR TITLE
Fix/issue 2576 - Link correction in automated tax description

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.2.2 - 2023-xx-xx =
+* Fix   - Link correction on Automated taxes description text.
+
 = 2.2.1 - 2023-01-24 =
 * Fix   - Fix warning on checkout page apper if zipcode doesn't match selected state.
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -176,11 +176,9 @@ class WC_Connect_TaxJar_Integration {
 		$enabled                = $this->is_enabled();
 		$backedup_tax_rates_url = admin_url( '/admin.php?page=wc-status&tab=connect#tax-rate-backups' );
 
-		$powered_by_wct_notice = '<p>' . __( 'Powered by WooCommerce Tax. If automated taxes are enabled, you\'ll need to enter prices exclusive of tax.', 'woocommerce-services' ) . '</p>';
+		$powered_by_wct_notice = '<p>' . sprintf( __( 'Automated taxes take over from the WooCommerce core tax settings. This means that "Display prices" will be set to Excluding tax and tax will be Calculated using Customer shipping address. %1$sLearn more about Automated taxes here.%2$s', 'woocommerce-services' ), '<a href="https://href.li/?https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#automated-tax-calculation">', '</a>' ) . '</p>';
 
-		if ( ! empty( WC_Connect_Functions::get_backed_up_tax_rate_files() ) ) {
-			$powered_by_wct_notice .= '<p>' . sprintf( __( 'Your previous tax rates were backed up and can be downloaded %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . esc_url( $backedup_tax_rates_url ) . '">', '</a>' ) . '</p>';
-		}
+		$backup_notice = ( ! empty( WC_Connect_Functions::get_backed_up_tax_rate_files() ) ) ? '<p>' . sprintf( __( 'Your previous tax rates were backed up and can be downloaded %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . esc_url( $backedup_tax_rates_url ) . '">', '</a>' ) . '</p>' : '';
 
 		$desctructive_action_notice  = '<p>' . __( 'Enabling this option overrides any tax rates you have manually added.', 'woocommerce-services' ) . '</p>';
 		$desctructive_action_notice .= '<p>' . sprintf( __( 'Your existing tax rates will be backed-up to a CSV that you can download %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . esc_url( $backedup_tax_rates_url ) . '">', '</a>' ) . '</p>';
@@ -192,6 +190,7 @@ class WC_Connect_TaxJar_Integration {
 			$enabled ? [
 				$powered_by_wct_notice,
 				$tax_nexus_notice,
+				$backup_notice,
 			] : [ $desctructive_action_notice, $tax_nexus_notice ]
 		);
 		$automated_taxes             = array(
@@ -235,10 +234,10 @@ class WC_Connect_TaxJar_Integration {
 		$full_state     = isset( $all_states[ $store_settings['state'] ] ) ? $all_states[ $store_settings['state'] ] : '';
 		if ( $full_state ) {
 			/* translators: 1: Full state name 2: full country name */
-			return sprintf( __( 'Your tax rates and settings will be automatically configured for %1$s, %2$s. <a href="https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-12">Learn more about setting up tax rates for additional nexuses</a>', 'woocommerce-services' ), $full_state, $full_country );
+			return sprintf( __( 'Your tax rates are now automatically calculated for %1$s, %2$s. Automated taxes uses your store address as your "tax nexus". If you want to charge tax for any other state, you can add a tax rate for that state in addition to using automated taxes. %3$sLearn more about Tax Nexus here%4$s.', 'woocommerce-services' ), $full_state, $full_country, '<a href="https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-12">', '</a>' );
 		}
 		/* translators: 1: full country name */
-		return sprintf( __( 'Your tax rates and settings will be automatically configured for %1$s. <a href="https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-12">Learn more about setting up tax rates for additional nexuses</a>', 'woocommerce-services' ), $full_country );
+		return sprintf( __( 'Your tax rates are now automatically calculated for %1$s. Automated taxes uses your store address as your "tax nexus". If you want to charge tax for any other state, you can add a tax rate for that state in addition to using automated taxes. %2$sLearn more about Tax Nexus here%3$s.', 'woocommerce-services' ), $full_country, '<a href="https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-12">', '</a>' );
 	}
 
 	/**
@@ -916,7 +915,7 @@ class WC_Connect_TaxJar_Integration {
 		if ( ! isset( $taxjar_resp_tax ) ) {
 			return;
 		}
-		
+
 		$new_tax_rate = floatval( apply_filters( 'woocommerce_services_override_tax_rate', $taxjar_resp_tax->rate, $taxjar_resp_tax, $body ) );
 
 		if ( $new_tax_rate === floatval( $taxjar_resp_tax->rate ) ) {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -180,8 +180,8 @@ class WC_Connect_TaxJar_Integration {
 
 		$backup_notice = ( ! empty( WC_Connect_Functions::get_backed_up_tax_rate_files() ) ) ? '<p>' . sprintf( __( 'Your previous tax rates were backed up and can be downloaded %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . esc_url( $backedup_tax_rates_url ) . '">', '</a>' ) . '</p>' : '';
 
-		$desctructive_action_notice  = '<p>' . __( 'Enabling this option overrides any tax rates you have manually added.', 'woocommerce-services' ) . '</p>';
-		$desctructive_action_notice .= '<p>' . sprintf( __( 'Your existing tax rates will be backed-up to a CSV that you can download %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . esc_url( $backedup_tax_rates_url ) . '">', '</a>' ) . '</p>';
+		$desctructive_action_notice = '<p>' . __( 'Enabling this option overrides any tax rates you have manually added.', 'woocommerce-services' ) . '</p>';
+		$desctructive_backup_notice = '<p>' . sprintf( __( 'Your existing tax rates will be backed-up to a CSV that you can download %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . esc_url( $backedup_tax_rates_url ) . '">', '</a>' ) . '</p>';
 
 		$tax_nexus_notice = '<p>' . $this->get_tax_tooltip() . '</p>';
 
@@ -189,9 +189,9 @@ class WC_Connect_TaxJar_Integration {
 			'',
 			$enabled ? [
 				$powered_by_wct_notice,
-				$tax_nexus_notice,
 				$backup_notice,
-			] : [ $desctructive_action_notice, $tax_nexus_notice ]
+				$tax_nexus_notice,
+			] : [ $desctructive_action_notice, $desctructive_backup_notice, $tax_nexus_notice ]
 		);
 		$automated_taxes             = array(
 			'title'    => __( 'Automated taxes', 'woocommerce-services' ),

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -232,12 +232,16 @@ class WC_Connect_TaxJar_Integration {
 		$all_countries  = WC()->countries->get_countries();
 		$full_country   = $all_countries[ $store_settings['country'] ];
 		$full_state     = isset( $all_states[ $store_settings['state'] ] ) ? $all_states[ $store_settings['state'] ] : '';
-		if ( $full_state ) {
-			/* translators: 1: Full state name 2: full country name */
-			return sprintf( __( 'Your tax rates are now automatically calculated for %1$s, %2$s. Automated taxes uses your store address as your "tax nexus". If you want to charge tax for any other state, you can add a tax rate for that state in addition to using automated taxes. %3$sLearn more about Tax Nexus here%4$s.', 'woocommerce-services' ), $full_state, $full_country, '<a href="https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-12">', '</a>' );
+
+		$country_state = ( $full_state ) ? $full_state . ', ' . $full_country : $full_country;
+
+		if ( ! $this->is_enabled() ) {
+			/* translators: 1: full state and country name */
+			return sprintf( __( 'Your tax rates and settings will be automatically configured for %1$s. %2$sLearn more about setting up tax rates for additional nexuses%3$s', 'woocommerce-services' ), $country_state, '<a href="https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-12">', '</a>' );
 		}
-		/* translators: 1: full country name */
-		return sprintf( __( 'Your tax rates are now automatically calculated for %1$s. Automated taxes uses your store address as your "tax nexus". If you want to charge tax for any other state, you can add a tax rate for that state in addition to using automated taxes. %2$sLearn more about Tax Nexus here%3$s.', 'woocommerce-services' ), $full_country, '<a href="https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-12">', '</a>' );
+
+		/* translators: 1: full state and country name, 2: anchor opening with link, 3: anchor closing */
+		return sprintf( __( 'Your tax rates are now automatically calculated for %1$s. Automated taxes uses your store address as your "tax nexus". If you want to charge tax for any other state, you can add a tax rate for that state in addition to using automated taxes. %2$sLearn more about Tax Nexus here%3$s.', 'woocommerce-services' ), $country_state, '<a href="https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-12">', '</a>' );
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -237,11 +237,11 @@ class WC_Connect_TaxJar_Integration {
 
 		if ( ! $this->is_enabled() ) {
 			/* translators: 1: full state and country name */
-			return sprintf( __( 'Your tax rates and settings will be automatically configured for %1$s. Automated taxes uses your store address as your "tax nexus". If you want to charge tax for any other state, you can add a tax rate for that state in addition to using automated taxes. %2$sLearn more about Tax Nexus here%3$s.', 'woocommerce-services' ), $country_state, '<a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#automated-taxes-do-not-appear-to-be-calculating">', '</a>' );
+			return sprintf( __( 'Your tax rates and settings will be automatically configured for %1$s. Automated taxes uses your store address as your "tax nexus". If you want to charge tax for any other state, you can add a %2$stax rate%3$s for that state in addition to using automated taxes. %4$sLearn more about Tax Nexus here%5$s.', 'woocommerce-services' ), $country_state, '<a href="https://woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-12">', '</a>', '<a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#automated-taxes-do-not-appear-to-be-calculating">', '</a>' );
 		}
 
 		/* translators: 1: full state and country name, 2: anchor opening with link, 3: anchor closing */
-		return sprintf( __( 'Your tax rates are now automatically calculated for %1$s. Automated taxes uses your store address as your "tax nexus". If you want to charge tax for any other state, you can add a tax rate for that state in addition to using automated taxes. %2$sLearn more about Tax Nexus here%3$s.', 'woocommerce-services' ), $country_state, '<a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#automated-taxes-do-not-appear-to-be-calculating">', '</a>' );
+		return sprintf( __( 'Your tax rates are now automatically calculated for %1$s. Automated taxes uses your store address as your "tax nexus". If you want to charge tax for any other state, you can add a %2$stax rate%3$s for that state in addition to using automated taxes. %4$sLearn more about Tax Nexus here%5$s.', 'woocommerce-services' ), $country_state, '<a href="https://woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-12">', '</a>', '<a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#automated-taxes-do-not-appear-to-be-calculating">', '</a>' );
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -237,7 +237,7 @@ class WC_Connect_TaxJar_Integration {
 
 		if ( ! $this->is_enabled() ) {
 			/* translators: 1: full state and country name */
-			return sprintf( __( 'Your tax rates and settings will be automatically configured for %1$s. %2$sLearn more about setting up tax rates for additional nexuses%3$s', 'woocommerce-services' ), $country_state, '<a href="https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-12">', '</a>' );
+			return sprintf( __( 'Your tax rates and settings will be automatically configured for %1$s. Automated taxes uses your store address as your "tax nexus". If you want to charge tax for any other state, you can add a tax rate for that state in addition to using automated taxes. %2$sLearn more about Tax Nexus here%3$s.', 'woocommerce-services' ), $country_state, '<a href="https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-12">', '</a>' );
 		}
 
 		/* translators: 1: full state and country name, 2: anchor opening with link, 3: anchor closing */

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -237,11 +237,11 @@ class WC_Connect_TaxJar_Integration {
 
 		if ( ! $this->is_enabled() ) {
 			/* translators: 1: full state and country name */
-			return sprintf( __( 'Your tax rates and settings will be automatically configured for %1$s. Automated taxes uses your store address as your "tax nexus". If you want to charge tax for any other state, you can add a tax rate for that state in addition to using automated taxes. %2$sLearn more about Tax Nexus here%3$s.', 'woocommerce-services' ), $country_state, '<a href="https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-12">', '</a>' );
+			return sprintf( __( 'Your tax rates and settings will be automatically configured for %1$s. Automated taxes uses your store address as your "tax nexus". If you want to charge tax for any other state, you can add a tax rate for that state in addition to using automated taxes. %2$sLearn more about Tax Nexus here%3$s.', 'woocommerce-services' ), $country_state, '<a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#automated-taxes-do-not-appear-to-be-calculating">', '</a>' );
 		}
 
 		/* translators: 1: full state and country name, 2: anchor opening with link, 3: anchor closing */
-		return sprintf( __( 'Your tax rates are now automatically calculated for %1$s. Automated taxes uses your store address as your "tax nexus". If you want to charge tax for any other state, you can add a tax rate for that state in addition to using automated taxes. %2$sLearn more about Tax Nexus here%3$s.', 'woocommerce-services' ), $country_state, '<a href="https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-12">', '</a>' );
+		return sprintf( __( 'Your tax rates are now automatically calculated for %1$s. Automated taxes uses your store address as your "tax nexus". If you want to charge tax for any other state, you can add a tax rate for that state in addition to using automated taxes. %2$sLearn more about Tax Nexus here%3$s.', 'woocommerce-services' ), $country_state, '<a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#automated-taxes-do-not-appear-to-be-calculating">', '</a>' );
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -176,7 +176,7 @@ class WC_Connect_TaxJar_Integration {
 		$enabled                = $this->is_enabled();
 		$backedup_tax_rates_url = admin_url( '/admin.php?page=wc-status&tab=connect#tax-rate-backups' );
 
-		$powered_by_wct_notice = '<p>' . sprintf( __( 'Automated taxes take over from the WooCommerce core tax settings. This means that "Display prices" will be set to Excluding tax and tax will be Calculated using Customer shipping address. %1$sLearn more about Automated taxes here.%2$s', 'woocommerce-services' ), '<a href="https://href.li/?https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#automated-tax-calculation">', '</a>' ) . '</p>';
+		$powered_by_wct_notice = '<p>' . sprintf( __( 'Automated taxes take over from the WooCommerce core tax settings. This means that "Display prices" will be set to Excluding tax and tax will be Calculated using Customer shipping address. %1$sLearn more about Automated taxes here.%2$s', 'woocommerce-services' ), '<a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#automated-tax-calculation">', '</a>' ) . '</p>';
 
 		$backup_notice = ( ! empty( WC_Connect_Functions::get_backed_up_tax_rate_files() ) ) ? '<p>' . sprintf( __( 'Your previous tax rates were backed up and can be downloaded %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . esc_url( $backedup_tax_rates_url ) . '">', '</a>' ) . '</p>' : '';
 

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 2.2.2 - 2023-xx-xx =
+* Fix   - Link correction on Automated taxes description text.
+
 = 2.2.1 - 2023-01-24 =
 * Fix   - Fix warning on checkout page apper if zipcode doesn't match selected state.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Correcting the link and change the wording for automated tax description.
<!-- Explain the motivation for making this change -->

### Related issue(s)
Fixes #2576 
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
1. Make sure the tax is enabled.
2. Go to WooCommerce >> Settings >> Tax.
3. Enable the Automated Tax and the description will be changed as in the screenshot : 
<img width="1107" alt="Screenshot 2023-02-02 at 14 02 15" src="https://user-images.githubusercontent.com/631098/216254631-056d1189-ae27-4f90-9403-df6ba195a9bc.png">
4. Disable the Automated tax and the description will be changed as in the screenshot : 
<img width="1110" alt="Screenshot 2023-02-02 at 14 03 42" src="https://user-images.githubusercontent.com/631098/216254852-752c62d7-a159-490d-851b-a3080d65787c.png">

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

