### PR TITLE
Adapt the migration banner popup to reusing WCS&T

### DIFF
--- a/client/components/migration/feature-announcement.jsx
+++ b/client/components/migration/feature-announcement.jsx
@@ -62,7 +62,7 @@ const FeatureAnnouncement = ( { translate, isEligable, previousMigrationState } 
 						{translate('A new dedicated WooCommerce Shipping extension is now available')}
 					</h2>
 					<p>{translate(
-						'WooCommerce Shipping and WooCommerce Tax are now two dedicated extensions. We\'ll automatically deactivate WooCommerce Shipping & Tax and carry over your settings when you update.')}</p>
+						'WooCommerce Shipping is now a new dedicated extension. We\'ll allow you to carry over your settings and shipping labels when you update.')}</p>
 					<p>{translate('Here\'s what you can expect from the new shipping experience:')}</p>
 
 					<ul>

--- a/client/components/migration/feature-announcement.jsx
+++ b/client/components/migration/feature-announcement.jsx
@@ -61,8 +61,7 @@ const FeatureAnnouncement = ( { translate, isEligable, previousMigrationState } 
 					<h2>
 						{translate('A new dedicated WooCommerce Shipping extension is now available')}
 					</h2>
-					<p>{translate(
-						'WooCommerce Shipping is now a new dedicated extension. We\'ll allow you to carry over your settings and shipping labels when you update.')}</p>
+					<p>{translate('We\'ll ensure a smooth transition by providing the functionality to carry over all your settings and shipping labels when you update.')}</p>
 					<p>{translate('Here\'s what you can expect from the new shipping experience:')}</p>
 
 					<ul>


### PR DESCRIPTION
## Description
Since we're going to reuse WCS&T for taxes purposes while WooCommerce Tax is in review process, we need to reword the migration banner popup to reflect this change.

### Related issue(s)

N/A

### Steps to reproduce & screenshots/GIFs

Just checkout this branch and show the migration popup from the orders page. The copy should show the new changes.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added