### PR TITLE
Fix phpcs against some WordPress.Security rules

### DIFF
--- a/classes/class-wc-connect-debug-tools.php
+++ b/classes/class-wc-connect-debug-tools.php
@@ -53,14 +53,16 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 		function test_connection() {
 			$test_request = $this->api_client->auth_test();
 			if ( $test_request && ! is_wp_error( $test_request ) && $test_request->authorized ) {
-				echo '<div class="updated inline"><p>' . __( 'Your site is successfully communicating to the WooCommerce Shipping & Tax API.', 'woocommerce-services' ) . '</p></div>';
+				echo '<div class="updated inline"><p>' . esc_html(__( 'Your site is successfully communicating to the WooCommerce Shipping & Tax API.', 'woocommerce-services' )) . '</p></div>';
 			} else {
-				echo '<div class="error inline"><p>' . __( 'ERROR: Your site has a problem connecting to the WooCommerce Shipping & Tax API. Please make sure your Jetpack connection is working.', 'woocommerce-services' ) . '</p></div>';
+				echo '<div class="error inline"><p>' 
+				. esc_html(__( 'ERROR: Your site has a problem connecting to the WooCommerce Shipping & Tax API. Please make sure your Jetpack connection is working.', 'woocommerce-services' )) 
+				. '</p></div>';
 			}
 		}
 
 		/**
-		 * Back up all existing tax rates from the database in a CSV file.         *
+		 * Back up all existing tax rates from the database in a CSV file.
 		 * Then, if successfully backed up, loop through the tax rates
 		 * in the database and delete rates where:
 		 * tax_rate_country = 'US' and
@@ -74,7 +76,7 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 
 			if ( ! $backed_up ) {
 				echo '<div class="error inline"><p>';
-				echo __( 'ERROR: The "CA" tax rate deletion process was cancelled because the existing tax rates could not be backed up.', 'woocommerce-services' );
+				echo esc_html(__( 'ERROR: The "CA" tax rate deletion process was cancelled because the existing tax rates could not be backed up.', 'woocommerce-services' ));
 				echo '</p></div>';
 
 				return;
@@ -98,7 +100,7 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 			 */
 			if ( empty( $found_ca_rates ) ) {
 				echo '<div class="updated inline"><p>';
-				echo __( 'No "CA" tax rates were found.', 'woocommerce-services' );
+				echo esc_html(__( 'No "CA" tax rates were found.', 'woocommerce-services' ));
 				echo '</p></div>';
 
 				return;
@@ -115,7 +117,7 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 			}
 
 			echo '<div class="updated inline"><p>';
-			echo sprintf( __( 'Successfully deleted %1$d rows from the database.', 'woocommerce-services' ), $deleted_count );
+			echo sprintf( esc_html(__( 'Successfully deleted %1$d rows from the database.', 'woocommerce-services' ), $deleted_count );
 			echo '</p></div>';
 		}
 
@@ -134,7 +136,7 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 			);
 
 			echo '<div class="updated inline"><p>';
-			echo sprintf( __( 'Successfully deleted %1$d transients from the database.', 'woocommerce-services' ), $deleted_count );
+			echo sprintf( esc_html(__( 'Successfully deleted %1$d transients from the database.', 'woocommerce-services' ), $deleted_count ));
 			echo '</p></div>';
 		}
 	}

--- a/classes/class-wc-connect-debug-tools.php
+++ b/classes/class-wc-connect-debug-tools.php
@@ -117,7 +117,7 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 			}
 
 			echo '<div class="updated inline"><p>';
-			echo sprintf( esc_html(__( 'Successfully deleted %1$d rows from the database.', 'woocommerce-services' ), $deleted_count );
+			echo sprintf( esc_html(__( 'Successfully deleted %1$d rows from the database.', 'woocommerce-services' ), $deleted_count ));
 			echo '</p></div>';
 		}
 

