### PR TITLE
Get the migration banner info from the connect server

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ If you'd just like to check out the latest code and/or wish to contribute code, 
     * For Development: run `npm run up`, let the process finish, connect your site to Jetpack using Jurassic Tube or ngrok.
     * For testing or pre-production use: Run `npm run dist` which will build the files into the `dist` folder, and will be loaded by the plugin without any additional configuration
 
-## Security
+*note*: if `npm install` gets stuck, you may have to update your GitHub urls in your git config. Use this command to fix it:
+
+```git config --global url.https://github.com/.insteadOf git://github.com/```
+
+
+## SECURITY
 
 Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
 

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -38,7 +38,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 * @return array|WP_Error
 		 */
 		public function get_service_schemas() {
-			$response_body = $this->request( 'POST', '/services' );
+			$response_body = $this->request( 'POST', '/services', array( 'settings' => array( 'wcship_migration_supported' => true ) ) );
 
 			if ( is_wp_error( $response_body ) ) {
 				return $response_body;

--- a/classes/class-wc-connect-service-schemas-store.php
+++ b/classes/class-wc-connect-service-schemas-store.php
@@ -271,7 +271,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 		public function get_wcship_wctax_upgrade_banner() {
 			$service_schemas = $this->get_service_schemas();
 			// check if $service_schemas->features->wcshippingtax_upgrade_banner exists
-			if ( ! is_object( $service_schemas ) || ! property_exists( $service_schemas, 'features' ) || ! property_exists( $service_schemas->features, 'wcshippingtax_upgrade_banner' ) ) {
+			if ( ! is_object( $service_schemas ) || ! property_exists( $service_schemas, 'features' ) || ! property_exists( $service_schemas->features, 'wcshippingtax_upgrade_banner' ) || empty( $service_schemas->features->wcshippingtax_upgrade_banner ) ) {
 				return null;
 			}
 

--- a/classes/class-wc-connect-service-schemas-store.php
+++ b/classes/class-wc-connect-service-schemas-store.php
@@ -262,5 +262,20 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 
 			return $predefined_packages;
 		}
+
+		/**
+		 * Returns the WooCommerce Shipping and WooCommerce Tax upgrade banners
+		 *
+		 * @return object|null The banners schema or null if no such id was found
+		 */
+		public function get_wcship_wctax_upgrade_banner() {
+			$service_schemas = $this->get_service_schemas();
+			// check if $service_schemas->features->wcshippingtax_upgrade_banner exists
+			if ( ! is_object( $service_schemas ) || ! property_exists( $service_schemas, 'features' ) || ! property_exists( $service_schemas->features, 'wcshippingtax_upgrade_banner' ) ) {
+				return null;
+			}
+
+			return $service_schemas->features->wcshippingtax_upgrade_banner;
+		}
 	}
 }

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1899,7 +1899,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$schema = $this->get_service_schemas_store();
 			$banner = $schema->get_wcship_wctax_upgrade_banner();
 			echo wp_kses_post(
-				'<div class="notice notice-error is-dismissible wcst-wcshipping-migration-notice"><p style="margin-bottom:0px">' .
+				sprintf(
+					'<div class="notice notice-%s is-dismissible wcst-wcshipping-migration-notice"><p style="margin-bottom:0px">',
+					$banner->type
+				) .
 				sprintf(
 					/* translators: %s: documentation URL */
 					__( $banner->message, 'woocommerce-services' ),

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1475,7 +1475,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * @return boolean
 		 */
 		public function is_on_order_list_page() {
-			if ( !is_admin() ) {
+			if ( ! is_admin() ) {
 				return false;
 			}
 
@@ -1507,7 +1507,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			*   $screen->id = "woocommerce_page_wc-orders"
 			*   $$wc_order_screen_id = "woocommerce_page_wc-orders"
 			*/
-			if ( $screen->id !== "edit-shop_order" && $screen->id !== "woocommerce_page_wc-orders" ) {
+			if ( $screen->id !== 'edit-shop_order' && $screen->id !== 'woocommerce_page_wc-orders' ) {
 				return false;
 			}
 
@@ -1515,14 +1515,15 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		public function edit_orders_page_actions() {
-			if ( !$this->is_on_order_list_page() ) {
+			if ( ! $this->is_on_order_list_page() ) {
 				// If this is not on the order list page, then don't add any action.
 				return;
 			}
 
 			// Add the WCS&T to WCShipping migratio notice, creating a button to update.
 			$settings_store = $this->get_service_settings_store();
-			if ( $settings_store->is_eligible_for_migration() ) {
+			$schemas_store  = $this->get_service_schemas_store();
+			if ( $settings_store->is_eligible_for_migration() && $schemas_store->get_wcship_wctax_upgrade_banner() ) {
 				add_action( 'admin_notices', array( $this, 'display_wcst_to_wcshipping_migration_notice' ) );
 			}
 		}
@@ -1889,18 +1890,26 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			echo '<div class="error"><p><strong>' . esc_html__( 'Woo Shipping and Woo Tax plugins are already active. Please deactivate WooCommerce Shipping & Tax.', 'woocommerce-services' ) . '</strong></p></div>';
 		}
 
+		/**
+		 * Returns the notice for migrating from WCST to WC Shipping.
+		 *
+		 * @return bool
+		 */
 		public function display_wcst_to_wcshipping_migration_notice() {
+			$schema = $this->get_service_schemas_store();
+			$banner = $schema->get_wcship_wctax_upgrade_banner();
 			echo wp_kses_post(
 				'<div class="notice notice-error is-dismissible wcst-wcshipping-migration-notice"><p style="margin-bottom:0px">' .
-				 sprintf(
+				sprintf(
 					/* translators: %s: documentation URL */
-					__( 'WooCommerce Shipping & Tax is splitting into two dedicated extensions: WooCommerce Shipping and WooCommerce Tax. To minimize disruption, your settings and data will be carried over to the new extensions when you upgrade. <a href="%s" style="color:#3858E9;">Learn more about this change.</a>', 'woocommerce-services' ),
+					__( $banner->message, 'woocommerce-services' ),
 					'https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#how-do-i-migrate-from-wcst'
-				)  .
-				'</p>
-				<button style="color:#3858E9;margin: 12px 0;border: 1px solid #3858E9;padding: 11.5px 12px 11.5px 12px;border-radius: 2px;background-color:#fff;">Confirm update</button>
-				</div>'
-		)	;
+				) .
+				sprintf(
+					'</p><button style="color:#3858E9;margin: 12px 0;border: 1px solid #3858E9;padding: 11.5px 12px 11.5px 12px;border-radius: 2px;background-color:#fff;">Confirm update</button></div>',
+					$banner->action
+				)
+			);
 		}
 	}
 }


### PR DESCRIPTION
## Description

Retrieves the migration admin banner contents from the connect server, which also allows the client to show (or not) this info to the users. The client needs to pass a specific payload `settings.wcship_migration_supported` set to `true` to the server to let it know the client is prepared to receive the banner info.

Note: the feature also needs to be enabled in the server side, which currently is only enabled for the staging server.

### Related issue(s)

N/A

### Steps to reproduce & screenshots/GIFs

1. Set to `true` the `false` statement in this line in `woocommerce-services/classes/class-wc-connect-service-settings-store.php`:

``` php
public function is_eligible_for_migration() {
	$migration_state = WC_Connect_Options::get_option( 'wcshipping_migration_state' );
	//TODO: Return $migration_state check && connect-server flag
	return WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED !== $migration_state && false;
}
```

2. Setup WooCommerce Shipping & Tax to connect to the staging WooCommerce Connect Server: https://api-staging.woocommerce.com

3. Go to the [`WooCommerce > Orders`](http://localhost/wp-admin/edit.php?post_type=shop_order) page.

4. The banner with the right content should be displayed.


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added