### PR TITLE
Fetch "Add payment method" URL from WCS

### DIFF
--- a/classes/class-wc-connect-account-settings.php
+++ b/classes/class-wc-connect-account-settings.php
@@ -51,6 +51,7 @@ class WC_Connect_Account_Settings {
 				'master_user_wpcom_login' => $connection_owner_wpcom_data ? $connection_owner_wpcom_data['login'] : '',
 				'master_user_email'       => $connection_owner_wpcom_data ? $connection_owner_wpcom_data['email'] : '',
 				'payment_methods'         => $this->payment_methods_store->get_payment_methods(),
+				'add_payment_method_url'  => $this->payment_methods_store->get_add_payment_method_url(),
 				'warnings'                => array( 'payment_methods' => $payment_methods_warning ),
 			),
 			'userMeta'     => array(

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -42,6 +42,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				'store_guid',
 				'debug_logging_enabled',
 				'debug_display_enabled',
+				'add_payment_method_url',
 				'payment_methods',
 				'account_settings',
 				'paper_size',

--- a/classes/class-wc-connect-payment-methods-store.php
+++ b/classes/class-wc-connect-payment-methods-store.php
@@ -42,13 +42,17 @@ if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 				return false;
 			}
 
-			$payment_methods = $this->get_payment_methods_from_response_body( $response_body );
-			if ( is_wp_error( $payment_methods ) ) {
-				$this->logger->log( $payment_methods, __FUNCTION__ );
+			if ( is_wp_error( $this->validate_payment_methods_response( $response_body ) ) ) {
+				$this->logger->log( $response_body, __FUNCTION__ );
 				return false;
 			}
 
-			// If we made it this far, it is safe to store the object.
+			// Get add payment method url from response body.
+			$add_payment_method_url = $this->get_add_payment_method_url_from_response_body( $response_body );
+			$payment_methods        = $this->get_payment_methods_from_response_body( $response_body );
+
+			// Store the payment methods and add payment method url.
+			$this->update_add_payment_method_url( $add_payment_method_url );
 			$this->update_payment_methods( $payment_methods );
 
 			$this->potentially_update_selected_payment_method_from_payment_methods( $payment_methods );
@@ -90,15 +94,29 @@ if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 			WC_Connect_Options::update_option( 'payment_methods', $payment_methods );
 		}
 
-		protected function get_payment_methods_from_response_body( $response_body ) {
+		/**
+		 * Validate that the response body is valid and contains the correct properties.
+		 *
+		 * @param object $response_body The response body object.
+		 * @return true|WP_Error Whether the response body is valid.
+		 */
+		protected function validate_payment_methods_response( $response_body ) {
 			if ( ! is_object( $response_body ) ) {
-				return new WP_Error( 'payment_method_response_body_type', 'Expected but did not receive object for response body.' );
+				return new WP_Error( 'payment_method_response_body_type', __( 'Expected but did not receive object for response body.', 'woocommerce-services' ) );
 			}
 
 			if ( ! property_exists( $response_body, 'payment_methods' ) ) {
-				return new WP_Error( 'payment_method_response_body_missing_payment_methods', 'Expected but did not receive payment_methods in response body.' );
+				return new WP_Error( 'payment_method_response_body_missing_payment_methods', __( 'Expected but did not receive payment_methods in response body.', 'woocommerce-services' ) );
 			}
 
+			if ( ! property_exists( $response_body, 'add_payment_method_url' ) ) {
+				return new WP_Error( 'payment_method_response_body_missing_add_payment_method_url', __( 'Expected but did not receive add_payment_method_url in response body.', 'woocommerce-services' ) );
+			}
+
+			return true;
+		}
+
+		protected function get_payment_methods_from_response_body( $response_body ) {
 			$payment_methods = $response_body->payment_methods;
 			if ( ! is_array( $payment_methods ) ) {
 				return new WP_Error( 'payment_methods_type', 'Expected but did not receive array for payment_methods.' );
@@ -114,6 +132,35 @@ if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 			}
 
 			return $payment_methods;
+		}
+
+		/**
+		 * Get the URL to add a payment method from the response body.
+		 *
+		 * @param object $response_body The response body object.
+		 * @return string The URL to add a payment method.
+		 */
+		protected function get_add_payment_method_url_from_response_body( $response_body ) {
+			return $response_body->add_payment_method_url;
+		}
+
+		/**
+		 * Get the URL to add a payment method.
+		 *
+		 * @return string The URL to add a payment method.
+		 */
+		public function get_add_payment_method_url() {
+			return WC_Connect_Options::get_option( 'add_payment_method_url', '' );
+		}
+
+		/**
+		 * Update the URL to add a payment method.
+		 *
+		 * @param string $add_payment_method_url The URL to add a payment method.
+		 * @return void
+		 */
+		protected function update_add_payment_method_url( $add_payment_method_url ) {
+			WC_Connect_Options::update_option( 'add_payment_method_url', esc_url_raw( $add_payment_method_url ) );
 		}
 	}
 }

