### PR TITLE
Fix failing PHP tests

### DIFF
--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -62,13 +62,17 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
+      - name: Get WC pinned pnpm version
+        id: get_wc_pnpm_version
+        run: echo "WC_PNPM=$(node -p "require('/tmp/woocommerce/plugins/woocommerce/package.json').engines.pnpm")"  >> $GITHUB_OUTPUT
       - name: Setup PNPM
         uses: pnpm/action-setup@v2
         with:
-          version: '^7.13.3'
+          version: ${{ steps.get_wc_pnpm_version.outputs.WC_PNPM }}
       - uses: actions/setup-node@v3
         with:
           node-version: 'v16'
+
       - name: Build WooCommerce essentials for running tests
         run: |
           cd /tmp/woocommerce/plugins/woocommerce

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -64,7 +64,7 @@ jobs:
           php-version: '8.2'
       - name: Get WC pinned pnpm version
         id: get_wc_pnpm_version
-        run: echo "WC_PNPM=$(node -p "require('/tmp/woocommerce/plugins/woocommerce/package.json').engines.pnpm")"  >> $GITHUB_OUTPUT
+        run: echo "WC_PNPM=$(node -p "require('/tmp/woocommerce/plugins/woocommerce/package.json').engines.pnpm")" >> "$GITHUB_OUTPUT"
       - name: Setup PNPM
         uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mariadb:
-        image: mariadb:latest
+        image: mariadb:10.9
         ports:
           - 3306:3306
         env:


### PR DESCRIPTION
## Description
- Our test suit had issues running MariaDB with `mariadb:latest` and this PR pins the version number to the latest working version.
- Makes sure the pnpm version used matches the pinned version in WC plugin.
