### PR TITLE
Tweak/issue 2723 - WordPress 6.5 Compatibility

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.5.4 - 2024-xx-xx =
+* Tweak - WordPress 6.5 compatibility.
+
 = 2.5.3 - 2024-03-12 =
 * Fix - Colorado tax nexus workaround should only apply to Colorado from addresses.
 

--- a/classes/class-wc-connect-debug-tools.php
+++ b/classes/class-wc-connect-debug-tools.php
@@ -92,10 +92,11 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 			$found_ca_rates = $wpdb->get_results(
 				$wpdb->prepare(
 					"SELECT * FROM {$wpdb->prefix}woocommerce_tax_rates
-			        WHERE tax_rate_country = %s AND tax_rate_state = %s AND tax_rate_name LIKE '% Tax'
+			        WHERE tax_rate_country = %s AND tax_rate_state = %s AND tax_rate_name LIKE %s
 			        ",
 					'US',
-					'CA'
+					'CA',
+					'% Tax'
 				),
 				ARRAY_A
 			);

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -35,8 +35,8 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 
 		private function get_all_labels() {
 			global $wpdb;
-			$query      = "SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = 'wc_connect_labels'";
-			$db_results = $wpdb->get_results( $query );
+			$query      = "SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s";
+			$db_results = $wpdb->get_results( $wpdb->prepare( $query, 'wc_connect_labels' ) );
 			$results    = array();
 
 			foreach ( $db_results as $meta ) {

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -35,8 +35,13 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 
 		private function get_all_labels() {
 			global $wpdb;
-			$query      = "SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s";
-			$db_results = $wpdb->get_results( $wpdb->prepare( $query, 'wc_connect_labels' ) );
+
+			$db_results = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s",
+					'wc_connect_labels'
+				)
+			);
 			$results    = array();
 
 			foreach ( $db_results as $meta ) {

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -134,8 +134,8 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			$is_new_user = get_transient( self::IS_NEW_LABEL_USER );
 			if ( false === $is_new_user ) {
 				global $wpdb;
-				$query       = "SELECT meta_key FROM {$wpdb->postmeta} WHERE meta_key = 'wc_connect_labels' LIMIT 1";
-				$results     = $wpdb->get_results( $query );
+				$query       = "SELECT meta_key FROM {$wpdb->postmeta} WHERE meta_key = %s LIMIT 1";
+				$results     = $wpdb->get_results( $wpdb->prepare( $query, 'wc_connect_labels' ) );
 				$is_new_user = 0 === count( $results ) ? 'yes' : 'no';
 				set_transient( self::IS_NEW_LABEL_USER, $is_new_user );
 			}

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -134,8 +134,13 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			$is_new_user = get_transient( self::IS_NEW_LABEL_USER );
 			if ( false === $is_new_user ) {
 				global $wpdb;
-				$query       = "SELECT meta_key FROM {$wpdb->postmeta} WHERE meta_key = %s LIMIT 1";
-				$results     = $wpdb->get_results( $wpdb->prepare( $query, 'wc_connect_labels' ) );
+
+				$results     = $wpdb->get_results(
+					$wpdb->prepare(
+						"SELECT meta_key FROM {$wpdb->postmeta} WHERE meta_key = %s LIMIT 1",
+						'wc_connect_labels'
+					)
+				);
 				$is_new_user = 0 === count( $results ) ? 'yes' : 'no';
 				set_transient( self::IS_NEW_LABEL_USER, $is_new_user );
 			}

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -378,6 +378,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			}
 
 			global $wpdb;
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared --- Need to use interpolated for the `IN()` condition
 			$methods = $wpdb->get_results(
 				"SELECT * FROM {$wpdb->prefix}woocommerce_shipping_zone_methods " .
 				"LEFT JOIN {$wpdb->prefix}woocommerce_shipping_zones " .
@@ -385,6 +386,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				"WHERE method_id IN ({$escaped_list}) " .
 				'ORDER BY zone_order, instance_id;'
 			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 			if ( empty( $methods ) ) {
 				return $enabled_services;

--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 2.5.4 - 2024-xx-xx =
+* Tweak - WordPress 6.5 compatibility.
+
 = 2.5.3 - 2024-03-12 =
 * Fix - Colorado tax nexus workaround should only apply to Colorado from addresses.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,10 @@
 === WooCommerce Shipping & Tax ===
 Contributors: woocommerce, automattic, woothemes, allendav, kellychoffman, jkudish, jeffstieler, nabsul, robobot3000, danreylop, mikeyarce, shaunkuschel, orangesareorange, pauldechov, dappermountain, radogeorgiev, bor0, royho, cshultz88, bartoszbudzanowski, harriswong, ferdev, superdav42
 Tags: shipping, stamps, usps, woocommerce, taxes, payment, dhl, labels
-Requires PHP: 7.3
+Requires PHP: 7.4
 Requires at least: 6.3
-Tested up to: 6.4
+Requires Plugins: woocommerce
+Tested up to: 6.5
 WC requires at least: 8.4
 WC tested up to: 8.6
 Stable tag: 2.5.3

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Plugin Name: WooCommerce Shipping & Tax
+ * Requires Plugins: woocommerce
  * Plugin URI: https://woocommerce.com/
  * Description: Hosted services for WooCommerce: automated tax calculation, shipping label printing, and smoother payment setup.
  * Author: WooCommerce
@@ -9,7 +10,7 @@
  * Domain Path: /i18n/languages/
  * Version: 2.5.3
  * Requires at least: 6.3
- * Tested up to: 6.4
+ * Tested up to: 6.5
  * WC requires at least: 8.4
  * WC tested up to: 8.6
  *


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Making sure the plugin is compatible with 6.5. In this PR, it also introduces `Requires Plugins:` into readme file and plugin headers.
<!-- Explain the motivation for making this change -->

### Related issue(s)
Fixes #2723 
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
1. Install WP 6.5 RC 1 or above.
2. Go to Plugins > Installed Plugins page.
3. Take a look into WooCommerce row, WC Shipping & Tax now is being listed on `Required by:` info.
![image](https://github.com/Automattic/woocommerce-services/assets/631098/5d2ec52d-ce6e-49ed-afe2-ca7c92ab83bc)
4. Take a look into WooCommerce Shipping & Tax row. WooCommerce is now being listed on `Requires:` info.
5. The plugin will not be able to be activated if WooCommerce is not activated yet.
![image](https://github.com/Automattic/woocommerce-services/assets/631098/0f38c12c-4205-4e4c-9cfb-f2a8f74e31db)
6. Try to test the plugin features. It should still work on WP 6.5 RC 1 or above.
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

