### PR TITLE
Action workflow: Prevent "E2E port 8084 kill step" to break flow on exitcode 1

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -25,7 +25,18 @@ jobs:
         shell: bash
         run: |
             echo "::group::Kill webserver running on port 8084"
-            sudo fuser -k -n tcp 8084
+            set +e #
+            sudo fuser -k -n tcp 8084 > /dev/null 2>&1
+            EXIT_CODE=$?
+            set -e
+            if [ $EXIT_CODE -eq 1 ]; then
+              echo "No process found on port 8084, ignoring exit code 1."
+              exit 0
+            fi
+            if [ $EXIT_CODE -ne 0 ]; then
+              echo "fuser encountered an error with exit code $EXIT_CODE."
+              exit $EXIT_CODE
+            fi
             echo "::endgroup::"
       - name: Build WCS&T
         run: |


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

When trying to run our GitHub Action workflows locally via [`act`](https://github.com/nektos/act), I get the following error which prevents the next step(s) from being executed.

```
[E2E Tests/Build Container and Run E2E Tests]   ❓  ::group::Kill webserver running on port 8084
[E2E Tests/Build Container and Run E2E Tests]   ❌  Failure - Main Kill process running on port 8084 to unblock it
[E2E Tests/Build Container and Run E2E Tests] exitcode '1': failure
[E2E Tests/Build Container and Run E2E Tests] 🏁  Job failed
Error: Job 'Build Container and Run E2E Tests' failed
```

### Suggested changes

The issue is that `fuser` tries to kill anything that already runs on port `8084` (which we want to use for the website to run our E2E tests on).
If nothing is running on that specific port, then we get `exitcode: 1` back which just means "nothing to shut down".

TL;DR: Code 1 means that we're ready to proceed to next step since the port is available, so we need to update our bash code to accept "code 1" (we do this by catching `code 1` and returning `code 0`), but still "throw" all other error codes to prevent false positives from our change.

#### `fuser` exit code meanings:

* **0**: At least one process has been found and successfully terminated.
* **1**: No processes were found using the specified files or sockets.
* **2**: An error occurred.

### Related issue(s)

- Related to #2640 

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

* Install `act` locally ([you can use brew](https://formulae.brew.sh/formula/act))
* In CLI, be in the root of this repository and run `act`
    * You can use `act --container-architecture linux/amd64` if you're on a silicone Mac
 * Verify that you continue to the next step (named "`Build WCS&T`").
     * It's not important what happens in this step. We just need to reach it.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

