### PR TITLE
Update readme.txt so that Jetpack Connection requirement is at the top

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.3.5 - 2023-xx-xx =
+* Tweak - Move Jetpack Connection requirement to the top in FAQ.
+
 = 2.3.4 - 2023-09-05 =
 * Fix - Shipping label reports to display proper HTML.
 

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,10 @@ This section describes how to install the plugin and get it working.
 
 == Frequently Asked Questions ==
 
+= Why is a Jetpack Connection and WordPress.com account required? =
+
+We use the Jetpack connection to authenticate each request and, if you use the shipping label service, to charge your credit card on file.
+
 = What services are included? =
 
 * USPS and DHL label purchase/printing
@@ -53,10 +57,6 @@ Yes! You can buy and print USPS shipping labels for domestic destinations and US
 = This works with WooCommerce, right? =
 
 Yep! WooCommerce version 3.0 or newer, please.
-
-= Why is a Jetpack Connection and WordPress.com account required? =
-
-We use the Jetpack connection to authenticate each request and, if you use the shipping label service, to charge your credit card on file.
 
 = Are there Terms of Service and data usage policies? =
 
@@ -77,6 +77,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 6. Checking and exporting the label purchase reports
 
 == Changelog ==
+
+= 2.3.5 - 2023-xx-xx =
+* Tweak - Move Jetpack Connection requirement to the top in FAQ.
 
 = 2.3.4 - 2023-09-05 =
 * Fix - Shipping label reports to display proper HTML.


### PR DESCRIPTION
## Description
We would like to move the Jetpack Connection FAQ item to the top:
![image](https://github.com/Automattic/woocommerce-services/assets/572862/e8170739-82fc-48c9-bbaf-4177e5532eb9)

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

