### PR TITLE
Display migration banner on all WC settings page [shipping-152]

### DIFF
--- a/client/wcshipping-migration-admin-notice.js
+++ b/client/wcshipping-migration-admin-notice.js
@@ -28,7 +28,11 @@ const wcstMigrationNoticeDimissButton = document.querySelector('.wcst-wcshipping
 // Add all button events
 ["click", "keydown"].forEach(eventName => {
 	// Clicking "Confirm update" will start the migration. This is the same as popping up the modal and clicking the "Update" button there.
-	wcstWCShippingMigrationNoticeButton.addEventListener(eventName, () => {
+	wcstWCShippingMigrationNoticeButton.addEventListener(eventName, (evt) => {
+		/**
+		 * Prevent form submission when rendered in a form or alike that listens to button click
+		 */
+		evt.preventDefault();
 		// Pop open feature announcement modal.
 		ReactDOM.render(
 			<Provider store={store}>

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1511,8 +1511,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				return false;
 			}
 
-			// WC settings page the "WooCommerce Shipping" tab
-			if ( $screen->id === 'woocommerce_page_wc-settings' && isset( $_GET['section'] ) && $_GET['section'] === 'woocommerce-services-settings' ) {
+			// All WC settings pages
+			if ( $screen->id === 'woocommerce_page_wc-settings' ) {
 				return true;
 			}
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -931,7 +931,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_filter( 'woocommerce_admin_reports', array( $this, 'reports_tabs' ) );
 			add_action( 'woocommerce_checkout_order_processed', array( $this, 'track_completed_order' ), 10, 3 );
 			add_action( 'admin_print_footer_scripts', array( $this, 'add_sift_js_tracker' ) );
-			add_action( 'current_screen', array( $this, 'edit_orders_page_actions' ) );
+			add_action( 'current_screen', array( $this, 'maybe_render_upgrade_banner' ) );
 
 			$tracks = $this->get_tracks();
 			$tracks->init();
@@ -1487,7 +1487,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 *
 		 * @return boolean
 		 */
-		public function is_on_order_list_page() {
+		public function should_render_upgrade_banner() {
 			if ( ! is_admin() ) {
 				return false;
 			}
@@ -1511,6 +1511,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				return false;
 			}
 
+			// WC settings page the "WooCommerce Shipping" tab
+			if ( $screen->id === 'woocommerce_page_wc-settings' && isset( $_GET['section'] ) && $_GET['section'] === 'woocommerce-services-settings' ) {
+				return true;
+			}
+
 			/*
 			* Non-HPOS:
 			*   $screen->id = "edit-shop_order"
@@ -1527,8 +1532,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			return true;
 		}
 
-		public function edit_orders_page_actions() {
-			if ( ! $this->is_on_order_list_page() ) {
+		public function maybe_render_upgrade_banner() {
+			if ( ! $this->should_render_upgrade_banner() ) {
 				// If this is not on the order list page, then don't add any action.
 				return;
 			}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1959,7 +1959,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					'</p>
 					<button type="button" class="notice-dismiss %s"><span class="screen-reader-text">Dismiss this notice.</span></button>
 					</div>
-					<div class="notice-action"><button id="wcst-wcshipping-migration-notice__click" class="action-button">%s</button></div>
+					<div class="notice-action"><button id="wcst-wcshipping-migration-notice__click" type="button" class="action-button">%s</button></div>
 					</div>',
 					$banner->dismissible ? '' : 'hide-dismissible',
 					$banner->action


### PR DESCRIPTION
## Description
This PR adds the migration banner to shipping settings under the **WooCommerce Shipping** tab.

### Related issue(s)
https://github.com/woocommerce/shipping/issues/152


### Notes: 
- See [this comment](https://github.com/woocommerce/shipping/issues/152#issuecomment-2231517482) on the issue.

### Steps to reproduce & screenshots/GIFs

- Checkout this branch.
- Build the plugin.
- Remove `wcshipping_migration_state` from options table.
- Use connect-server staging for your local dev install by setting `https://api-staging.woocommerce.com/as value for `WOOCOMMERCE_CONNECT_SERVER_URL` env.
- Install WC Shipping plugin without activating it.
- Visit WC -> Settings -> Shipping -> WooCommerce Shipping.
- Verify you can see the upgrade banner.
- Click on `Confirm update` and verify you get redirected to the plugins page and WC Shipping plugin is activated.

![Wuqexz.png](https://github.com/user-attachments/assets/3a21530d-4d1a-4210-882b-bd4e38a24910)
### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added