### PR TITLE
Conditionally load shipping functionality based on if WC Shipping is active

### DIFF
--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -119,6 +119,10 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			return $health_items;
 		}
 
+		protected function is_shipping_loaded() {
+			return ! in_array( 'woocommerce-shipping/woocommerce-shipping.php', get_option( 'active_plugins' ) );
+		}
+
 		protected function get_services_items() {
 			$available_service_method_ids = $this->service_schemas_store->get_all_shipping_method_ids();
 			if ( empty( $available_service_method_ids ) ) {
@@ -261,16 +265,17 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 		 */
 		protected function get_form_data() {
 			return array(
-				'health_items'     => $this->get_health_items(),
-				'services'         => $this->get_services_items(),
-				'logging_enabled'  => $this->logger->is_logging_enabled(),
-				'debug_enabled'    => $this->logger->is_debug_enabled(),
-				'logs'             => array(
+				'health_items'       => $this->get_health_items(),
+				'services'           => $this->get_services_items(),
+				'logging_enabled'    => $this->logger->is_logging_enabled(),
+				'debug_enabled'      => $this->logger->is_debug_enabled(),
+				'logs'               => array(
 					'shipping' => $this->get_debug_log_data( 'shipping' ),
 					'taxes'    => $this->get_debug_log_data( 'taxes' ),
 					'other'    => $this->get_debug_log_data(),
 				),
-				'tax_rate_backups' => WC_Connect_Functions::get_backed_up_tax_rate_files(),
+				'tax_rate_backups'   => WC_Connect_Functions::get_backed_up_tax_rate_files(),
+				'is_shipping_loaded' => $this->is_shipping_loaded(),
 			);
 		}
 
@@ -296,8 +301,9 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 				'enqueue_wc_connect_script',
 				'wc-connect-admin-test-print',
 				array(
-					'storeOptions' => $this->service_settings_store->get_store_options(),
-					'paperSize'    => $this->service_settings_store->get_preferred_paper_size(),
+					'isShippingLoaded' => $this->is_shipping_loaded(),
+					'storeOptions'     => $this->service_settings_store->get_store_options(),
+					'paperSize'        => $this->service_settings_store->get_preferred_paper_size(),
 				)
 			);
 		}
@@ -308,42 +314,42 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 		protected function get_tax_health_item() {
 			$store_country = WC()->countries->get_base_country();
 			if ( ! $this->taxjar_integration->is_supported_country( $store_country ) ) {
-				return [
+				return array(
 					'state'              => 'error',
 					'settings_link_type' => '',
 					'message'            => sprintf( __( 'Your store\'s country (%s) is not supported. Automated taxes functionality is disabled', 'woocommerce-services' ), $store_country ),
-				];
+				);
 			}
 
 			if ( class_exists( 'WC_Taxjar' ) ) {
-				return [
+				return array(
 					'state'              => 'error',
 					'settings_link_type' => '',
 					'message'            => __( 'TaxJar extension detected. Automated taxes functionality is disabled', 'woocommerce-services' ),
-				];
+				);
 			}
 
 			if ( ! wc_tax_enabled() ) {
-				return [
+				return array(
 					'state'              => 'error',
 					'settings_link_type' => 'general',
 					'message'            => __( 'The core WooCommerce taxes functionality is disabled. Please ensure the "Enable tax rates and calculations" setting is turned "on" in the WooCommerce settings page', 'woocommerce-services' ),
-				];
+				);
 			}
 
 			if ( ! $this->taxjar_integration->is_enabled() ) {
-				return [
+				return array(
 					'state'              => 'error',
 					'settings_link_type' => 'tax',
 					'message'            => __( 'The automated taxes functionality is disabled. Enable the "Automated taxes" setting on the WooCommerce settings page', 'woocommerce-services' ),
-				];
+				);
 			}
 
-			return [
+			return array(
 				'state'              => 'success',
 				'settings_link_type' => 'tax',
 				'message'            => __( 'Automated taxes are enabled', 'woocommerce-services' ),
-			];
+			);
 		}
 	}
 

--- a/client/apps/plugin-status/health.js
+++ b/client/apps/plugin-status/health.js
@@ -14,7 +14,7 @@ import WooCommerceServicesIndicator from './woocommerce-services-indicator';
 import SettingsGroupCard from 'woocommerce/woocommerce-services/components/settings-group-card';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
