### PR TITLE
Limit migration banner to shipping supported countries and currencies

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.8.2 - 2024-xx-xx =
+* Tweak - Hide shipping migration banner for all stores not eligible to buy shipping labels.
+
 = 2.8.1 - 2024-09-09 =
 * Tweak - Hide migration banner for merchants still using legacy functionality.
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 2.8.2 - 2024-xx-xx =
+* Tweak - Hide shipping migration banner for all stores not eligible to buy shipping labels.
+
 = 2.8.1 - 2024-09-09 =
 * Tweak - Hide migration banner for merchants still using legacy functionality.
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1571,7 +1571,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			// Add the WCS&T to WCShipping migration notice, creating a button to update.
 			$settings_store = $this->get_service_settings_store();
-			if ( $settings_store->is_eligible_for_migration() ) {
+			if ( $settings_store->is_eligible_for_migration() && $this->shipping_label->is_store_eligible_for_shipping_label_creation() ) {
 				add_action( 'admin_notices', array( $this, 'display_wcst_to_wcshipping_migration_notice' ) );
 				add_action( 'admin_notices', array( $this, 'register_wcshipping_migration_modal' ) );
 			}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

TL;DR: Hide migration banner for all stores not eligible to purchase shipping labels based on country and currency.

We have 2 different migration nudges in WCS&T:

1. The Feature Announcement when someone opens the "purchase shipping label" modal (introduced in: #2743)
2. The banner that appears of settings pages (introduced in: #2771)

Bullet 1 is only being showed to "shipping eligible stores" since it depends on the shipping label modal.
The issue is the migration banner in bullet 2. We're showing the banner to _all_ origin countries and currencies.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

* Resolves #2816
* Related to https://github.com/woocommerce/woocommerce-shipping/issues/769

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

1. Spin up a new site
2. Set the store address to be any of the supported countries (e.g. US)
3. Set the store currency to USD
4. Checkout this branch and activate WCS&T
5. Verify you see the migration banner
6. Change the currency to anything not USD
7. Verify the banner is hidden
8. Change currency back to USD
9. Verify it's showing again
10. Change country to any non-supported country (e.g. Denmark or Canada)
11. Verify the banner is hidden

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

