### PR TITLE
Fix/issue 2712 - Make The Tariff Number Field a Required Field when the Destination is Within EU

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 2.6.2 - 2024-xx-xx =
-* Fix - Tariff number field on customs should be required field when the destination country is within EU.
+* Fix - Require HS Tariff number on customs form for EU destination countries.
 
 = 2.6.1 - 2024-07-02 =
 * Tweak - WooCommerce 9.0 and WordPress 6.6 compatibility.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.6.2 - 2024-xx-xx =
+* Fix - Tariff number field on customs should be required field when the destination country is within EU.
+
 = 2.6.1 - 2024-07-02 =
 * Tweak - WooCommerce 9.0 and WordPress 6.6 compatibility.
 

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -598,6 +598,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 					'packagesSettings'  => $this->package_settings->get(),
 					'shippingLabelData' => $this->get_label_payload( $order->get_id() ),
 					'continents'        => $this->continents->get(),
+					'euCountries'       => WC()->countries->get_european_union_countries(),
 					'context'           => $args['args']['context'],
 					'items'             => $items_count,
 				),

--- a/client/apps/shipping-label/index.js
+++ b/client/apps/shipping-label/index.js
@@ -29,7 +29,7 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import initializeLabelsState from 'woocommerce/woocommerce-services/lib/initialize-labels-state';
 import './style.scss';
 
-export default ( { order, accountSettings, packagesSettings, shippingLabelData, continents, context, items } ) => {
+export default ( { order, accountSettings, packagesSettings, shippingLabelData, continents, euCountries, context, items } ) => {
 	const orderId = order ? order.id : null;
 	const isPreloaded = ( undefined !== accountSettings );
 
@@ -81,6 +81,7 @@ export default ( { order, accountSettings, packagesSettings, shippingLabelData, 
 		}
 		initialState.extensions.woocommerce.sites[1].data = {
 			locations: continents,
+			euCountries
 		}
 
 		return initialState;

--- a/client/extensions/woocommerce/state/sites/data/locations/selectors.js
+++ b/client/extensions/woocommerce/state/sites/data/locations/selectors.js
@@ -96,6 +96,15 @@ export const getAllCountries = ( state, siteId = getSelectedSiteId( state ) ) =>
 
 /**
  * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Array} An array of EU countries represented by { code, name, states } objects. Sorted alphabetically by name.
+ */
+export const getEUCountries = ( state, siteId = getSelectedSiteId( state ) ) => {
+	return get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'data', 'euCountries' ] );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
  * @param {String} continentCode 2-letter continent code
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Array} A list of countries in the given continent, represented by { code, name } pairs. Sorted alphabetically by name.

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -51,6 +51,7 @@ import {
 	areLocationsErrored,
 	getCountryName,
 	getAllCountryNames,
+	getEUCountries,
 	getStates,
 	hasStates,
 } from 'woocommerce/state/sites/data/locations/selectors';
@@ -339,7 +340,9 @@ export const getCustomsErrors = (
 	packages,
 	customs,
 	destinationCountryCode,
-	destinationCountryName
+	destinationCountryName,
+	state,
+	siteId = getSelectedSiteId( state )
 ) => {
 	const usedProductIds = uniq(
 		flatten( map( packages, pckg => map( pckg.items, 'product_id' ) ) )
@@ -437,6 +440,8 @@ export const getCustomsErrors = (
 			}
 			if ( itemData.tariffNumber && 6 !== itemData.tariffNumber.length ) {
 				itemErrors.tariffNumber = translate( 'The tariff number must be 6 digits long' );
+			} else if ( ! itemData.tariffNumber && isEUCountry( state, destinationCountryCode, siteId ) ) {
+				itemErrors.tariffNumber = translate( 'The tariff number is required for EU countries' );
 			}
 			return itemErrors;
 		} ),
@@ -501,7 +506,9 @@ export const getFormErrors = createSelector(
 				form.packages.selected,
 				form.customs,
 				destinationCountryCode,
-				destinationCountryName
+				destinationCountryName,
+				state,
+				siteId
 			),
 			rates: getRatesErrors( form.rates ),
 			sidebar: getSidebarErrors( paperSize ),
@@ -535,6 +542,16 @@ export const isAddressUsable = createSelector(
 		getShippingLabel( state, orderId, siteId ).form[ group ],
 	]
 );
