### PR TITLE
Fix/issue 2732 - Add Logger for "Live Rates" Feature.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.5.8 - 2024-xx-xx =
+* Add - Logger for "Live Rates" feature on the front-end.
+
 = 2.5.7 - 2024-05-13 =
 * Add - wc_connect_shipment_item_quantity_threshold and wc_connect_max_shipments_if_quantity_exceeds_threshold filter hooks to be able to cap the number of shipment splits possible for an item with very large quantity.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
-= 2.5.8 - 2024-xx-xx =
+= 2.6.0 - 2024-xx-xx =
 * Add - Logger for "Live Rates" feature on the front-end.
 
 = 2.5.7 - 2024-05-13 =

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -646,6 +646,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			if ( WC_Connect_Functions::is_cart() || WC_Connect_Functions::is_checkout() || isset( $_POST['update_cart'] ) || WC_Connect_Functions::is_store_api_call() ) {
 				$debug_message = sprintf( '%s (%s:%d)', $message, esc_html( $this->title ), $this->instance_id );
 				$this->logger->debug( $debug_message, $type );
+				$this->logger->log( $debug_message, __CLASS__ );
 			}
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Requires PHP: 7.4
 Requires at least: 6.3
 Requires Plugins: woocommerce
 Tested up to: 6.5
-WC requires at least: 8.6
-WC tested up to: 8.8
+WC requires at least: 8.7
+WC tested up to: 8.9
 Stable tag: 2.5.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -78,6 +78,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 6. Checking and exporting the label purchase reports
 
 == Changelog ==
+
+= 2.5.8 - 2024-xx-xx =
+* Add - Logger for "Live Rates" feature on the front-end.
 
 = 2.5.7 - 2024-05-13 =
 * Add - wc_connect_shipment_item_quantity_threshold and wc_connect_max_shipments_if_quantity_exceeds_threshold filter hooks to be able to cap the number of shipment splits possible for an item with very large quantity.

--- a/readme.txt
+++ b/readme.txt
@@ -79,7 +79,7 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
-= 2.5.8 - 2024-xx-xx =
+= 2.6.0 - 2024-xx-xx =
 * Add - Logger for "Live Rates" feature on the front-end.
 
 = 2.5.7 - 2024-05-13 =

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -11,8 +11,8 @@
  * Version: 2.5.7
  * Requires at least: 6.3
  * Tested up to: 6.5
- * WC requires at least: 8.6
- * WC tested up to: 8.8
+ * WC requires at least: 8.7
+ * WC tested up to: 8.9
  *
  * Copyright (c) 2017-2023 Automattic
  *


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Adding the debug info into logger. It needs to be done so the user can still see the debug from the **WooCommerce > Status > Logs** page when debug mode is enabled.
<!-- Explain the motivation for making this change -->

### Related issue(s)
Fixes #2732 
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

1. Set the cart and checkout page to use WC Blocks.
2. Make sure the "Live Rates" feature and "Debug Mode" is enabled.
3. Add something to product.
4. Go to cart or checkout to make the debug running.
5. Go to **WooCommerce > Status > Logs** in the admin.
6. "woocommerce-services-shipping" log will appear.
![image](https://github.com/Automattic/woocommerce-services/assets/631098/33420169-1af2-4e44-badf-59d79e6bcc2d)

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

