### PR TITLE
Conditionally shows legacy reports shipping tab

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -809,7 +809,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$shipping_label        = new WC_Connect_Shipping_Label( $api_client, $settings_store, $schemas_store, $payment_methods_store );
 			$nux                   = new WC_Connect_Nux( $tracks, $shipping_label );
 			$taxjar                = new WC_Connect_TaxJar_Integration( $api_client, $taxes_logger, $this->wc_connect_base_url );
-			$options               = new WC_Connect_Options();
 			$paypal_ec             = new WC_Connect_PayPal_EC( $api_client, $nux );
 			$label_reports         = new WC_Connect_Label_Reports( $settings_store );
 
@@ -872,7 +871,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'admin_enqueue_scripts', array( $this->nux, 'show_pointers' ) );
 			add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'add_plugin_action_links' ) );
 			add_action( 'enqueue_wc_connect_script', array( $this, 'enqueue_wc_connect_script' ), 10, 2 );
-			add_filter( 'woocommerce_admin_reports', array( $this, 'reports_tabs' ) );
 
 			$tracks = $this->get_tracks();
 			$tracks->init();
@@ -895,6 +893,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function init_shipping() {
 			$schemas_store = $this->get_service_schemas_store();
 			$schemas       = $schemas_store->get_service_schemas();
+
+			add_filter( 'woocommerce_admin_reports', array( $this, 'reports_tabs' ) );
 
 			// Changing the postcode, currency, weight or dimension units affect the returned schema from the server.
 			// Make sure to update the service schemas when these options change.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Kind of a random finding when checking out some unrelated analytics functionality, but we didn't include the `WooCommerce > Reports > Shipping Labels` tab

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

- Fixed #2781

### Steps to reproduce

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

* Checkout this trunk locally
* Activate any version of WC Shipping
  * _You don't need to run the dev server if you're using a dev version - the plugin just needs to be activated to trigger the conditional loading logic_
* Go to `/wp-admin/admin.php?page=wc-reports&tab=wcs_labels`
* Verify you see the reports `Shipping Labels` tab
* Checkout this branch
* Refresh the `/wp-admin/admin.php?page=wc-reports&tab=wcs_labels` page
* Verify that the `Shipping Labels` tab is no longer appearing
  * _You'll probably be shown the `Orders` tab instead_

## Screenshots

![Screenshot 2024-07-24 at 20 59 40](https://github.com/user-attachments/assets/900f588a-a5ad-488c-9e60-6dce5a9aecf6)

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

