### PR TITLE
Use GitHub release notes when releasing the plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "wrap-loader": "^0.2.0"
   },
   "config": {
-    "wp_org_slug": "woocommerce-services"
+    "wp_org_slug": "woocommerce-services",
+    "use_gh_release_notes": true
   }
 }


### PR DESCRIPTION
## Description
This config updates the release process to use GitHub-style release notes. https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

Reference: pevPIe-wL-p2 

### Related issue(s)
N/A

### Steps to reproduce & screenshots/GIFs
N/A

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added