### PR TITLE
Don't register functionality if both Woo Shipping and Woo Tax are active

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 2.5.5 - 2024-xx-xx =
-* Add - Don't register functionality if Woo Shipping is active.
+* Add - Don't register functionality if Woo Shipping or Woo Tax is active.
 
 = 2.5.4 - 2024-03-25 =
 * Tweak - WordPress 6.5 compatibility.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.5.5 - 2024-xx-xx =
+* Add - Don't register functionality if Woo Shipping is active.
+
 = 2.5.4 - 2024-03-25 =
 * Tweak - WordPress 6.5 compatibility.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 2.5.5 - 2024-xx-xx =
-* Add - Don't register functionality if Woo Shipping or Woo Tax is active.
+* Add - Prevent upcoming Woo Shipping and Woo Tax plugins from running in parallel with this plugin unless both are active, then they will take over for this plugin.
 
 = 2.5.4 - 2024-03-25 =
 * Tweak - WordPress 6.5 compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 2.5.5 - 2024-xx-xx =
+* Add - Don't register functionality if Woo Shipping is active.
+
 = 2.5.4 - 2024-03-25 =
 * Tweak - WordPress 6.5 compatibility.
 

--- a/readme.txt
+++ b/readme.txt
@@ -80,7 +80,7 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 == Changelog ==
 
 = 2.5.5 - 2024-xx-xx =
-* Add - Don't register functionality if Woo Shipping is active.
+* Add - Don't register functionality if Woo Shipping or Woo Tax is active.
 
 = 2.5.4 - 2024-03-25 =
 * Tweak - WordPress 6.5 compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -80,7 +80,7 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 == Changelog ==
 
 = 2.5.5 - 2024-xx-xx =
