### PR TITLE
Fix/adjust how feature announcement looks on smaller screens

### DIFF
--- a/client/components/migration/feature-announcement.jsx
+++ b/client/components/migration/feature-announcement.jsx
@@ -51,7 +51,7 @@ const FeatureAnnouncement = ({ translate, isEligable }) => {
 						{translate('A new dedicated WooCommerce Shipping extension is now available')}
 					</h2>
 					<p>{translate(
-						'WooCommerce Shipping and WooCommerce Tax are now two dedicated extensions. We\'ll automatically deactivate WooCommerce Shipping & Tax and carry over your settings when you update.')}< /p>
+						'WooCommerce Shipping and WooCommerce Tax are now two dedicated extensions. We\'ll automatically deactivate WooCommerce Shipping & Tax and carry over your settings when you update.')}</p>
 					<p>{translate('Here\'s what you can expect from the new shipping experience:')}</p>
 
 					<ul>

--- a/client/components/migration/style.scss
+++ b/client/components/migration/style.scss
@@ -1,4 +1,6 @@
 $modal-height: 700px;
+$view-port-width-small: 660px;
+$view-port-width-medium: 1080px;
 
 .wp-admin.woocommerce-feature-enabled-product-block-editor .migration__announcement-modal.components-modal__frame,
 .migration__announcement-modal.components-modal__frame {
@@ -9,6 +11,10 @@ $modal-height: 700px;
   border-radius: 2px;
   height: $modal-height;
   box-shadow: 0px 3px 30px 0px rgba(25, 30, 35, 0.20);
+
+  @media( max-width: $view-port-width-small ) {
+    height: unset;
+  }
 
   .components-modal__header {
     position: absolute;
@@ -49,6 +55,11 @@ $modal-height: 700px;
 
     > .components-flex {
 
+      @media( max-width: $view-port-width-small ) {
+        height: 100%;
+        flex-direction: column;
+      }
+
       .components-flex__item {
         padding: var(--grid-unit-40, 32px);
         margin: 0;
@@ -60,6 +71,7 @@ $modal-height: 700px;
           flex: 7;
           flex-direction: column;
           gap: 32px;
+          justify-content: space-between;
 
           span {
             display: flex;
@@ -105,6 +117,7 @@ $modal-height: 700px;
                 font-style: normal;
                 font-weight: 400;
                 line-height: 13px;
+                height: 40px;
 
                 &.is-tertiary {
                   color: var(--Upcoming-Blueberry, #3858E9);
@@ -138,6 +151,14 @@ $modal-height: 700px;
           flex: 5;
           padding: 0;
           min-height: $modal-height;
+
+          @media ( max-width: $view-port-width-medium ) {
+            min-width: 200px;
+          }
+
+          @media( max-width: $view-port-width-small ) {
+            display: none;
+          }
         }
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
This PR fixes how the Feature Announcement component looks on smaller screens.

### Related issue(s)
https://github.com/woocommerce/shipping/issues/122

### Notes:
A [follow up issue](https://github.com/woocommerce/shipping/issues/132) is created to further re-polish this.

### Steps to reproduce & screenshots/GIFs

- Checkout this branch.
- Build the project.
- Set [this boolean to true](https://github.com/Automattic/woocommerce-services/pull/2743/files#diff-d4f6c48565de5a19d0ea35c131cab7b53f92578a1ac94bd9bc3f8edb6472f274R620-R622).
- Visit an order page and click on **Create shipping label** button.
- Verify the Feature Announcement modal opens up and overlaps the purchase modal.
- Resize browser window or toggle into mobile simulator and verify changing the view port size keeps the component usable.


https://github.com/Automattic/woocommerce-services/assets/789421/5299801f-9f60-4fd6-aeae-4f2273b431ea



### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added