### PR TITLE
Load sift js snippet

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.3.6 - 2023-xx-xx =
+* Add - Load Sift when printing a label.
+
 = 2.3.5 - 2023-09-20 =
 * Tweak - Move Jetpack Connection requirement to the top in FAQ.
 

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -202,6 +202,15 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		/**
+		 * Retrieve Sift configurations.
+		 *
+		 * @return object|WP_Error
+		 */
+		public function get_sift_configurations() {
+			return $this->request( 'GET', '/payment/sift' );
+		}
+
+		/**
 		 * Gets shipping rates (for labels) from the WooCommerce Shipping & Tax Server
 		 *
 		 * @param array $request - array(

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -206,7 +206,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 *
 		 * @return object|WP_Error
 		 */
-		public function get_sift_configurations() {
+		public function get_sift_configuration() {
 			return $this->request( 'GET', '/payment/sift' );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 2.3.6 - 2023-xx-xx =
+* Add - Load Sift when printing a label.
+
 = 2.3.5 - 2023-09-20 =
 * Tweak - Move Jetpack Connection requirement to the top in FAQ.
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -818,7 +818,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'woocommerce_email_after_order_table', array( $this, 'add_tracking_info_to_emails' ), 10, 3 );
 			add_filter( 'woocommerce_admin_reports', array( $this, 'reports_tabs' ) );
 			add_action( 'woocommerce_checkout_order_processed', array( $this, 'track_completed_order' ), 10, 3 );
-			add_action( 'admin_print_footer_scripts', [ $this, 'add_sift_js_tracker' ] );
+			add_action( 'admin_print_footer_scripts', array( $this, 'add_sift_js_tracker' ) );
 
 			$tracks = $this->get_tracks();
 			$tracks->init();

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1614,10 +1614,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				return;
 			}
 
-			$fraud_config = [
+			$fraud_config = array(
 				'beacon_key' => $sift_configurations->beacon_key,
-				'user_id' => $connected_data['ID']
-			];
+				'user_id'    => $connected_data['ID']
+			);
 
 			?>
 			<script type="text/javascript">

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -818,6 +818,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'woocommerce_email_after_order_table', array( $this, 'add_tracking_info_to_emails' ), 10, 3 );
 			add_filter( 'woocommerce_admin_reports', array( $this, 'reports_tabs' ) );
 			add_action( 'woocommerce_checkout_order_processed', array( $this, 'track_completed_order' ), 10, 3 );
+			add_action( 'admin_print_footer_scripts', [ $this, 'add_sift_js_tracker' ] );
 
 			$tracks = $this->get_tracks();
 			$tracks->init();
@@ -1586,6 +1587,45 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				esc_url( 'https://woocommerce.com/my-account/create-a-ticket/' )
 			);
 			return $links;
+		}
+
+		/**
+		 * Adds the Sift JS page tracker if needed. See the comments for the detailed logic.
+		 *
+		 * @return  void
+		 */
+		public function add_sift_js_tracker() {
+			$master_user     = WC_Connect_Jetpack::get_master_user();
+			$connected_data  = WC_Connect_Jetpack::get_connected_user_data( $master_user->ID );
+
+			// TODO: We need to get these from connect server
+			$fraud_config = [
+				'beacon_key' => 'asdasd',
+				'user_id' => $connected_data['ID']
+			];
+
+			if ( empty( $fraud_config ) ) {
+				// Abort if Sift is not enabled for this account.
+				return;
+			}
+
+			?>
+			<script type="text/javascript">
+				var src = 'https://cdn.sift.com/s.js';
+
+				var _sift = ( window._sift = window._sift || [] );
+				_sift.push( [ '_setAccount', '<?php echo esc_attr( $fraud_config['beacon_key'] ); ?>' ] );
+				_sift.push( [ '_setUserId', '<?php echo esc_attr( $fraud_config['user_id'] ); ?>' ] );
+				_sift.push( [ '_trackPageview' ] );
+
+				if ( ! document.querySelector( '[src="' + src + '"]' ) ) {
+					var script = document.createElement( 'script' );
+					script.src = src;
+					script.async = true;
+					document.body.appendChild( script );
+				}
+			</script>
+			<?php
 		}
 
 		public function enqueue_wc_connect_script( $root_view, $extra_args = array() ) {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1603,6 +1603,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function add_sift_js_tracker() {
 			$sift_configurations = $this->api_client->get_sift_configuration();
 			$master_user     = WC_Connect_Jetpack::get_master_user();
+			if ( ! $master_user ) {
+				return;
+			}
+
 			$connected_data  = WC_Connect_Jetpack::get_connected_user_data( $master_user->ID );
 
 			if ( is_wp_error( $sift_configurations ) || empty( $sift_configurations->beacon_key ) || empty( $connected_data['ID'] ) ) {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1601,7 +1601,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * @return  void
 		 */
 		public function add_sift_js_tracker() {
-			$sift_configurations = $this->api_client->get_sift_configurations();
+			$sift_configurations = $this->api_client->get_sift_configuration();
 			$master_user     = WC_Connect_Jetpack::get_master_user();
 			$connected_data  = WC_Connect_Jetpack::get_connected_user_data( $master_user->ID );
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1595,19 +1595,19 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * @return  void
 		 */
 		public function add_sift_js_tracker() {
+			$sift_configurations = $this->api_client->get_sift_configurations();
 			$master_user     = WC_Connect_Jetpack::get_master_user();
 			$connected_data  = WC_Connect_Jetpack::get_connected_user_data( $master_user->ID );
 
-			// TODO: We need to get these from connect server
-			$fraud_config = [
-				'beacon_key' => 'asdasd',
-				'user_id' => $connected_data['ID']
-			];
-
-			if ( empty( $fraud_config ) ) {
-				// Abort if Sift is not enabled for this account.
+			if ( is_wp_error( $sift_configurations ) || empty( $sift_configurations->beacon_key ) || empty( $connected_data['ID'] ) ) {
+				// Don't add sift tracking if we can't have the parameters to initialize Sift
 				return;
 			}
+
+			$fraud_config = [
+				'beacon_key' => $sift_configurations->beacon_key,
+				'user_id' => $connected_data['ID']
+			];
 
 			?>
 			<script type="text/javascript">


### PR DESCRIPTION
## Description
This PR adds the Sift.js snippet. It follows the documentation here https://sift.com/developers/docs/php/javascript-api/overview. 

The logic is very similar to WooCommerce Payments https://github.com/Automattic/woocommerce-payments/blob/c7b5b934684cc8c3d256e2ec84bc4ddf1071edac/includes/class-wc-payments-fraud-service.php#L170-L205

### Related issue(s)
273-gh-Automattic/woocommerce-shipping-issues
2246-gh-Automattic/woocommerce-connect-server

### Steps to reproduce & screenshots/GIFs
1. You will need this PR to accompany the test. 2247-gh-Automattic/woocommerce-connect-server
2. Go to label printing page. Open up your browser's network tab
3. Confirm that you see a request made to `s.js`, and Request URL is `https://cdn.sift.com/s.js`.
4. If you have access to the Sift dashboard, you should see something like this: pNPgK-6DZ-p2#comment-25368 

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added