-* Add - Don't register functionality if Woo Shipping or Woo Tax is active.
+* Add - Prevent upcoming Woo Shipping and Woo Tax plugins from running in parallel with this plugin unless both are active, then they will take over for this plugin.
 
 = 2.5.4 - 2024-03-25 =
 * Tweak - WordPress 6.5 compatibility.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -582,11 +582,22 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function on_plugins_loaded() {
 			$this->load_textdomain();
 
-			if ( in_array( 'woocommerce-shipping/woocommerce-shipping.php', get_option( 'active_plugins' ) ) ) {
+			$is_woo_shipping_active = in_array( 'woocommerce-shipping/woocommerce-shipping.php', get_option( 'active_plugins' ) );
+			$is_woo_tax_active      = in_array( 'woocommerce-tax/woocommerce-tax.php', get_option( 'active_plugins' ) );
+
+			if ( $is_woo_shipping_active || $is_woo_tax_active ) {
 				add_action(
 					'admin_notices',
-					function () {
-						echo '<div class="error"><p><strong>' . esc_html__( 'Woo Shipping plugin is already active. Please deactivate WooCommerce Shipping & Tax.', 'woocommerce-shipping' ) . '</strong></p></div>';
+					function () use ( $is_woo_shipping_active, $is_woo_tax_active ) {
+						if ( $is_woo_shipping_active && $is_woo_tax_active ) {
+							$active_plugins = esc_html__( 'Woo Shipping and Woo Tax plugins are already active.', 'woocommerce-services' );
+						} elseif ( $is_woo_shipping_active ) {
+							$active_plugins = esc_html__( 'Woo Shipping plugin is already active.', 'woocommerce-services' );
+						} else {
+							$active_plugins = esc_html__( 'Woo Tax plugin is already active.', 'woocommerce-services' );
+						}
+
+						echo '<div class="error"><p><strong>' . $active_plugins . ' ' . esc_html__( 'Please deactivate WooCommerce Shipping & Tax.', 'woocommerce-services' ) . '</strong></p></div>';
 					}
 				);
 				return;

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -343,8 +343,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			if ( $this->are_woo_shipping_and_woo_tax_active() ) {
 				/**
-				 * Used to let Woo Shipping and Woo Tax know WCS&T will handle the plugins' coexistence
-				 * by displaying an appropriate notice and not registering its functionality.
+				 * Used to let Woo Shipping and Woo Tax know WCS&T will handle the plugins' coexistence.
+				 *
+				 * WCS&T does it by not registering its functionality and displaying an appropriate notice
+				 * in WP admin.
 				 */
 				add_filter( 'wc_services_will_handle_coexistence_with_woo_shipping_and_woo_tax', '__return_true' );
 				return;

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -589,12 +589,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->load_textdomain();
 
 			if ( apply_filters( 'wc_services_will_handle_coexistence_with_woo_shipping_and_woo_tax', false ) ) {
-				add_action(
-					'admin_notices',
-					function () {
-						echo '<div class="error"><p><strong>' . esc_html__( 'Woo Shipping and Woo Tax plugins are already active. Please deactivate WooCommerce Shipping & Tax.', 'woocommerce-services' ) . '</strong></p></div>';
-					}
-				);
+				add_action( 'admin_notices', array( $this, 'display_woo_shipping_and_woo_tax_are_active_notice' ) );
 				return;
 			}
 
@@ -1775,6 +1770,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$is_woo_tax_active      = in_array( 'woocommerce-tax/woocommerce-tax.php', get_option( 'active_plugins' ) );
 
 			return $is_woo_shipping_active && $is_woo_tax_active;
+		}
+
+		public function display_woo_shipping_and_woo_tax_are_active_notice() {
+			echo '<div class="error"><p><strong>' . esc_html__( 'Woo Shipping and Woo Tax plugins are already active. Please deactivate WooCommerce Shipping & Tax.', 'woocommerce-services' ) . '</strong></p></div>';
 		}
 	}
 }

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -351,9 +351,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$is_woo_shipping_active = in_array( 'woocommerce-shipping/woocommerce-shipping.php', get_option( 'active_plugins' ) );
 			$is_woo_tax_active      = in_array( 'woocommerce-tax/woocommerce-tax.php', get_option( 'active_plugins' ) );
 
-			if ( $is_woo_shipping_active && $is_woo_tax_active ) {
-				add_filter( 'wc_services_will_handle_coexistence_with_woo_shipping_and_woo_tax', '__return_true' );
-			}
+			return $is_woo_shipping_active && $is_woo_tax_active;
 		}
 
 		public function get_logger() {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -338,6 +338,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					}
 				}
 			);
+			/*
+			 * Used to let Woo Shipping know WCS&T will handle the plugins' coexistence
+			 * by displaying an appropriate notice and not registering its functionality.
+			 */
+			add_filter( 'wc_services_will_handle_coexistence_with_woo_shipping', '__return_true' );
 			add_action( 'plugins_loaded', array( $this, 'jetpack_on_plugins_loaded' ), 1 );
 			add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ) );
 		}
@@ -576,6 +581,16 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		public function on_plugins_loaded() {
 			$this->load_textdomain();
+
+			if ( in_array( 'woocommerce-shipping/woocommerce-shipping.php', get_option( 'active_plugins' ) ) ) {
+				add_action(
+					'admin_notices',
+					function () {
+						echo '<div class="error"><p><strong>' . esc_html__( 'Woo Shipping plugin is already active. Please deactivate WooCommerce Shipping & Tax.', 'woocommerce-shipping' ) . '</strong></p></div>';
+					}
+				);
+				return;
+			}
 
 			if ( ! class_exists( 'WooCommerce' ) ) {
 				add_action(

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -597,6 +597,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 							$active_plugins = __( 'Woo Tax plugin is already active.', 'woocommerce-services' );
 						}
 
+						/* translators: %s: the reason WCS&T has to be deactivated */
 						echo '<div class="error"><p><strong>' . sprintf( esc_html__( '%s Please deactivate WooCommerce Shipping & Tax.', 'woocommerce-services' ), esc_html( $active_plugins ) ) . '</strong></p></div>';
 					}
 				);

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -338,20 +338,19 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					}
 				}
 			);
