### PR TITLE
Remove db migration and deactivation

### DIFF
--- a/client/components/migration/migration-runner.js
+++ b/client/components/migration/migration-runner.js
@@ -43,7 +43,7 @@ const MIGRATION_ENUM_TO_STATE_NAME_MAP = {
     12: 'stateDone'
 }
 
-const plugins = 'woocommerce-shipping,woocommerce-tax'; //this needs to be a CSV string.
+const plugins = 'woocommerce-shipping'; //this needs to be a CSV string.
 
 const getHeaders = () => ({
     "Content-Type": "application/json",

--- a/client/components/migration/migration-runner.js
+++ b/client/components/migration/migration-runner.js
@@ -180,7 +180,7 @@ const migrationStateTransitions = {
     stateDone: { // Done state.
         success: null,
         fail: null,
-        callback: null
+        callback: stateErrorHandlingAPICall( MIGRATION_STATE_ENUM.COMPLETED )
     }
 }
 

--- a/client/components/migration/migration-runner.js
+++ b/client/components/migration/migration-runner.js
@@ -148,7 +148,7 @@ const migrationStateTransitions = {
         callback: stateErrorHandlingAPICall( MIGRATION_STATE_ENUM.ERROR_INSTALLING ),
     },
     stateActivating: {
-        success: 'stateDeactivating', // TODO: This should be stateDBMigrating to migrate DB.
+        success: 'stateDone',
         fail: 'stateErrorActivating',
         callback: fetchAPICall( activatePluginAPICall ),
     },

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -267,22 +267,18 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			require_once __DIR__ . '/classes/class-wc-connect-tracks.php';
 			require_once __DIR__ . '/classes/class-wc-connect-wcst-to-wcshipping-migration-state-enum.php';
 
-			$migration_state = get_option( 'wcshipping_migration_state' );
-			if ( ! $migration_state || intval( $migration_state ) !== WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED ) {
-				$result = update_option( 'wcshipping_migration_state', WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED );
-
-				if ( $result ) {
-					$core_logger = new WC_Logger();
-					$logger      = new WC_Connect_Logger( $core_logger );
-					$tracks      = new WC_Connect_Tracks( $logger, __FILE__ );
-					$tracks->record_user_event(
-						'migration_flag_state_update',
-						array(
-							'migration_state' => $migration_state,
-							'updated'         => $result,
-						)
-					);
-				}
+			$migration_state = intval( get_option( 'wcshipping_migration_state' ) );
+			if ( $migration_state === WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED ) {
+				$core_logger = new WC_Logger();
+				$logger      = new WC_Connect_Logger( $core_logger );
+				$tracks      = new WC_Connect_Tracks( $logger, __FILE__ );
+				$tracks->record_user_event(
+					'migration_flag_state_update',
+					array(
+						'migration_state' => $migration_state,
+						'updated'         => $result,
+					)
+				);
 			}
 		}
 


### PR DESCRIPTION
## Description
This PR changes the state machine to the following
![image](https://github.com/user-attachments/assets/f3e6712c-09ef-44ac-b455-8b22abab4df8)

1. It skips the DB updates from the migration-runner.js
2. It skips the "deactivating WCS&T" step
3. Once we activated "Woo Shipping", the migration is done and we will redirect the user to the plugins page.
4. Because WCS&T is no longer being activated, it means that the `WC_REST_Connect_Migration_Flag_Controller` controller `wc/v1/connect/migration-flag` will continue to work. The `migration-runner` will now be able to make an API call to update the `wcshipping_migration_state` without relying on `plugin_deactivation` hook. 

This PR also removes `woocommerce-tax` from the installation API call. 

### Related issue(s)
Closes https://github.com/woocommerce/shipping/issues/150

### Steps to test
1. Pull this branch, 
2. Go to plugins page `http://localhost/wp-admin/plugins.php?plugin_status=all&paged=1&s`, enabled WCS&T, deactivate Woo Shipping (wcs-migration branch) and Woo Tax.
3. Open `wordpress/wp-content/plugins/woocommerce-services/classes/class-wc-connect-service-settings-store.php` and add `delete_option( 'wcshipping_migration_state' );` in the `is_eligible_for_migration()`, something like this:
```
+			delete_option( 'wcshipping_migration_state' );
			$migration_state = get_option( 'wcshipping_migration_state' );
```
The idea is to delete the `wcshipping_migration_state` flag so that we can keep testing the banner.
4. Go to the order listing page http://localhost/wp-admin/edit.php?post_type=shop_order, you should see this banner
![image](https://github.com/user-attachments/assets/54c90f27-c160-47bb-9613-b11bf5fcce85)
5. Open the network tab, click "Confirm update". You should see `migration-flag` API called twice to update status from `2` to `12`. You should also be able to see `install` and `activate` API calls go through. In the plugins page, you should see only WCS&T and Woo Shipping activated, where Woo Tax remains deactivated.
![image](https://github.com/user-attachments/assets/a50786b6-3eb0-4f97-bb11-607beb6314bb)


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