--- a/classes/class-wc-connect-payment-methods-store.php
+++ b/classes/class-wc-connect-payment-methods-store.php
@@ -42,8 +42,9 @@ if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 				return false;
 			}
 
-			if ( is_wp_error( $this->validate_payment_methods_response( $response_body ) ) ) {
-				$this->logger->log( $response_body, __FUNCTION__ );
+			$validation = $this->validate_payment_methods_response( $response_body );
+			if ( is_wp_error( $validation ) ) {
+				$this->logger->log( sprintf( '[%s] %s', $validation->get_error_code(), $validation->get_error_message() ), __FUNCTION__ );
 				return false;
 			}
 

--- a/client/extensions/woocommerce/woocommerce-services/state/label-settings/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/label-settings/selectors.js
@@ -116,6 +116,12 @@ export const getPaymentMethods = ( state, siteId = getSelectedSiteId( state ) ) 
 		.sort( ( a, b ) => b.payment_method_id - a.payment_method_id );
 };
 
+export const getAddPaymentMethodURL = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const data = getLabelSettingsFormMeta( state, siteId );
+
+	return data && data.add_payment_method_url;
+};
+
 export const getPaymentMethodsWarning = ( state, siteId = getSelectedSiteId( state ) ) => {
 	const meta = getLabelSettingsFormMeta( state, siteId );
 	return meta && meta.warnings && meta.warnings.payment_methods;

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -25,7 +25,6 @@ import FormSelect from 'wcs-client/components/forms/form-select';
 import Notice from 'wcs-client/components/notice';
 import NoticeAction from 'wcs-client/components/notice/notice-action';
 import PaymentMethod, { getPaymentMethodTitle } from './label-payment-method';
-import { getOrigin } from 'woocommerce/lib/nav-utils';
 import {
 	openAddCardDialog,
 	fetchSettings,
@@ -40,6 +39,7 @@ import {
 	getMasterUserInfo,
 	getPaperSize,
 	getPaymentMethods,
+	getAddPaymentMethodURL,
 	getPaymentMethodsWarning,
 	getSelectedPaymentMethodId,
 	isPristine,
@@ -189,6 +189,7 @@ class ShippingLabels extends Component {
 			siteId,
 			canEditPayments,
 			paymentMethods,
+			addPaymentMethodURL,
 			selectedPaymentMethod,
 			isReloading,
 			translate,
@@ -269,7 +270,7 @@ class ShippingLabels extends Component {
 		};
 
 		const onAddCardExternal = () => {
-			this.addCreditCardWindow = window.open( getOrigin() + '/me/purchases/add-credit-card' );
+			this.addCreditCardWindow = window.open( addPaymentMethodURL );
 			document.addEventListener( 'visibilitychange', this.onVisibilityChange );
 		};
 		const buttonClasses = classNames( 'button','is-compact');
@@ -464,6 +465,7 @@ export default connect(
 			isReloading: areSettingsFetching( state, siteId ) && areSettingsLoaded( state, siteId ),
 			pristine: isPristine( state, siteId ),
 			paymentMethods: getPaymentMethods( state, siteId ),
+			addPaymentMethodURL: getAddPaymentMethodURL( state, siteId ),
 			paymentMethodsWarning: getPaymentMethodsWarning( state, siteId ),
 			selectedPaymentMethod: getSelectedPaymentMethodId( state, siteId ),
 			paperSize: getPaperSize( state, siteId ),

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-section/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-section/index.js
@@ -16,10 +16,10 @@ import {
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 import PurchaseButton from './purchase-button';
 import CreditCardButton from './credit-card-button';
-import { getOrigin } from 'woocommerce/lib/nav-utils';
 import {
 	getSelectedPaymentMethodId,
 	getPaymentMethods,
+	getAddPaymentMethodURL,
 } from 'woocommerce/woocommerce-services/state/label-settings/selectors';
 
 /**
@@ -33,6 +33,7 @@ export const PurchaseSection = props => {
 		siteId,
 		hasLabelsPaymentMethod,
 		paymentMethods,
+		addPaymentMethodURL,
 		form,
 		disablePurchase,
 		translate,
@@ -70,10 +71,9 @@ export const PurchaseSection = props => {
 			) : ( ! paymentMethods.length ) ? (
 				<CreditCardButton
 					disabled={ disablePurchase }
-					url={ getOrigin() + '/me/purchases/add-credit-card' }
+					url={ addPaymentMethodURL }
 					buttonLabel={ translate( 'Add credit card' ) }
 					buttonDescription={ addCardButtonDescription }
-
 				/>
 			) : (
 				<CreditCardButton
@@ -97,6 +97,7 @@ const mapStateToProps = ( state, { orderId, siteId } ) => {
 		form,
 		hasLabelsPaymentMethod: Boolean( getSelectedPaymentMethodId( state, siteId ) ),
 		paymentMethods: getPaymentMethods( state, siteId ),
+		addPaymentMethodURL: getAddPaymentMethodURL( state, siteId ),
 		disablePurchase: ! form.needsPrintConfirmation && ( ! purchaseReady || form.isSubmitting ),
 	};
 };

--- a/tests/e2e/fixtures/account_settings.js
+++ b/tests/e2e/fixtures/account_settings.js
@@ -20,6 +20,7 @@ const AccountWithNoCreditCard = {
 		"master_user_wpcom_login": "johndoe",
 		"master_user_email": "john.doe@automattic.com",
 		"payment_methods": [],
+		"add_payment_method_url": "https://wordpress.com/me/purchases/add-credit-card",
 		"warnings": {
 			"payment_methods": false
 		}

--- a/tests/php/test_data/services_data_mock_with_card.json
+++ b/tests/php/test_data/services_data_mock_with_card.json
@@ -69,7 +69,8 @@
           "card_digits": "1234",
           "expiry": "2050-01-31"
         }
-      ]
+      ],
+      "add_payment_method_url": "https://wordpress.com/me/purchases/add-credit-card"
     },
     "/services": {
       "shipping": [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

We want to have greater control over where we send merchants to add payment methods since it happens outside of WP Admin and the URL might change in the future - but it's a primary function that should always be supported.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

* Fixes #2735
* Similar work was done in 452-gh-woocommerce/woocommerce-shipping

### Steps to reproduce

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

We have two location that are affected by this change: The settings page and the "purchase" button.

1. Checkout branch locally and activate WCS&T
2. Go to `/wp-admin/admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings`
3. Click `Choose a different card` (or directly add a payment method if you do not have one or more cards attached to your WPCOM account)
4. Press the `Add another credit card` button
5. Verify you were sent to `https://wordpress.com/me/purchases/add-credit-card`
6. Edit an order that has a shippable product (`/wp-admin/admin.php?page=wc-orders&action=edit&id={SOMETHING}`)
7. Open the shipping label modal by clicking on the `Create shipping label` button
8. **(Situation A)** If it's a fresh WPCOM user, then you should see a "Add credit card" button
9. **(Situation B)** If you already have one or more payment methods attach to your WPCOM account, then you can force the "Add credit card" state by:
    * Open `client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-section/index.js` in your IDE
    * Change the return of `<PurchaseSection>` to just ignore the surrounding conditions and just render the "Add credit card" `CreditCardButton` component.
10. Click either the "Add credit card" button or the "add a credit card to your account" link in the description below the button
    * _Both the link and button uses the same function, so they're technically identical and one will validate the other._
11. Verify you were sent to `https://wordpress.com/me/purchases/add-credit-card`

### Screenshots/GIFs

#### Settings page

![Screenshot 2024-05-22 at 01 43 02](https://github.com/Automattic/woocommerce-services/assets/3846700/451d508e-786e-499a-947e-942b48374f3c)

#### Purchase modal
![Screenshot 2024-05-22 at 01 42 30](https://github.com/Automattic/woocommerce-services/assets/3846700/eb7ba991-5fa9-4ce5-aa2d-633bd77b0e81)

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