-			add_action( 'plugins_loaded', array( $this, 'jetpack_on_plugins_loaded' ), 1 );
-			add_action( 'plugins_loaded', array( $this, 'maybe_handle_coexistence_with_woo_shipping_and_woo_tax' ), 5 );
+
 			add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ) );
-		}
 
-		/**
-		 * Used to let Woo Shipping and Woo Tax know WCS&T will handle the plugins' coexistence
-		 * by displaying an appropriate notice and not registering its functionality.
-		 */
-		public function maybe_handle_coexistence_with_woo_shipping_and_woo_tax() {
-			$is_woo_shipping_active = in_array( 'woocommerce-shipping/woocommerce-shipping.php', get_option( 'active_plugins' ) );
-			$is_woo_tax_active      = in_array( 'woocommerce-tax/woocommerce-tax.php', get_option( 'active_plugins' ) );
+			if ( $this->are_woo_shipping_and_woo_tax_active() ) {
+				/**
+				 * Used to let Woo Shipping and Woo Tax know WCS&T will handle the plugins' coexistence
+				 * by displaying an appropriate notice and not registering its functionality.
+				 */
+				add_filter( 'wc_services_will_handle_coexistence_with_woo_shipping_and_woo_tax', '__return_true' );
+				return;
+			}
 
-			return $is_woo_shipping_active && $is_woo_tax_active;
+			add_action( 'plugins_loaded', array( $this, 'jetpack_on_plugins_loaded' ), 1 );
 		}
 
 		public function get_logger() {
@@ -1769,6 +1768,13 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				</div>
 				<?php
 			}
+		}
+
+		public function are_woo_shipping_and_woo_tax_active() {
+			$is_woo_shipping_active = in_array( 'woocommerce-shipping/woocommerce-shipping.php', get_option( 'active_plugins' ) );
+			$is_woo_tax_active      = in_array( 'woocommerce-tax/woocommerce-tax.php', get_option( 'active_plugins' ) );
+
+			return $is_woo_shipping_active && $is_woo_tax_active;
 		}
 	}
 }

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -588,6 +588,17 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function on_plugins_loaded() {
 			$this->load_textdomain();
 
+			/**
+			 * Allow third party logic to determine if this plugin should initiate its logic.
+			 *
+			 * The primary purpose here is to allow a smooth transition between the new Woo Shipping / Woo Tax plugins
+			 * and WooCommerce Shipping & Tax (this plugin), by letting them take over all responsibilities if all three
+			 * plugins are activated at the same time.
+			 *
+			 * @since {{next-release}}
+			 * 
+			 * @param bool $status The value will determine if we should initiate the plugins logic or not.
+			 */
 			if ( apply_filters( 'wc_services_will_handle_coexistence_with_woo_shipping_and_woo_tax', false ) ) {
 				add_action( 'admin_notices', array( $this, 'display_woo_shipping_and_woo_tax_are_active_notice' ) );
 				return;

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -342,7 +342,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			 * Used to let Woo Shipping know WCS&T will handle the plugins' coexistence
 			 * by displaying an appropriate notice and not registering its functionality.
 			 */
-			add_filter( 'wc_services_will_handle_coexistence_with_woo_shipping', '__return_true' );
+			add_filter( 'wc_services_will_handle_coexistence_with_woo_shipping_and_woo_tax', '__return_true' );
 			add_action( 'plugins_loaded', array( $this, 'jetpack_on_plugins_loaded' ), 1 );
 			add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ) );
 		}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -590,14 +590,14 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					'admin_notices',
 					function () use ( $is_woo_shipping_active, $is_woo_tax_active ) {
 						if ( $is_woo_shipping_active && $is_woo_tax_active ) {
-							$active_plugins = esc_html__( 'Woo Shipping and Woo Tax plugins are already active.', 'woocommerce-services' );
+							$active_plugins = __( 'Woo Shipping and Woo Tax plugins are already active.', 'woocommerce-services' );
 						} elseif ( $is_woo_shipping_active ) {
-							$active_plugins = esc_html__( 'Woo Shipping plugin is already active.', 'woocommerce-services' );
+							$active_plugins = __( 'Woo Shipping plugin is already active.', 'woocommerce-services' );
 						} else {
-							$active_plugins = esc_html__( 'Woo Tax plugin is already active.', 'woocommerce-services' );
+							$active_plugins = __( 'Woo Tax plugin is already active.', 'woocommerce-services' );
 						}
 
-						echo '<div class="error"><p><strong>' . sprintf( esc_html__( '%s Please deactivate WooCommerce Shipping & Tax.', 'woocommerce-services' ), $active_plugins ) . '</strong></p></div>';
+						echo '<div class="error"><p><strong>' . sprintf( esc_html__( '%s Please deactivate WooCommerce Shipping & Tax.', 'woocommerce-services' ), esc_html( $active_plugins ) ) . '</strong></p></div>';
 					}
 				);
 				return;

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -597,7 +597,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 							$active_plugins = esc_html__( 'Woo Tax plugin is already active.', 'woocommerce-services' );
 						}
 
