### PR TITLE
Bump supported WC versions to L-2 and its WP & PHP requirements

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.4.0 - 2023-xx-xx =
+* Update - Bump supported WC versions to L-2, and WP and PHP versions to WC L-2's requirements.
+
 = 2.3.7 - 2023-10-23 =
 * Add - Load Sift when printing a label.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,11 +1,11 @@
 === WooCommerce Shipping & Tax ===
 Contributors: woocommerce, automattic, woothemes, allendav, kellychoffman, jkudish, jeffstieler, nabsul, robobot3000, danreylop, mikeyarce, shaunkuschel, orangesareorange, pauldechov, dappermountain, radogeorgiev, bor0, royho, cshultz88, bartoszbudzanowski, harriswong, ferdev, superdav42
 Tags: shipping, stamps, usps, woocommerce, taxes, payment, dhl, labels
-Requires PHP: 5.6
-Requires at least: 4.6
+Requires PHP: 7.3
+Requires at least: 6.2
 Tested up to: 6.3
-WC requires at least: 3.6
-WC tested up to: 8.0
+WC requires at least: 8.0
+WC tested up to: 8.2
 Stable tag: 2.3.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 2.4.0 - 2023-xx-xx =
+* Update - Bump supported WC versions to L-2, and WP and PHP versions to WC L-2's requirements.
+
 = 2.3.7 - 2023-10-23 =
 * Add - Load Sift when printing a label.
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -8,10 +8,10 @@
  * Text Domain: woocommerce-services
  * Domain Path: /i18n/languages/
  * Version: 2.3.7
- * Requires at least: 4.6
+ * Requires at least: 6.2
  * Tested up to: 6.3
- * WC requires at least: 3.6
- * WC tested up to: 8.1
+ * WC requires at least: 8.0
+ * WC tested up to: 8.2
  *
  * Copyright (c) 2017-2023 Automattic
  *
@@ -1602,12 +1602,12 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 */
 		public function add_sift_js_tracker() {
 			$sift_configurations = $this->api_client->get_sift_configuration();
-			$master_user     = WC_Connect_Jetpack::get_master_user();
+			$master_user         = WC_Connect_Jetpack::get_master_user();
 			if ( ! $master_user ) {
 				return;
 			}
 
-			$connected_data  = WC_Connect_Jetpack::get_connected_user_data( $master_user->ID );
+			$connected_data = WC_Connect_Jetpack::get_connected_user_data( $master_user->ID );
 
 			if ( is_wp_error( $sift_configurations ) || empty( $sift_configurations->beacon_key ) || empty( $connected_data['ID'] ) ) {
 				// Don't add sift tracking if we can't have the parameters to initialize Sift
@@ -1616,7 +1616,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			$fraud_config = array(
 				'beacon_key' => $sift_configurations->beacon_key,
-				'user_id'    => $connected_data['ID']
+				'user_id'    => $connected_data['ID'],
 			);
 
 			?>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
In line with [this change to WooPayments](https://developer.woocommerce.com/2021/05/12/woocommerce-payments-is-adopting-a-new-version-support-policy/), we are adopting a WC L-2 version support policy. This means that we will support the current release of WC, as well as the last two major releases. For example, if the current version is WC 8.2.1, we will support the latest patch release (the last digit in the version number) for the following WC major verisons:

- WC 8.2.x
- WC 8.1.x
- WC 8.0.x

As well as these WooCommerce versions' WP and PHP dependencies. The WP and PHP requirements of WC 8.0 are PHP 7.3 and WP 6.2.

**Before merging, we should sort out announcing this change**: p1698148432153039-slack-C3ECCGUVC Once done, this can be converted from Draft to a published PR.

### Checklist

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added