--- a/classes/class-wc-connect-debug-tools.php
+++ b/classes/class-wc-connect-debug-tools.php
@@ -53,10 +53,10 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 		function test_connection() {
 			$test_request = $this->api_client->auth_test();
 			if ( $test_request && ! is_wp_error( $test_request ) && $test_request->authorized ) {
-				echo '<div class="updated inline"><p>' . esc_html(__( 'Your site is successfully communicating to the WooCommerce Shipping & Tax API.', 'woocommerce-services' )) . '</p></div>';
+				echo '<div class="updated inline"><p>' . esc_html__( 'Your site is successfully communicating to the WooCommerce Shipping & Tax API.', 'woocommerce-services' ) . '</p></div>';
 			} else {
 				echo '<div class="error inline"><p>' 
-				. esc_html(__( 'ERROR: Your site has a problem connecting to the WooCommerce Shipping & Tax API. Please make sure your Jetpack connection is working.', 'woocommerce-services' )) 
+				. esc_html__( 'ERROR: Your site has a problem connecting to the WooCommerce Shipping & Tax API. Please make sure your Jetpack connection is working.', 'woocommerce-services' ) 
 				. '</p></div>';
 			}
 		}
@@ -76,7 +76,7 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 
 			if ( ! $backed_up ) {
 				echo '<div class="error inline"><p>';
-				echo esc_html(__( 'ERROR: The "CA" tax rate deletion process was cancelled because the existing tax rates could not be backed up.', 'woocommerce-services' ));
+				echo esc_html__( 'ERROR: The "CA" tax rate deletion process was cancelled because the existing tax rates could not be backed up.', 'woocommerce-services' );
 				echo '</p></div>';
 
 				return;
@@ -100,7 +100,7 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 			 */
 			if ( empty( $found_ca_rates ) ) {
 				echo '<div class="updated inline"><p>';
-				echo esc_html(__( 'No "CA" tax rates were found.', 'woocommerce-services' ));
+				echo esc_html__( 'No "CA" tax rates were found.', 'woocommerce-services' );
 				echo '</p></div>';
 
 				return;
@@ -117,7 +117,7 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 			}
 
 			echo '<div class="updated inline"><p>';
-			echo sprintf( esc_html(__( 'Successfully deleted %1$d rows from the database.', 'woocommerce-services' ), $deleted_count ));
+			echo sprintf( esc_html__( 'Successfully deleted %1$d rows from the database.', 'woocommerce-services' ), $deleted_count );
 			echo '</p></div>';
 		}
 
@@ -136,7 +136,7 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 			);
 
 			echo '<div class="updated inline"><p>';
-			echo sprintf( esc_html(__( 'Successfully deleted %1$d transients from the database.', 'woocommerce-services' ), $deleted_count ));
+			echo sprintf( esc_html__( 'Successfully deleted %1$d transients from the database.', 'woocommerce-services' ), $deleted_count );
 			echo '</p></div>';
 		}
 	}

