### PR TITLE
Hide migration nudges for legacy WCS&T merchants

### DIFF
--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -625,6 +625,11 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				return false;
 			}
 
+			// Hide the migration notification if the site has any active shipping methods defined by WCS&T.
+			if ( ! empty( $this->get_enabled_services() ) ) {
+				return false;
+			}
+
 			$migration_dismissed = false;
 			if ( isset( $_COOKIE[ WC_Connect_Loader::MIGRATION_DISMISSAL_COOKIE_KEY ] ) && (int) $_COOKIE[ WC_Connect_Loader::MIGRATION_DISMISSAL_COOKIE_KEY ] === 1 ) {
 				$migration_dismissed = true;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Although new users of the feature has been disabled for about 6 years, then we still have some WCS&T merchants that user our live rate Shipping Method. Migrating them to WC Shipping will cause them to lose their shipping methods and thereby, potentially, not charge any shipping fees in checkout (read: they might not have other alternative shipping methods in place).

This PR aims to hide the migration banner so we can reach out to them via email and share custom path forward to reach feature parity.

## Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

* pevPIe-PB-p2

## Steps to reproduce

1. Checkout trunk locally
2. Delete the `wcshipping_migration_state` option
3. Make sure WC Shipping isn't activated
4. Follow the instructions in the WCS PR no. 2590 to enable legacy shipping methods on your site
3. Go to "WooCommerce > Settings > Shipping > Shipping Zones" (/wp-admin/admin.php?page=wc-settings&tab=shipping)
4. Edit (or add) a shipping zone
5. Add a WCS&T shipping method to any zone (the settings doesn't matter)
6. Refresh the page
7. Verify you see the migration banner from the screenshot section
8. Checkout this branch locally
9. Refresh the page
10. Verify the banner is no longer showing
11. Go to "WooCommerce > Settings > Shipping > Shipping Zones" (`/wp-admin/admin.php?page=wc-settings&tab=shipping`)
12. Delete all WCS&T shipping methods
13. Refresh the page
14. Verify you're seeing the banner again

_**Bonus**: if you repeat the steps above but with the feature announcement instead (read: the announcement we show when opening the "Purchase shipping labels" modal)._

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

## Screenshots/GIFs

![Screenshot 2024-09-08 at 18 43 15](https://github.com/user-attachments/assets/446ee9ca-d253-43c6-9871-6c64c7a1f027)


## Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added