### PR TITLE
Update readme.txt to indicate that a new Woo Shipping plugin is available for download.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,5 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
-= 2.7.1 - 2024-xx-xx =
-* Update - Update readme.txt file to indicate that a new Woo Shipping plugin is available for download.
-
 = 2.7.0 - 2024-07-25 =
 * Add - Parallel compatibility with WooCommerce Shipping plugin.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.7.1 - 2024-xx-xx =
+* Update - Update readme.txt file to indicate that a new Woo Shipping plugin is available for download.
+
 = 2.7.0 - 2024-07-25 =
 * Add - Parallel compatibility with WooCommerce Shipping plugin.
 

--- a/readme.txt
+++ b/readme.txt
@@ -15,6 +15,8 @@ WooCommerce Shipping & Tax offers automated tax calculation, shipping label prin
 
 == Description ==
 
+**Attention:** Shipping features have moved to a new dedicated plugin. [Download the new plugin](https://wordpress.org/plugins/woocommerce-shipping/).
+
 WooCommerce Shipping & Tax makes basic eCommerce features like shipping more reliable by taking the burden off of your site’s infrastructure.
 
 With WooCommerce Shipping & Tax, critical services are hosted on Automattic’s best-in-class infrastructure, rather than relying on your store’s hosting. That means your store will be more stable and faster.
@@ -78,6 +80,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 6. Checking and exporting the label purchase reports
 
 == Changelog ==
+
+= 2.7.1 - 2024-xx-xx =
+* Update - Update readme.txt file to indicate that a new Woo Shipping plugin is available for download.
 
 = 2.7.0 - 2024-07-25 =
 * Add - Parallel compatibility with WooCommerce Shipping plugin.

--- a/readme.txt
+++ b/readme.txt
@@ -15,7 +15,7 @@ WooCommerce Shipping & Tax offers automated tax calculation, shipping label prin
 
 == Description ==
 
-**Attention:** Shipping features have moved to a new dedicated plugin. [Download the new plugin](https://wordpress.org/plugins/woocommerce-shipping/).
+**Attention:** Shipping features have moved to a new dedicated plugin. [Download WooCommerce Shipping](https://wordpress.org/plugins/woocommerce-shipping/).
 
 WooCommerce Shipping & Tax makes basic eCommerce features like shipping more reliable by taking the burden off of your site’s infrastructure.
 
@@ -80,9 +80,6 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 6. Checking and exporting the label purchase reports
 
 == Changelog ==
-
-= 2.7.1 - 2024-xx-xx =
-* Update - Update readme.txt file to indicate that a new Woo Shipping plugin is available for download.
 
 = 2.7.0 - 2024-07-25 =
 * Add - Parallel compatibility with WooCommerce Shipping plugin.


### PR DESCRIPTION
## Description
Add `**Attention:** Shipping features have moved to a new dedicated plugin. [Download the new plugin](https://wordpress.org/plugins/woocommerce-shipping/).` to readme.txt.

### Related issue(s)
Closes https://github.com/Automattic/woocommerce-services/issues/2788

### Steps to test
We can run the readme.txt through the validator https://wordpress.org/plugins/developers/readme-validator/. But nothing else to test. 


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

