### PR TITLE
Use `actions/upload-artifact@v4`

### DIFF
--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -47,7 +47,7 @@ jobs:
         run: cat ${{ github.workspace }}/qit-results/qit-security-results.txt
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: qit-results
           path: ${{ github.workspace }}/qit-results/

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -47,7 +47,7 @@ jobs:
         run: cat ${{ github.workspace }}/qit-results/qit-security-results.txt
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: qit-results
           path: ${{ github.workspace }}/qit-results/


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description

Our QIT tests are currently failing. This is because GH Actions no longer support `actions/upload-artifact@v1` that the workflow is using. Background: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

This PR replaces usage of v1 with the newest v4.

### Steps to reproduce & screenshots/GIFs

1. Try triggering a QIT run on `trunk` and see it fail.
2. Look at the test status on this PR and see that it is successful.