--- a/classes/class-wc-connect-error-notice.php
+++ b/classes/class-wc-connect-error-notice.php
@@ -13,6 +13,7 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 
 	class WC_Connect_Error_Notice {
 
+
 		private static $inst = null;
 
 		public static function instance() {
@@ -32,7 +33,7 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 		}
 
 		public function render_notice() {
-			$error_notice = filter_input( INPUT_GET, 'wc-connect-error-notice' );
+			$error_notice = filter_input( INPUT_GET, 'wc-connect-error-notice', FILTER_SANITIZE_ENCODED );
 			if ( 'disable' === $error_notice ) {
 				WC_Connect_Options::update_option( 'error_notice', false );
 				$url = remove_query_arg( 'wc-connect-error-notice' );
@@ -46,7 +47,7 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 		}
 
 		private function notice_enabled() {
-			return WC_Connect_Options::get_option( 'error_notice', false );
+			 return WC_Connect_Options::get_option( 'error_notice', false );
 		}
 
 		private function show_notice() {
@@ -70,8 +71,7 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 
 				if (
 					! $product ||
-					(
-						$product->has_weight() &&
+					( $product->has_weight() &&
 						$product->get_length() &&
 						$product->get_height() &&
 						$product->get_width()
@@ -108,5 +108,4 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 			echo '';
 		}
 	}
-
 }

--- a/classes/class-wc-connect-functions.php
+++ b/classes/class-wc-connect-functions.php
@@ -14,7 +14,7 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 				// Skip for carts loaded from session in the dashboard.
 				( is_admin() && did_action( 'woocommerce_cart_loaded_from_session' ) ) ||
 				// Skip during Jetpack API requests.
-				( false !== strpos( $_SERVER['REQUEST_URI'], 'jetpack/v4/' ) ) ||
+				( !empty($_SERVER['REQUEST_URI']) && false !== strpos( $_SERVER['REQUEST_URI'], 'jetpack/v4/' ) ) || // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
 				// Skip during REST API or XMLRPC requests.
 				( defined( 'REST_REQUEST' ) || defined( 'REST_API_REQUEST' ) || defined( 'XMLRPC_REQUEST' ) ) ||
 				// Skip during Jetpack REST API proxy requests.
@@ -175,7 +175,7 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 				__( 'Shipping', 'woocommerce' ) . ',' .
 				__( 'Tax Class', 'woocommerce' ) . "\n";
 
-			echo $header;
+			echo $header; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 			foreach ( $rates as $rate ) {
 				if ( $rate->tax_rate_country ) {

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -301,7 +301,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 		public function page() {
 			?>
 				<h2>
-					<?php _e( 'WooCommerce Shipping & Tax Status', 'woocommerce-services' ); ?>
+					<?php esc_html_e( 'WooCommerce Shipping & Tax Status', 'woocommerce-services' ); ?>
 				</h2>
 			<?php
 

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -20,7 +20,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 			?>
 			<a
 				href="#"
-				download="report-shipping-labels-<?php echo esc_attr( $current_range ); ?>-<?php echo date_i18n( 'Y-m-d', current_time( 'timestamp' ) ); ?>.csv"
+				download="report-shipping-labels-<?php echo esc_attr( $current_range ); ?>-<?php echo esc_html(date_i18n( 'Y-m-d', current_time( 'timestamp' ) )); ?>.csv"
 				class="export_csv"
 				data-export="table"
 			>
@@ -179,19 +179,19 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 						<?php foreach ( $labels as $label ) : ?>
 							<tr>
 								<th scope="row">
-									<?php echo get_date_from_gmt( date( 'Y-m-d H:i:s', $label['created'] / 1000 ) ); ?>
+									<?php echo esc_html(get_date_from_gmt( date( 'Y-m-d H:i:s', $label['created'] / 1000 ) )); ?>
 								</th>
 								<td>
-									<?php echo $this->get_edit_order_link( $label['order_id'] ); ?>
+									<?php echo esc_html($this->get_edit_order_link( $label['order_id'] )); ?>
 								</td>
 								<td>
-									<?php echo wc_price( $label['rate'] ); ?>
+									<?php echo esc_html(wc_price( $label['rate'] )); ?>
 								</td>
 								<td>
-									<?php echo $label['service_name']; ?>
+									<?php echo esc_html($label['service_name']); ?>
 								</td>
 								<td>
-									<?php echo $this->get_label_refund_status( $label ); ?>
+									<?php echo esc_html($this->get_label_refund_status( $label )); ?>
 								</td>
 							</tr>
 						<?php endforeach; ?>
@@ -208,7 +208,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 								<?php echo count( $labels ); ?>
 							</th>
 							<th>
-								<?php echo wc_price( $total ); ?>
+								<?php echo esc_html(wc_price( $total )); ?>
 							</th>
 							<th></th>
 							<th></th>

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -24,7 +24,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 				class="export_csv"
 				data-export="table"
 			>
-				<?php _e( 'Export CSV', 'woocommerce-services' ); ?>
+				<?php esc_html_e( 'Export CSV', 'woocommerce-services' ); ?>
 			</a>
 			<?php
 		}
@@ -202,7 +202,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 						?>
 						<tr>
 							<th scope="row">
-								<?php _e( 'Total', 'woocommerce-services' ); ?>
+								<?php esc_html_e( 'Total', 'woocommerce-services' ); ?>
 							</th>
 							<th>
 								<?php echo count( $labels ); ?>

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -635,7 +635,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 						<?php echo esc_html( $content['title'] ); ?>
 					</h1>
 					<p class="wcs-nux__notice-content-text">
-						<?php echo $content['description']; ?>
+						<?php echo esc_html($content['description']); ?>
 					</p>
 					<?php if ( isset( $content['should_show_terms'] ) && $content['should_show_terms'] ) : ?>
 						<p class="wcs-nux__notice-content-tos">

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -407,7 +407,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			// Remove [...]/wp-admin so we can use admin_url().
 			$new_index = strpos( $full_path, '/wp-admin' ) + strlen( '/wp-admin' );
 			$path      = substr( $full_path, $new_index );
-			return admin_url( $path );
+			return esc_url( admin_url( $path ) );
 		}
 
 		public function set_up_nux_notices() {

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -98,7 +98,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				}
 			}
 
-			trigger_error( sprintf( 'Invalid WooCommerce Shipping & Tax option name: %s', $name ), E_USER_WARNING );
+			trigger_error( sprintf( 'Invalid WooCommerce Shipping & Tax option name: %s', $name ), E_USER_WARNING ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			return $default;
 		}
 
@@ -119,7 +119,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 					return self::update_grouped_option( $group, $name, $value );
 				}
 			}
-			trigger_error( sprintf( 'Invalid WooCommerce Shipping & Tax option name: %s', $name ), E_USER_WARNING );
+			trigger_error( sprintf( 'Invalid WooCommerce Shipping & Tax option name: %s', $name ), E_USER_WARNING ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			return false;
 		}
 
@@ -135,7 +135,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			$result = true;
 			$names  = (array) $names;
 			if ( ! self::is_valid( $names ) ) {
-				trigger_error( sprintf( 'Invalid WooCommerce Shipping & Tax option names: %s', print_r( $names, 1 ) ), E_USER_WARNING );
+				trigger_error( sprintf( 'Invalid WooCommerce Shipping & Tax option names: %s', print_r( $names, 1 ) ), E_USER_WARNING ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				return false;
 			}
 			foreach ( array_intersect( $names, self::get_option_names( 'non_compact' ) ) as $name ) {
@@ -165,7 +165,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			$option_name = self::get_shipping_method_option_name( $name, $service_id, $service_instance );
 
 			if ( ! $option_name ) {
-				trigger_error( sprintf( 'Invalid WooCommerce Shipping & Tax shipping method option name: %s', $name ), E_USER_WARNING );
+				trigger_error( sprintf( 'Invalid WooCommerce Shipping & Tax shipping method option name: %s', $name ), E_USER_WARNING ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				return $default;
 			}
 
@@ -186,7 +186,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			$option_name = self::get_shipping_method_option_name( $name, $service_id, $service_instance );
 
 			if ( ! $option_name ) {
-				trigger_error( sprintf( 'Invalid WooCommerce Shipping & Tax shipping method option name: %s', $name ), E_USER_WARNING );
+				trigger_error( sprintf( 'Invalid WooCommerce Shipping & Tax shipping method option name: %s', $name ), E_USER_WARNING ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				return false;
 			}
 
@@ -206,7 +206,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			$option_name = self::get_shipping_method_option_name( $name, $service_id, $service_instance );
 
 			if ( ! $option_name ) {
-				trigger_error( sprintf( 'Invalid WooCommerce Shipping & Tax shipping method option name: %s', $name ), E_USER_WARNING );
+				trigger_error( sprintf( 'Invalid WooCommerce Shipping & Tax shipping method option name: %s', $name ), E_USER_WARNING ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				return false;
 			}
 

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -98,7 +98,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				}
 			}
 
-			trigger_error( sprintf( 'Invalid WooCommerce Shipping & Tax option name: %s', $name ), E_USER_WARNING ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			trigger_error( esc_html( sprintf( 'Invalid WooCommerce Shipping & Tax option name: %s', $name ), E_USER_WARNING ) );
 			return $default;
 		}
 
@@ -119,7 +119,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 					return self::update_grouped_option( $group, $name, $value );
 				}
 			}
-			trigger_error( sprintf( 'Invalid WooCommerce Shipping & Tax option name: %s', $name ), E_USER_WARNING ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			trigger_error( esc_html( sprintf( 'Invalid WooCommerce Shipping & Tax option name: %s', $name ), E_USER_WARNING ) );
 			return false;
 		}
 
@@ -135,7 +135,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			$result = true;
 			$names  = (array) $names;
 			if ( ! self::is_valid( $names ) ) {
-				trigger_error( sprintf( 'Invalid WooCommerce Shipping & Tax option names: %s', print_r( $names, 1 ) ), E_USER_WARNING ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				trigger_error( esc_html( sprintf( 'Invalid WooCommerce Shipping & Tax option names: %s', print_r( $names, 1 ) ), E_USER_WARNING ) );
 				return false;
 			}
 			foreach ( array_intersect( $names, self::get_option_names( 'non_compact' ) ) as $name ) {
@@ -165,7 +165,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			$option_name = self::get_shipping_method_option_name( $name, $service_id, $service_instance );
 
 			if ( ! $option_name ) {
-				trigger_error( sprintf( 'Invalid WooCommerce Shipping & Tax shipping method option name: %s', $name ), E_USER_WARNING ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				trigger_error( esc_html( sprintf( 'Invalid WooCommerce Shipping & Tax shipping method option name: %s', $name ), E_USER_WARNING ) );
 				return $default;
 			}
 
@@ -186,7 +186,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			$option_name = self::get_shipping_method_option_name( $name, $service_id, $service_instance );
 
 			if ( ! $option_name ) {
-				trigger_error( sprintf( 'Invalid WooCommerce Shipping & Tax shipping method option name: %s', $name ), E_USER_WARNING ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				trigger_error( esc_html( sprintf( 'Invalid WooCommerce Shipping & Tax shipping method option name: %s', $name ), E_USER_WARNING ) );
 				return false;
 			}
 
@@ -206,7 +206,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			$option_name = self::get_shipping_method_option_name( $name, $service_id, $service_instance );
 
 			if ( ! $option_name ) {
-				trigger_error( sprintf( 'Invalid WooCommerce Shipping & Tax shipping method option name: %s', $name ), E_USER_WARNING ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				trigger_error( esc_html( sprintf( 'Invalid WooCommerce Shipping & Tax shipping method option name: %s', $name ), E_USER_WARNING ) );
 				return false;
 			}
 

--- a/classes/class-wc-connect-paypal-ec.php
+++ b/classes/class-wc-connect-paypal-ec.php
@@ -337,7 +337,8 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 			if (
 				! isset( $_GET['page'] ) || 'wc-settings' !== $_GET['page'] ||
 				empty( $_GET['reroute_requests'] ) ||
-				empty( $_GET['nonce'] ) || ! wp_verify_nonce( $_GET['nonce'], 'reroute_requests' )
+				empty( $_GET['nonce'] ) || 
+				! wp_verify_nonce( $_GET['nonce'], 'reroute_requests' ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			) {
 				return;
 			}

--- a/classes/class-wc-connect-paypal-ec.php
+++ b/classes/class-wc-connect-paypal-ec.php
@@ -279,12 +279,12 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 				);
 				$api_creds_template = __( 'Payments will be authenticated by WooCommerce Shipping & Tax and directed to the following email address. To disable this feature and link a PayPal account, <a href="%s">click here</a>.', 'woocommerce-services' );
 				if ( empty( $settings->api_username ) ) {
-					$api_creds_text                                = sprintf( $api_creds_template, add_query_arg( 'environment', 'live', $reset_link ) );
+					$api_creds_text                                = sprintf( $api_creds_template, esc_url( add_query_arg( 'environment', 'live', $reset_link ) ) );
 					$form_fields['api_credentials']['description'] = $api_creds_text;
 					unset( $form_fields['api_username'], $form_fields['api_password'], $form_fields['api_signature'], $form_fields['api_certificate'] );
 				}
 				if ( empty( $settings->sandbox_api_username ) ) {
-					$api_creds_text                                        = sprintf( $api_creds_template, add_query_arg( 'environment', 'sandbox', $reset_link ) );
+					$api_creds_text                                        = sprintf( $api_creds_template, esc_url( add_query_arg( 'environment', 'sandbox', $reset_link ) ) );
 					$form_fields['sandbox_api_credentials']['description'] = $api_creds_text;
 					unset( $form_fields['sandbox_api_username'], $form_fields['sandbox_api_password'], $form_fields['sandbox_api_signature'], $form_fields['sandbox_api_certificate'] );
 				}
@@ -299,11 +299,11 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 				);
 				$api_creds_template = __( 'To authenticate payments with WooCommerce Shipping & Tax, <a href="%s">click here</a>.', 'woocommerce-services' );
 				if ( empty( $settings->api_username ) ) {
-					$api_creds_text                                 = sprintf( $api_creds_template, add_query_arg( 'environment', 'live', $reset_link ) );
+					$api_creds_text                                 = sprintf( $api_creds_template, esc_url( add_query_arg( 'environment', 'live', $reset_link ) ) );
 					$form_fields['api_credentials']['description'] .= '<br /><br />' . $api_creds_text;
 				}
 				if ( empty( $settings->sandbox_api_username ) ) {
-					$api_creds_text = sprintf( $api_creds_template, add_query_arg( 'environment', 'sandbox', $reset_link ) );
+					$api_creds_text = sprintf( $api_creds_template, esc_url( add_query_arg( 'environment', 'sandbox', $reset_link ) ) );
 					$form_fields['sandbox_api_credentials']['description'] .= '<br /><br />' . $api_creds_text;
 				}
 			}

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -101,12 +101,14 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 			}
 
 			if ( isset( $_GET['from_order'] ) ) {
-				$extra_args['order_id']   = $_GET['from_order'];
-				$extra_args['order_href'] = get_edit_post_link( $_GET['from_order'] );
+				$from_order = sanitize_text_field($_GET['from_order']);
+				$extra_args['order_id']   = $from_order;
+				$extra_args['order_href'] = get_edit_post_link( $from_order );
 			}
 
 			if ( ! empty( $_GET['carrier'] ) ) {
-				$extra_args['carrier']    = $_GET['carrier'];
+				$carrier = sanitize_text_field($_GET['carrier']);
+				$extra_args['carrier']    = $carrier;
 				$extra_args['continents'] = $this->continents->get();
 
 				$carrier_information = array();
@@ -115,7 +117,7 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 						array_filter(
 							$extra_args['carrier_accounts'],
 							function( $carrier ) {
-								return $carrier->type === $_GET['carrier'];
+								return $carrier->type === $carrier;
 							}
 						)
 					);

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -689,11 +689,11 @@ class WC_Connect_TaxJar_Integration {
 	 * @return array
 	 */
 	protected function get_backend_address() {
-		$to_country = isset( $_POST['country'] ) ? strtoupper( wc_clean( $_POST['country'] ) ) : false;  // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$to_state   = isset( $_POST['state'] ) ? strtoupper( wc_clean( $_POST['state'] ) ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$to_zip     = isset( $_POST['postcode'] ) ? strtoupper( wc_clean( $_POST['postcode'] ) ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$to_city    = isset( $_POST['city'] ) ? strtoupper( wc_clean( $_POST['city'] ) ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$to_street  = isset( $_POST['street'] ) ? strtoupper( wc_clean( $_POST['street'] ) ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$to_country = isset( $_POST['country'] ) ? strtoupper( wc_clean( $_POST['country'] ) ) : false;
+		$to_state   = isset( $_POST['state'] ) ? strtoupper( wc_clean( $_POST['state'] ) ) : false;
+		$to_zip     = isset( $_POST['postcode'] ) ? strtoupper( wc_clean( $_POST['postcode'] ) ) : false;
+		$to_city    = isset( $_POST['city'] ) ? strtoupper( wc_clean( $_POST['city'] ) ) : false;
+		$to_street  = isset( $_POST['street'] ) ? strtoupper( wc_clean( $_POST['street'] ) ) : false;
 
 		return array(
 			'to_country' => $to_country,

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -689,11 +689,11 @@ class WC_Connect_TaxJar_Integration {
 	 * @return array
 	 */
 	protected function get_backend_address() {
-		$to_country = isset( $_POST['country'] ) ? strtoupper( wc_clean( $_POST['country'] ) ) : false;
-		$to_state   = isset( $_POST['state'] ) ? strtoupper( wc_clean( $_POST['state'] ) ) : false;
-		$to_zip     = isset( $_POST['postcode'] ) ? strtoupper( wc_clean( $_POST['postcode'] ) ) : false;
-		$to_city    = isset( $_POST['city'] ) ? strtoupper( wc_clean( $_POST['city'] ) ) : false;
-		$to_street  = isset( $_POST['street'] ) ? strtoupper( wc_clean( $_POST['street'] ) ) : false;
+		$to_country = isset( $_POST['country'] ) ? strtoupper( wc_clean( $_POST['country'] ) ) : false;  // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$to_state   = isset( $_POST['state'] ) ? strtoupper( wc_clean( $_POST['state'] ) ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$to_zip     = isset( $_POST['postcode'] ) ? strtoupper( wc_clean( $_POST['postcode'] ) ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$to_city    = isset( $_POST['city'] ) ? strtoupper( wc_clean( $_POST['city'] ) ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$to_street  = isset( $_POST['street'] ) ? strtoupper( wc_clean( $_POST['street'] ) ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		return array(
 			'to_country' => $to_country,

--- a/classes/class-wc-connect-tracks.php
+++ b/classes/class-wc-connect-tracks.php
@@ -97,9 +97,9 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 				$data = array();
 			}
 
-			$data['_via_ua']         = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
-			$data['_via_ip']         = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : '';
-			$data['_lg']             = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? $_SERVER['HTTP_ACCEPT_LANGUAGE'] : '';
+			$data['_via_ua'] = isset( $_SERVER['HTTP_USER_AGENT'] ) ? wc_clean( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$data['_via_ip'] = isset( $_SERVER['REMOTE_ADDR'] ) ? wc_clean( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$data['_lg']     = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? wc_clean( wp_unslash( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$data['blog_url']        = $site_url;
 			$data['blog_id']         = $jetpack_blog_id;
 			$data['wcs_version']     = $wcs_version;

--- a/classes/class-wc-connect-tracks.php
+++ b/classes/class-wc-connect-tracks.php
@@ -97,9 +97,9 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 				$data = array();
 			}
 
-			$data['_via_ua'] = isset( $_SERVER['HTTP_USER_AGENT'] ) ? wc_clean( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$data['_via_ip'] = isset( $_SERVER['REMOTE_ADDR'] ) ? wc_clean( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$data['_lg']     = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? wc_clean( wp_unslash( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$data['_via_ua'] = isset( $_SERVER['HTTP_USER_AGENT'] ) ? wc_clean( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
+			$data['_via_ip'] = isset( $_SERVER['REMOTE_ADDR'] ) ? wc_clean( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+			$data['_lg']     = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? wc_clean( wp_unslash( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) : '';
 			$data['blog_url']        = $site_url;
 			$data['blog_id']         = $jetpack_blog_id;
 			$data['wcs_version']     = $wcs_version;

--- a/classes/class-wc-rest-connect-shipping-label-preview-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-preview-controller.php
@@ -33,7 +33,7 @@ class WC_REST_Connect_Shipping_Label_Preview_Controller extends WC_REST_Connect_
 		}
 
 		header( 'content-type: ' . $raw_response['headers']['content-type'] );
-		echo $raw_response['body'];
+		echo $raw_response['body']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		die();
 	}
 

--- a/classes/class-wc-rest-connect-shipping-label-print-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-print-controller.php
@@ -61,7 +61,7 @@ class WC_REST_Connect_Shipping_Label_Print_Controller extends WC_REST_Connect_Ba
 			);
 		} else {
 			header( 'content-type: ' . $raw_response['headers']['content-type'] );
-			echo $raw_response['body'];
+			echo $raw_response['body']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			die();
 		}
 	}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1250,7 +1250,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 							</tr>
 						</thead>
 						<tbody>
-							<?php echo $markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> 
+							<?php echo wp_kses_post($markup); ?>
 						</tbody>
 					</table>
 				</div>

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1611,10 +1611,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			);
 
 			$encoded_arguments = wp_json_encode( $extra_args );
-			$escaped_arguments = function_exists( 'wc_esc_json' ) ? wc_esc_json( $encoded_arguments ) : esc_attr( $encoded_arguments );
-
 			?>
-				<div class="wcc-root woocommerce <?php echo esc_attr( $root_view ); ?>" data-args="<?php echo $escaped_arguments; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>">
+				<div class="wcc-root woocommerce <?php echo esc_attr( $root_view ); ?>" data-args="<?php echo wc_esc_json( $encoded_arguments ); ?>">
 					<span class="form-troubles" style="opacity: 0">
 						<?php printf( esc_html__( 'Section not loading? Visit the <a href="%s">status page</a> for troubleshooting steps.', 'woocommerce-services' ), $debug_page_uri ); ?>
 					</span>

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1235,7 +1235,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			if ( $plain_text ) {
 				echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 				echo esc_html(mb_strtoupper( __( 'Tracking', 'woocommerce-services' ), 'UTF-8' )) . "\n\n";
-				echo $markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped 
+				echo wp_kses( $markup, [] );
 				return;
 			}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1234,23 +1234,23 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			if ( $plain_text ) {
 				echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
-				echo mb_strtoupper( __( 'Tracking', 'woocommerce-services' ), 'UTF-8' ) . "\n\n";
-				echo $markup;
+				echo esc_html(mb_strtoupper( __( 'Tracking', 'woocommerce-services' ), 'UTF-8' )) . "\n\n";
+				echo $markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped 
 				return;
 			}
 
 			?>
 				<div style="font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif; margin-bottom: 40px;">
-					<h2><?php echo __( 'Tracking', 'woocommerce-services' ); ?></h2>
+					<h2><?php esc_html_e( 'Tracking', 'woocommerce-services' ); ?></h2>
 					<table class="td" cellspacing="0" cellpadding="6" style="margin-top: 10px; width: 100%;">
 						<thead>
 							<tr>
-								<th class="td" scope="col"><?php echo __( 'Provider', 'woocommerce-services' ); ?></th>
-								<th class="td" scope="col"><?php echo __( 'Tracking number', 'woocommerce-services' ); ?></th>
+								<th class="td" scope="col"><?php esc_html_e( 'Provider', 'woocommerce-services' ); ?></th>
+								<th class="td" scope="col"><?php esc_html_e( 'Tracking number', 'woocommerce-services' ); ?></th>
 							</tr>
 						</thead>
 						<tbody>
-							<?php echo $markup; ?>
+							<?php echo $markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> 
 						</tbody>
 					</table>
 				</div>
@@ -1614,9 +1614,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$escaped_arguments = function_exists( 'wc_esc_json' ) ? wc_esc_json( $encoded_arguments ) : esc_attr( $encoded_arguments );
 
 			?>
-				<div class="wcc-root woocommerce <?php echo esc_attr( $root_view ); ?>" data-args="<?php echo $escaped_arguments; ?>">
+				<div class="wcc-root woocommerce <?php echo esc_attr( $root_view ); ?>" data-args="<?php echo $escaped_arguments; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>">
 					<span class="form-troubles" style="opacity: 0">
-						<?php printf( __( 'Section not loading? Visit the <a href="%s">status page</a> for troubleshooting steps.', 'woocommerce-services' ), $debug_page_uri ); ?>
+						<?php printf( esc_html(__( 'Section not loading? Visit the <a href="%s">status page</a> for troubleshooting steps.', 'woocommerce-services' ), $debug_page_uri )); ?>
 					</span>
 				</div>
 			<?php

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1616,7 +1616,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			?>
 				<div class="wcc-root woocommerce <?php echo esc_attr( $root_view ); ?>" data-args="<?php echo $escaped_arguments; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>">
 					<span class="form-troubles" style="opacity: 0">
-						<?php printf( esc_html(__( 'Section not loading? Visit the <a href="%s">status page</a> for troubleshooting steps.', 'woocommerce-services' ), $debug_page_uri )); ?>
+						<?php printf( esc_html__( 'Section not loading? Visit the <a href="%s">status page</a> for troubleshooting steps.', 'woocommerce-services' ), $debug_page_uri ); ?>
 					</span>
 				</div>
 			<?php


### PR DESCRIPTION
## Description
Make sure semgrep returns no error and the following 3 rules from QIT aren't flagged by phpcs:
```
<rule ref="WordPress.Security.EscapeOutput.OutputNotEscaped"/>
<rule ref="WordPress.Security.EscapeOutput.UnsafePrintingFunction"/>
<rule ref="WordPress.Security.ValidatedSanitizedInput.InputNotSanitized"/>
```

### How to test semgrep
1. Pull this branch
2. Check semgrep, in your local terminal, run `semgrep --no-git-ignore -c audit /path/to/plugins/woocommerce-services --exclude="vendor/*" --exclude="docker/*"`
3. Make sure that has 0 scans found

### How to test QIT rules
1. Pull this branch
2. Open `phpcs.xml.dist`, for testing this PR, change the entire file to check against the 3 rules I listed:
```
<?xml version="1.0"?>
<ruleset name="WordPress Coding Standards">
	<!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
	<!-- See
	https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress-Core/ruleset.xml -->

	<description>WooCommerce dev PHP_CodeSniffer ruleset.</description>

	<!-- Exclude paths -->
	<exclude-pattern>*/node_modules/*</exclude-pattern>
	<exclude-pattern>*/vendor/*</exclude-pattern>
	<exclude-pattern>bin/*</exclude-pattern>

	<!-- Configs -->
	<config name="minimum_supported_wp_version" value="4.7" />
	<config name="testVersion" value="5.6-" />

	<rule ref="WordPress.Security.EscapeOutput.OutputNotEscaped"/>
	<rule ref="WordPress.Security.EscapeOutput.UnsafePrintingFunction"/>
	<rule ref="WordPress.Security.ValidatedSanitizedInput.InputNotSanitized"/>

</ruleset>
``` 
3. Make sure you have `phpcs` globally installed, if not, install it locally `composer require "squizlabs/php_codesniffer=*"`
4. Run `./vendor/bin/phpcs -s --error-severity=5 **/*.php`
5. You should see no errors found.

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

