### PR TITLE
Save transients after a migration has been completed

### DIFF
--- a/classes/class-wc-connect-account-settings.php
+++ b/classes/class-wc-connect-account-settings.php
@@ -39,7 +39,7 @@ class WC_Connect_Account_Settings {
 		$last_box_id                 = $last_box_id === 'individual' ? '' : $last_box_id;
 		$last_service_id             = get_user_meta( get_current_user_id(), 'wc_connect_last_service_id', true );
 		$last_carrier_id             = get_user_meta( get_current_user_id(), 'wc_connect_last_carrier_id', true );
-		$wcshipping_migration_state  = WC_Connect_Options::get_option( 'wcshipping_migration_state' );
+		$wcshipping_migration_state  = get_option( 'wcshipping_migration_state' );
 
 		return array(
 			'storeOptions' => $this->settings_store->get_store_options(),

--- a/classes/class-wc-connect-account-settings.php
+++ b/classes/class-wc-connect-account-settings.php
@@ -39,7 +39,7 @@ class WC_Connect_Account_Settings {
 		$last_box_id                 = $last_box_id === 'individual' ? '' : $last_box_id;
 		$last_service_id             = get_user_meta( get_current_user_id(), 'wc_connect_last_service_id', true );
 		$last_carrier_id             = get_user_meta( get_current_user_id(), 'wc_connect_last_carrier_id', true );
-		$wcshipping_migration_state  = get_option( 'wcshipping_migration_state' );
+		$wcshipping_migration_state  = intval( get_option( 'wcshipping_migration_state' ) );
 
 		return array(
 			'storeOptions' => $this->settings_store->get_store_options(),

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -52,7 +52,6 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				'should_display_nux_after_jp_cxn_banner',
 				'needs_tax_environment_setup',
 				'banner_ppec',
-				'wcshipping_migration_state',
 			);
 		}
 

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -617,7 +617,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		}
 
 		public function is_eligible_for_migration() {
-			$migration_state = WC_Connect_Options::get_option( 'wcshipping_migration_state' );
+			$migration_state = get_option( 'wcshipping_migration_state' );
 
 			$migration_pending = WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED !== $migration_state;
 			$migration_enabled = $this->service_schemas_store->is_wcship_wctax_migration_enabled();

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -619,7 +619,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		public function is_eligible_for_migration() {
 			$migration_state = get_option( 'wcshipping_migration_state' );
 
-			$migration_pending = WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED !== $migration_state;
+			$migration_pending = ! $migration_state || WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED !== intval( $migration_state );
 			$migration_enabled = $this->service_schemas_store->is_wcship_wctax_migration_enabled();
 
 			return $migration_pending && $migration_enabled;

--- a/classes/class-wc-rest-connect-migration-flag-controller.php
+++ b/classes/class-wc-rest-connect-migration-flag-controller.php
@@ -60,6 +60,12 @@ class WC_REST_Connect_Migration_Flag_Controller extends WC_REST_Connect_Base_Con
 					'updated'         => $result,
 				)
 			);
+
+			if ( WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED === $migration_state ) {
+				set_transient( 'wcshipping_migration_completed', true, DAY_IN_SECONDS );
+				set_transient( 'wctax_migration_completed', true, DAY_IN_SECONDS );
+			}
+
 			return new WP_REST_Response( array( 'result' => 'Migration flag updated successfully.' ), 200 );
 		}
 

--- a/classes/class-wc-rest-connect-migration-flag-controller.php
+++ b/classes/class-wc-rest-connect-migration-flag-controller.php
@@ -46,7 +46,7 @@ class WC_REST_Connect_Migration_Flag_Controller extends WC_REST_Connect_Base_Con
 		}
 
 		$existing_migration_state = get_option( 'wcshipping_migration_state' );
-		if ( $existing_migration_state === $migration_state ) {
+		if ( $existing_migration_state && intval( $existing_migration_state ) === $migration_state ) {
 			return new WP_REST_Response( array( 'result' => 'Migration flag is the same, no changes needed.' ), 304 );
 		}
 

--- a/classes/class-wc-rest-connect-migration-flag-controller.php
+++ b/classes/class-wc-rest-connect-migration-flag-controller.php
@@ -45,12 +45,12 @@ class WC_REST_Connect_Migration_Flag_Controller extends WC_REST_Connect_Base_Con
 			return $error;
 		}
 
