### PR TITLE
Add tracking data for the migration process

### DIFF
--- a/classes/class-wc-rest-connect-migration-flag-controller.php
+++ b/classes/class-wc-rest-connect-migration-flag-controller.php
@@ -53,7 +53,13 @@ class WC_REST_Connect_Migration_Flag_Controller extends WC_REST_Connect_Base_Con
 		$result = WC_Connect_Options::update_option( 'wcshipping_migration_state', $migration_state );
 
 		if ( $result ) {
-			$this->tracks->record_user_event( 'migration_flag_updated', array( 'migration_state' => $migration_state ) );
+			$this->tracks->record_user_event(
+				'migration_flag_state_update',
+				array(
+					'migration_state' => $migration_state,
+					'updated'         => $result,
+				)
+			);
 			return new WP_REST_Response( array( 'result' => 'Migration flag updated successfully.' ), 200 );
 		}
 

--- a/classes/class-wc-rest-connect-migration-flag-controller.php
+++ b/classes/class-wc-rest-connect-migration-flag-controller.php
@@ -11,6 +11,31 @@ if ( class_exists( 'WC_REST_Connect_Migration_Flag_Controller' ) ) {
 class WC_REST_Connect_Migration_Flag_Controller extends WC_REST_Connect_Base_Controller {
 	protected $rest_base = 'connect/migration-flag';
 
+	/**
+	 * Tracks instance.
+	 *
+	 * @var WC_Connect_Tracks
+	 */
+	protected $tracks;
+
+	public function __construct( $api_client, $settings_store, $logger, $tracks ) {
+		parent::__construct( $api_client, $settings_store, $logger );
+
+		error_log( 'WC_REST_Connect_Migration_Flag_Controller::__construct' );
+		error_log( print_r( $tracks, true ) );
+
+		$this->set_tracks( $tracks );
+	}
+
+	/**
+	 * Set tracks instance.
+	 *
+	 * @param WC_Connect_Tracks $tracks Tracks instance.
+	 */
+	public function set_tracks( $tracks ) {
+		$this->tracks = $tracks;
+	}
+
 	public function post( $request ) {
 		$params          = $request->get_json_params();
 		$migration_state = intval( $params['migration_state'] );
@@ -31,6 +56,7 @@ class WC_REST_Connect_Migration_Flag_Controller extends WC_REST_Connect_Base_Con
 		$result = WC_Connect_Options::update_option( 'wcshipping_migration_state', $migration_state );
 
 		if ( $result ) {
+			$this->tracks->record_user_event( 'migration_flag_updated', array( 'migration_state' => $migration_state ) );
 			return new WP_REST_Response( array( 'result' => 'Migration flag updated successfully.' ), 200 );
 		}
 

--- a/classes/class-wc-rest-connect-migration-flag-controller.php
+++ b/classes/class-wc-rest-connect-migration-flag-controller.php
@@ -21,9 +21,6 @@ class WC_REST_Connect_Migration_Flag_Controller extends WC_REST_Connect_Base_Con
 	public function __construct( $api_client, $settings_store, $logger, $tracks ) {
 		parent::__construct( $api_client, $settings_store, $logger );
 
-		error_log( 'WC_REST_Connect_Migration_Flag_Controller::__construct' );
-		error_log( print_r( $tracks, true ) );
-
 		$this->set_tracks( $tracks );
 	}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1072,7 +1072,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$rest_carrier_types_controller->register_routes();
 
 			require_once __DIR__ . '/classes/class-wc-rest-connect-migration-flag-controller.php';
-			$rest_migration_flag_controller = new WC_REST_Connect_Migration_Flag_Controller( $this->api_client, $settings_store, $logger );
+			$rest_migration_flag_controller = new WC_REST_Connect_Migration_Flag_Controller( $this->api_client, $settings_store, $logger, $this->tracks );
 			$this->set_rest_migration_flag_controller( $rest_migration_flag_controller );
 			$rest_migration_flag_controller->register_routes();
 


### PR DESCRIPTION
-------

## Description
This PR adds tracking data for all the different states the migration process can go through.

The tracking code has been added in the controller that takes care of updating the migration status in the database whenever it changes during the migration process.

### Related issue(s)

N/A

### Steps to reproduce & screenshots/GIFs

1. After checking out this branch, replace this method in `class-wc-connect-service-settings-store.php`:

``` php
public function is_eligible_for_migration() {
	WC_Connect_Options::delete_option( 'wcshipping_migration_state' );
	$migration_state = WC_Connect_Options::get_option( 'wcshipping_migration_state' );

	$migration_pending = WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED !== $migration_state;
	$migration_enabled = $this->service_schemas_store->is_wcship_wctax_migration_enabled();

	return $migration_pending && $migration_enabled;
}
```

This will remove the current migration status from the database, so we can be sure the migration popup will display again.

2. Create a new order and try to create a new shipping label.

3. When the create shipping label button is pressed, the migration popup should appear. Click it.

4. The migration flow will start, and when it ends the tracks API should be called. If logging is enabled in your WooCommerce Shipping & Tax setup, you should see an entry in the log like this one:

``` text
Tracked the following event: woocommerceconnect_migration_flag_updated, referer: http://localhost:8889/wp-admin/post.php?post=34&action=edit
```

This is logged right before the data is sent to the tracks server.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added