-						echo '<div class="error"><p><strong>' . $active_plugins . ' ' . esc_html__( 'Please deactivate WooCommerce Shipping & Tax.', 'woocommerce-services' ) . '</strong></p></div>';
+						echo '<div class="error"><p><strong>' . sprintf( esc_html__( '%s Please deactivate WooCommerce Shipping & Tax.', 'woocommerce-services' ), $active_plugins ) . '</strong></p></div>';
 					}
 				);
 				return;

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -596,7 +596,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			 * plugins are activated at the same time.
 			 *
 			 * @since {{next-release}}
-			 * 
+			 *
 			 * @param bool $status The value will determine if we should initiate the plugins logic or not.
 			 */
 			if ( apply_filters( 'wc_services_will_handle_coexistence_with_woo_shipping_and_woo_tax', false ) ) {
@@ -1776,6 +1776,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 		}
 
+		/**
+		 * Returns if both Woo Shipping and Woo Tax are active.
+		 *
+		 * @return bool
+		 */
 		public function are_woo_shipping_and_woo_tax_active() {
 			$is_woo_shipping_active = in_array( 'woocommerce-shipping/woocommerce-shipping.php', get_option( 'active_plugins' ) );
 			$is_woo_tax_active      = in_array( 'woocommerce-tax/woocommerce-tax.php', get_option( 'active_plugins' ) );
@@ -1783,6 +1788,13 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			return $is_woo_shipping_active && $is_woo_tax_active;
 		}
 
+		/**
+		 * Echoes an admin notice informing of Woo Shipping and Woo Tax being active.
+		 *
+		 * To be used in the `admin_notices` hook.
+		 *
+		 * @return void
+		 */
 		public function display_woo_shipping_and_woo_tax_are_active_notice() {
 			echo '<div class="error"><p><strong>' . esc_html__( 'Woo Shipping and Woo Tax plugins are already active. Please deactivate WooCommerce Shipping & Tax.', 'woocommerce-services' ) . '</strong></p></div>';
 		}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Fixes #2726.

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

<img width="810" alt="Screenshot 2024-04-04 at 11 36 08" src="https://github.com/Automattic/woocommerce-services/assets/1759681/46197af5-da88-43d3-b80f-7ea778318571">

### Testing instructions

1. Install & activate both Woo Shipping and WCS&T.
2. See the notice in the screenshot.
3. Go to Edit Order and see that WCS&T didn't register its functionality but Woo Shipping did.

The same should work for Woo Tax instead of Woo Shipping, as well as both Woo Shipping and Woo Tax, with an appropriate change in the message.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

