### PR TITLE
Fix modal image not loading on orders listing [570]

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -21,10 +21,6 @@ import { setNonce, setBaseURL } from 'api/request';
 import wpcomApiMiddleware from 'state/data-layer/wpcom-api-middleware';
 import localApiMiddleware from 'lib/local-api-middleware';
 
-// Modify webpack pubilcPath at runtime based on location of WordPress Plugin.
-// eslint-disable-next-line no-undef
-__webpack_public_path__ = global.wcsPluginData.assetPath;
-
 // We need to lazy load the moment locale files.
 // First we try language code with region if it's different then fall back to language code only.
 if ( window.i18nLocale && ! [ 'en-US', 'en' ].includes( window.i18nLocale.localeSlug ) ) {

--- a/client/provide-public-path.js
+++ b/client/provide-public-path.js
@@ -1,0 +1,3 @@
+// Modify webpack pubilcPath at runtime based on location of WordPress Plugin.
+// eslint-disable-next-line no-undef
+__webpack_public_path__ = global.wcsPluginData.assetPath;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,11 +51,17 @@ module.exports = {
 	devtool: isDev ? 'inline-source-map' : false,
 	cache: true,
 	entry: {
-		'woocommerce-services': [ './client/main.js' ],
+		'woocommerce-services': [
+			'./client/provide-public-path.js',
+			'./client/main.js'
+		],
 		'woocommerce-services-banner': [ './client/banner.js' ],
 		'woocommerce-services-admin-pointers': [ './client/admin-pointers.js' ],
 		'woocommerce-services-new-order-taxjar': [ './client/new-order-taxjar.js' ],
-		'woocommerce-services-wcshipping-migration-admin-notice': [ './client/wcshipping-migration-admin-notice.js' ],
+		'woocommerce-services-wcshipping-migration-admin-notice': [
+			'./client/provide-public-path.js',
+			'./client/wcshipping-migration-admin-notice.js'
+		],
 	},
 	output: Object.assign(
 			{},

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1966,6 +1966,14 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$plugin_version = self::get_wcs_version();
 			wp_register_style( 'wcst_wcshipping_migration_admin_notice', $this->wc_connect_base_url . 'woocommerce-services-wcshipping-migration-admin-notice-' . $plugin_version . '.css', array(), null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 			wp_register_script( 'wcst_wcshipping_migration_admin_notice', $this->wc_connect_base_url . 'woocommerce-services-wcshipping-migration-admin-notice-' . $plugin_version . '.js', array(), null );
+			wp_localize_script(
+				'wcst_wcshipping_migration_admin_notice',
+				'wcsPluginData',
+				array(
+					'assetPath'       => self::get_wc_connect_base_url(),
+					'adminPluginPath' => admin_url( 'plugins.php' ),
+				)
+			);
 			wp_enqueue_script( 'wcst_wcshipping_migration_admin_notice' );
 			wp_enqueue_style( 'wcst_wcshipping_migration_admin_notice' );
 			wp_enqueue_script( 'wc_connect_admin' );


### PR DESCRIPTION
## Description
This PR fixes the issue where then absolute path to the dist folder is not present properly when the asset is getting requested.
The PR fixes the issue by providing the right path to the dist folder to the js files.

### Related issue(s)
https://github.com/woocommerce/woocommerce-shipping/issues/570

### Steps to reproduce
[copied from the issue]
1. Go to your local's override file and comment out the `WOOCOMMERCE_CONNECT_DEV_SERVER_URL` constant: `// define('WOOCOMMERCE_CONNECT_DEV_SERVER_URL', 'http://localhost:8085'); //WCS&T`. This disable dev server and uses `dist/`. 
2. Build the files into `/dists`. I used `npm run build`. 
3. Return true from WC_Connect_Service_Settings_Store::is_eligible_for_migration
4. Refresh your page and go to order list page, click "Confirm update", confirm the image is loaded.
5. Visit an order page, click on `Create shipping label` and verify the migration modal properly loads the image.

![TnJvoD.png](https://github.com/user-attachments/assets/0aea2bdc-df9d-4c91-b76e-357b5d64c576)
### Dev notes
To make testing/debugging easier, we don't want the order list "Confirm update" to redirect us every time. I go to `wordpress/wp-content/plugins/woocommerce-services/client/components/migration/migration-runner.js` and modify:
1.  I comment out `// window.location = global.wcsPluginData.adminPluginPath;` so it no longer redirects.
2. I replace `fetch( getBaseURL() + 'wc-admin/plugins/install', {` to `fetch( getBaseURL() + 'wc-admin/plugins/install2', {`. This trips the installer and it will always fail at the installation stage, so it won't deactivate itself. 

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added