### PR TITLE
Replace status page "Jetpack" section with "WordPress.com Connection"

### DIFF
--- a/classes/class-wc-connect-debug-tools.php
+++ b/classes/class-wc-connect-debug-tools.php
@@ -56,7 +56,7 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 				echo '<div class="updated inline"><p>' . esc_html__( 'Your site is successfully communicating to the WooCommerce Shipping & Tax API.', 'woocommerce-services' ) . '</p></div>';
 			} else {
 				echo '<div class="error inline"><p>'
-				. esc_html__( 'ERROR: Your site has a problem connecting to the WooCommerce Shipping & Tax API. Please make sure your Jetpack connection is working.', 'woocommerce-services' )
+				. esc_html__( 'ERROR: Your site has a problem connecting to the WooCommerce Shipping & Tax API. Please make sure your WordPress.com connection is working.', 'woocommerce-services' )
 				. '</p></div>';
 			}
 		}

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -78,28 +78,25 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			}
 			$health_items['woocommerce'] = $health_item;
 
-			// Jetpack
-			// Only one of the following should present
-			// Check that Jetpack is active
-			// Check that Jetpack is connected
-			$is_connected = WC_Connect_Jetpack::is_connected() || WC_Connect_Jetpack::is_development_mode();
+			// WordPress.com connection
+			$is_connected = WC_Connect_Jetpack::is_connected() || WC_Connect_Jetpack::is_offline_mode();
 			if ( ! $is_connected ) {
 				$health_item = array(
 					'state'   => 'error',
-					'message' => __( 'Jetpack is not connected to WordPress.com. Make sure the Jetpack plugin is installed, activated, and connected.', 'woocommerce-services' ),
+					'message' => __( 'Not connected to WordPress.com', 'woocommerce-services' ),
 				);
 			} elseif ( WC_Connect_Jetpack::is_staging_site() ) {
 				$health_item = array(
 					'state'   => 'warning',
-					'message' => __( 'This is a Jetpack staging site', 'woocommerce-services' ),
+					'message' => __( 'This site was identified as a staging site', 'woocommerce-services' ),
 				);
 			} else {
 				$health_item = array(
 					'state'   => 'success',
-					'message' => __( 'Jetpack is connected and working correctly', 'woocommerce-services' ),
+					'message' => __( 'Connected to WordPress.com', 'woocommerce-services' ),
 				);
 			}
-			$health_items['jetpack'] = $health_item;
+			$health_items['wpcom_connection'] = $health_item;
 
 			// Automated taxes status
 			$health_items['automated_taxes'] = $this->get_tax_health_item();

--- a/classes/class-wc-connect-jetpack.php
+++ b/classes/class-wc-connect-jetpack.php
@@ -138,7 +138,7 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 			if ( ! $connection_manager->is_connected() ) {
 				$result = $connection_manager->try_registration();
 				if ( is_wp_error( $result ) ) {
-					wp_die( $result->get_error_message(), 'wc_services_jetpack_register_site_failed', 500 );
+					wp_die( esc_html( $result->get_error_message() ), 'wc_services_jetpack_register_site_failed', 500 );
 				}
 			}
 

--- a/classes/class-wc-connect-jetpack.php
+++ b/classes/class-wc-connect-jetpack.php
@@ -22,11 +22,11 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 		}
 
 		/**
-		 * Helper method to get if Jetpack is in development mode
+		 * Helper method to get if Jetpack is in offline mode
 		 *
 		 * @return bool
 		 */
