### PR TITLE
Fix activate/deactivate e2e test

### DIFF
--- a/tests/e2e/specs/admin/1-activate-extension.test.js
+++ b/tests/e2e/specs/admin/1-activate-extension.test.js
@@ -9,11 +9,11 @@ describe( 'Store admin can login and make sure WooCommerce Shipping & Tax extens
 		await StoreOwnerFlow.login();
 		await StoreOwnerFlow.updateWPDB();
 		await StoreOwnerFlow.openPluginsPage();
-		const disableLink = await page.$( `tr[data-slug="${ slug }"] .deactivate a` );
+		const disableLink = await page.$( `a#deactivate-${ slug }` );
 		if ( disableLink ) {
 			return;
 		}
-		await page.click( `tr[data-slug="${ slug }"] .activate a` );
-		await page.waitForSelector( `tr[data-slug="${ slug }"] .deactivate a` );
+		await page.click( `a#activate-${ slug }` );
+		await page.waitForSelector( `a#deactivate-${ slug }` );
 	});
 } );


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
E2E tests are failing waiting for the activate/deactivate link to appear on plugins page.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

