### PR TITLE
Fix E2E tests

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -10,7 +10,8 @@ jobs:
       E2E_WP_VERSION: 6.1.0
       TRAVIS_MARIADB_VERSION: 10.8.3
     steps:
-      - run: git config --global url.https://github.com/.insteadOf git://github.com/
+      - name: Set Git to use HTTPS instead of SSH
+        run: git config --global url.https://github.com/.insteadOf git://github.com/
       - uses: actions/checkout@v3
         with:
           submodules: recursive

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -5,18 +5,18 @@ on: [push, workflow_dispatch]
 jobs:
   e2e_build_and_test:
     name: Build Container and Run E2E Tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
-      WP_VERSION: 6.1.0
+      E2E_WP_VERSION: 6.1.0
       TRAVIS_MARIADB_VERSION: 10.8.3
     steps:
-      - uses: actions/checkout@v2
+      - run: git config --global url.https://github.com/.insteadOf git://github.com/
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - uses: actions/setup-node@v2
         with:
-          node-version: '10.16.0'
-      - run: git config --global url.https://github.com/.insteadOf git://github.com/
+            node-version-file: '.nvmrc'
       # Kill process running on port 8084
       - name: Kill mono-xsp4.service
         shell: bash
@@ -24,7 +24,6 @@ jobs:
             echo "::group::Kill webserver running on port 8084"
             sudo fuser -k -n tcp 8084
             echo "::endgroup::"
-
       - run: npm ci
       - run: npm run dist
       - run: npm run test:e2e-docker-up

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -18,12 +18,10 @@ jobs:
       - uses: actions/setup-node@v2
         with:
             node-version-file: '.nvmrc'
-      - name: Kill process running on port 8084 to unblock it
-        shell: bash
+      - name: Disable and stop mono-xsp4.service to unblock port 8084
         run: |
-            echo "::group::Kill webserver running on port 8084"
-            sudo fuser -k -n tcp 8084
-            echo "::endgroup::"
+            sudo systemctl stop mono-xsp4.service || true
+            sudo systemctl disable mono-xsp4.service || true
       - name: Build WCS&T
         run: |
             npm ci

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -18,10 +18,12 @@ jobs:
       - uses: actions/setup-node@v2
         with:
             node-version-file: '.nvmrc'
-      - name: Disable and stop mono-xsp4.service to unblock port 8084
+      - name: Kill process running on port 8084 to unblock it
+        shell: bash
         run: |
-            sudo systemctl stop mono-xsp4.service || true
-            sudo systemctl disable mono-xsp4.service || true
+            echo "::group::Kill webserver running on port 8084"
+            sudo fuser -k -n tcp 8084
+            echo "::endgroup::"
       - name: Build WCS&T
         run: |
             npm ci

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -17,6 +17,14 @@ jobs:
         with:
           node-version: '10.16.0'
       - run: git config --global url.https://github.com/.insteadOf git://github.com/
+      # Kill process running on port 8084
+      - name: Kill mono-xsp4.service
+        shell: bash
+        run: |
+            echo "::group::Kill webserver running on port 8084"
+            sudo fuser -k -n tcp 8084
+            echo "::endgroup::"
+
       - run: npm ci
       - run: npm run dist
       - run: npm run test:e2e-docker-up

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -7,7 +7,7 @@ jobs:
     name: Build Container and Run E2E Tests
     runs-on: ubuntu-latest
     env:
-      E2E_WP_VERSION: 6.1.0
+      WP_VERSION: 6.1.0
       TRAVIS_MARIADB_VERSION: 10.8.3
     steps:
       - name: Set Git to use HTTPS instead of SSH
@@ -18,16 +18,21 @@ jobs:
       - uses: actions/setup-node@v2
         with:
             node-version-file: '.nvmrc'
-      # Kill process running on port 8084
-      - name: Kill mono-xsp4.service
+      - name: Kill process running on port 8084 to unblock it
         shell: bash
         run: |
             echo "::group::Kill webserver running on port 8084"
             sudo fuser -k -n tcp 8084
             echo "::endgroup::"
-      - run: npm ci
-      - run: npm run dist
-      - run: npm run test:e2e-docker-up
-      - run: npm run test:e2e-docker-ping
-      - run: npm run test:e2e
-      - run: npm run test:e2e-docker-down
+      - name: Build WCS&T
+        run: |
+            npm ci
+            npm run dist
+      - name: Setup E2E container
+        run: |
+            npm run test:e2e-docker-up
+            npm run test:e2e-docker-ping
+      - name: Run E2E tests
+        run: npm run test:e2e
+      - name: Stop E2E container
+        run: npm run test:e2e-docker-down

--- a/tests/e2e/docker/initialize.sh
+++ b/tests/e2e/docker/initialize.sh
@@ -4,6 +4,9 @@ echo "Initializing WooCommerce Services E2E"
 WP_CORE_DIR="/var/www/html"
 WCS_DIR="$WP_CORE_DIR/wp-content/plugins/woocommerce-services"
 
+# Update WP to the latest version
+wp core update --quiet
+
 # install default theme
 wp theme install storefront --activate
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Update Ubuntu and WordPress to latest. Kill service running on port 8084 so the E2E service can run. 

+ minor changes such as using .nvmrc

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