-		public static function is_development_mode() {
+		public static function is_offline_mode() {
 			$status = new Status();
 
 			return $status->is_offline_mode();
@@ -122,7 +122,7 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 		 */
 		public static function is_connected() {
 			return self::get_connection_manager()->is_connected() &&
-			       self::get_connection_manager()->has_connected_owner();
+				   self::get_connection_manager()->has_connected_owner();
 		}
 
 		/**
@@ -147,7 +147,7 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 
 			wp_redirect(
 				add_query_arg(
-					[ 'from' => WC_Connect_Jetpack::JETPACK_PLUGIN_SLUG ],
+					[ 'from' => self::JETPACK_PLUGIN_SLUG ],
 					$connection_manager->get_authorization_url( null, $redirect_url )
 				)
 			);

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -599,7 +599,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 							<?php echo esc_html( $content['button_text'] ); ?>
 						</a>
 					<?php else : ?>
-						<form action="<?php echo admin_url( 'admin-post.php' ); ?>" method="post">
+						<form action="<?php echo esc_attr( admin_url( 'admin-post.php' ) ); ?>" method="post">
 							<input type="hidden" name="action" value="register_woocommerce_services_jetpack"/>
 							<input type="hidden" name="redirect_url"
 								   value="<?php echo esc_url( $this->get_jetpack_redirect_url() ); ?>"/>

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -112,7 +112,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		}
 
 		public function can_user_manage_payment_methods() {
-			return WC_Connect_Jetpack::is_development_mode() || WC_Connect_Jetpack::is_current_user_connection_owner();
+			return WC_Connect_Jetpack::is_offline_mode() || WC_Connect_Jetpack::is_current_user_connection_owner();
 		}
 
 		public function get_origin_address() {

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -68,9 +68,9 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 
 			if ( WC_Connect_Jetpack::is_offline_mode() ) {
 				if ( WC_Connect_Jetpack::is_connected() ) {
-					$message = __( 'Note: Jetpack is connected, but development mode is also enabled on this site. Please disable development mode.', 'woocommerce-services' );
+					$message = __( 'Note: Your site is connected but WooCommerce Shipping & Tax is configured to work in offline mode. Please disable offline mode.', 'woocommerce-services' );
 				} else {
-					$message = __( 'Note: Jetpack development mode is enabled on this site. This site will not be able to obtain payment methods from WooCommerce Shipping & Tax production servers.', 'woocommerce-services' );
+					$message = __( 'Note: WooCommerce Shipping & Tax is configured to work in offline mode. This site will not be able to obtain payment methods from WooCommerce Shipping & Tax production servers.', 'woocommerce-services' );
 				}
 				?>
 					<div class="wc-connect-admin-dev-notice">

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -66,7 +66,7 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 			global $hide_save_button;
 			$hide_save_button = true;
 
-			if ( WC_Connect_Jetpack::is_development_mode() ) {
+			if ( WC_Connect_Jetpack::is_offline_mode() ) {
 				if ( WC_Connect_Jetpack::is_connected() ) {
 					$message = __( 'Note: Jetpack is connected, but development mode is also enabled on this site. Please disable development mode.', 'woocommerce-services' );
 				} else {

--- a/client/apps/plugin-status/health.js
+++ b/client/apps/plugin-status/health.js
@@ -25,9 +25,9 @@ const HealthView = ( { translate, healthItems } ) => {
 				state={healthItems.woocommerce.state}
 			/>
 			<Indicator
-				title={translate('Jetpack')}
-				state={healthItems.jetpack.state}
-				message={healthItems.jetpack.message}
+				title={translate('WordPress.com Connection')}
+				state={healthItems.wpcom_connection.state}
+				message={healthItems.wpcom_connection.message}
 			/>
 			<Indicator
 				title={translate('Automated Taxes')}

--- a/client/apps/plugin-status/test/health.test.js
+++ b/client/apps/plugin-status/test/health.test.js
@@ -26,9 +26,9 @@ const defaultHealthStoreValues = {
 		state: 'success',
 		message: 'WooCommerce 5.0.0 is configured correctly'
 	},
-	jetpack: {
+	wpcom_connection: {
 		state: 'success',
-		message: 'Jetpack 9.4 is connected and working correctly',
+		message: 'Connected to WordPress.com',
 	},
 	woocommerce_services: {
 		timestamp: 1614185820,
@@ -84,12 +84,12 @@ describe('Health View', () => {
 		expect(sections).toHaveLength(4)
 
 		const wooCommerceSection = sections.at(0)
-		const jetpackSection = sections.at(1)
+		const wpcomConnectionSection = sections.at(1)
 		const taxesSection = sections.at(2)
 		const wcsSection = sections.at(3)
 
 		expect(wooCommerceSection.text()).toContain('WooCommerce 5.0.0 is configured correctly')
-		expect(jetpackSection.text()).toContain('Jetpack 9.4 is connected and working correctly')
+		expect(wpcomConnectionSection.text()).toContain('Connected to WordPress.com')
 		expect(taxesSection.text()).toContain('Automated taxes are enabled')
 		expect(taxesSection.text()).toContain('Go to the Tax settings')
 		expect(wcsSection.text()).toContain('Service data is up-to-date')


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description

Since the Jetpack plugin will no longer be needed once #2439 is merged, replace the "Jetpack" section label and the name for the back-end connection therein with "WordPress.com Connection" (opted for uppercase "Connection" because automated taxes on that page are labeled "Automated Taxes").

### Related issue(s)

Closes https://github.com/woocommerce/shipping/issues/11

Please reference the above issue for some earlier discussion.

### Steps to reproduce & screenshots/GIFs

#### Before

##### Success

<img width="709" alt="Screenshot 2023-08-29 at 14 19 40" src="https://github.com/Automattic/woocommerce-services/assets/1759681/b77aba79-4b3c-465f-9d6e-40f1dc80e67c">

##### Staging warning

<img width="694" alt="Screenshot 2023-08-29 at 14 19 59" src="https://github.com/Automattic/woocommerce-services/assets/1759681/f84c34cf-9ef5-48d1-9da1-bf2fbf7cc13c">

##### Error

<img width="1122" alt="Screenshot 2023-08-29 at 14 19 49" src="https://github.com/Automattic/woocommerce-services/assets/1759681/f2b332d4-9ae1-42d3-87ae-a4919c2413e8">

#### After

##### Success

<img width="706" alt="Screenshot 2023-08-29 at 14 18 42" src="https://github.com/Automattic/woocommerce-services/assets/1759681/d019094f-5444-4994-9925-e5c78f246e1b">

##### Staging warning

<img width="699" alt="Screenshot 2023-08-29 at 14 19 21" src="https://github.com/Automattic/woocommerce-services/assets/1759681/11b6b202-6302-4bf4-a85a-8fcebea6b667">

##### Error

<img width="695" alt="Screenshot 2023-08-29 at 14 19 10" src="https://github.com/Automattic/woocommerce-services/assets/1759681/13909a99-601d-4c19-a3b8-5dfed4b62b5b">

### Testing instructions

1. Go to WooCommerce > Status > WooCommerce Shipping & Tax.
2. Trigger the individual statuses according to the code or force them by replacing individual `if` conditions with `true`.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests - same tests as before - no new tests added

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added (in #2439)
- [x] `readme.txt` entry added (in #2439)