### PR TITLE
Fix fatal error that it cannot call constructor

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.5.1 - 2024-xx-xx =
+* Fix - Cannot call constructor in classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php.
+
 = 2.5.0 - 2024-01-08 =
 * Add - Ability to keep connected to WordPress.com after Jetpack is uninstalled.
 * Fix - Deprecation notices for PHP 8.2.

--- a/classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php
+++ b/classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php
@@ -44,7 +44,6 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 	protected $rest_base = 'data/continents';
 
 	public function __construct() {
-		parent::__construct();
 		$this->continents = new WC_Connect_Continents();
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 2.5.1 - 2024-xx-xx =
+* Fix - Cannot call constructor in classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php.
+
 = 2.5.0 - 2024-01-08 =
 * Add - Ability to keep connected to WordPress.com after Jetpack is uninstalled.
 * Fix - Deprecation notices for PHP 8.2.


### PR DESCRIPTION
## Description
This PR removes the `parent::__construct();` since there are no parent constructors to call. 

### Related issue(s)
Closes https://github.com/Automattic/woocommerce-services/issues/2714

### Steps to reproduce & screenshots/GIFs
1. Pull `trunk`, open `woocommerce-services.php` and go to line 1028. Change `if ( ! isset( $existing_routes['/wc/v3/data/continents'] ) ) {` to `if ( true || ! isset( $existing_routes['/wc/v3/data/continents'] ) ) {`. This forces the plugin to use our own continents controller.
2. Make a GET request to `http://localhost/wp-json/wc/v3/data/continents`, you should be able to reproduce the error:
![image](https://github.com/Automattic/woocommerce-services/assets/572862/2de99b1a-530b-4813-b696-e3da1633ae11)
3. Now, pull this branch. Repeat step 1 to 2.
4. You should now get this instead
![image](https://github.com/Automattic/woocommerce-services/assets/572862/5d10efa2-14bc-4173-a425-da7f35b0f946)


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

