### PR TITLE
Status page should respect shipping conditional loading

### DIFF
--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -119,6 +119,10 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			return $health_items;
 		}
 
+		protected function is_shipping_loaded() {
+			return ! in_array( 'woocommerce-shipping/woocommerce-shipping.php', get_option( 'active_plugins' ) );
+		}
+
 		protected function get_services_items() {
 			$available_service_method_ids = $this->service_schemas_store->get_all_shipping_method_ids();
 			if ( empty( $available_service_method_ids ) ) {
@@ -261,16 +265,17 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 		 */
 		protected function get_form_data() {
 			return array(
-				'health_items'     => $this->get_health_items(),
-				'services'         => $this->get_services_items(),
-				'logging_enabled'  => $this->logger->is_logging_enabled(),
-				'debug_enabled'    => $this->logger->is_debug_enabled(),
-				'logs'             => array(
+				'health_items'       => $this->get_health_items(),
+				'services'           => $this->get_services_items(),
+				'logging_enabled'    => $this->logger->is_logging_enabled(),
+				'debug_enabled'      => $this->logger->is_debug_enabled(),
+				'logs'               => array(
 					'shipping' => $this->get_debug_log_data( 'shipping' ),
 					'taxes'    => $this->get_debug_log_data( 'taxes' ),
 					'other'    => $this->get_debug_log_data(),
 				),
-				'tax_rate_backups' => WC_Connect_Functions::get_backed_up_tax_rate_files(),
+				'tax_rate_backups'   => WC_Connect_Functions::get_backed_up_tax_rate_files(),
+				'is_shipping_loaded' => $this->is_shipping_loaded(),
 			);
 		}
 
@@ -296,8 +301,9 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 				'enqueue_wc_connect_script',
 				'wc-connect-admin-test-print',
 				array(
-					'storeOptions' => $this->service_settings_store->get_store_options(),
-					'paperSize'    => $this->service_settings_store->get_preferred_paper_size(),
+					'isShippingLoaded' => $this->is_shipping_loaded(),
+					'storeOptions'     => $this->service_settings_store->get_store_options(),
+					'paperSize'        => $this->service_settings_store->get_preferred_paper_size(),
 				)
 			);
 		}
@@ -308,42 +314,42 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 		protected function get_tax_health_item() {
 			$store_country = WC()->countries->get_base_country();
 			if ( ! $this->taxjar_integration->is_supported_country( $store_country ) ) {
-				return [
+				return array(
 					'state'              => 'error',
 					'settings_link_type' => '',
 					'message'            => sprintf( __( 'Your store\'s country (%s) is not supported. Automated taxes functionality is disabled', 'woocommerce-services' ), $store_country ),
-				];
+				);
 			}
 
 			if ( class_exists( 'WC_Taxjar' ) ) {
-				return [
+				return array(
 					'state'              => 'error',
 					'settings_link_type' => '',
 					'message'            => __( 'TaxJar extension detected. Automated taxes functionality is disabled', 'woocommerce-services' ),
-				];
+				);
 			}
 
 			if ( ! wc_tax_enabled() ) {
-				return [
+				return array(
 					'state'              => 'error',
 					'settings_link_type' => 'general',
 					'message'            => __( 'The core WooCommerce taxes functionality is disabled. Please ensure the "Enable tax rates and calculations" setting is turned "on" in the WooCommerce settings page', 'woocommerce-services' ),
-				];
+				);
 			}
 
 			if ( ! $this->taxjar_integration->is_enabled() ) {
-				return [
+				return array(
 					'state'              => 'error',
 					'settings_link_type' => 'tax',
 					'message'            => __( 'The automated taxes functionality is disabled. Enable the "Automated taxes" setting on the WooCommerce settings page', 'woocommerce-services' ),
-				];
+				);
 			}
 
-			return [
+			return array(
 				'state'              => 'success',
 				'settings_link_type' => 'tax',
 				'message'            => __( 'Automated taxes are enabled', 'woocommerce-services' ),
-			];
+			);
 		}
 	}
 

--- a/client/apps/plugin-status/health.js
+++ b/client/apps/plugin-status/health.js
@@ -14,7 +14,7 @@ import WooCommerceServicesIndicator from './woocommerce-services-indicator';
 import SettingsGroupCard from 'woocommerce/woocommerce-services/components/settings-group-card';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
