### PR TITLE
Cap max allowed shipments to prevent 504 on order page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.5.7 - 2024-xx-xx =
+* Add - wc_connect_shipment_item_quantity_threshold and wc_connect_max_shipments_if_quantity_exceeds_threshold filter hooks to be able to cap the number of shipment splits possible for an item with very large quantity.
+
 = 2.5.6 - 2024-05-06 =
 * Tweak - WooCommerce 8.8 compatibility.
 

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -175,7 +175,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 					),
 				);
 			}
-
 			$formatted_packages = array();
 
 			foreach ( $packages as $package_obj ) {
@@ -226,10 +225,48 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				}
 
 				$refunded_qty = $order->get_qty_refunded_for_item( $item->get_id() );
+				$remaining_quantity = $item['qty'] - absint( $refunded_qty );
+				/**
+				 * The threshold at which we will start batching items together.
+				 * As an example, if a single order item has a quantity 60, which is more than the default threshold
+				 * value of 20 we will start batching together.
+				 */
+				$threshold = apply_filters( 'wc_connect_shipment_item_quantity_threshold', 20 );
+				/**
+				 * Max number of shipments allowed to be created for this item should quantity of this order items
+				 * exceeds `wc_connect_shipment_item_quantity_threshold`
+				 */
+				$max_shipments = apply_filters( 'wc_connect_max_shipments_if_quantity_exceeds_threshold', 5 );
+				/**
+				 * Default quantity per item if the `wc_connect_shipments_item_threshold_quantity` is not exceeded.
+				 */
+				$quantity_per_shipment = 1;
 
-				for ( $i = 0; $i < ( $item['qty'] - absint( $refunded_qty ) ); $i ++ ) {
-					$items[] = $item_data;
+				$weight_per_item = $item_data['weight'];
+				$should_cap_shipments = $remaining_quantity > $threshold;
+
+				if ( $should_cap_shipments ) {
+					$quantity_per_shipment = floor( $remaining_quantity / $max_shipments );
+					for ( $i = 0; $i < $max_shipments; $i ++ ) {
+						$item_data['weight'] = $quantity_per_shipment * $weight_per_item;
+						$remaining_quantity -= $quantity_per_shipment;
+
+						if( $remaining_quantity > $quantity_per_shipment ) {
+							$item_data['quantity'] = $quantity_per_shipment;
+						} else {
+							$item_data['quantity'] = $quantity_per_shipment + $remaining_quantity;
+						}
+
+						$items[] = $item_data;
+					}
+				} else {
+					for ( $i = 0; $i < $remaining_quantity; $i ++ ) {
+						$items[] = $item_data;
+					}
 				}
+
+
+
 			}
 
 			return $items;

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -237,10 +237,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				 * exceeds `wc_connect_shipment_item_quantity_threshold`
 				 */
 				$max_shipments = apply_filters( 'wc_connect_max_shipments_if_quantity_exceeds_threshold', 5 );
-				/**
-				 * Default quantity per item if the `wc_connect_shipments_item_threshold_quantity` is not exceeded.
-				 */
-				$quantity_per_shipment = 1;
 
 				$weight_per_item = $item_data['weight'];
 				$should_cap_shipments = $remaining_quantity > $threshold;

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -244,15 +244,15 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				if ( $should_cap_shipments ) {
 					$quantity_per_shipment = floor( $remaining_quantity / $max_shipments );
 					for ( $i = 0; $i < $max_shipments; $i ++ ) {
-						$item_data['weight'] = $quantity_per_shipment * $weight_per_item;
 						$remaining_quantity -= $quantity_per_shipment;
 
-						if( $remaining_quantity > $quantity_per_shipment ) {
+						if( $remaining_quantity >= $quantity_per_shipment ) {
 							$item_data['quantity'] = $quantity_per_shipment;
 						} else {
 							$item_data['quantity'] = $quantity_per_shipment + $remaining_quantity;
 						}
 
+						$item_data['weight'] = round( $item_data['quantity'] * $weight_per_item, 2 );
 						$items[] = $item_data;
 					}
 				} else {

--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 2.5.7 - 2024-xx-xx =
+* Add - wc_connect_shipment_item_quantity_threshold and wc_connect_max_shipments_if_quantity_exceeds_threshold filter hooks to be able to cap the number of shipment splits possible for an item with very large quantity.
+
 = 2.5.6 - 2024-05-06 =
 * Tweak - WooCommerce 8.8 compatibility.
 


### PR DESCRIPTION
## Description
This PR  caps the max allowes shipments to make should too many number of shipments don't cause performance issue for client nor server side.

### Related issue(s)
Fixes #2731

### Steps to reproduce & screenshots/GIFs
- With the trunk branch, create and order with a product, and add the quantity of 140,000 for this order item.
- Visit this order details page and see that the page breaks or doesn't load properly.
- Now switch to this branch, and refresh the order detail page and verify the page loads without any problem.


https://github.com/Automattic/woocommerce-services/assets/789421/86e1aa16-07b7-41a8-977b-8183dcec030f



### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added