### PR TITLE
Fix Failing PHP and E2E Tests

### DIFF
--- a/classes/class-wc-connect-tracks.php
+++ b/classes/class-wc-connect-tracks.php
@@ -110,7 +110,7 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 
 			$event_type = self::$product_name . '_' . $event_type;
 
-			$this->debug( 'Tracked the following eventssssss: ' . $event_type );
+			$this->debug( 'Tracked the following event: ' . $event_type );
 			WC_Connect_Jetpack::tracks_record_event( $user, $event_type, $data );
 		}
 

--- a/classes/class-wc-connect-tracks.php
+++ b/classes/class-wc-connect-tracks.php
@@ -110,7 +110,7 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 
 			$event_type = self::$product_name . '_' . $event_type;
 
-			$this->debug( 'Tracked the following event: ' . $event_type );
+			$this->debug( 'Tracked the following eventssssss: ' . $event_type );
 			WC_Connect_Jetpack::tracks_record_event( $user, $event_type, $data );
 		}
 

--- a/tests/e2e/specs/admin/1-activate-extension.test.js
+++ b/tests/e2e/specs/admin/1-activate-extension.test.js
@@ -7,6 +7,7 @@ describe( 'Store admin can login and make sure WooCommerce Shipping & Tax extens
 	it( 'Can activate WooCommerce Shipping & Tax extension if it is deactivated' , async () => {
 		const slug = 'woocommerce-services'
 		await StoreOwnerFlow.login();
+		await StoreOwnerFlow.updateWPDB();
 		await StoreOwnerFlow.openPluginsPage();
 		const disableLink = await page.$( `tr[data-slug="${ slug }"] .deactivate a` );
 		if ( disableLink ) {

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -5,8 +5,8 @@ const adminUserName = process.env.WORDPRESS_DB_USER || defaultConfig.users.admin
 const adminUserPassword = process.env.WORDPRESS_DB_PASSWORD || defaultConfig.users.admin.password;
 
 const WP_ADMIN_LOGIN = baseUrl + '/wp-login.php';
+const WP_ADMIN_UPGRADE = baseUrl + '/wp-admin/upgrade.php';
 const WP_ADMIN_PLUGINS_PAGE = baseUrl + '/wp-admin/plugins.php';
-const WP_ADMIN_ORDERS_PAGE = baseUrl + '/wp-admin/edit.php?post_type=shop_order';
 const WP_ADMIN_EDIT_ORDER_PAGE = function( orderId ) {
 	return baseUrl + `/wp-admin/post.php?post=${ orderId }&action=edit`;
 };
@@ -74,6 +74,16 @@ const StoreOwnerFlow = {
 		await Promise.all( [
 			page.waitForNavigation( { waitUntil: 'networkidle0' } ),
 			page.click( 'a' ),
+		] );
+	},
+
+	updateWPDB: async () => {
+		await page.goto( WP_ADMIN_UPGRADE );
+		await expect( page.title() ).resolves.toMatch( 'WordPress &rsaquo; Update' );
+		
+		await Promise.all( [
+			page.click( '.step a' ),
+			page.waitForSelector( 'body' ),
 		] );
 	},
 

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -83,7 +83,7 @@ const StoreOwnerFlow = {
 		
 		await Promise.all( [
 			page.click( '.step a' ),
-			page.waitForSelector( 'body' ),
+			page.waitForNavigation(),
 		] );
 	},
 

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -79,7 +79,7 @@ const StoreOwnerFlow = {
 
 	updateWPDB: async () => {
 		await page.goto( WP_ADMIN_UPGRADE );
-		await expect( page.title() ).resolves.toMatch( 'WordPress &rsaquo; Update' );
+		await expect( page.title() ).resolves.toContain( 'Update' );
 		
 		await Promise.all( [
 			page.click( '.step a' ),

--- a/tests/php/mocks/jetpack.php
+++ b/tests/php/mocks/jetpack.php
@@ -12,17 +12,19 @@ function jetpack_tracks_record_event() {
 	return func_get_args();
 }
 
-class Jetpack_Options {
-	static function get_option( $option ) {
-		switch ( $option ) {
-			case 'id':
-				return 12345;
-			default:
-				return false;
+if ( version_compare( WC()->version, '7.9.0', '<' ) || ! class_exists( 'Jetpack_Options' ) ) {
+	class Jetpack_Options {
+		static function get_option( $option ) {
+			switch ( $option ) {
+				case 'id':
+					return 12345;
+				default:
+					return false;
+			}
+		}
+
+		public function isMock() {
+			return true;
 		}
 	}
-
-  public function isMock() {
-    return true;
-  }
 }

--- a/tests/php/test-woocommerce-connect-tracks.php
+++ b/tests/php/test-woocommerce-connect-tracks.php
@@ -40,12 +40,12 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
 
-		if ( ! defined( 'JETPACK__VERSION' ) ) {
-			define( 'JETPACK__VERSION', '4.0' );
-		}
-
 		if ( version_compare( WC()->version, '7.9.0', '<' ) || ! class_exists( 'Jetpack_Options' ) ) {
 			require_once dirname( __FILE__ ) . '/mocks/jetpack.php';
+		}
+
+		if ( ! defined( 'JETPACK__VERSION' ) ) {
+			define( 'JETPACK__VERSION', '4.0' );
 		}
 	}
 

--- a/tests/php/test-woocommerce-connect-tracks.php
+++ b/tests/php/test-woocommerce-connect-tracks.php
@@ -43,11 +43,21 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		if ( version_compare( WC()->version, '7.9.0', '<' ) || ! class_exists( 'Jetpack_Options' ) ) {
 			require_once dirname( __FILE__ ) . '/mocks/jetpack.php';
 		}
+	}
 
+	public function set_up() {
 		$this->jetpack_options = $this->getMockBuilder( 'Jetpack_Options' )
 			->disableOriginalConstructor()
 			->setMethods( array( 'get_option' ) )
 			->getMock();
+
+		$this->logger = $this->getMockBuilder( 'WC_Connect_Logger' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'log' ) )
+			->getMock();
+
+		$this->tracks = new WC_Connect_Tracks( $this->logger, __FILE__ );
+		$this->tracks->init();
 	}
 
 	public function test_record_user_event() {

--- a/tests/php/test-woocommerce-connect-tracks.php
+++ b/tests/php/test-woocommerce-connect-tracks.php
@@ -162,34 +162,16 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 
 	public function test_saved_service_settings() {
 
-		// `withConsecutive` was introduced in phpunit 4.1 which only supports
-		// php 5.3.3 and higher. So we have a slightly different set of expectations
-		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
-		// rather then the less precise for all versions
-		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
-			$this->logger->expects( $this->exactly( 2 ) )
-				->method( 'log' )
-				->withConsecutive(
-					array(
-						$this->stringContains( 'woocommerceconnect_saved_service_settings' ),
-					),
-					array(
-						$this->stringContains( 'woocommerceconnect_saved_usps_settings' ),
-					)
-				);
-		} else {
-			$this->logger->expects( $this->at( 0 ) )
-				->method( 'log' )
-				->with(
-					$this->stringContains( 'woocommerceconnect_saved_service_settings' )
-				);
-
-			$this->logger->expects( $this->at( 1 ) )
-				->method( 'log' )
-				->with(
-					$this->stringContains( 'woocommerceconnect_saved_usps_settings' )
-				);
-		}
+		$this->logger->expects( $this->exactly( 2 ) )
+			->method( 'log' )
+			->withConsecutive(
+				array(
+					$this->stringContains( 'woocommerceconnect_saved_service_settings' ),
+				),
+				array(
+					$this->stringContains( 'woocommerceconnect_saved_usps_settings' ),
+				)
+			);
 
 		$this->tracks->saved_service_settings( 'usps' );
 	}

--- a/tests/php/test-woocommerce-connect-tracks.php
+++ b/tests/php/test-woocommerce-connect-tracks.php
@@ -23,22 +23,18 @@ abstract class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 class WP_Test_WC_Connect_Tracks_No_Jetpack extends WP_Test_WC_Connect_Tracks {
 
 	public function test_no_jetpack() {
+		// Only test WC < 7.9.0.
+		// Because WC >= 7.9.0 has JetPack built-in on the plugin.
 		if ( version_compare( WC()->version, '7.9.0', '<' ) ) {
 			$this->logger->expects( $this->once() )
 				->method( 'log' )
 				->with(
 					$this->stringContains( 'Error. jetpack_tracks_record_event is not defined.' )
 				);
-		} else {
-			$this->logger->expects( $this->once() )
-				->method( 'log' )
-				->with(
-					$this->stringContains( 'woocommerceconnect_opted_out' )
-				);
-		}
 
-		$record = $this->tracks->opted_out();
-		$this->assertNull( $record );
+			$record = $this->tracks->opted_out();
+			$this->assertNull( $record );
+		}
 	}
 
 }

--- a/tests/php/test-woocommerce-connect-tracks.php
+++ b/tests/php/test-woocommerce-connect-tracks.php
@@ -35,17 +35,29 @@ class WP_Test_WC_Connect_Tracks_No_Jetpack extends WP_Test_WC_Connect_Tracks {
 }
 
 class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
+	protected $jetpack_options;
 
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
-    if ( !method_exists( 'Jetpack_Options', 'isMock' ) ) {
-      require_once dirname( __FILE__ ) . '/mocks/jetpack.php';
-    }
+
+		if ( version_compare( WC()->version, '7.9.0', '<' ) || ! class_exists( 'Jetpack_Options' ) ) {
+			require_once dirname( __FILE__ ) . '/mocks/jetpack.php';
+		}
+
+		$this->jetpack_options = $this->getMockBuilder( 'Jetpack_Options' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'get_option' ) )
+			->getMock();
 	}
 
 	public function test_record_user_event() {
 		global $mock_recorded_tracks_events;
 		$mock_recorded_tracks_events = array();
+
+		$this->api_client_mock->expects( $this->once() )
+			->method( 'get_option' )
+			->with( 'id' )
+			->willReturn( '12345' );
 
 		$this->logger->expects( $this->once() )
 			->method( 'log' )
@@ -73,6 +85,11 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		global $mock_recorded_tracks_events;
 		$mock_recorded_tracks_events = array();
 
+		$this->api_client_mock->expects( $this->once() )
+			->method( 'get_option' )
+			->with( 'id' )
+			->willReturn( '12345' );
+
 		$this->logger->expects( $this->once() )
 			->method( 'log' )
 			->with(
@@ -99,6 +116,11 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		global $mock_recorded_tracks_events;
 		$mock_recorded_tracks_events = array();
 
+		$this->api_client_mock->expects( $this->once() )
+			->method( 'get_option' )
+			->with( 'id' )
+			->willReturn( '12345' );
+
 		$this->logger->expects( $this->once() )
 			->method( 'log' )
 			->with(
@@ -122,6 +144,11 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 	}
 
 	public function test_saved_service_settings() {
+
+		$this->api_client_mock->expects( $this->once() )
+			->method( 'get_option' )
+			->with( 'id' )
+			->willReturn( '12345' );
 
 		// `withConsecutive` was introduced in phpunit 4.1 which only supports
 		// php 5.3.3 and higher. So we have a slightly different set of expectations
@@ -157,6 +184,11 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 
 	public function test_shipping_zone_method_added() {
 
+		$this->api_client_mock->expects( $this->once() )
+			->method( 'get_option' )
+			->with( 'id' )
+			->willReturn( '12345' );
+
 		// `withConsecutive` was introduced in phpunit 4.1 which only supports
 		// php 5.3.3 and higher. So we have a slightly different set of expectations
 		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
@@ -190,6 +222,11 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 	}
 
 	public function test_shipping_zone_method_deleted() {
+
+		$this->api_client_mock->expects( $this->once() )
+			->method( 'get_option' )
+			->with( 'id' )
+			->willReturn( '12345' );
 
 		// `withConsecutive` was introduced in phpunit 4.1 which only supports
 		// php 5.3.3 and higher. So we have a slightly different set of expectations
@@ -225,6 +262,11 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 
 	public function test_shipping_zone_method_enabled() {
 
+		$this->api_client_mock->expects( $this->once() )
+			->method( 'get_option' )
+			->with( 'id' )
+			->willReturn( '12345' );
+
 		// `withConsecutive` was introduced in phpunit 4.1 which only supports
 		// php 5.3.3 and higher. So we have a slightly different set of expectations
 		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
@@ -258,6 +300,11 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 	}
 
 	public function test_shipping_zone_method_disabled() {
+
+		$this->api_client_mock->expects( $this->once() )
+			->method( 'get_option' )
+			->with( 'id' )
+			->willReturn( '12345' );
 
 		// `withConsecutive` was introduced in phpunit 4.1 which only supports
 		// php 5.3.3 and higher. So we have a slightly different set of expectations

--- a/tests/php/test-woocommerce-connect-tracks.php
+++ b/tests/php/test-woocommerce-connect-tracks.php
@@ -159,11 +159,6 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 
 	public function test_saved_service_settings() {
 
-		$this->jetpack_options->expects( $this->once() )
-			->method( 'get_option' )
-			->with( 'id' )
-			->willReturn( '12345' );
-
 		// `withConsecutive` was introduced in phpunit 4.1 which only supports
 		// php 5.3.3 and higher. So we have a slightly different set of expectations
 		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
@@ -197,11 +192,6 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 	}
 
 	public function test_shipping_zone_method_added() {
-
-		$this->jetpack_options->expects( $this->once() )
-			->method( 'get_option' )
-			->with( 'id' )
-			->willReturn( '12345' );
 
 		// `withConsecutive` was introduced in phpunit 4.1 which only supports
 		// php 5.3.3 and higher. So we have a slightly different set of expectations
@@ -237,11 +227,6 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 
 	public function test_shipping_zone_method_deleted() {
 
-		$this->jetpack_options->expects( $this->once() )
-			->method( 'get_option' )
-			->with( 'id' )
-			->willReturn( '12345' );
-
 		// `withConsecutive` was introduced in phpunit 4.1 which only supports
 		// php 5.3.3 and higher. So we have a slightly different set of expectations
 		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
@@ -276,11 +261,6 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 
 	public function test_shipping_zone_method_enabled() {
 
-		$this->jetpack_options->expects( $this->once() )
-			->method( 'get_option' )
-			->with( 'id' )
-			->willReturn( '12345' );
-
 		// `withConsecutive` was introduced in phpunit 4.1 which only supports
 		// php 5.3.3 and higher. So we have a slightly different set of expectations
 		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
@@ -314,11 +294,6 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 	}
 
 	public function test_shipping_zone_method_disabled() {
-
-		$this->jetpack_options->expects( $this->once() )
-			->method( 'get_option' )
-			->with( 'id' )
-			->willReturn( '12345' );
 
 		// `withConsecutive` was introduced in phpunit 4.1 which only supports
 		// php 5.3.3 and higher. So we have a slightly different set of expectations

--- a/tests/php/test-woocommerce-connect-tracks.php
+++ b/tests/php/test-woocommerce-connect-tracks.php
@@ -41,10 +41,6 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		parent::set_up_before_class();
 
 		require_once dirname( __FILE__ ) . '/mocks/jetpack.php';
-
-		if ( ! defined( 'JETPACK__VERSION' ) ) {
-			define( 'JETPACK__VERSION', '4.0' );
-		}
 	}
 
 	public function set_up() {

--- a/tests/php/test-woocommerce-connect-tracks.php
+++ b/tests/php/test-woocommerce-connect-tracks.php
@@ -62,7 +62,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		global $mock_recorded_tracks_events;
 		$mock_recorded_tracks_events = array();
 
-		$this->jetpack_options->expects( $this->once() )
+		$this->jetpack_options->expects( $this->any() )
 			->method( 'get_option' )
 			->with( 'id' )
 			->willReturn( '12345' );
@@ -93,7 +93,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		global $mock_recorded_tracks_events;
 		$mock_recorded_tracks_events = array();
 
-		$this->jetpack_options->expects( $this->once() )
+		$this->jetpack_options->expects( $this->any() )
 			->method( 'get_option' )
 			->with( 'id' )
 			->willReturn( '12345' );
@@ -124,7 +124,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		global $mock_recorded_tracks_events;
 		$mock_recorded_tracks_events = array();
 
-		$this->jetpack_options->expects( $this->once() )
+		$this->jetpack_options->expects( $this->any() )
 			->method( 'get_option' )
 			->with( 'id' )
 			->willReturn( '12345' );

--- a/tests/php/test-woocommerce-connect-tracks.php
+++ b/tests/php/test-woocommerce-connect-tracks.php
@@ -64,7 +64,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		global $mock_recorded_tracks_events;
 		$mock_recorded_tracks_events = array();
 
-		$this->api_client_mock->expects( $this->once() )
+		$this->jetpack_options->expects( $this->once() )
 			->method( 'get_option' )
 			->with( 'id' )
 			->willReturn( '12345' );
@@ -95,7 +95,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		global $mock_recorded_tracks_events;
 		$mock_recorded_tracks_events = array();
 
-		$this->api_client_mock->expects( $this->once() )
+		$this->jetpack_options->expects( $this->once() )
 			->method( 'get_option' )
 			->with( 'id' )
 			->willReturn( '12345' );
@@ -126,7 +126,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		global $mock_recorded_tracks_events;
 		$mock_recorded_tracks_events = array();
 
-		$this->api_client_mock->expects( $this->once() )
+		$this->jetpack_options->expects( $this->once() )
 			->method( 'get_option' )
 			->with( 'id' )
 			->willReturn( '12345' );
@@ -155,7 +155,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 
 	public function test_saved_service_settings() {
 
-		$this->api_client_mock->expects( $this->once() )
+		$this->jetpack_options->expects( $this->once() )
 			->method( 'get_option' )
 			->with( 'id' )
 			->willReturn( '12345' );
@@ -194,7 +194,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 
 	public function test_shipping_zone_method_added() {
 
-		$this->api_client_mock->expects( $this->once() )
+		$this->jetpack_options->expects( $this->once() )
 			->method( 'get_option' )
 			->with( 'id' )
 			->willReturn( '12345' );
@@ -233,7 +233,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 
 	public function test_shipping_zone_method_deleted() {
 
-		$this->api_client_mock->expects( $this->once() )
+		$this->jetpack_options->expects( $this->once() )
 			->method( 'get_option' )
 			->with( 'id' )
 			->willReturn( '12345' );
@@ -272,7 +272,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 
 	public function test_shipping_zone_method_enabled() {
 
-		$this->api_client_mock->expects( $this->once() )
+		$this->jetpack_options->expects( $this->once() )
 			->method( 'get_option' )
 			->with( 'id' )
 			->willReturn( '12345' );
@@ -311,7 +311,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 
 	public function test_shipping_zone_method_disabled() {
 
-		$this->api_client_mock->expects( $this->once() )
+		$this->jetpack_options->expects( $this->once() )
 			->method( 'get_option' )
 			->with( 'id' )
 			->willReturn( '12345' );

--- a/tests/php/test-woocommerce-connect-tracks.php
+++ b/tests/php/test-woocommerce-connect-tracks.php
@@ -23,11 +23,20 @@ abstract class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 class WP_Test_WC_Connect_Tracks_No_Jetpack extends WP_Test_WC_Connect_Tracks {
 
 	public function test_no_jetpack() {
-		$this->logger->expects( $this->once() )
-			->method( 'log' )
-			->with(
-				$this->stringContains( 'Error. jetpack_tracks_record_event is not defined.' )
-			);
+		if ( version_compare( WC()->version, '7.9.0', '<' ) ) {
+			$this->logger->expects( $this->once() )
+				->method( 'log' )
+				->with(
+					$this->stringContains( 'Error. jetpack_tracks_record_event is not defined.' )
+				);
+		} else {
+			$this->logger->expects( $this->once() )
+				->method( 'log' )
+				->with(
+					$this->stringContains( 'woocommerceconnect_opted_out' )
+				);
+		}
+
 		$record = $this->tracks->opted_out();
 		$this->assertNull( $record );
 	}

--- a/tests/php/test-woocommerce-connect-tracks.php
+++ b/tests/php/test-woocommerce-connect-tracks.php
@@ -229,103 +229,47 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 	}
 
 	public function test_shipping_zone_method_deleted() {
-
-		// `withConsecutive` was introduced in phpunit 4.1 which only supports
-		// php 5.3.3 and higher. So we have a slightly different set of expectations
-		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
-		// rather then the less precise for all versions
-		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
-			$this->logger->expects( $this->exactly( 2 ) )
-				->method( 'log' )
-				->withConsecutive(
-					array(
-						$this->stringContains( 'woocommerceconnect_shipping_zone_method_deleted' ),
-					),
-					array(
-						$this->stringContains( 'woocommerceconnect_shipping_zone_canada_post_deleted' ),
-					)
-				);
-		} else {
-			$this->logger->expects( $this->at( 0 ) )
-				->method( 'log' )
-				->with(
-					$this->stringContains( 'woocommerceconnect_shipping_zone_method_deleted' )
-				);
-
-			$this->logger->expects( $this->at( 1 ) )
-				->method( 'log' )
-				->with(
-					$this->stringContains( 'woocommerceconnect_shipping_zone_canada_post_deleted' )
-				);
-		}
+		$this->logger->expects( $this->exactly( 2 ) )
+			->method( 'log' )
+			->withConsecutive(
+				array(
+					$this->stringContains( 'woocommerceconnect_shipping_zone_method_deleted' ),
+				),
+				array(
+					$this->stringContains( 'woocommerceconnect_shipping_zone_canada_post_deleted' ),
+				)
+			);
 
 		do_action( 'wc_connect_shipping_zone_method_deleted', 2, 'canada_post', 3 );
 	}
 
 	public function test_shipping_zone_method_enabled() {
-
-		// `withConsecutive` was introduced in phpunit 4.1 which only supports
-		// php 5.3.3 and higher. So we have a slightly different set of expectations
-		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
-		// rather then the less precise for all versions
-		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
-			$this->logger->expects( $this->exactly( 2 ) )
-				->method( 'log' )
-				->withConsecutive(
-					array(
-						$this->stringContains( 'woocommerceconnect_shipping_zone_method_enabled' ),
-					),
-					array(
-						$this->stringContains( 'woocommerceconnect_shipping_zone_usps_enabled' ),
-					)
-				);
-		} else {
-			$this->logger->expects( $this->at( 0 ) )
-				->method( 'log' )
-				->with(
-					$this->stringContains( 'woocommerceconnect_shipping_zone_method_enabled' )
-				);
-
-			$this->logger->expects( $this->at( 1 ) )
-				->method( 'log' )
-				->with(
-					$this->stringContains( 'woocommerceconnect_shipping_zone_usps_enabled' )
-				);
-		}
+		$this->logger->expects( $this->exactly( 2 ) )
+			->method( 'log' )
+			->withConsecutive(
+				array(
+					$this->stringContains( 'woocommerceconnect_shipping_zone_method_enabled' ),
+				),
+				array(
+					$this->stringContains( 'woocommerceconnect_shipping_zone_usps_enabled' ),
+				)
+			);
 
 		do_action( 'wc_connect_shipping_zone_method_status_toggled', 2, 'usps', 3, true );
 	}
 
 	public function test_shipping_zone_method_disabled() {
 
-		// `withConsecutive` was introduced in phpunit 4.1 which only supports
-		// php 5.3.3 and higher. So we have a slightly different set of expectations
-		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
-		// rather then the less precise for all versions
-		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
-			$this->logger->expects( $this->exactly( 2 ) )
-				->method( 'log' )
-				->withConsecutive(
-					array(
-						$this->stringContains( 'woocommerceconnect_shipping_zone_method_disabled' ),
-					),
-					array(
-						$this->stringContains( 'woocommerceconnect_shipping_zone_usps_disabled' ),
-					)
-				);
-		} else {
-			$this->logger->expects( $this->at( 0 ) )
-				->method( 'log' )
-				->with(
-					$this->stringContains( 'woocommerceconnect_shipping_zone_method_disabled' )
-				);
-
-			$this->logger->expects( $this->at( 1 ) )
-				->method( 'log' )
-				->with(
-					$this->stringContains( 'woocommerceconnect_shipping_zone_usps_disabled' )
-				);
-		}
+		$this->logger->expects( $this->exactly( 2 ) )
+			->method( 'log' )
+			->withConsecutive(
+				array(
+					$this->stringContains( 'woocommerceconnect_shipping_zone_method_disabled' ),
+				),
+				array(
+					$this->stringContains( 'woocommerceconnect_shipping_zone_usps_disabled' ),
+				)
+			);
 
 		do_action( 'wc_connect_shipping_zone_method_status_toggled', 2, 'usps', 3, false );
 	}

--- a/tests/php/test-woocommerce-connect-tracks.php
+++ b/tests/php/test-woocommerce-connect-tracks.php
@@ -40,6 +40,10 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
 
+		if ( ! defined( 'JETPACK__VERSION' ) ) {
+			define( 'JETPACK__VERSION', '4.0' );
+		}
+
 		if ( version_compare( WC()->version, '7.9.0', '<' ) || ! class_exists( 'Jetpack_Options' ) ) {
 			require_once dirname( __FILE__ ) . '/mocks/jetpack.php';
 		}

--- a/tests/php/test-woocommerce-connect-tracks.php
+++ b/tests/php/test-woocommerce-connect-tracks.php
@@ -40,9 +40,7 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
 
-		if ( version_compare( WC()->version, '7.9.0', '<' ) || ! class_exists( 'Jetpack_Options' ) ) {
-			require_once dirname( __FILE__ ) . '/mocks/jetpack.php';
-		}
+		require_once dirname( __FILE__ ) . '/mocks/jetpack.php';
 
 		if ( ! defined( 'JETPACK__VERSION' ) ) {
 			define( 'JETPACK__VERSION', '4.0' );

--- a/tests/php/test-woocommerce-connect-tracks.php
+++ b/tests/php/test-woocommerce-connect-tracks.php
@@ -196,34 +196,16 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 
 	public function test_shipping_zone_method_added() {
 
-		// `withConsecutive` was introduced in phpunit 4.1 which only supports
-		// php 5.3.3 and higher. So we have a slightly different set of expectations
-		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
-		// rather then the less precise for all versions
-		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
-			$this->logger->expects( $this->exactly( 2 ) )
-				->method( 'log' )
-				->withConsecutive(
-					array(
-						$this->stringContains( 'woocommerceconnect_shipping_zone_method_added' ),
-					),
-					array(
-						$this->stringContains( 'woocommerceconnect_shipping_zone_usps_added' ),
-					)
-				);
-		} else {
-			$this->logger->expects( $this->at( 0 ) )
-				->method( 'log' )
-				->with(
-					$this->stringContains( 'woocommerceconnect_shipping_zone_method_added' )
-				);
-
-			$this->logger->expects( $this->at( 1 ) )
-				->method( 'log' )
-				->with(
-					$this->stringContains( 'woocommerceconnect_shipping_zone_usps_added' )
-				);
-		}
+		$this->logger->expects( $this->exactly( 2 ) )
+			->method( 'log' )
+			->withConsecutive(
+				array(
+					$this->stringContains( 'woocommerceconnect_shipping_zone_method_added' ),
+				),
+				array(
+					$this->stringContains( 'woocommerceconnect_shipping_zone_usps_added' ),
+				)
+			);
 
 		do_action( 'wc_connect_shipping_zone_method_added', 2, 'usps', 3 );
 	}

--- a/tests/php/test-woocommerce-services-compatibility.php
+++ b/tests/php/test-woocommerce-services-compatibility.php
@@ -53,7 +53,7 @@ class WP_Test_WC_Services_Compatibility extends WC_Unit_Test_Case {
 		$variations = $product->get_available_variations();
 		$variation  = new WC_Product_Variation( $variations[0]['variation_id'] );
 		$this->assertTrue( is_string( wc_get_formatted_variation( $variation ) ) );
-		$this->assertRegExp( '/^\<dl class="variation"/', wc_get_formatted_variation( $variation ) );
+		$this->assertMatchesRegularExpression( '/^\<dl class="variation"/', wc_get_formatted_variation( $variation ) );
 	}
 
 	public function test_get_product_id() {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
This PR is fixing the PHP and E2E tests. 
The issue with PHP tests was because Jetpack_Options is declared twice when using WC >= 7.9.0.
The issue with E2E tests was because everytime the automated test try to login, it got blocked by the upgrade page :
![image](https://github.com/Automattic/woocommerce-services/assets/631098/d9445ded-465f-42c1-acd4-b324af69d22c)

<!-- Explain the motivation for making this change -->

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added


Closes https://github.com/Automattic/woocommerce-services/issues/2665
