### PR TITLE
Fix HTML reporting to show proper HTML

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.3.4 - 2023-xx-xx =
+* Fix - Shipping label reports to display proper HTML.
+
 = 2.3.3 - 2023-08-22 =
 * Tweak - Update .org assets.
 

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -182,10 +182,16 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 									<?php echo esc_html( get_date_from_gmt( date( 'Y-m-d H:i:s', $label['created'] / 1000 ) ) ); ?>
 								</th>
 								<td>
-									<?php echo esc_html( $this->get_edit_order_link( $label['order_id'] ) ); ?>
+									<?php echo wp_kses( $this->get_edit_order_link( $label['order_id'] ),
+										array(
+											'a' => array(
+												'href'   => array()
+											),
+										)
+									); ?>
 								</td>
 								<td>
-									<?php echo esc_html( wc_price( $label['rate'] ) ); ?>
+									<?php echo wp_kses_post( wc_price( $label['rate'] ) ); ?>
 								</td>
 								<td>
 									<?php echo esc_html( $label['service_name'] ); ?>
@@ -208,7 +214,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 								<?php echo count( $labels ); ?>
 							</th>
 							<th>
-								<?php echo esc_html( wc_price( $total ) ); ?>
+								<?php echo wp_kses_post( wc_price( $total ) ); ?>
 							</th>
 							<th></th>
 							<th></th>

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: woocommerce, automattic, woothemes, allendav, kellychoffman, jkudi
 Tags: shipping, stamps, usps, woocommerce, taxes, payment, dhl, labels
 Requires PHP: 5.6
 Requires at least: 4.6
-Tested up to: 6.2
+Tested up to: 6.3
 WC requires at least: 3.6
-WC tested up to: 7.8
+WC tested up to: 8.0
 Stable tag: 2.3.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -77,6 +77,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 6. Checking and exporting the label purchase reports
 
 == Changelog ==
+
+= 2.3.4 - 2023-xx-xx =
+* Fix - Shipping label reports to display proper HTML.
 
 = 2.3.3 - 2023-08-22 =
 * Tweak - Update .org assets.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -9,9 +9,9 @@
  * Domain Path: /i18n/languages/
  * Version: 2.3.3
  * Requires at least: 4.6
- * Tested up to: 6.2
+ * Tested up to: 6.3
  * WC requires at least: 3.6
- * WC tested up to: 7.8
+ * WC tested up to: 8.0
  *
  * Copyright (c) 2017-2023 Automattic
  *


### PR DESCRIPTION
## Description
Shipping Labels are not displaying HTML properly for "order" and "price" tabs. This PR fixes it by replacing esc_html to wp_kses* functions.

### Related issue(s)
Closes https://github.com/Automattic/woocommerce-services/issues/2658

### Steps to reproduce & screenshots/GIFs
1. `nvm use 10`, `npm i`, `npm run start`, `composer install`
2. Login as admin, go to WooComemrce > Reports > Shipping Labels.
3. The reporting on this page shows HTML properly, versus the issue described https://github.com/Automattic/woocommerce-services/issues/2658
![image](https://github.com/Automattic/woocommerce-services/assets/572862/1510dcc2-401d-4293-99c4-a0aec50aa107)

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added