-const HealthView = ( { translate, healthItems } ) => {
+const HealthView = ( { translate, healthItems, isShippingLoaded } ) => {
 	return (
 		<SettingsGroupCard heading={translate('Health', {
 			context: 'This section displays the overall health of WooCommerce Shipping & Tax and the things it depends on',
@@ -62,7 +62,8 @@ const HealthView = ( { translate, healthItems } ) => {
 					</ExternalLink>
 				</FormSettingExplanation>
 			</Indicator>
-			<WooCommerceServicesIndicator/>
+
+			{ isShippingLoaded && <WooCommerceServicesIndicator/> }
 		</SettingsGroupCard>
 
 	);
@@ -71,5 +72,6 @@ const HealthView = ( { translate, healthItems } ) => {
 export default connect(
 	( state ) => ( {
 		healthItems: state.status.health_items,
+		isShippingLoaded: state.status.is_shipping_loaded
 	} )
 )( localize( HealthView ) );

--- a/client/apps/plugin-status/test/health.test.js
+++ b/client/apps/plugin-status/test/health.test.js
@@ -50,7 +50,8 @@ const Wrapper = ({ children, healthStoreOverrides }) => (
 			health_items: {
 				...defaultHealthStoreValues,
 				...healthStoreOverrides,
-			}
+			},
+			is_shipping_loaded: true,
 		},
 	})}>
 		{children}

--- a/client/apps/plugin-status/view.js
+++ b/client/apps/plugin-status/view.js
@@ -22,7 +22,7 @@ import {
 	toggleDebugging,
 } from './state/actions';
 
-const StatusView = ( { onLoggingToggle, onDebuggingToggle, isLoggingEnabled, isDebuggingEnabled, taxRateBackups, translate } ) => {
+const StatusView = ( { onLoggingToggle, onDebuggingToggle, isLoggingEnabled, isDebuggingEnabled, taxRateBackups, translate, isShippingLoaded } ) => {
 	return (
 		<div>
 			<GlobalNotices id="notices" notices={ notices.list } />
@@ -47,9 +47,7 @@ const StatusView = ( { onLoggingToggle, onDebuggingToggle, isLoggingEnabled, isD
 					falseText={ translate( 'Disabled' ) }
 					onUpdate={ onLoggingToggle }
 				/>
-				<LogView
-					logKey="shipping"
-					title={ translate( 'Shipping Log' ) } />
+				{ isShippingLoaded && <LogView logKey="shipping" title={ translate( 'Shipping Log' ) }/> }
 				<LogView
 					logKey="taxes"
 					title={ translate( 'Taxes Log' ) } />
@@ -112,6 +110,7 @@ const mapStateToProps = ( state ) => ( {
 	isLoggingEnabled: Boolean( state.status.logging_enabled ),
 	isDebuggingEnabled: Boolean( state.status.debug_enabled ),
 	taxRateBackups: state.status.tax_rate_backups,
+	isShippingLoaded: state.status.is_shipping_loaded,
 } );
 
 const mapDispatchToProps = {

--- a/client/apps/print-test-label/index.js
+++ b/client/apps/print-test-label/index.js
@@ -10,7 +10,7 @@ import './style.scss';
 import PrintTestLabelView from './view';
 import reducer from './state/reducer';
 
-export default ( { paperSize, storeOptions } ) => ( {
+export default ( { paperSize, storeOptions, isShippingLoaded } ) => ( {
 	getReducer() {
 		return reducer;
 	},
@@ -19,6 +19,7 @@ export default ( { paperSize, storeOptions } ) => ( {
 		return {
 			paperSize,
 			country: storeOptions.origin_country,
+			isShippingLoaded,
 		};
 	},
 

--- a/client/apps/print-test-label/view.js
+++ b/client/apps/print-test-label/view.js
@@ -32,8 +32,13 @@ class PrintTestLabelView extends Component {
 	onPaperSizeChange = ( event ) => this.props.updatePaperSize( event.target.value );
 
 	render() {
-		const { paperSize, country, printingInProgress, error, print } = this.props;
+		const { paperSize, country, printingInProgress, error, print, isShippingLoaded } = this.props;
 		const paperSizes = getPaperSizes( country );
+
+		// Bail early if shipping is not enabled since it no longer makes sense to do label test prints.
+		if ( ! isShippingLoaded ) {
+			return null;
+		}
 
 		return (
 			<SettingsGroupCard heading={ __( 'Print' ) } >


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

The status page needs to respect the new "conditional shipping loading" condition where WC Shipping is able to take over the entire shipping experience.

This PR aims to hide all shipping status on the status page by hiding the following sections:

**Health > WooCommerce Shipping & Tax Data**: Although it includes "Tax Data" in its name, then the services data we fetch are all shipping related, so it's a bit misleading. TL;DR: We should just hide it.

**Debug > Shipping Log**: We should, hopefully, not log anything shipping related, but even if we do, then this just hides it from the UI which is good enough.

**Print**: No need for us to allow test label prints when we have disabled all shipping features.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

- Related to #2761 

### How to test

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

1. Spin up plugin locally using this branch
2. Create a WPCOM connection
3. Go to `/wp-admin/admin.php?page=wc-status&tab=connect`
4. Verify that all of the sections from the screenshot appears
5. Activate WC Shipping (any version will do)
6. Refresh `/wp-admin/admin.php?page=wc-status&tab=connect`
7. Verify that the following sections are now hidden:
    a. Health > WooCommerce Shipping & Tax Data
    b. Debug > Shipping Log
    c. Print

### screenshots/GIFs

#### Before PR when WC Shipping is activated

![Screenshot 2024-07-23 at 03 58 39](https://github.com/user-attachments/assets/4b6f181a-4a72-4d63-9eeb-0877ba38dc81)

#### With PR when WC Shipping is activated

![Screenshot 2024-07-23 at 04 36 58](https://github.com/user-attachments/assets/cc4441be-520a-48ed-9c4a-060229825f31)

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

