### PR TITLE
Add missing tracking data for the migration process

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -267,7 +267,17 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			$migration_state = get_option( 'wcshipping_migration_state' );
 			if ( ! $migration_state || intval( $migration_state ) !== WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED ) {
-				update_option( 'wcshipping_migration_state', WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED );
+				$result = update_option( 'wcshipping_migration_state', WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED );
+
+				if ( $result ) {
+					$this->tracks->record_user_event(
+						'migration_flag_state_update',
+						array(
+							'migration_state' => $migration_state,
+							'updated'         => $result,
+						)
+					);
+				}
 			}
 		}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -931,7 +931,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'woocommerce_checkout_order_processed', array( $this, 'track_completed_order' ), 10, 3 );
 			add_action( 'admin_print_footer_scripts', array( $this, 'add_sift_js_tracker' ) );
 			add_action( 'current_screen', array( $this, 'edit_orders_page_actions' ) );
-			add_action( 'after_plugin_row_woocommerce-services/woocommerce-services.php', array( $this, 'add_custom_message_to_plugin_list' ), 10, 2 );
 
 			$tracks = $this->get_tracks();
 			$tracks->init();
@@ -1538,30 +1537,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			if ( $settings_store->is_eligible_for_migration() ) {
 				add_action( 'admin_notices', array( $this, 'display_wcst_to_wcshipping_migration_notice' ) );
 				add_action( 'admin_notices', array( $this, 'register_wcshipping_migration_modal' ) );
-			}
-		}
-
-		/**
-		 * Add a "deactivated" message to the plugin list table for WooCommerce Shipping & Tax
-		 *
-		 * @param string $plugin_file
-		 * @param array  $plugin_data
-		 */
-		public function add_custom_message_to_plugin_list() {
-			if ( false ) {
-				printf(
-					'<style>
-						.plugins tr[data-slug="woocommerce-services"] td, .plugins tr[data-slug="woocommerce-services"] th { box-shadow: none; }
-					</style>
-					<tr class="plugin-update-tr active update">
-    					<td colspan="4" class="plugin-update colspanchange">
-    	    				<div class="notice inline notice-warning" style="border:0; border-left: 5px solid #4AB866; padding: 12px; background-color: #EFF9F1;">
-    	        				<p>%s</p>
-    	    				</div>
-						</td>
-					 </tr>',
-					wp_kses_post( __( 'WooCommerce Shipping & Tax has been deactivated. Your data and settings have been carried over to the dedicated WooCommerce Shipping and WooCommerce Tax extensions.<br />For support, please <a href="https://woocommerce.com/my-account/create-a-ticket/">contact our Happiness Engineers</a>.', 'woocommerce-services' ) )
-				);
 			}
 		}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -263,6 +263,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			 * When we deactivate the plugin after wcshipping_migration_state has started,
 			 * that means the migration is done. We can mark it as completed before we deactivate the plugin.
 			 */
+			require_once __DIR__ . '/classes/class-wc-connect-logger.php';
+			require_once __DIR__ . '/classes/class-wc-connect-tracks.php';
 			require_once __DIR__ . '/classes/class-wc-connect-wcst-to-wcshipping-migration-state-enum.php';
 
 			$migration_state = get_option( 'wcshipping_migration_state' );
@@ -270,7 +272,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				$result = update_option( 'wcshipping_migration_state', WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED );
 
 				if ( $result ) {
-					$this->tracks->record_user_event(
+					$core_logger = new WC_Logger();
+					$logger      = new WC_Connect_Logger( $core_logger );
+					$tracks      = new WC_Connect_Tracks( $logger, __FILE__ );
+					$tracks->record_user_event(
 						'migration_flag_state_update',
 						array(
 							'migration_state' => $migration_state,


### PR DESCRIPTION
## Description
When the plugin is deactivated and the migration is marked as completed, a call to Tracks was missing. We need to track that metric, so this PR takes care of that.

Also removes the "plugin successfully deactivated" message from the plugins list entry, as has been moved to the WooCommerce Shipping plugin.

### Related issue(s)
N/A

### Steps to reproduce & screenshots/GIFs
1. Create a test site, add this plugin and enable it. Ensure that is connected to WooCommerce Connect Server staging server.
2. Create a WooCommerce Shipping build using latest `wcs-migration` branch and add it to the test site. Don't enable it.
3. Create a build of WooCommerce Tax and add it to the site, but don't enable it.
4. Make sure none of the options in the following query are set:

```sql
select *
from wp_options
where option_name in (
  'wcshipping_migration_state',
  'wcshipping_migration_completed_message_shown',
  'wcst_plugin_deactivated_message_shown'
);
```

Remove them if they exist.

5. Create a few orders (hint, you can use https://github.com/woocommerce/wc-smooth-generator/releases/ for that) and go to the orders page. The message to start the migration should appear at the top of the page. Click the button to start the process.
6. When the migration is completed, a call to Tracks should've been made when WooCommerce Shipping & Tax was deactivated.


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added