### PR TITLE
Add a "deactivated" message to the plugins list entry

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1542,7 +1542,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					</style>
 					<tr class="plugin-update-tr active update">
     					<td colspan="4" class="plugin-update colspanchange">
-    	    				<div class="notice inline notice-warning" style="border:0; border-left: 5px solid #4AB866; padding: 12px;">
+    	    				<div class="notice inline notice-warning" style="border:0; border-left: 5px solid #4AB866; padding: 12px; background-color: #EFF9F1;">
     	        				<p>%s</p>
     	    				</div>
 						</td>

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -919,6 +919,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'woocommerce_checkout_order_processed', array( $this, 'track_completed_order' ), 10, 3 );
 			add_action( 'admin_print_footer_scripts', array( $this, 'add_sift_js_tracker' ) );
 			add_action( 'current_screen', array( $this, 'edit_orders_page_actions' ) );
+			add_action( 'after_plugin_row', array( $this, 'add_custom_message_to_plugin_list' ), 10, 2 );
 
 			$tracks = $this->get_tracks();
 			$tracks->init();
@@ -1524,6 +1525,32 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$settings_store = $this->get_service_settings_store();
 			if ( $settings_store->is_eligible_for_migration() ) {
 				add_action( 'admin_notices', array( $this, 'display_wcst_to_wcshipping_migration_notice' ) );
+			}
+		}
+
+		/**
+		 * Add a "deactivated" message to the plugin list table for WooCommerce Shipping & Tax
+		 *
+		 * @param string $plugin_file
+		 * @param array  $plugin_data
+		 */
+		public function add_custom_message_to_plugin_list( $plugin_file, $plugin_data ) {
+			if ( 'woocommerce-services/woocommerce-services.php' === $plugin_file && false ) {
+				esc_html(
+					printf(
+						'<style>
+							.plugins tr[data-slug="woocommerce-services"] td, .plugins tr[data-slug="woocommerce-services"] th { box-shadow: none; }
+						</style>
+						<tr class="plugin-update-tr active update">
+    						<td colspan="4" class="plugin-update colspanchange">
+    	    					<div class="notice inline notice-warning" style="border:0; border-left: 5px solid #4AB866; padding: 12px;">
+    	        					<p>%s</p>
+    	    					</div>
+							</td>
+						 </tr>',
+						__( 'WooCommerce Shipping & Tax has been deactivated. Your data and settings have been carried over to the dedicated WooCommerce Shipping and WooCommerce Tax extensions.<br />For support, please <a href="https://woocommerce.com/my-account/create-a-ticket/">contact our Happiness Engineers</a>.', 'woocommerce-tax' )
+					)
+				);
 			}
 		}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -919,7 +919,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'woocommerce_checkout_order_processed', array( $this, 'track_completed_order' ), 10, 3 );
 			add_action( 'admin_print_footer_scripts', array( $this, 'add_sift_js_tracker' ) );
 			add_action( 'current_screen', array( $this, 'edit_orders_page_actions' ) );
-			add_action( 'after_plugin_row', array( $this, 'add_custom_message_to_plugin_list' ), 10, 2 );
+			add_action( 'after_plugin_row_woocommerce-services/woocommerce-services.php', array( $this, 'add_custom_message_to_plugin_list' ), 10, 2 );
 
 			$tracks = $this->get_tracks();
 			$tracks->init();
@@ -1534,8 +1534,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * @param string $plugin_file
 		 * @param array  $plugin_data
 		 */
