### PR TITLE
Add a new widget in settings to start the migration

### DIFF
--- a/client/apps/shipping-settings/view-wrapper.js
+++ b/client/apps/shipping-settings/view-wrapper.js
@@ -13,6 +13,7 @@ import classNames from 'classnames';
  */
 // from calypso
 import GlobalNotices from 'components/global-notices';
+import MigratorSettings from '../../extensions/woocommerce/woocommerce-services/views/migrator-settings';
 import LabelSettings from '../../extensions/woocommerce/woocommerce-services/views/label-settings';
 import notices from 'notices';
 import Packages from '../../extensions/woocommerce/woocommerce-services/views/packages';
@@ -69,6 +70,7 @@ class LabelSettingsWrapper extends Component {
 			return (
 				<div>
 					<GlobalNotices id="notices" notices={ notices.list } />
+					<MigratorSettings />
 					<LabelSettings onChange={ this.onChange } />
 					<Packages onChange={ this.onChange } />
 					<LiveRatesCarriersList carrierIds={ liveRatesTypes } />

--- a/client/components/migration/feature-announcement.jsx
+++ b/client/components/migration/feature-announcement.jsx
@@ -20,7 +20,7 @@ import {
 import { installAndActivatePlugins } from './migration-runner';
 import { TIME_TO_REMMEMBER_DISMISSAL_SECONDS } from './constants';
 
-const FeatureAnnouncement = ( { translate, isEligable, previousMigrationState } ) => {
+const FeatureAnnouncement = ( { translate, isEligable, previousMigrationState, onClose } ) => {
 	const [isOpen, setIsOpen] = useState(isEligable);
 	const [isUpdating, setIsUpdating] = useState(false);
 
@@ -33,11 +33,13 @@ const FeatureAnnouncement = ( { translate, isEligable, previousMigrationState } 
 
 	const closeModal = () => {
 		setIsOpen(false);
+		onClose && onClose();
 	};
 
 	const snooze = () => {
 		window.wpCookies.set( 'wcst-wcshipping-migration-dismissed', 1, TIME_TO_REMMEMBER_DISMISSAL_SECONDS );
 		setIsOpen( false );
+		onClose && onClose();
 	};
 
 	const update = async () => {

--- a/client/extensions/woocommerce/woocommerce-services/views/migrator-settings/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/migrator-settings/index.js
@@ -1,0 +1,93 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { localize } from 'i18n-calypso';
+import { Button } from '@wordpress/components';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import ExtendedHeader from 'woocommerce/components/extended-header';
+import FeatureAnnouncement from 'components/migration/feature-announcement';
+import './style.scss';
+
+class MigratorSettingsRootView extends Component {
+	state = {
+		isMigrationNoticeVisible: false,
+		isMigrationNoticeDismissed: false,
+	};
+
+	componentWillMount() {
+		const migrationCookie = window.wpCookies.get( 'wcst-wcshipping-migration-dismissed' );
+		this.setState({ isMigrationNoticeDismissed: migrationCookie && parseInt( migrationCookie ) });
+	}
+
+	componentWillUnmount() {
+		this.props.restorePristineSettings(this.props.siteId);
+	}
+
+	addPackage = () => {
+		this.props.onChange();
+		this.props.addPackage(siteId);
+	};
+
+	showMigrationNotice = () => {
+		window.wpCookies.remove( 'wcst-wcshipping-migration-dismissed' );
+		this.setState({ isMigrationNoticeVisible: true });
+	}
+
+	onFeatureAnnouncementClosed = () => {
+		this.setState({ isMigrationNoticeVisible: false });
+	}
+
+	render() {
+		const {
+			translate,
+		} = this.props;
+
+		if ( ! this.state.isMigrationNoticeDismissed ) {
+			return null
+		}
+
+		return (
+			<div className="woocommerce-migrator-settings-root-view">
+				<ExtendedHeader
+					label={translate('Migration to WooCommerce Shipping')}
+					description={translate(
+						'You can now migrate to WooCommerce Shipping. This will provide you with a dedicated WooCommerce Shipping extension, which will carry over all your settings and shipping labels when you update.'
+					)}
+				>
+					<Button
+						className={classNames('button')}
+						onClick={ this.showMigrationNotice }
+					>{translate('Start migration process')}</Button>
+				</ExtendedHeader>
+				{ this.state.isMigrationNoticeVisible && (
+					<FeatureAnnouncement onClose={ this.onFeatureAnnouncementClosed }/>
+				) }
+			</div>
+		);
+	}
+}
+
+MigratorSettingsRootView.propTypes = {};
+
+function mapStateToProps() {
+	return {};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators( {}, dispatch );
+}
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( MigratorSettingsRootView ) );

--- a/client/extensions/woocommerce/woocommerce-services/views/migrator-settings/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/migrator-settings/index.js
@@ -39,6 +39,9 @@ class MigratorSettingsRootView extends Component {
 	};
 
 	showMigrationNotice = () => {
+		if ( window.wcTracks ) {
+			window.wcTracks.recordEvent( 'woocommerceconnect_migration_started_from_settings' );
+		}
 		window.wpCookies.remove( 'wcst-wcshipping-migration-dismissed' );
 		this.setState({ isMigrationNoticeVisible: true });
 	}

--- a/client/extensions/woocommerce/woocommerce-services/views/migrator-settings/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/migrator-settings/style.scss
@@ -1,0 +1,3 @@
+.woocommerce-migrator-settings-root-view {
+	margin-bottom: 10px;
+}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1852,10 +1852,20 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function enqueue_wc_connect_script( $root_view, $extra_args = array() ) {
 			$is_alive = $this->api_client->is_alive_cached();
 
-			$payload = array(
+			$account_settings  = new WC_Connect_Account_Settings(
+				$this->service_settings_store,
+				$this->payment_methods_store
+			);
+			$packages_settings = new WC_Connect_Package_Settings(
+				$this->service_settings_store,
+				$this->service_schemas_store
+			);
+			$payload           = array(
 				'nonce'                 => wp_create_nonce( 'wp_rest' ),
 				'baseURL'               => get_rest_url(),
 				'wcs_server_connection' => $is_alive,
+				'accountSettings'       => $account_settings->get(),
+				'packagesSettings'      => $packages_settings->get(),
 			);
 
 			wp_localize_script( 'wc_connect_admin', 'wcConnectData', $payload );


### PR DESCRIPTION
## Description
When the user dismisses the migration notice, there's no way to start the migration until the user is remembered again after a few days. This PR adds a new widget at the top of the settings page to start the migration manually.

### Related issue(s)
N/A

### Steps to reproduce & screenshots/GIFs
1. Checkout this branch.
2. Deactivate WooCommerce Shipping in case is already activated.
3. Go to the WooCommerce Shipping & Tax settings page `/wp-admin/admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings`. The widget should **not** appear at the top of the settings form.
![shot-2024-08-14-09-51-43](https://github.com/user-attachments/assets/7681f3f4-079f-4d35-9f6c-5e5807551111)

4. Go to the orders list page, and dismiss the migration notice by clicking on the close button of the notice.
5. Now go to the WooCommerce Shipping & Tax settings page again. The widget should appear at the top of the settings form.
![shot-2024-08-14-09-52-11](https://github.com/user-attachments/assets/71766f48-97de-4060-999f-fb2703819e7b)

6. Press the "Start migration process" button. The migration popup should appear, allowing you to start the migration.
7. Pressing the close button or the "Maybe later" button, should close the popup.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added