+
+export const isEUCountry = ( state, destinationCountryCode, siteId = getSelectedSiteId( state ) ) => {
+	const EUCountries = getEUCountries( state, siteId );
+
+	return includes( EUCountries, destinationCountryCode ); 
+}
+
+export const getTariffNumberPlaceholder = ( state, destinationCountryCode, siteId = getSelectedSiteId( state ) ) => {
+	return ! isEUCountry( state, destinationCountryCode, siteId ) ? translate( 'Optional' ) : '';
+}
 
 export const isCustomsFormStepSubmitted = (
 	state,

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -441,7 +441,7 @@ export const getCustomsErrors = (
 			if ( itemData.tariffNumber && 6 !== itemData.tariffNumber.length ) {
 				itemErrors.tariffNumber = translate( 'The tariff number must be 6 digits long' );
 			} else if ( ! itemData.tariffNumber && isEUCountry( state, destinationCountryCode, siteId ) ) {
-				itemErrors.tariffNumber = translate( 'The tariff number is required for EU countries' );
+				itemErrors.tariffNumber = translate( 'The tariff number is required for EU countries destination' );
 			}
 			return itemErrors;
 		} ),

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/item-row.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/item-row.js
@@ -19,6 +19,7 @@ import {
 } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
 import {
 	getShippingLabel,
+	getTariffNumberPlaceholder,
 	isLoaded,
 	getFormErrors,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
@@ -40,6 +41,7 @@ const ItemRow = props => {
 		value,
 		tariffNumber,
 		originCountry,
+		TariffNumberPlaceholder,
 		countryNames,
 		weightUnit,
 	} = props;
@@ -59,7 +61,7 @@ const ItemRow = props => {
 				id={ packageId + '_' + productId + '_tariffNumber' }
 				className="customs-step__item-code-column"
 				title={ <TariffCodeTitle /> }
-				placeholder={ translate( 'Optional' ) }
+				placeholder={ TariffNumberPlaceholder }
 				value={ tariffNumber }
 				updateValue={ props.setCustomsItemTariffNumber }
 				error={ errors.tariffNumber }
@@ -104,6 +106,7 @@ ItemRow.propTypes = {
 	weight: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ).isRequired,
 	value: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ).isRequired,
 	originCountry: PropTypes.string.isRequired,
+	TariffNumberPlaceholder: PropTypes.string.isRequired,
 	errors: PropTypes.object,
 	countryNames: PropTypes.object.isRequired,
 	setCustomsItemDescription: PropTypes.func.isRequired,
@@ -116,6 +119,8 @@ ItemRow.propTypes = {
 const mapStateToProps = ( state, { orderId, siteId, productId } ) => {
 	const isShippingLabelLoaded = isLoaded( state, orderId, siteId );
 	const shippingLabel = getShippingLabel( state, orderId, siteId );
+	const destinationCountry = shippingLabel.form.destination.values.country;
+	const TariffNumberPlaceholder = getTariffNumberPlaceholder( state, destinationCountry, siteId );
 	const {
 		description,
 		defaultDescription,
@@ -132,6 +137,7 @@ const mapStateToProps = ( state, { orderId, siteId, productId } ) => {
 		weight,
 		value,
 		originCountry,
+		TariffNumberPlaceholder,
 		errors: isShippingLabelLoaded
 			? getFormErrors( state, orderId, siteId ).customs.items[ productId ]
 			: {},

--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 2.6.2 - 2024-xx-xx =
+* Fix - Tariff number field on customs should be required field when the destination country is within EU.
+
 = 2.6.1 - 2024-07-02 =
 * Tweak - WooCommerce 9.0 and WordPress 6.6 compatibility.
 

--- a/readme.txt
+++ b/readme.txt
@@ -80,7 +80,7 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 == Changelog ==
 
 = 2.6.2 - 2024-xx-xx =
-* Fix - Tariff number field on customs should be required field when the destination country is within EU.
+* Fix - Require HS Tariff number on customs form for EU destination countries.
 
 = 2.6.1 - 2024-07-02 =
 * Tweak - WooCommerce 9.0 and WordPress 6.6 compatibility.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Add condition to make the tariff number field become a required field when the destination is within EU.
<!-- Explain the motivation for making this change -->

### Related issue(s)

Fixes #2712   #2720 
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

1. Add a new order with the destination to EU countries.
2. Try to create the labels from order admin page.
3. Upon the customs, the HS Tariff Number field will be required field : 
![image](https://github.com/Automattic/woocommerce-services/assets/631098/e604ec21-46ad-4100-afce-1c4d54b8d4f9)

4. Add the HS Tariff Number and continue the process until buy the label.
5. The label will be purchased successfully.
6. Try to create a new order again but change the destination to outside EU countries ( such as : UK ).
7. And try to repeat the process from no. 2.
8. The HS Tariff Number field will be optional field. You can leave it blank.
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

