### PR TITLE
Move require_once for WC_REST_Connect_Migration_Flag_Controller out from the is_wc_shipping_activated() condition

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1102,12 +1102,12 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				$rest_carrier_types_controller = new WC_REST_Connect_Shipping_Carrier_Types_Controller( $this->api_client, $settings_store, $logger );
 				$this->set_carrier_types_controller( $rest_carrier_types_controller );
 				$rest_carrier_types_controller->register_routes();
-
-				require_once __DIR__ . '/classes/class-wc-rest-connect-migration-flag-controller.php';
-				$rest_migration_flag_controller = new WC_REST_Connect_Migration_Flag_Controller( $this->api_client, $settings_store, $logger, $this->tracks );
-				$this->set_rest_migration_flag_controller( $rest_migration_flag_controller );
-				$rest_migration_flag_controller->register_routes();
 			}
+			require_once __DIR__ . '/classes/class-wc-rest-connect-migration-flag-controller.php';
+			$rest_migration_flag_controller = new WC_REST_Connect_Migration_Flag_Controller( $this->api_client, $settings_store, $logger, $this->tracks );
+			$this->set_rest_migration_flag_controller( $rest_migration_flag_controller );
+			$rest_migration_flag_controller->register_routes();
+
 			require_once __DIR__ . '/classes/class-wc-rest-connect-shipping-carriers-controller.php';
 			$rest_carriers_controller = new WC_REST_Connect_Shipping_Carriers_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_carriers_controller( $rest_carriers_controller );


### PR DESCRIPTION
## Description
The `require_once __DIR__ . '/classes/class-wc-rest-connect-migration-flag-controller.php';` is not loaded if WCShipping is activated.

This API endpoint needs to work on both plugins. This PR moves it out from the `if ( ! $this->is_wc_shipping_activated() ) {..}` condition.

### Related issue(s)
Fixes https://github.com/woocommerce/woocommerce-shipping/issues/687

### Steps to test
1. Pull this branch, deactivate "WooCommerce Shipping", activate WCS&T.
2. Delete this option `delete from wp_options where option_name = 'wcshipping_migration_completed_message_shown';`
3. Open `wordpress/wp-content/plugins/woocommerce-services/classes/class-wc-connect-service-settings-store.php` and add `delete_option( 'wcshipping_migration_state' );` in the `is_eligible_for_migration()`, something like this:
```diff
+			delete_option( 'wcshipping_migration_state' );
			$migration_state = get_option( 'wcshipping_migration_state' );
```
Step 2 and 3 above resets the migration state memory, which will show this banner again
![image](https://github.com/user-attachments/assets/106e95b2-c00e-4df5-ae42-ac8358f0bd37)

4. Go to the orders page http://localhost/wp-admin/edit.php?post_type=shop_order and click the "Confirm Update" button.
5. The green successful banner is now shown
![image](https://github.com/user-attachments/assets/21c39f7e-04f0-4bbf-a86b-ed3a1e9659da)

### Dev notes
I didn't add a changelog for this because the existing `2.8.0` changelog already has something similar `* Add - A new migration experience from this plugin to the newly released WooCommerce Shipping plugin.`.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

