### PR TITLE
Change dismiss icon and behaviour [shipping-140]

### DIFF
--- a/assets/stylesheets/admin-notices.scss
+++ b/assets/stylesheets/admin-notices.scss
@@ -1,0 +1,50 @@
+.notice.wcst-wcshipping-migration-notice,
+.notice.wcst-wcshipping-migration-notice.is-dismissible {
+  padding: 12px;
+  color: var(--Gutenberg-Gray-900, #1E1E1E);
+  font-size: 13px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 150%;
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+  justify-content: space-between;
+
+  .notice-content {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    justify-content: space-between;
+  }
+
+  p {
+    margin: 0
+  }
+
+  .action-button {
+    color: #3858E9;
+    margin: 12px 0;
+    border: 1px solid #3858E9;
+    padding: 11.5px 12px 11.5px 12px;
+    border-radius: 2px;
+    background-color: #fff;
+    cursor: pointer;
+    margin: 0;
+  }
+
+  .notice-dismiss {
+    width: 24px;
+    height: 24px;
+    position: relative;
+    padding: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    &:before {
+      content: '\f335';
+      color: #1E1E1E;
+    }
+  }
+}

--- a/client/admin-notices.js
+++ b/client/admin-notices.js
@@ -7,3 +7,10 @@
  */
 import '../assets/stylesheets/admin-notices.scss';
 
+const TIME_TO_REMMEMBER_DISMISSAL_SECONDS = 3 * 24 * 60 * 60; // 3 Days - number of seconds
+
+( function ( $ ) {
+	$( '.wcst-wcshipping-migration-notice' ).on( 'click', '.notice-dismiss', () => {
+		window.wpCookies.set( window.wc_connect_admin_notices.dismissalCookieKey, 1, TIME_TO_REMMEMBER_DISMISSAL_SECONDS );
+	} );
+})( window.jQuery );

--- a/client/admin-notices.js
+++ b/client/admin-notices.js
@@ -1,0 +1,9 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import '../assets/stylesheets/admin-notices.scss';
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,6 +55,7 @@ module.exports = {
 		'woocommerce-services-banner': [ './client/banner.js' ],
 		'woocommerce-services-admin-pointers': [ './client/admin-pointers.js' ],
 		'woocommerce-services-new-order-taxjar': [ './client/new-order-taxjar.js' ],
+		'woocommerce-services-admin-notices': [ './client/admin-notices.js' ],
 	},
 	output: Object.assign(
 			{},

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1523,6 +1523,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			// Add the WCS&T to WCShipping migratio notice, creating a button to update.
 			$settings_store = $this->get_service_settings_store();
 			if ( $settings_store->is_eligible_for_migration() ) {
+				wp_enqueue_script( 'wc_connect_admin_notices' );
+				wp_enqueue_style( 'wc_connect_admin_notices' );
 				add_action( 'admin_notices', array( $this, 'display_wcst_to_wcshipping_migration_notice' ) );
 			}
 		}
@@ -1543,9 +1545,12 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					"var link = document.createElement('link');link.rel = 'stylesheet';link.type = 'text/css';link.href = '" . esc_js( $stylesheet_url ) . "';document.getElementsByTagName('HEAD')[0].appendChild(link);"
 				);
 			}
+
 			wp_register_script( 'wc_services_admin_pointers', $this->wc_connect_base_url . 'woocommerce-services-admin-pointers-' . $plugin_version . '.js', array( 'wp-pointer', 'jquery' ), null );
 			wp_register_style( 'wc_connect_banner', $this->wc_connect_base_url . 'woocommerce-services-banner-' . $plugin_version . '.css', array(), null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 			wp_register_script( 'wc_connect_banner', $this->wc_connect_base_url . 'woocommerce-services-banner-' . $plugin_version . '.js', array(), null );
+			wp_register_script( 'wc_connect_admin_notices', $this->wc_connect_base_url . 'woocommerce-services-admin-notices-' . $plugin_version . '.js', array(), null );
+			wp_register_style( 'wc_connect_admin_notices', $this->wc_connect_base_url . 'woocommerce-services-admin-notices-' . $plugin_version . '.css', array(), null );
 
 			$i18n_json = $this->get_i18n_json();
 			/** @var array $i18nStrings defined in i18n/strings.php */
@@ -1902,9 +1907,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 			echo wp_kses_post(
 				sprintf(
-					'<div class="notice notice-%s %s wcst-wcshipping-migration-notice"><p style="margin-bottom:0px">',
+					'<div class="notice notice-%s %s wcst-wcshipping-migration-notice"><div class="notice-content"><p>',
 					$banner->type,
-          $banner->dismissible ? 'is-dismissible' : ''
+					$banner->dismissible ? 'is-dismissible' : ''
 				) .
 				sprintf(
 					/* translators: %s: documentation URL */
@@ -1912,7 +1917,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					'https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#how-do-i-migrate-from-wcst'
 				) .
 				sprintf(
-					'</p><button style="color:#3858E9;margin: 12px 0;border: 1px solid #3858E9;padding: 11.5px 12px 11.5px 12px;border-radius: 2px;background-color:#fff;">%s</button></div>',
+					'</p><div><button class="action-button">%s</button></div></div></div>',
 					$banner->action
 				)
 			);

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1902,8 +1902,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 			echo wp_kses_post(
 				sprintf(
-					'<div class="notice notice-%s is-dismissible wcst-wcshipping-migration-notice"><p style="margin-bottom:0px">',
-					$banner->type
+					'<div class="notice notice-%s %s wcst-wcshipping-migration-notice"><p style="margin-bottom:0px">',
+					$banner->type,
+          $banner->dismissible ? 'is-dismissible' : ''
 				) .
 				sprintf(
 					/* translators: %s: documentation URL */
@@ -1911,7 +1912,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					'https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#how-do-i-migrate-from-wcst'
 				) .
 				sprintf(
-					'</p><button style="color:#3858E9;margin: 12px 0;border: 1px solid #3858E9;padding: 11.5px 12px 11.5px 12px;border-radius: 2px;background-color:#fff;">Confirm update</button></div>',
+					'</p><button style="color:#3858E9;margin: 12px 0;border: 1px solid #3858E9;padding: 11.5px 12px 11.5px 12px;border-radius: 2px;background-color:#fff;">%s</button></div>',
 					$banner->action
 				)
 			);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
This PR:
1) Adjust the styling of the notice and updates the dismiss button icon.
2) Make the dismiss button function and remember the dismissal for 3 days.
3) Use the values from connect-server to compose the notice ( dismissal and action button text )

### Related issue(s)

https://github.com/woocommerce/shipping/issues/140

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
- Checkout this branch and build the frontend app
- Make WC_Connect_Service_Settings_Store::is_eligible_for_migration return true.
- Visit wp-admin/admin.php?page=wc-orders and verify you can see the notice as in the screenshot.
- Click on the dismiss button and verify the notice doesn't show up on reload.
- Check the set cookies and verify the value for `wcst-wcshipping-migration-dismissed` expires in 3 days.


![UKljti.png](https://github.com/Automattic/woocommerce-services/assets/789421/29270b7d-0042-4032-a998-140640af1985)

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added