### PR TITLE
Correct `migration_flag_state_update` event property

### DIFF
--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -276,7 +276,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					'migration_flag_state_update',
 					array(
 						'migration_state' => $migration_state,
-						'updated'         => $result,
+						'updated'         => false,
 					)
 				);
 			}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

You can read more on #2803 but TL;DR: `$result` doesn't exist.
Looking at the other location the track is use, then it's expected to be a boolean. We're not modifying the value in this location, so it should be `false`.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

* Fixes #2803

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

N/A

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

