### PR TITLE
Ensure Colorado tax nexus workaround is only applied when from_state is CO - Fix/issue 2721

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.5.3 - 2024-xx-xx =
+* Fix - Colorado tax nexus workaround should only apply to Colorado from addresses.
+
 = 2.5.2 - 2024-03-04 =
 * Fix - Miscalculation tax from TaxJar and decided to use nexus address.
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1010,14 +1010,21 @@ class WC_Connect_TaxJar_Integration {
 				'to_country'   => 'US',
 				'to_state'     => 'CO',
 				'from_country' => 'US',
+				'from_state'   => 'CO',
 			),
 		);
 
 		foreach ( $cases as $case ) {
-			if ( $case['to_country'] !== $body['to_country'] ||
-				$case['to_state'] !== $body['to_state'] ||
-				$case['from_country'] !== $body['from_country'] ) {
-				continue;
+
+			/**
+			 * Ensure the body has all the required address keys, and that the body address
+			 * values match the case address values before applying the workaround.
+			 */
+			$address_keys = array_keys( $case );
+			foreach ( $address_keys as $address_key ) {
+				if ( ! isset( $body[ $address_key ] ) || $body[ $address_key ] !== $case[ $address_key ] ) {
+					continue 2;
+				}
 			}
 
 			$body['nexus_addresses'] = array(

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Contributors: woocommerce, automattic, woothemes, allendav, kellychoffman, jkudish, jeffstieler, nabsul, robobot3000, danreylop, mikeyarce, shaunkuschel, orangesareorange, pauldechov, dappermountain, radogeorgiev, bor0, royho, cshultz88, bartoszbudzanowski, harriswong, ferdev, superdav42
 Tags: shipping, stamps, usps, woocommerce, taxes, payment, dhl, labels
 Requires PHP: 7.3
-Requires at least: 6.2
+Requires at least: 6.3
 Tested up to: 6.4
-WC requires at least: 8.0
-WC tested up to: 8.3
+WC requires at least: 8.4
+WC tested up to: 8.6
 Stable tag: 2.5.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -77,6 +77,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 6. Checking and exporting the label purchase reports
 
 == Changelog ==
+
+= 2.5.3 - 2024-xx-xx =
+* Fix - Colorado tax nexus workaround should only apply to Colorado from addresses.
 
 = 2.5.2 - 2024-03-04 =
 * Fix - Miscalculation tax from TaxJar and decided to use nexus address.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -8,10 +8,10 @@
  * Text Domain: woocommerce-services
  * Domain Path: /i18n/languages/
  * Version: 2.5.2
- * Requires at least: 6.2
+ * Requires at least: 6.3
  * Tested up to: 6.4
- * WC requires at least: 8.0
- * WC tested up to: 8.3
+ * WC requires at least: 8.4
+ * WC tested up to: 8.6
  *
  * Copyright (c) 2017-2023 Automattic
  *
@@ -331,7 +331,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->wc_connect_base_url = self::get_wc_connect_base_url();
 			add_action(
 				'before_woocommerce_init',
-				function() {
+				function () {
 					if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
 						\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', 'woocommerce-services/woocommerce-services.php' );
 					}
@@ -579,7 +579,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			if ( ! class_exists( 'WooCommerce' ) ) {
 				add_action(
 					'admin_notices',
-					function() {
+					function () {
 						/* translators: %s WC download URL link. */
 						echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'WooCommerce Shipping & Tax requires the WooCommerce plugin to be installed and active. You can download %s here.', 'woocommerce-services' ), '<a href="https://wordpress.org/plugins/woocommerce/" target="_blank">WooCommerce</a>' ) . '</strong></p></div>';
 					}
@@ -1221,8 +1221,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			// Abort if no $order was passed, if the order is not marked as 'completed' or if another extension is handling the emailing.
 			if ( ! $order
-				 || ! $order->has_status( 'completed' )
-				 || ! WC_Connect_Extension_Compatibility::should_email_tracking_details( $order->get_id() ) ) {
+				|| ! $order->has_status( 'completed' )
+				|| ! WC_Connect_Extension_Compatibility::should_email_tracking_details( $order->get_id() ) ) {
 				return;
 			}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -331,7 +331,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->wc_connect_base_url = self::get_wc_connect_base_url();
 			add_action(
 				'before_woocommerce_init',
-				function () {
+				function() {
 					if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
 						\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', 'woocommerce-services/woocommerce-services.php' );
 					}
@@ -579,7 +579,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			if ( ! class_exists( 'WooCommerce' ) ) {
 				add_action(
 					'admin_notices',
-					function () {
+					function() {
 						/* translators: %s WC download URL link. */
 						echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'WooCommerce Shipping & Tax requires the WooCommerce plugin to be installed and active. You can download %s here.', 'woocommerce-services' ), '<a href="https://wordpress.org/plugins/woocommerce/" target="_blank">WooCommerce</a>' ) . '</strong></p></div>';
 					}
@@ -1221,8 +1221,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			// Abort if no $order was passed, if the order is not marked as 'completed' or if another extension is handling the emailing.
 			if ( ! $order
-				|| ! $order->has_status( 'completed' )
-				|| ! WC_Connect_Extension_Compatibility::should_email_tracking_details( $order->get_id() ) ) {
+				 || ! $order->has_status( 'completed' )
+				 || ! WC_Connect_Extension_Compatibility::should_email_tracking_details( $order->get_id() ) ) {
 				return;
 			}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
A tax nexus workaround was recently applied to correct a tax miscalculation from TaxJar's API. This should apparently only apply if Colorado is the from state. This PR adds an extra condition to make sure the workaround only applies when the store is also in Colorado.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
Fixes #2721 

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

1. Follow the steps to reproduce in [this issue](https://github.com/Automattic/woocommerce-services/issues/2721).
2. The taxes should not be added if the from state is not Colorado.
3. The taxes should still be added when from state is Colorado.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

