### PR TITLE
Try WC Shipping Modal Tweak

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.8.2 - 2024-xx-xx =
+* Tweak - Try WooCommerce Shipping modal copy.
+
 = 2.8.1 - 2024-09-09 =
 * Tweak - Hide migration banner for merchants still using legacy functionality.
 

--- a/client/components/migration/feature-announcement.jsx
+++ b/client/components/migration/feature-announcement.jsx
@@ -58,12 +58,12 @@ const FeatureAnnouncement = ( { translate, isEligable, previousMigrationState, o
 			<FlexItem>
 				<Flex>
 					<span>
-						{translate('Update')}
+						{translate('Try WooCommerce Shipping')}
 					</span>
 					<h2>
-						{translate('A new dedicated WooCommerce Shipping extension is now available')}
+						{translate('A new WooCommerce Shipping experience is now available')}
 					</h2>
-					<p>{translate('We\'ll ensure a seamless transition by transferring all your settings and shipping labels when you update.')}</p>
+					<p>{translate('We\'ll ensure a seamless transition by allowing you to migrate all your compatible settings and shipping labels when you update.')}</p>
 					<p>{translate('Here\'s what you can expect from the new shipping experience:')}</p>
 
 					<ul>
@@ -74,7 +74,7 @@ const FeatureAnnouncement = ( { translate, isEligable, previousMigrationState, o
 									{translate('A seamless transition')}
 								</h3>
 								<p>
-									{translate('All of your settings and shipment history have been imported to the new extension.')}
+									{translate('Automatically migrate all your compatible settings and shipment history to the new extension.')}
 								</p>
 							</div>
 						</li>
@@ -98,7 +98,7 @@ const FeatureAnnouncement = ( { translate, isEligable, previousMigrationState, o
 								</h3>
 								<p>
 									{translate(
-										'Send using trusted shipping carriers like USPS and DHL Express, with more options and carriers coming soon.')}
+										'Ship your productss using trusted shipping carriers like USPS and DHL Express at discounted rates, with more options and carriers coming soon.')}
 								</p>
 							</div>
 						</li>
@@ -121,7 +121,7 @@ const FeatureAnnouncement = ( { translate, isEligable, previousMigrationState, o
 						{translate('Maybe later')}
 					</Button>}
 					<Button id="migration__announcement-update-button" isPrimary onClick={update} isBusy={isUpdating} disabled={isUpdating}>
-						{isUpdating ? translate('Updating') : translate('Update now')}
+						{isUpdating ? translate('Installing WooCommerce Shipping…') : translate('Try WooCommerce Shipping now')}
 					</Button>
 				</Flex>
 			</FlexItem>

--- a/client/wcshipping-migration-admin-notice.js
+++ b/client/wcshipping-migration-admin-notice.js
@@ -40,10 +40,6 @@ const wcstMigrationNoticeDimissButton = document.querySelector('.wcst-wcshipping
 			</Provider>,
 			container
 		);
-
-		// Click the update button in the modal to start the migration.
-		const update_button = document.getElementById('migration__announcement-update-button');
-		update_button.click();
 	});
 
 	// Dismiss it for 3 days, then remove it from view.

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 2.8.2 - 2024-xx-xx =
+* Tweak - Try WooCommerce Shipping modal copy.
+
 = 2.8.1 - 2024-09-09 =
 * Tweak - Hide migration banner for merchants still using legacy functionality.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
Remove the auto click of the confirm button when the modal opens to give merchants time to read the modal and decide to proceed.

Update the copy of the modal.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
```
delete_option( 'wcshipping_migration_state' );
delete_option( 'wcst_data_migration_required' );
delete_option( 'wcshipping_installation_completed_shown' );
delete_option( 'wcst_data_migration_processes_to_run' );
delete_option( 'wcshipping_version' );
```
Ensure you have the `wcship_migration_supported` flag set to true in your development API server.

Checkout this branch and build, visit any wp-admin page like WooCommerce -> Settings and verify the Migration banner shows, click confirm and verify the modal opens and does not auto click the CTA button.

Check the copy looks good and matches the screenshot.

<img width="869" alt="Screenshot 2024-09-12 at 20 51 15" src="https://github.com/user-attachments/assets/d2d5da39-7949-43c7-b486-1792eaa21491">


<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

