### PR TITLE
Add support to PHP tests for WC >= 8.5 build process.

### DIFF
--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -72,12 +72,30 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 'v16'
-
-      - name: Build WooCommerce essentials for running tests
+      - name: Install Semvar
+        run: npm install semver
+      - name: Check new build version
+        id: check_new_build_version
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const semver = require('semver');
+            const currentVersion = '${{ matrix.wc-version }}';
+            const minimumVersion = '8.5.0';
+            return semver.gte(currentVersion, minimumVersion);
+      - name: Build WooCommerce < 8.5.0 essentials for running tests
+        if: steps.check_new_build_version.outputs.result == 'false'
         run: |
           cd /tmp/woocommerce/plugins/woocommerce
           composer install
           pnpm run build:feature-config
+      - name: Build WooCommerce >= 8.5.0 essentials for running tests
+        if: steps.check_new_build_version.outputs.result == 'true'
+        run: |
+          cd /tmp/woocommerce/plugins/woocommerce
+          composer install
+          pnpm install
+          pnpm --filter='@woocommerce/plugin-woocommerce' build
       - name: Setup WordPress
         run: bash /tmp/woocommerce/plugins/woocommerce/tests/bin/install.sh wordpress_test root root 127.0.0.1 ${{ matrix.wp-version }}
       - name: Use PHPUnit v8 for WC < 7.7.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
This PR updates our PHP tests to accommodate the new build process introduced in WC 8.5. We need to support both the new and old version since we have an L-2 support approach.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
Verify that the PHP tests pass on this PR.
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist
No release is needed as this is just a development process change.
<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