-const HealthView = ( { translate, healthItems } ) => {
+const HealthView = ( { translate, healthItems, isShippingLoaded } ) => {
 	return (
 		<SettingsGroupCard heading={translate('Health', {
 			context: 'This section displays the overall health of WooCommerce Shipping & Tax and the things it depends on',
@@ -62,7 +62,8 @@ const HealthView = ( { translate, healthItems } ) => {
 					</ExternalLink>
 				</FormSettingExplanation>
 			</Indicator>
-			<WooCommerceServicesIndicator/>
+
+			{ isShippingLoaded && <WooCommerceServicesIndicator/> }
 		</SettingsGroupCard>
 
 	);
@@ -71,5 +72,6 @@ const HealthView = ( { translate, healthItems } ) => {
 export default connect(
 	( state ) => ( {
 		healthItems: state.status.health_items,
+		isShippingLoaded: state.status.is_shipping_loaded
 	} )
 )( localize( HealthView ) );

--- a/client/apps/plugin-status/test/health.test.js
+++ b/client/apps/plugin-status/test/health.test.js
@@ -50,7 +50,8 @@ const Wrapper = ({ children, healthStoreOverrides }) => (
 			health_items: {
 				...defaultHealthStoreValues,
 				...healthStoreOverrides,
-			}
+			},
+			is_shipping_loaded: true,
 		},
 	})}>
 		{children}

--- a/client/apps/plugin-status/view.js
+++ b/client/apps/plugin-status/view.js
@@ -22,7 +22,7 @@ import {
 	toggleDebugging,
 } from './state/actions';
 
-const StatusView = ( { onLoggingToggle, onDebuggingToggle, isLoggingEnabled, isDebuggingEnabled, taxRateBackups, translate } ) => {
+const StatusView = ( { onLoggingToggle, onDebuggingToggle, isLoggingEnabled, isDebuggingEnabled, taxRateBackups, translate, isShippingLoaded } ) => {
 	return (
 		<div>
 			<GlobalNotices id="notices" notices={ notices.list } />
@@ -47,9 +47,7 @@ const StatusView = ( { onLoggingToggle, onDebuggingToggle, isLoggingEnabled, isD
 					falseText={ translate( 'Disabled' ) }
 					onUpdate={ onLoggingToggle }
 				/>
-				<LogView
-					logKey="shipping"
-					title={ translate( 'Shipping Log' ) } />
+				{ isShippingLoaded && <LogView logKey="shipping" title={ translate( 'Shipping Log' ) }/> }
 				<LogView
 					logKey="taxes"
 					title={ translate( 'Taxes Log' ) } />
@@ -112,6 +110,7 @@ const mapStateToProps = ( state ) => ( {
 	isLoggingEnabled: Boolean( state.status.logging_enabled ),
 	isDebuggingEnabled: Boolean( state.status.debug_enabled ),
 	taxRateBackups: state.status.tax_rate_backups,
+	isShippingLoaded: state.status.is_shipping_loaded,
 } );
 
 const mapDispatchToProps = {

--- a/client/apps/print-test-label/index.js
+++ b/client/apps/print-test-label/index.js
@@ -10,7 +10,7 @@ import './style.scss';
 import PrintTestLabelView from './view';
 import reducer from './state/reducer';
 
-export default ( { paperSize, storeOptions } ) => ( {
+export default ( { paperSize, storeOptions, isShippingLoaded } ) => ( {
 	getReducer() {
 		return reducer;
 	},
@@ -19,6 +19,7 @@ export default ( { paperSize, storeOptions } ) => ( {
 		return {
 			paperSize,
 			country: storeOptions.origin_country,
+			isShippingLoaded,
 		};
 	},
 

--- a/client/apps/print-test-label/view.js
+++ b/client/apps/print-test-label/view.js
@@ -32,8 +32,13 @@ class PrintTestLabelView extends Component {
 	onPaperSizeChange = ( event ) => this.props.updatePaperSize( event.target.value );
 
 	render() {
-		const { paperSize, country, printingInProgress, error, print } = this.props;
+		const { paperSize, country, printingInProgress, error, print, isShippingLoaded } = this.props;
 		const paperSizes = getPaperSizes( country );
+
+		// Bail early if shipping is not enabled since it no longer makes sense to do label test prints.
+		if ( ! isShippingLoaded ) {
+			return null;
+		}
 
 		return (
 			<SettingsGroupCard heading={ __( 'Print' ) } >

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -587,8 +587,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			 *
 			 * @since {{next-release}}
 			 *
-			 * @todo Replace this notice with something that says "This will purely be a Tax plugin by <date>".
-			 *
 			 * @param bool $status The value will determine if we should initiate the plugins logic or not.
 			 */
 			if ( apply_filters( 'wc_services_will_handle_coexistence_with_woo_shipping_and_woo_tax', false ) ) {
@@ -696,7 +694,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		public function init_core_wizard_shipping_config() {
-			// @todo Verify what happens if WCS&T was installed without this, and WC Shipping is then deactivated.
 			if ( $this->is_wc_shipping_activated() ) {
 				return;
 			}
@@ -852,7 +849,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 */
 		public function attach_hooks() {
 			add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
-			add_action( 'rest_api_init', array( $this, 'wc_api_dev_init' ), 9999 );
 
 			add_action( 'admin_enqueue_scripts', array( $this->nux, 'show_pointers' ) );
 			add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'add_plugin_action_links' ) );
@@ -867,6 +863,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			// Primary condition to initiate shipping.
 			if ( ! $this->is_wc_shipping_activated() ) {
+				add_action( 'rest_api_init', array( $this, 'wc_api_dev_init' ), 9999 );
+
 				$this->init_shipping();
 			}
 
@@ -1065,8 +1063,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		/**
 		 * If the required v3 REST API endpoints haven't been loaded at this point, load the local copies of said endpoints.
 		 * Delete this when the "v3" REST API is included in all the WC versions we support.
-		 *
-		 * @todo Make sure the Woo mobile app is supported as well.
 		 */
 		public function wc_api_dev_init() {
 			$rest_server     = rest_get_server();

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -599,6 +599,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				return;
 			}
 
+			// We indicate that we will handle coexistence with WC Shipping
+			add_filter( 'wc_services_will_handle_coexistence_with_woo_shipping_and_woo_tax', '__return_true' );
+
 			if ( ! class_exists( 'WooCommerce' ) ) {
 				add_action(
 					'admin_notices',

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -258,9 +258,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		/**
 		 * Deletes WC Admin notices.
-		 *
-		 * @todo We'd need to make sure the DHL Live Rates class reachable during uninstall.
-		 *       We should be able to require everything in the 'pre_uninstall_plugin' action, so it shouldn't be an issue.
 		 */
 		public static function delete_notices() {
 			if ( self::can_add_wc_admin_notice() ) {
@@ -335,7 +332,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->wc_connect_base_url = self::get_wc_connect_base_url();
 			add_action(
 				'before_woocommerce_init',
-				function() {
+				function () {
 					if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
 						\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', 'woocommerce-services/woocommerce-services.php' );
 					}
@@ -605,7 +602,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			if ( ! class_exists( 'WooCommerce' ) ) {
 				add_action(
 					'admin_notices',
-					function() {
+					function () {
 						/* translators: %s WC download URL link. */
 						echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'WooCommerce Shipping & Tax requires the WooCommerce plugin to be installed and active. You can download %s here.', 'woocommerce-services' ), '<a href="https://wordpress.org/plugins/woocommerce/" target="_blank">WooCommerce</a>' ) . '</strong></p></div>';
 					}
@@ -1270,8 +1267,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			// Abort if no $order was passed, if the order is not marked as 'completed' or if another extension is handling the emailing.
 			if ( ! $order
-				 || ! $order->has_status( 'completed' )
-				 || ! WC_Connect_Extension_Compatibility::should_email_tracking_details( $order->get_id() ) ) {
+				|| ! $order->has_status( 'completed' )
+				|| ! WC_Connect_Extension_Compatibility::should_email_tracking_details( $order->get_id() ) ) {
 				return;
 			}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -573,7 +573,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				'connection',
 				array(
 					'slug' => WC_Connect_Jetpack::JETPACK_PLUGIN_SLUG,
-					'name' => __( 'WooCommerce Tax', 'woocommerce-services' ),
+					'name' => __( 'WooCommerce Shipping & Tax', 'woocommerce-services' ),
 				)
 			);
 		}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Just playing around in context of paJDVv-3NH-p2

Fixes: [2766](https://github.com/Automattic/woocommerce-services/issues/2766)

We need to:

* [x] Update name of status page to (conditionally?) say "WooCommerce Tax" or "WooCommerce Tax & Shipping".
  * TL;DR: We shouldn't: https://github.com/Automattic/woocommerce-services/pull/2761/commits/d6fbe3e5141f5c28f6e2b984326ab0e0172962d5 
* [x] The status page should also, conditionally, display shipping settings and content.
  *  https://github.com/Automattic/woocommerce-services/pull/2776
* [x] We need to rename the tab from "connect" in WC Shipping since that's conflicting
  *  https://github.com/woocommerce/woocommerce-shipping/pull/578
* [ ] We need to update our connect / ToS banners.
* [x] Verify that mobile will continue to work
    * The REST endpoints continue to be functional.
* [x] Since we expect WCS&T to be around for a while: maybe add a banner / notification saying WCS&T doesn't show WC Shipping labels if the merchant disabled the plugin afterwards (and that we do not support backwards migration)
    * The migration project already has enough "WC Shipping is activated" type communication. 

What's working without issue:
* WPCOM connection!
* I'm able to fetch taxes without UI or debug.log warnings/errors
* I'm able to purchase shipping labels when using WC Shipping in parallel

### Testing instructions

#### WCS&T
The first test is to ensure that WCS&T is functioning as it should on its own, things to test:
- Establishing a connection
- All label functionality
- Automated taxes
- Settings
- Debug info

#### WC Shipping combined with WCS&T
The second test would be to see how well WC Shipping works with WCS&T installed already. There are a couple of starting scenarios to test ie: establishing a connection with WCS&T and then activating WC Shipping and ensuring the connection is kept established, this is the most likely scenario that would be used in the wild, but we should also test for instances where WC Shipping is installed first and then you install WCS&T, does it allow for establishing a new connection for tax purposes in WCS&T.

Things to test include:
- Connections, WC Shipping and WCS&T have separate connections/tos agreements.
- Automated taxes, does it continue functioning
- Label functionality, does it utilise the label purchase flow from WC Shipping instead of WCS&T.
- WC Shipping settings, does the settings of WC Shipping show and work instead of that of WCS&T.
- Debugging info, are there no conflicts between the debug info from WCS&T and WC Shipping

Please test around this these instruction in any way you can think.


### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added