### PR TITLE
Add state machine to drive migration states

### DIFF
--- a/classes/class-wc-connect-account-settings.php
+++ b/classes/class-wc-connect-account-settings.php
@@ -39,21 +39,23 @@ class WC_Connect_Account_Settings {
 		$last_box_id                 = $last_box_id === 'individual' ? '' : $last_box_id;
 		$last_service_id             = get_user_meta( get_current_user_id(), 'wc_connect_last_service_id', true );
 		$last_carrier_id             = get_user_meta( get_current_user_id(), 'wc_connect_last_carrier_id', true );
+		$wcshipping_migration_state  = WC_Connect_Options::get_option( 'wcshipping_migration_state' );
 
 		return array(
 			'storeOptions' => $this->settings_store->get_store_options(),
 			'formData'     => $this->settings_store->get_account_settings(),
 			'formMeta'     => array(
-				'can_manage_payments'     => $this->settings_store->can_user_manage_payment_methods(),
-				'can_edit_settings'       => true,
-				'master_user_name'        => $connection_owner ? $connection_owner->display_name : '',
-				'master_user_login'       => $connection_owner ? $connection_owner->user_login : '',
-				'master_user_wpcom_login' => $connection_owner_wpcom_data ? $connection_owner_wpcom_data['login'] : '',
-				'master_user_email'       => $connection_owner_wpcom_data ? $connection_owner_wpcom_data['email'] : '',
-				'payment_methods'         => $this->payment_methods_store->get_payment_methods(),
-				'add_payment_method_url'  => $this->payment_methods_store->get_add_payment_method_url(),
-				'warnings'                => array( 'payment_methods' => $payment_methods_warning ),
-				'is_eligible_to_migrate'  => $this->settings_store->is_eligible_for_migration()
+				'can_manage_payments'        => $this->settings_store->can_user_manage_payment_methods(),
+				'can_edit_settings'          => true,
+				'master_user_name'           => $connection_owner ? $connection_owner->display_name : '',
+				'master_user_login'          => $connection_owner ? $connection_owner->user_login : '',
+				'master_user_wpcom_login'    => $connection_owner_wpcom_data ? $connection_owner_wpcom_data['login'] : '',
+				'master_user_email'          => $connection_owner_wpcom_data ? $connection_owner_wpcom_data['email'] : '',
+				'payment_methods'            => $this->payment_methods_store->get_payment_methods(),
+				'add_payment_method_url'     => $this->payment_methods_store->get_add_payment_method_url(),
+				'warnings'                   => array( 'payment_methods' => $payment_methods_warning ),
+				'is_eligible_to_migrate'     => $this->settings_store->is_eligible_for_migration(),
+				'wcshipping_migration_state' => $wcshipping_migration_state,
 			),
 			'userMeta'     => array(
 				'last_box_id'     => $last_box_id,

--- a/classes/class-wc-connect-wcst-to-wcshipping-migration-state-enum.php
+++ b/classes/class-wc-connect-wcst-to-wcshipping-migration-state-enum.php
@@ -4,17 +4,33 @@
  */
 class WC_Connect_WCST_To_WCShipping_Migration_State_Enum {
 	// These are used for WCS&T to WCShipping migration.
-	public const NOT_STARTED = 1;
-	public const STARTED     = 2;
-	public const COMPLETED   = 3;
-	public const FAILED      = 4;
+	public const NOT_STARTED        = 1;
+	public const STARTED            = 2;
+	public const ERROR_STARTED      = 3;
+	public const INSTALLING         = 4;
+	public const ERROR_INSTALLING   = 5;
+	public const ACTIVATING         = 6;
+	public const ERROR_ACTIVATING   = 7;
+	public const DB_MIGRATION       = 8;
+	public const ERROR_DB_MIGRATION = 9;
+	public const DEACTIVATING       = 10;
+	public const ERROR_DEACTIVATING = 11;
+	public const COMPLETED          = 12;
 
 	public static function is_valid_value( $state ) {
 		$valid_states = array(
 			self::NOT_STARTED,
 			self::STARTED,
+			self::ERROR_STARTED,
+			self::INSTALLING,
+			self::ERROR_INSTALLING,
+			self::ACTIVATING,
+			self::ERROR_ACTIVATING,
+			self::DB_MIGRATION,
+			self::ERROR_DB_MIGRATION,
+			self::DEACTIVATING,
+			self::ERROR_DEACTIVATING,
 			self::COMPLETED,
-			self::FAILED,
 		);
 		return in_array( $state, $valid_states, true );
 	}

--- a/classes/class-wc-rest-connect-migration-flag-controller.php
+++ b/classes/class-wc-rest-connect-migration-flag-controller.php
@@ -23,6 +23,11 @@ class WC_REST_Connect_Migration_Flag_Controller extends WC_REST_Connect_Base_Con
 			return $error;
 		}
 
+		$existing_migration_state = WC_Connect_Options::get_option( 'wcshipping_migration_state' );
+		if ( $existing_migration_state === $migration_state ) {
+			return new WP_REST_Response( array( 'result' => 'Migration flag is the same, no changes needed.' ), 304 );
+		}
+
 		$result = WC_Connect_Options::update_option( 'wcshipping_migration_state', $migration_state );
 
 		if ( $result ) {

--- a/client/components/migration/feature-announcement.jsx
+++ b/client/components/migration/feature-announcement.jsx
@@ -38,7 +38,7 @@ const FeatureAnnouncement = ({ translate, isEligable }) => {
 	   };
 
 		const installPluginAPICall = () =>
-			fetch( getBaseURL() + 'wc-admin/plugins/install', {
+			fetch( getBaseURL() + 'wc-admin/plugins/install2', {
 				method: 'POST',
 				headers,
 				body: JSON.stringify({
@@ -63,71 +63,88 @@ const FeatureAnnouncement = ({ translate, isEligable }) => {
 					status: 'inactive'
 				})
 			} );
-		const markMigrationStartedAPICall = () =>
+		const markMigrationStartedAPICall = (migrationState) => () =>
 			fetch( getBaseURL() + 'wc/v1/connect/migration-flag', {
 				method: 'POST',
 				headers,
 				body: JSON.stringify({
-					migration_state: 2 // Check WC_Connect_WCST_To_WCShipping_Migration_State_Enum::STARTED
+					migration_state: migrationState // Check WC_Connect_WCST_To_WCShipping_Migration_State_Enum::STARTED
 				})
 			} );
 
-		const stateErrorHandling = () => {
+		const stateErrorHandling = (failedMigrationState) => () => {
+			// TODO: Print the error somewhere in an inbox box?
+			console.log(failedMigrationState);
+
+			return fetch( getBaseURL() + 'wc/v1/connect/migration-flag', {
+				method: 'POST',
+				headers,
+				body: JSON.stringify({
+					migration_state: failedMigrationState // Check WC_Connect_WCST_To_WCShipping_Migration_State_Enum::STARTED
+				})
+			} );
 		};
 
 		const installAndActivatePlugins = async() => {
 			const migrationStateTransitions = {
-				s0: {
-					success: 's1',
-					fail: 's0',
-					callback: markMigrationStartedAPICall,
+				stateInit: {
+					success: 'stateInstalling',
+					fail: 'stateInit',
+					callback: markMigrationStartedAPICall(2),
 				},
-				s1: {
-					success: 's3',
-					fail: 's2',
+				stateErrorInit: {
+					success: 'stateInit',
+					fail: 'stateErrorInit',
+					callback: stateErrorHandling('stateInit'),
+				},
+				stateInstalling: {
+					success: 'stateActivating',
+					fail: 'stateErrorInstalling',
 					callback: installPluginAPICall,
 				},
-				s2: {
-					success: 's1',
-					fail: 's2',
-					callback: stateErrorHandling,
+				stateErrorInstalling: {
+					success: 'stateInstalling',
+					fail: 'stateErrorInstalling',
+					callback: stateErrorHandling('stateInstalling'),
 				},
-				s3: {
-					success: 's7', // TODO: This should be s5 to migrate DB.
-					fail: 's4',
+				stateActivating: {
+					success: 'stateDeactivating', // TODO: This should be stateDBMigrating to migrate DB.
+					fail: 'stateErrorActivating',
 					callback: activatePluginAPICall,
 				},
-				s4: {
-					success: 's3',
-					fail: 's4',
-					callback: stateErrorHandling,
+				stateErrorActivating: {
+					success: 'stateActivating',
+					fail: 'stateErrorActivating',
+					callback: stateErrorHandling('stateActivating'),
 				},
-				s5: {
+				stateDB: {
 					success: 's7',
-					fail: 's6',
+					fail: 'stateErrorDB',
 					callback: new Promise((resolve) => resolve({status: 200})), // TODO: DB migration
 				},
-				s6: {
-					success: 's5',
-					fail: 's6',
-					callback: stateErrorHandling,
+				stateErrorDB: {
+					success: 'stateDBMigrating',
+					fail: 'stateErrorDB',
+					callback: stateErrorHandling('stateDBMigrating'),
 				},
-				s7: {
-					success: 's9',
-					fail: 's8',
+				stateDeactivating: {
+					success: 'stateDone',
+					fail: 'stateErrorDeactivating',
 					callback: deactivateWCSTPluginAPICall,
 				},
-				s8: {
-					success: 's7',
-					fail: 's8',
-					callback: stateErrorHandling,
+				stateErrorDeactivating: {
+					success: 'stateDeactivating',
+					fail: 'stateErrorDeactivating',
+					callback: stateErrorHandling('stateDeactivating'),
 				},
-				s9: { // Done state.
+				stateDone: { // Done state.
 					success: null,
 					fail: null,
 					callback: null,
 				}
 			}
+
+			const errorStates = ['stateErrorInstalling', 'stateErrorActivating', 'stateErrorDB', 'stateErrorDeactivating'];
 
 			const runNext = async (migrationState) => {
 				const currentMigrationState = migrationStateTransitions[migrationState];
@@ -150,9 +167,9 @@ const FeatureAnnouncement = ({ translate, isEligable }) => {
 			};
 
 			// Run the migration chain
-			let nextMigrationStateToRun = 's0';
+			let nextMigrationStateToRun = 'stateInit';
 			let runAttemps = 0;
-			while ( runAttemps++ < 15 && nextMigrationStateToRun !== 's9' ) {
+			while ( runAttemps++ < 15 && nextMigrationStateToRun !== 'stateDone' && ! errorStates.includes(nextMigrationStateToRun)) {
 				nextMigrationStateToRun = await runNext(nextMigrationStateToRun);
 				console.log(runAttemps);
 			}

--- a/client/components/migration/feature-announcement.jsx
+++ b/client/components/migration/feature-announcement.jsx
@@ -31,9 +31,9 @@ const FeatureAnnouncement = ( { translate, isEligable, previousMigrationState } 
 		// Todo: implement maybe later
 	};
 
-	const update = () => {
+	const update = async () => {
 		setIsUpdating( true );
-		installAndActivatePlugins( previousMigrationState );
+		await installAndActivatePlugins( previousMigrationState );
 		setIsUpdating( false );
 	};
 

--- a/client/components/migration/feature-announcement.jsx
+++ b/client/components/migration/feature-announcement.jsx
@@ -97,7 +97,7 @@ const FeatureAnnouncement = ({ translate, isEligable }) => {
 				method: 'POST',
 				headers,
 				body: JSON.stringify({
-					migration_state: failedMigrationState // Check WC_Connect_WCST_To_WCShipping_Migration_State_Enum::STARTED
+					migration_state: failedMigrationState
 				})
 			} );
 		};

--- a/client/components/migration/feature-announcement.jsx
+++ b/client/components/migration/feature-announcement.jsx
@@ -17,9 +17,9 @@ import {
 	isEligableToMigrate,
 	wcshippingMigrationState,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
-import {installAndActivatePlugins} from './migration-runner';
+import { installAndActivatePlugins } from './migration-runner';
 
-const FeatureAnnouncement = ({ translate, isEligable, previousMigrationState }) => {
+const FeatureAnnouncement = ( { translate, isEligable, previousMigrationState } ) => {
 	const [isOpen, setIsOpen] = useState(isEligable);
 	const [isUpdating, setIsUpdating] = useState(false);
 
@@ -32,9 +32,9 @@ const FeatureAnnouncement = ({ translate, isEligable, previousMigrationState }) 
 	};
 
 	const update = () => {
-		setIsUpdating(true);
-		installAndActivatePlugins(previousMigrationState);
-		setIsUpdating(false);
+		setIsUpdating( true );
+		installAndActivatePlugins( previousMigrationState );
+		setIsUpdating( false );
 	};
 
 	return <>{isOpen && (<Modal
@@ -128,7 +128,7 @@ const FeatureAnnouncement = ({ translate, isEligable, previousMigrationState }) 
 
 const mapStateToProps = (state, { siteId }) => ({
 	isEligable: isEligableToMigrate(state, siteId),
-	previousMigrationState: wcshippingMigrationState(state, siteId),
+	previousMigrationState: wcshippingMigrationState( state, siteId ),
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({}, dispatch);

--- a/client/components/migration/feature-announcement.jsx
+++ b/client/components/migration/feature-announcement.jsx
@@ -7,7 +7,6 @@ import { useState } from '@wordpress/element';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
-import { getNonce, getBaseURL } from 'api/request'; // client/api/request.js
 
 /**
  * Internal dependencies
@@ -18,6 +17,7 @@ import {
 	isEligableToMigrate,
 	wcshippingMigrationState,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
+import {installAndActivatePlugins} from './migration-runner';
 
 const FeatureAnnouncement = ({ translate, isEligable, previousMigrationState }) => {
 	const [isOpen, setIsOpen] = useState(isEligable);
@@ -31,227 +31,10 @@ const FeatureAnnouncement = ({ translate, isEligable, previousMigrationState }) 
 		// Todo: implement maybe later
 	};
 
-	// Check WC_Connect_WCST_To_WCShipping_Migration_State_Enum
-	const MIGRATION_STATE_ENUM = {
-		NOT_STARTED: 1,
-		STARTED: 2,
-		ERROR_STARTED: 3,
-		INSTALLING: 4,
-		ERROR_INSTALLING: 5,
-		ACTIVATING: 6,
-		ERROR_ACTIVATING: 7,
-		DB_MIGRATION: 8,
-		ERROR_DB_MIGRATION: 9,
-		DEACTIVATING: 10,
-		ERROR_DEACTIVATING: 11,
-		COMPLETED: 12,
-	}
-	// Maps the numeric state from PHP to the more descriptive installAndActivatePlugins object we use below.
-	const MIGRATION_STATE_NAME = {
-		2: 'stateInit',
-		3: 'stateErrorInit',
-		4: 'stateInstalling',
-		5: 'stateErrorInstalling',
-		6: 'stateActivating',
-		7: 'stateErrorActivating',
-		8: 'stateDB',
-		9: 'stateErrorDB',
-		10: 'stateDeactivating',
-		11: 'stateErrorDeactivating',
-		12: 'stateDone'
-	}
-
 	const update = () => {
-		const plugins = 'woocommerce-shipping,woocommerce-tax'; //this needs to be a CSV string.
-		const headers = {
-			"Content-Type": "application/json",
-			'X-WP-Nonce': getNonce()
-	   };
-
-		const installPluginAPICall = () =>
-			fetch( getBaseURL() + 'wc-admin/plugins/install', {
-				method: 'POST',
-				headers,
-				body: JSON.stringify({
-					plugins
-				})
-			} );
-
-		const activatePluginAPICall = () =>
-			fetch( getBaseURL() + 'wc-admin/plugins/activate', {
-				method: 'POST',
-				headers,
-				body: JSON.stringify({
-					plugins
-				})
-			} );
-
-		const deactivateWCSTPluginAPICall = () =>
-			fetch( getBaseURL() + 'wp/v2/plugins/woocommerce-services/woocommerce-services', {
-				method: 'POST',
-				headers,
-				body: JSON.stringify({
-					status: 'inactive'
-				})
-			} );
-
-		/**
-		 * Note: this function can not be called under these conditions:
-		 * 1. WCS&T, Woo Shipping, Woo Tax are all activated. WCS&T will not load the migration-flag controller, returning 404.
-		 * 2. WCS&T is deactivated. The migration-flag controller is not loaded, this will return 404.
-		 *
-		 * @param {string} migrationState The numeric migration number from the PHP side. Check classes/class-wc-connect-wcst-to-wcshipping-migration-state-enum.php.
-		 * @returns {Promise} Check fetch.
-		 */
-		const markMigrationStartedAPICall = (migrationState) => () =>
-			fetch( getBaseURL() + 'wc/v1/connect/migration-flag', {
-				method: 'POST',
-				headers,
-				body: JSON.stringify({
-					migration_state: migrationState
-				})
-			} );
-
-		const stateErrorHandlingAPICall = (failedMigrationState) => () => {
-			// TODO: The error message doesn't show up anywhere. For now, update the flag in the option table so
-			// we know where it failed at.
-
-			return markMigrationStartedAPICall(failedMigrationState)();
-		};
-
-		/**
-		 * A wrapper function to make API calls and check the API status response.
-		 * Throw an exception up if the status > 400.
-		 *
-		 * @param {function} apiFn The API function that uses fetch.
-		 * @returns {Object} The API JSON response from fetch.
-		 */
-		const fetchAPICall = (apiFn) => async () => {
-			const apiResponse = await apiFn();
-			const apiJSONResponse = await apiResponse.json();
-			if (apiResponse.status >= 400) {
-				throw new Error(apiJSONResponse.message || translate("Failed to setup WooCommerce Shipping. Please try again."));
-			}
-			return apiJSONResponse;
-		};
-
-		const migrationStateTransitions = {
-			stateInit: {
-				success: 'stateInstalling',
-				fail: 'stateInit',
-				callback: fetchAPICall(markMigrationStartedAPICall(MIGRATION_STATE_ENUM.STARTED)),
-			},
-			stateErrorInit: {
-				success: 'stateInit',
-				fail: 'stateErrorInit',
-				callback: stateErrorHandlingAPICall(MIGRATION_STATE_ENUM.ERROR_STARTED),
-			},
-			stateInstalling: {
-				success: 'stateActivating',
-				fail: 'stateErrorInstalling',
-				callback: fetchAPICall(installPluginAPICall),
-			},
-			stateErrorInstalling: {
-				success: 'stateInstalling',
-				fail: 'stateErrorInstalling',
-				callback: stateErrorHandlingAPICall(MIGRATION_STATE_ENUM.ERROR_INSTALLING),
-			},
-			stateActivating: {
-				success: 'stateDeactivating', // TODO: This should be stateDBMigrating to migrate DB.
-				fail: 'stateErrorActivating',
-				callback: fetchAPICall(activatePluginAPICall),
-			},
-			stateErrorActivating: {
-				success: 'stateActivating',
-				fail: 'stateErrorActivating',
-				callback: stateErrorHandlingAPICall(MIGRATION_STATE_ENUM.ERROR_ACTIVATING),
-			},
-			stateDB: {
-				success: 'stateDeactivating',
-				fail: 'stateErrorDB',
-				callback: new Promise((resolve) => resolve({status: 200})), // TODO: DB migration
-			},
-			stateErrorDB: {
-				success: 'stateDBMigrating',
-				fail: 'stateErrorDB',
-				callback: stateErrorHandlingAPICall(MIGRATION_STATE_ENUM.ERROR_DB_MIGRATION),
-			},
-			stateDeactivating: {
-				success: 'stateDone',
-				fail: 'stateErrorDeactivating',
-				callback: fetchAPICall(deactivateWCSTPluginAPICall),
-			},
-			stateErrorDeactivating: {
-				success: 'stateDeactivating',
-				fail: 'stateErrorDeactivating',
-				callback: stateErrorHandlingAPICall(MIGRATION_STATE_ENUM.ERROR_DEACTIVATING),
-			},
-			stateDone: { // Done state.
-				success: null,
-				fail: null,
-				callback: null
-			}
-		}
-
-		// Any of the state that halts the machine. Including "done" or any errors.
-		const stopStates = ['stateDone', 'stateErrorInstalling', 'stateErrorActivating', 'stateErrorDB', 'stateErrorDeactivating'];
-
-		const installAndActivatePlugins = async() => {
-			const runNext = async (migrationState) => {
-				if (!migrationState) {
-					// Nothing to run, do nothing and return.
-					return;
-				}
-
-				const currentMigrationState = migrationStateTransitions[migrationState];
-				let nextMigrationStateToRun = '';
-				try {
-					setIsUpdating(true);
-					await currentMigrationState.callback();
-					nextMigrationStateToRun = currentMigrationState.success;
-				} catch (e) {
-					nextMigrationStateToRun = currentMigrationState.fail;
-				} finally {
-					setIsUpdating(false);
-					return nextMigrationStateToRun;
-				}
-			};
-
-			/**
-			 * This function checks what the next state to run is. If there is no record of any migration run, then we start from the beginning.
-			 * If there is a record of where it was stuck at, then we start from its next state.
-			 *
-			 * @returns {string} The next state to run. The name of the state is the key in this object migrationStateTransitions.
-			 */
-			const getNextStateToRun = () => {
-				if ( ! previousMigrationState) {
-					// stateInit
-					return MIGRATION_STATE_NAME[2];
-				}
-
-				const currentStateName = MIGRATION_STATE_NAME[previousMigrationState];
-				return migrationStateTransitions[currentStateName].success;
-			};
-
-			// Run the migration chain from where it last stopped. If there is no record, start from the beginning.
-			let nextMigrationStateToRun = getNextStateToRun();
-			let runAttemps = 0;
-			const maxAttempts = Object.keys(migrationStateTransitions).length; // The states don't loop, thus it can't be more than its size. Serve as a safe guard in case of infinite loop.
-			while ( runAttemps++ < maxAttempts ) {
-				nextMigrationStateToRun = await runNext(nextMigrationStateToRun);
-				if (stopStates.includes(nextMigrationStateToRun)) {
-					// If this is the end of any of the error states, run the callback once more and then quit.
-					// This gives the state a chance to run its job before the machine quits.
-					await runNext(nextMigrationStateToRun);
-					break;
-				}
-			}
-
-			//Redirect to plugins page regardless of migration success. If there was an error, the best place to check is the plugins page.
-			window.location = global.wcsPluginData.adminPluginPath;
-		};
-
-		installAndActivatePlugins();
+		setIsUpdating(true);
+		installAndActivatePlugins(previousMigrationState);
+		setIsUpdating(false);
 	};
 
 	return <>{isOpen && (<Modal

--- a/client/components/migration/migration-runner.js
+++ b/client/components/migration/migration-runner.js
@@ -109,11 +109,11 @@ const stateErrorHandlingAPICall = ( failedMigrationState ) => () => {
  */
 const fetchAPICall = ( apiFn ) => async () => {
     const apiResponse = await apiFn();
-    const apiJSONResponse = await apiResponse.json();
     if ( apiResponse.status >= 400 ) {
+        const apiJSONResponse = await apiResponse.json();
         throw new Error( apiJSONResponse.message || translate( "Failed to setup WooCommerce Shipping. Please try again." ) );
     }
-    return apiJSONResponse;
+    return apiResponse;
 };
 
 /**

--- a/client/components/migration/migration-runner.js
+++ b/client/components/migration/migration-runner.js
@@ -183,6 +183,14 @@ const migrationStateTransitions = {
     }
 }
 
+// Before using the migration state, check if migration state exists, if not throw error.
+const getMigrationStateByName = (stateName) => {
+    if ( ! migrationStateTransitions[stateName] ) {
+        throw new Error( "Migration state [" + stateName + "] not found" );
+    }
+    return migrationStateTransitions[stateName];
+}
+
 // Any of the state that halts the machine. Including "done" or any errors.
 const stopStates = [ 'stateDone', 'stateErrorInstalling', 'stateErrorActivating', 'stateErrorDB', 'stateErrorDeactivating' ];
 
@@ -199,7 +207,7 @@ const installAndActivatePlugins = async( previousMigrationState ) => {
             return;
         }
 
-        const currentMigrationState = migrationStateTransitions[ migrationState ];
+        const currentMigrationState = getMigrationStateByName(migrationState);
         let nextMigrationStateToRun = '';
         try {
             await currentMigrationState.callback();
@@ -225,7 +233,8 @@ const installAndActivatePlugins = async( previousMigrationState ) => {
         }
 
         const currentStateName = MIGRATION_ENUM_TO_STATE_NAME_MAP[ previousMigrationState ];
-        return migrationStateTransitions[ currentStateName ].success; // The next state is "success".
+        const nextMigrationState = getMigrationStateByName( currentStateName );
+        return nextMigrationState.success; // The next state is "success".
     };
 
     // Run the migration chain from where it last stopped. If there is no record, start from the beginning.

--- a/client/components/migration/migration-runner.js
+++ b/client/components/migration/migration-runner.js
@@ -184,8 +184,8 @@ const migrationStateTransitions = {
 }
 
 // Before using the migration state, check if migration state exists, if not throw error.
-const getMigrationStateByName = (stateName) => {
-    if ( ! migrationStateTransitions[stateName] ) {
+const getMigrationStateByName = ( stateName ) => {
+    if ( ! migrationStateTransitions[ stateName ] ) {
         throw new Error( "Migration state [" + stateName + "] not found" );
     }
     return migrationStateTransitions[stateName];

--- a/client/components/migration/migration-runner.js
+++ b/client/components/migration/migration-runner.js
@@ -188,7 +188,7 @@ const getMigrationStateByName = ( stateName ) => {
     if ( ! migrationStateTransitions[ stateName ] ) {
         throw new Error( "Migration state [" + stateName + "] not found" );
     }
-    return migrationStateTransitions[stateName];
+    return migrationStateTransitions[ stateName ];
 }
 
 // Any of the state that halts the machine. Including "done" or any errors.

--- a/client/components/migration/migration-runner.js
+++ b/client/components/migration/migration-runner.js
@@ -6,7 +6,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { getNonce, getBaseURL } from 'api/request'; // client/api/request.js
+import { getNonce, getBaseURL } from 'wcs-client/api/request';
 
 // Check WC_Connect_WCST_To_WCShipping_Migration_State_Enum
 const MIGRATION_STATE_ENUM = {
@@ -222,7 +222,7 @@ const installAndActivatePlugins = async(previousMigrationState) => {
     }
 
     //Redirect to plugins page regardless of migration success. If there was an error, the best place to check is the plugins page.
-    // window.location = global.wcsPluginData.adminPluginPath;
+    window.location = global.wcsPluginData.adminPluginPath;
 };
 
 export {

--- a/client/components/migration/migration-runner.js
+++ b/client/components/migration/migration-runner.js
@@ -207,7 +207,7 @@ const installAndActivatePlugins = async( previousMigrationState ) => {
             return;
         }
 
-        const currentMigrationState = getMigrationStateByName(migrationState);
+        const currentMigrationState = getMigrationStateByName( migrationState );
         let nextMigrationStateToRun = '';
         try {
             await currentMigrationState.callback();

--- a/client/components/migration/migration-runner.js
+++ b/client/components/migration/migration-runner.js
@@ -1,0 +1,230 @@
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getNonce, getBaseURL } from 'api/request'; // client/api/request.js
+
+// Check WC_Connect_WCST_To_WCShipping_Migration_State_Enum
+const MIGRATION_STATE_ENUM = {
+    NOT_STARTED: 1,
+    STARTED: 2,
+    ERROR_STARTED: 3,
+    INSTALLING: 4,
+    ERROR_INSTALLING: 5,
+    ACTIVATING: 6,
+    ERROR_ACTIVATING: 7,
+    DB_MIGRATION: 8,
+    ERROR_DB_MIGRATION: 9,
+    DEACTIVATING: 10,
+    ERROR_DEACTIVATING: 11,
+    COMPLETED: 12,
+}
+// Maps the numeric state from PHP to the more descriptive installAndActivatePlugins object we use below.
+const MIGRATION_STATE_NAME = {
+    2: 'stateInit',
+    3: 'stateErrorInit',
+    4: 'stateInstalling',
+    5: 'stateErrorInstalling',
+    6: 'stateActivating',
+    7: 'stateErrorActivating',
+    8: 'stateDB',
+    9: 'stateErrorDB',
+    10: 'stateDeactivating',
+    11: 'stateErrorDeactivating',
+    12: 'stateDone'
+}
+
+const plugins = 'woocommerce-shipping,woocommerce-tax'; //this needs to be a CSV string.
+const headers = {
+    "Content-Type": "application/json",
+    'X-WP-Nonce': getNonce()
+};
+
+const installPluginAPICall = () =>
+    fetch( getBaseURL() + 'wc-admin/plugins/install', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+            plugins
+        })
+    } );
+
+const activatePluginAPICall = () =>
+    fetch( getBaseURL() + 'wc-admin/plugins/activate', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+            plugins
+        })
+    } );
+
+const deactivateWCSTPluginAPICall = () =>
+    fetch( getBaseURL() + 'wp/v2/plugins/woocommerce-services/woocommerce-services', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+            status: 'inactive'
+        })
+    } );
+
+/**
+ * Note: this function can not be called under these conditions:
+ * 1. WCS&T, Woo Shipping, Woo Tax are all activated. WCS&T will not load the migration-flag controller, returning 404.
+ * 2. WCS&T is deactivated. The migration-flag controller is not loaded, this will return 404.
+ *
+ * @param {string} migrationState The numeric migration number from the PHP side. Check classes/class-wc-connect-wcst-to-wcshipping-migration-state-enum.php.
+ * @returns {Promise} Check fetch.
+ */
+const markMigrationStartedAPICall = (migrationState) => () =>
+    fetch( getBaseURL() + 'wc/v1/connect/migration-flag', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+            migration_state: migrationState
+        })
+    } );
+
+const stateErrorHandlingAPICall = (failedMigrationState) => () => {
+    // TODO: The error message doesn't show up anywhere. For now, update the flag in the option table so
+    // we know where it failed at.
+
+    return markMigrationStartedAPICall(failedMigrationState)();
+};
+
+/**
+ * A wrapper function to make API calls and check the API status response.
+ * Throw an exception up if the status > 400.
+ *
+ * @param {function} apiFn The API function that uses fetch.
+ * @returns {Object} The API JSON response from fetch.
+ */
+const fetchAPICall = (apiFn) => async () => {
+    const apiResponse = await apiFn();
+    const apiJSONResponse = await apiResponse.json();
+    if (apiResponse.status >= 400) {
+        throw new Error(apiJSONResponse.message || translate("Failed to setup WooCommerce Shipping. Please try again."));
+    }
+    return apiJSONResponse;
+};
+
+const migrationStateTransitions = {
+    stateInit: {
+        success: 'stateInstalling',
+        fail: 'stateInit',
+        callback: fetchAPICall(markMigrationStartedAPICall(MIGRATION_STATE_ENUM.STARTED)),
+    },
+    stateErrorInit: {
+        success: 'stateInit',
+        fail: 'stateErrorInit',
+        callback: stateErrorHandlingAPICall(MIGRATION_STATE_ENUM.ERROR_STARTED),
+    },
+    stateInstalling: {
+        success: 'stateActivating',
+        fail: 'stateErrorInstalling',
+        callback: fetchAPICall(installPluginAPICall),
+    },
+    stateErrorInstalling: {
+        success: 'stateInstalling',
+        fail: 'stateErrorInstalling',
+        callback: stateErrorHandlingAPICall(MIGRATION_STATE_ENUM.ERROR_INSTALLING),
+    },
+    stateActivating: {
+        success: 'stateDeactivating', // TODO: This should be stateDBMigrating to migrate DB.
+        fail: 'stateErrorActivating',
+        callback: fetchAPICall(activatePluginAPICall),
+    },
+    stateErrorActivating: {
+        success: 'stateActivating',
+        fail: 'stateErrorActivating',
+        callback: stateErrorHandlingAPICall(MIGRATION_STATE_ENUM.ERROR_ACTIVATING),
+    },
+    stateDB: {
+        success: 'stateDeactivating',
+        fail: 'stateErrorDB',
+        callback: new Promise((resolve) => resolve({status: 200})), // TODO: DB migration
+    },
+    stateErrorDB: {
+        success: 'stateDBMigrating',
+        fail: 'stateErrorDB',
+        callback: stateErrorHandlingAPICall(MIGRATION_STATE_ENUM.ERROR_DB_MIGRATION),
+    },
+    stateDeactivating: {
+        success: 'stateDone',
+        fail: 'stateErrorDeactivating',
+        callback: fetchAPICall(deactivateWCSTPluginAPICall),
+    },
+    stateErrorDeactivating: {
+        success: 'stateDeactivating',
+        fail: 'stateErrorDeactivating',
+        callback: stateErrorHandlingAPICall(MIGRATION_STATE_ENUM.ERROR_DEACTIVATING),
+    },
+    stateDone: { // Done state.
+        success: null,
+        fail: null,
+        callback: null
+    }
+}
+
+// Any of the state that halts the machine. Including "done" or any errors.
+const stopStates = ['stateDone', 'stateErrorInstalling', 'stateErrorActivating', 'stateErrorDB', 'stateErrorDeactivating'];
+
+const installAndActivatePlugins = async(previousMigrationState) => {
+    const runNext = async (migrationState) => {
+        if (!migrationState) {
+            // Nothing to run, do nothing and return.
+            return;
+        }
+
+        const currentMigrationState = migrationStateTransitions[migrationState];
+        let nextMigrationStateToRun = '';
+        try {
+            await currentMigrationState.callback();
+            nextMigrationStateToRun = currentMigrationState.success;
+        } catch (e) {
+            nextMigrationStateToRun = currentMigrationState.fail;
+        } finally {
+            return nextMigrationStateToRun;
+        }
+    };
+
+    /**
+     * This function checks what the next state to run is. If there is no record of any migration run, then we start from the beginning.
+     * If there is a record of where it was stuck at, then we start from its next state.
+     *
+     * @returns {string} The next state to run. The name of the state is the key in this object migrationStateTransitions.
+     */
+    const getNextStateToRun = () => {
+        if ( ! previousMigrationState) {
+            // stateInit
+            return MIGRATION_STATE_NAME[2];
+        }
+
+        const currentStateName = MIGRATION_STATE_NAME[previousMigrationState];
+        return migrationStateTransitions[currentStateName].success;
+    };
+
+    // Run the migration chain from where it last stopped. If there is no record, start from the beginning.
+    let nextMigrationStateToRun = getNextStateToRun();
+    let runAttemps = 0;
+    const maxAttempts = Object.keys(migrationStateTransitions).length; // The states don't loop, thus it can't be more than its size. Serve as a safe guard in case of infinite loop.
+    while ( runAttemps++ < maxAttempts ) {
+        nextMigrationStateToRun = await runNext(nextMigrationStateToRun);
+        if (stopStates.includes(nextMigrationStateToRun)) {
+            // If this is the end of any of the error states, run the callback once more and then quit.
+            // This gives the state a chance to run its job before the machine quits.
+            await runNext(nextMigrationStateToRun);
+            break;
+        }
+    }
+
+    //Redirect to plugins page regardless of migration success. If there was an error, the best place to check is the plugins page.
+    // window.location = global.wcsPluginData.adminPluginPath;
+};
+
+export {
+    installAndActivatePlugins
+}

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -729,3 +729,12 @@ export const isEligableToMigrate = ( state, siteId = getSelectedSiteId( state ) 
 	);
 	return settingsMeta.is_eligible_to_migrate;
 }
+
+export const wcshippingMigrationState = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const settingsMeta = get(
+		state,
+		[ 'extensions', 'woocommerce', 'woocommerceServices', siteId, 'labelSettings', 'meta' ],
+		null
+	);
+	return settingsMeta.wcshipping_migration_state;
+}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -266,7 +266,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			require_once __DIR__ . '/classes/class-wc-connect-wcst-to-wcshipping-migration-state-enum.php';
 
 			$migration_state = WC_Connect_Options::get_option( 'wcshipping_migration_state' );
-			if ( $migration_state === WC_Connect_WCST_To_WCShipping_Migration_State_Enum::STARTED ) {
+			if ( $migration_state !== WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED ) {
 				WC_Connect_Options::update_option( 'wcshipping_migration_state', WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED );
 			}
 		}


### PR DESCRIPTION
## Description
This PR replaces the task queue with a state machine to drive the migration process. This PR will remember where the last "stopped" state is should an error occur. This allows the user to continue where they left off. For example, if the user installed the plugin but failed to activate it, the next time they run the migration, it will start from "activating" instead of the beginning. 

![image](https://github.com/Automattic/woocommerce-services/assets/572862/d7f36d8c-9710-4975-92ec-10e99008c04d)

### Related issue(s)
N/A

### Steps to test
#### Happy path - test the full migration
1. Go to `woocommerce-services/classes/class-wc-connect-service-settings-store.php` and replace the following `is_eligible_for_migration` function. This function decides if the modal should popup or not
```
		public function is_eligible_for_migration() {
			WC_Connect_Options::delete_option( 'wcshipping_migration_state' );
			$migration_state = WC_Connect_Options::get_option( 'wcshipping_migration_state' );

			$migration_pending = WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED !== $migration_state;
			$migration_enabled = $this->service_schemas_store->is_wcship_wctax_migration_enabled();

			return $migration_pending && $migration_enabled;
		}
```
2. Make sure you have "WooCommerce Shipping" and "WooCommerce Tax" in your plugins folder. We can't test the "install" part because they aren't part of dotorg yet.
3. Go to any order page with WCS&T enabled, click the WCS&T "Create shipping label" red button,
4. Click "Update now"
![image](https://github.com/Automattic/woocommerce-services/assets/572862/6d0b1591-9b4f-4ab4-8807-9a88ce91f769)
5. It should install, activate Woo Shipping & Woo Tax, deactivate WCS&T, and redirect you to the plugins page.
6. [Optional] Check DB's `wp_options` table, `wc_connect_options` should have the value `..."wcshipping_migration_state";i:12;}` appended at the end. Key thing here is `12` is the "done state". 

#### Test 404 on install and activate, fix the issue, then continue
1. Repeat Step 1 to 3 above. Refresh the page so it deletes the `wcshipping_migration_state` option.
2. Now, comment out `WC_Connect_Options::delete_option( 'wcshipping_migration_state' );` from the happy path step 1). In this test, we want to keep `wcshipping_migration_state` so we can test the exceptions.

What we want to test here is to mimic a 404 errors downloading from dotorg. Or some API errors during activation. Here, we will test by tripping the circuit breaker at the `wc-admin/plugins/install` and `wc-admin/plugins/activate` API calls. The goal is to test if the migration can continue where it last failed.

3. `npm run start`. Open up `client/components/migration/migration-runner.js`. Append `2` to the API URL so they fail and throw `404`.  Change the following
- `fetch( getBaseURL() + 'wc-admin/plugins/install', {` to `fetch( getBaseURL() + 'wc-admin/plugins/install2', {`
- `fetch( getBaseURL() + 'wc-admin/plugins/activate', {` to `fetch( getBaseURL() + 'wc-admin/plugins/activate2', {`
4. Click the "Update now" button
5. You should see this in the console because `/install2` failed 
![image](https://github.com/Automattic/woocommerce-services/assets/572862/29650ec2-27f8-42e8-8cc5-62270a2179b3)
The `migration_state` value should be `5` because it failed at installation. 
5.1 [optional] Check DB `wp_options`, `wc_connect_options` should have value appended at the end `"wcshipping_migration_state";i:5;}`.
6. Now, fix the issue by changing `/install2` back to `install`. Refresh the page. `install` should work, and activate will now fail. The installation should pick up from the "install" step.
7. Confirm it starts from "install" and failed at "activate". The `migration_state` should be 7. 
![image](https://github.com/Automattic/woocommerce-services/assets/572862/a0c7ae9f-4723-45b5-bfba-d139ab8c8e00)
7.1. [optional] Check DB `wp_options`, `wc_connect_options` should have value appended at the end `"wcshipping_migration_state";i:7;}`.
8. Now, fix the `activate2` to `activate`. The migration should pick up from state `7` and go through the whole migration.
![image](https://github.com/Automattic/woocommerce-services/assets/572862/2c4ccf52-1518-415a-9f98-0918ba2c2d1c)
9. [optional] Check DB `wp_options`, `wc_connect_options` should have value appended at the end `"wcshipping_migration_state";i:12;}`.
10. You should be on the plugins page `http://localhost/wp-admin/plugins.php?plugin_status=all&paged=1&s`. Confirm the WCS&T is deactivated, and Woo Shipping and Woo Tax are enabled.
![image](https://github.com/Automattic/woocommerce-services/assets/572862/5517130f-ba29-4afd-8e83-4157450fcd8b)


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

