### PR TITLE
NUX: Fix banner display on Edit Orders pages when using HPOS

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.3.8 - 2023-xx-xx =
+* Fix - NUX banner display on Edit Order pages.
+
 = 2.3.7 - 2023-10-23 =
 * Add - Load Sift when printing a label.
 

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -323,14 +323,13 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					'product' === $screen->post_type
 					&& 'edit' === $screen->base
 				)
-				|| ( // Orders list.
+				|| ( // Orders list and edit order page when not using HPOS.
 					'shop_order' === $screen->post_type
-					&& 'edit' === $screen->base
+					&& in_array( $screen->base, array( 'edit', 'post' ), true )
 					)
-				|| ( // Edit order page.
-					'shop_order' === $screen->post_type
-					&& 'post' === $screen->base
-					)
+				|| ( // Orders list and edit order page when using HPOS.
+					wc_get_page_screen_id( 'shop_order' ) === $screen->id
+				)
 				|| ( // WooCommerce settings.
 					'woocommerce_page_wc-settings' === $screen->base
 					)

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 2.3.8 - 2023-xx-xx =
+* Fix - NUX banner display on Edit Order pages.
+
 = 2.3.7 - 2023-10-23 =
 * Add - Load Sift when printing a label.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

When HPOS is enabled (which has been the default for new sites since WC 8.2 release on Oct 10th, 2023), the admin screen IDs for "Edit Order" pages are different. This causes WCS&T's NUX banner to not show up. This applies to both the order listing and single order edit pages.

### Steps to reproduce & screenshots/GIFs

<img width="1284" alt="Screenshot 2023-10-26 at 11 33 05" src="https://github.com/Automattic/woocommerce-services/assets/1759681/66f80531-1f10-4b39-b968-6118b5f36265">

1. Set up a fresh site. Install WCS&T and WC. Don't connect with Jetpack.
2. Go to the Edit Order page (listing or single order page).
3. If you're on HPOS, the banner won't show up without this PR.
4. You can toggle HPOS usage in WC > Settings > Advanced > Features. You have to have order sync enabled on that page to be able to toggle this setting.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