-		$existing_migration_state = WC_Connect_Options::get_option( 'wcshipping_migration_state' );
+		$existing_migration_state = get_option( 'wcshipping_migration_state' );
 		if ( $existing_migration_state === $migration_state ) {
 			return new WP_REST_Response( array( 'result' => 'Migration flag is the same, no changes needed.' ), 304 );
 		}
 
-		$result = WC_Connect_Options::update_option( 'wcshipping_migration_state', $migration_state );
+		$result = update_option( 'wcshipping_migration_state', $migration_state );
 
 		if ( $result ) {
 			$this->tracks->record_user_event(
@@ -60,11 +60,6 @@ class WC_REST_Connect_Migration_Flag_Controller extends WC_REST_Connect_Base_Con
 					'updated'         => $result,
 				)
 			);
-
-			if ( WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED === $migration_state ) {
-				set_transient( 'wcshipping_migration_completed', true, DAY_IN_SECONDS );
-				set_transient( 'wctax_migration_completed', true, DAY_IN_SECONDS );
-			}
 
 			return new WP_REST_Response( array( 'result' => 'Migration flag updated successfully.' ), 200 );
 		}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -266,7 +266,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			require_once __DIR__ . '/classes/class-wc-connect-wcst-to-wcshipping-migration-state-enum.php';
 
 			$migration_state = get_option( 'wcshipping_migration_state' );
-			if ( $migration_state !== WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED ) {
+			if ( ! $migration_state || intval( $migration_state ) !== WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED ) {
 				update_option( 'wcshipping_migration_state', WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED );
 			}
 		}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -265,11 +265,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			 */
 			require_once __DIR__ . '/classes/class-wc-connect-wcst-to-wcshipping-migration-state-enum.php';
 
-			$migration_state = WC_Connect_Options::get_option( 'wcshipping_migration_state' );
+			$migration_state = get_option( 'wcshipping_migration_state' );
 			if ( $migration_state !== WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED ) {
-				WC_Connect_Options::update_option( 'wcshipping_migration_state', WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED );
-				set_transient( 'wcshipping_migration_completed', true, DAY_IN_SECONDS );
-				set_transient( 'wctax_migration_completed', true, DAY_IN_SECONDS );
+				update_option( 'wcshipping_migration_state', WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED );
 			}
 		}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -268,6 +268,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$migration_state = WC_Connect_Options::get_option( 'wcshipping_migration_state' );
 			if ( $migration_state !== WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED ) {
 				WC_Connect_Options::update_option( 'wcshipping_migration_state', WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED );
+				set_transient( 'wcshipping_migration_completed', true, DAY_IN_SECONDS );
+				set_transient( 'wctax_migration_completed', true, DAY_IN_SECONDS );
 			}
 		}
 


### PR DESCRIPTION
-------

## Description
When the WooCommerce Shipping & Tax migration to WooCommerce Shipping and WooCommerce Tax is completed, we need to display migration status messages for each entry of these plugins in the plugins list screen. One issue is the migration status is stored in the WooCommerce Shipping & Tax options object, and the class helper that access that options object is not available for WooCommerce Shipping and WooCommerce Tax as WooCommerce Shipping & Tax is disabled. This PR solves that issue by creating a couple of transients that tell WooCommerce Shipping and WooCommerce Tax that the migration has been completed successfully. The transients last one day until they're deleted.

### Related issue(s)

N/A

### Steps to reproduce & screenshots/GIFs

1. Checkout this branch and make sure you're eligible to run the migration:

	- Reset the `wcshipping_migration_state` option with `WC_Connect_Options::delete_option( 'wcshipping_migration_state' );`
	- Use the WooCommerce Connect Server staging endpoint: `https://api-staging.woocommerce.com`

2. Go to the orders list, and click the migration button at the top of the screen. Wait for the migration to finish.

![shot-2024-07-06-13-51-19](https://github.com/Automattic/woocommerce-services/assets/130142/39186f35-60fb-48c8-9899-feb5b3284bb5)


3. Install a transients manager plugin and check if the transients `wcshipping_migration_completed` and `wctax_migration_completed` have been created.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added