### PR TITLE
Fix error launching the migration popup

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -2018,9 +2018,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					'adminPluginPath' => admin_url( 'plugins.php' ),
 				)
 			);
+			wp_enqueue_script( 'wc_connect_admin' );
 			wp_enqueue_script( 'wcst_wcshipping_migration_admin_notice' );
 			wp_enqueue_style( 'wcst_wcshipping_migration_admin_notice' );
-			wp_enqueue_script( 'wc_connect_admin' );
 		}
 	}
 }


### PR DESCRIPTION
-------

## Description
When the `wc_connect_admin` scripts are loaded after the migration ones, there's a JavaScript error avoiding us to launch the migration popup:

```
ReferenceError: regeneratorRuntime is not defined
    at fetchAPICall (migration-runner.js:111:22)
    at Module.<anonymous> (migration-runner.js:133:19)
    at ./client/components/migration/migration-runner.js (woocommerce-services-wcshipping-migration-admin-notice-2.7.0.js:3504:30)
    at __webpack_require__ (woocommerce-services-wcshipping-migration-admin-notice-2.7.0.js:833:30)
    at fn (woocommerce-services-wcshipping-migration-admin-notice-2.7.0.js:130:20)
    at Module.<anonymous> (woocommerce-services-wcshipping-migration-admin-notice-2.7.0.js:2757:76)
    at ./client/components/migration/feature-announcement.jsx (woocommerce-services-wcshipping-migration-admin-notice-2.7.0.js:2918:30)
    at __webpack_require__ (woocommerce-services-wcshipping-migration-admin-notice-2.7.0.js:833:30)
    at fn (woocommerce-services-wcshipping-migration-admin-notice-2.7.0.js:130:20)
    at Module.<anonymous> (woocommerce-services-wcshipping-migration-admin-notice-2.7.0.js:16291:99)
```

This PR fixes the issue by loading the `wc_connect_admin` scripts before the migration ones.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

N/A

### Steps to reproduce & screenshots/GIFs

1. Check out the `wcs-migration` branch, and try to trigger the migration popup in the orders screen with the developer console open. You'll see the error.
2. Check out this PR's branch and try again. The error should be gone and the migration flow should work as expected.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added