-		public function add_custom_message_to_plugin_list( $plugin_file ) {
-			if ( 'woocommerce-services/woocommerce-services.php' === $plugin_file && false ) {
+		public function add_custom_message_to_plugin_list() {
+			if ( false ) {
 				printf(
 					'<style>
 						.plugins tr[data-slug="woocommerce-services"] td, .plugins tr[data-slug="woocommerce-services"] th { box-shadow: none; }

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1536,20 +1536,18 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 */
 		public function add_custom_message_to_plugin_list( $plugin_file ) {
 			if ( 'woocommerce-services/woocommerce-services.php' === $plugin_file && false ) {
-				esc_html(
-					printf(
-						'<style>
-							.plugins tr[data-slug="woocommerce-services"] td, .plugins tr[data-slug="woocommerce-services"] th { box-shadow: none; }
-						</style>
-						<tr class="plugin-update-tr active update">
-    						<td colspan="4" class="plugin-update colspanchange">
-    	    					<div class="notice inline notice-warning" style="border:0; border-left: 5px solid #4AB866; padding: 12px;">
-    	        					<p>%s</p>
-    	    					</div>
-							</td>
-						 </tr>',
-						wp_kses_post( __( 'WooCommerce Shipping & Tax has been deactivated. Your data and settings have been carried over to the dedicated WooCommerce Shipping and WooCommerce Tax extensions.<br />For support, please <a href="https://woocommerce.com/my-account/create-a-ticket/">contact our Happiness Engineers</a>.', 'woocommerce-services' ) )
-					)
+				printf(
+					'<style>
+						.plugins tr[data-slug="woocommerce-services"] td, .plugins tr[data-slug="woocommerce-services"] th { box-shadow: none; }
+					</style>
+					<tr class="plugin-update-tr active update">
+    					<td colspan="4" class="plugin-update colspanchange">
+    	    				<div class="notice inline notice-warning" style="border:0; border-left: 5px solid #4AB866; padding: 12px;">
+    	        				<p>%s</p>
+    	    				</div>
+						</td>
+					 </tr>',
+					wp_kses_post( __( 'WooCommerce Shipping & Tax has been deactivated. Your data and settings have been carried over to the dedicated WooCommerce Shipping and WooCommerce Tax extensions.<br />For support, please <a href="https://woocommerce.com/my-account/create-a-ticket/">contact our Happiness Engineers</a>.', 'woocommerce-services' ) )
 				);
 			}
 		}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1548,7 +1548,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
     	    					</div>
 							</td>
 						 </tr>',
-						__( 'WooCommerce Shipping & Tax has been deactivated. Your data and settings have been carried over to the dedicated WooCommerce Shipping and WooCommerce Tax extensions.<br />For support, please <a href="https://woocommerce.com/my-account/create-a-ticket/">contact our Happiness Engineers</a>.', 'woocommerce-tax' )
+						__( 'WooCommerce Shipping & Tax has been deactivated. Your data and settings have been carried over to the dedicated WooCommerce Shipping and WooCommerce Tax extensions.<br />For support, please <a href="https://woocommerce.com/my-account/create-a-ticket/">contact our Happiness Engineers</a>.', 'woocommerce-services' )
 					)
 				);
 			}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1534,7 +1534,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * @param string $plugin_file
 		 * @param array  $plugin_data
 		 */
-		public function add_custom_message_to_plugin_list( $plugin_file, $plugin_data ) {
+		public function add_custom_message_to_plugin_list( $plugin_file ) {
 			if ( 'woocommerce-services/woocommerce-services.php' === $plugin_file && false ) {
 				esc_html(
 					printf(
@@ -1548,7 +1548,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
     	    					</div>
 							</td>
 						 </tr>',
-						__( 'WooCommerce Shipping & Tax has been deactivated. Your data and settings have been carried over to the dedicated WooCommerce Shipping and WooCommerce Tax extensions.<br />For support, please <a href="https://woocommerce.com/my-account/create-a-ticket/">contact our Happiness Engineers</a>.', 'woocommerce-services' )
+						wp_kses_post( __( 'WooCommerce Shipping & Tax has been deactivated. Your data and settings have been carried over to the dedicated WooCommerce Shipping and WooCommerce Tax extensions.<br />For support, please <a href="https://woocommerce.com/my-account/create-a-ticket/">contact our Happiness Engineers</a>.', 'woocommerce-services' ) )
 					)
 				);
 			}


### PR DESCRIPTION
## Description
Displays a message in the plugin's plugins list entry, letting the user know that the plugin was deactivated and the data transfered successfully after the migration process.

### Related issue(s)

N/A

### Steps to reproduce & screenshots/GIFs


1. Remove the `false` statement in line 1538 of `woocommerce-services.php`.
2. Visit the plugins list.
3. The message should be displayed below the WooCommerce Tax row.

![shot-2024-06-26-17-21-11](https://github.com/Automattic/woocommerce-services/assets/130142/d4e9d10d-20d2-49c8-a88c-9237e03ac60b)


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added