### PR TITLE
Fix issue with e2e not starting [2790]

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -43,6 +43,10 @@ jobs:
             composer install
             npm ci
             npm run dist
+      - name: Install docker-compose
+        run: |
+          sudo curl -L "https://github.com/docker/compose/releases/download/v2.3.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
       - name: Setup E2E container
         run: |
             npm run test:e2e-docker-up


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
This PR  make sure `docker-compose` command exists before trying to setup the e2e environment, which relies on this.

### Related issue(s)

#2790 
### Steps to reproduce & screenshots/GIFs

If the e2e tests can run, the PR is green.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

