### PR TITLE
Get the flag to display the migration banner from the connect server

### DIFF
--- a/classes/class-wc-connect-service-schemas-store.php
+++ b/classes/class-wc-connect-service-schemas-store.php
@@ -264,18 +264,29 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 		}
 
 		/**
+		 * Returns the WooCommerce Shipping and WooCommerce Tax migration enabled status
+		 *
+		 * @return bool
+		 */
+		public function is_wcship_wctax_migration_enabled() {
+			$service_schemas = $this->get_service_schemas();
+
+			return is_object( $service_schemas ) && property_exists( $service_schemas, 'features' ) && property_exists( $service_schemas->features, 'wcshippingtax_upgrade_banner' ) && ! empty( $service_schemas->features->wcshippingtax_upgrade_banner );
+		}
+
+		/**
 		 * Returns the WooCommerce Shipping and WooCommerce Tax upgrade banners
 		 *
 		 * @return object|null The banners schema or null if no such id was found
 		 */
 		public function get_wcship_wctax_upgrade_banner() {
 			$service_schemas = $this->get_service_schemas();
-			// check if $service_schemas->features->wcshippingtax_upgrade_banner exists
-			if ( ! is_object( $service_schemas ) || ! property_exists( $service_schemas, 'features' ) || ! property_exists( $service_schemas->features, 'wcshippingtax_upgrade_banner' ) || empty( $service_schemas->features->wcshippingtax_upgrade_banner ) ) {
-				return null;
+
+			if ( $this->is_wcship_wctax_migration_enabled() ) {
+				return $service_schemas->features->wcshippingtax_upgrade_banner;
 			}
 
-			return $service_schemas->features->wcshippingtax_upgrade_banner;
+			return null;
 		}
 	}
 }

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -618,8 +618,11 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 
 		public function is_eligible_for_migration() {
 			$migration_state = WC_Connect_Options::get_option( 'wcshipping_migration_state' );
-			//TODO: Return $migration_state check && connect-server flag
-			return WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED !== $migration_state && false;
+
+			$migration_pending = WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED !== $migration_state;
+			$migration_enabled = $this->service_schemas_store->is_wcship_wctax_migration_enabled();
+
+			return $migration_pending && $migration_enabled;
 		}
 
 		private function translate_unit( $value ) {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1522,7 +1522,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			// Add the WCS&T to WCShipping migratio notice, creating a button to update.
 			$settings_store = $this->get_service_settings_store();
-			$schemas_store  = $this->get_service_schemas_store();
 			if ( $settings_store->is_eligible_for_migration() ) {
 				add_action( 'admin_notices', array( $this, 'display_wcst_to_wcshipping_migration_notice' ) );
 			}
@@ -1898,6 +1897,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function display_wcst_to_wcshipping_migration_notice() {
 			$schema = $this->get_service_schemas_store();
 			$banner = $schema->get_wcship_wctax_upgrade_banner();
+			if ( empty( $banner ) ) {
+				return;
+			}
 			echo wp_kses_post(
 				sprintf(
 					'<div class="notice notice-%s is-dismissible wcst-wcshipping-migration-notice"><p style="margin-bottom:0px">',

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1523,7 +1523,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			// Add the WCS&T to WCShipping migratio notice, creating a button to update.
 			$settings_store = $this->get_service_settings_store();
 			$schemas_store  = $this->get_service_schemas_store();
-			if ( $settings_store->is_eligible_for_migration() && $schemas_store->get_wcship_wctax_upgrade_banner() ) {
+			if ( $settings_store->is_eligible_for_migration() ) {
 				add_action( 'admin_notices', array( $this, 'display_wcst_to_wcshipping_migration_notice' ) );
 			}
 		}


### PR DESCRIPTION
## Description
The Connect Server's endpoint `POST /services` includes a `features.wcshippingtax_upgrade_banner` property containing all the required info to display a banner with info about the migration to WooCommerce Shipping and WooCommerce Tax.

This PR leverages all control of enabling or disabling this banner to the Connect Server's new property mentioned above.

### Related issue(s)

N/A

### Steps to reproduce & screenshots/GIFs

1. Checkout this branch in your local setup.
2. Point the Connect Server to the staging instance: `https://api-staging.woocommerce.com`.
3. Visit the orders page: `http://localhost/wp-admin/admin.php?page=wc-orders`.
4. The banner should be displayed:

![shot-2024-06-21-16-50-20](https://github.com/Automattic/woocommerce-services/assets/130142/3b84ec98-5bae-4191-9a35-a4fe639c5d3d)

5. Change the Server's endpoint to production.
6. The banner should be no hidden after reloading the orders page, as it's not enabled in production yet.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added