### PR TITLE
Introduce new "wc_services_will_disable_shipping_logic" hook

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -346,7 +346,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'plugins_loaded', array( $this, 'jetpack_on_plugins_loaded' ), 1 );
 
 			/**
-			 * Used to let WC Tax know WCS&T will handle the plugins' coexistence.
+			 * Used to let WC Tax know WCS&T will handle the plugin's coexistence.
 			 *
 			 * WCS&T does it by not registering its functionality and displaying an appropriate notice
 			 * in WP admin.
@@ -355,11 +355,14 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			 * loading of all shipping functionality inside WCS&T, so there's no special need for any
 			 * "parallel support" being done in WC Shipping anymore.
 			 *
-			 * This filter is documented in woocommerce-services.php
+			 * This new feature is represented via the "wc_services_will_disable_shipping_logic" hook.
 			 */
 			if ( $this->are_woo_shipping_and_woo_tax_active() ) {
 				add_filter( 'wc_services_will_handle_coexistence_with_woo_shipping_and_woo_tax', '__return_true' );
 			}
+
+			// Let WC Shipping know that the current version of WCS&T supports conditional shipping logic loading.
+			add_filter( 'wc_services_will_disable_shipping_logic', '__return_true' );
 		}
 
 		public function get_logger() {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -335,7 +335,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->wc_connect_base_url = self::get_wc_connect_base_url();
 			add_action(
 				'before_woocommerce_init',
-				function() {
+				function () {
 					if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
 						\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', 'woocommerce-services/woocommerce-services.php' );
 					}
@@ -344,6 +344,22 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ) );
 			add_action( 'plugins_loaded', array( $this, 'jetpack_on_plugins_loaded' ), 1 );
+
+			/**
+			 * Used to let WC Tax know WCS&T will handle the plugins' coexistence.
+			 *
+			 * WCS&T does it by not registering its functionality and displaying an appropriate notice
+			 * in WP admin.
+			 *
+			 * The filter also includes "woo_shipping" in its name, but we've since implemented conditional
+			 * loading of all shipping functionality inside WCS&T, so there's no special need for any
+			 * "parallel support" being done in WC Shipping anymore.
+			 *
+			 * This filter is documented in woocommerce-services.php
+			 */
+			if ( $this->are_woo_shipping_and_woo_tax_active() ) {
+				add_filter( 'wc_services_will_handle_coexistence_with_woo_shipping_and_woo_tax', '__return_true' );
+			}
 		}
 
 		public function get_logger() {
@@ -584,28 +600,26 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			/**
 			 * Allow third party logic to determine if this plugin should initiate its logic.
 			 *
-			 * The primary purpose here is to allow a smooth transition between the new Woo Shipping / Woo Tax plugins
+			 * The primary purpose here is to allow a smooth transition between the new WC Tax plugin
 			 * and WooCommerce Shipping & Tax (this plugin), by letting them take over all responsibilities if all three
 			 * plugins are activated at the same time.
 			 *
 			 * @since {{next-release}}
 			 *
-			 * @todo Replace this notice with something that says "This will purely be a Tax plugin by <date>".
-			 *
 			 * @param bool $status The value will determine if we should initiate the plugins logic or not.
 			 */
 			if ( apply_filters( 'wc_services_will_handle_coexistence_with_woo_shipping_and_woo_tax', false ) ) {
+				// Show message that WCS&T is no longer doing anything.
 				add_action( 'admin_notices', array( $this, 'display_woo_shipping_and_woo_tax_are_active_notice' ) );
+
+				// Bail, so none of our tax and shipping logic will be initiated.
 				return;
 			}
-
-			// We indicate that we will handle coexistence with WC Shipping
-			add_filter( 'wc_services_will_handle_coexistence_with_woo_shipping_and_woo_tax', '__return_true' );
 
 			if ( ! class_exists( 'WooCommerce' ) ) {
 				add_action(
 					'admin_notices',
-					function() {
+					function () {
 						/* translators: %s WC download URL link. */
 						echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'WooCommerce Shipping & Tax requires the WooCommerce plugin to be installed and active. You can download %s here.', 'woocommerce-services' ), '<a href="https://wordpress.org/plugins/woocommerce/" target="_blank">WooCommerce</a>' ) . '</strong></p></div>';
 					}
@@ -699,7 +713,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		public function init_core_wizard_shipping_config() {
-			// @todo Verify what happens if WCS&T was installed without this, and WC Shipping is then deactivated.
 			if ( $this->is_wc_shipping_activated() ) {
 				return;
 			}
@@ -1270,8 +1283,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			// Abort if no $order was passed, if the order is not marked as 'completed' or if another extension is handling the emailing.
 			if ( ! $order
-				 || ! $order->has_status( 'completed' )
-				 || ! WC_Connect_Extension_Compatibility::should_email_tracking_details( $order->get_id() ) ) {
+				|| ! $order->has_status( 'completed' )
+				|| ! WC_Connect_Extension_Compatibility::should_email_tracking_details( $order->get_id() ) ) {
 				return;
 			}
 
@@ -1825,7 +1838,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * @return void
 		 */
 		public function display_woo_shipping_and_woo_tax_are_active_notice() {
-			echo '<div class="error"><p><strong>' . esc_html__( 'Woo Shipping and Woo Tax plugins are already active. Please deactivate WooCommerce Shipping & Tax.', 'woocommerce-services' ) . '</strong></p></div>';
+			echo '<div class="error"><p><strong>' . esc_html__( 'WC Shipping and WC Tax plugins are already active. Please deactivate WooCommerce Shipping & Tax.', 'woocommerce-services' ) . '</strong></p></div>';
 		}
 	}
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

We've previously agreed to rely on a hook called `wc_services_will_handle_coexistence_with_woo_shipping_and_woo_tax` that will return `true` if both WC Tax and WC Shipping are activated and that all logic in WCS&T will stop working if that's the case, so our individual plugins can take over.

The #2761 PR will force the hook to always be "true" which causes two issues:
1. It's purely down to a race-condition that we're not blocking both Tax and Shipping from being initiated.
    * _The "bail early" logic is defined in `on_plugins_loaded` which comes _after_ we force the hook to always be true._
2. WC Tax will always assume that it can initiate its logic while WCS&T _also_ initiates its tax logic which causes issues.

We should instead add a new filter (`wc_services_will_disable_shipping_logic`) that represents WCS&T supporting conditionally loading shipping, so WC Shipping can listen for that as well as the pre-existing `wc_services_will_handle_coexistence_with_woo_shipping_and_woo_tax` condition.

_Note: we could remove `wc_services_will_handle_coexistence_with_woo_shipping_and_woo_tax` but that would prevent us from being able to have months old versions of WCS&T be able to work with both individual plugins present and it's the only WC Tax specific support WCS&T has right now, so it doesn't make sense to remove it._ 

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

- Related to #2761 

### How to test

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

_**Important!** Make sure WC Tax isn't activated when you go through this test to make sure we're testing the new `wc_services_will_disable_shipping_logic` filter._

* Spin up a local environment using this branch
* Activate a version of WC Shipping that includes https://github.com/woocommerce/woocommerce-shipping/pull/586
* Activate automated taxes and verify that they still apply in checkout
* Go to your new order you just created while verifying automated taxes works
* Purchase a shipping label that uses the new WC Shipping experience.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

