### PR TITLE
Tweak/issue 2822 - WordPress 6.7 Compatibility

### DIFF
--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -52,6 +52,15 @@ jobs:
         wp-version: ${{ fromJSON(needs.find_latest_versions.outputs.wp-versions) }}
         wc-version: ${{ fromJSON(needs.find_latest_versions.outputs.wc-versions) }}
     steps:
+      - name: Install SVN if not already installed
+        run: |
+          if ! svn --version &> /dev/null
+          then
+            echo "SVN is not installed. Installing SVN..."
+            sudo apt-get update && sudo apt-get install -y subversion
+          else
+            echo "SVN is already installed."
+          fi
       - name: Checkout WCS&T
         uses: actions/checkout@v2
         with:

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.8.3 - 2024-xx-xx =
+* Tweak - WordPress 6.7 Compatibility.
+
 = 2.8.2 - 2024-09-23 =
 * Fix   - Keep live rates enabled for eligible stores when WCS&T is active alongside WooCommerce Shipping.
 * Tweak - Hide shipping migration banner for all stores not eligible to buy shipping labels.

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
@@ -70,6 +70,8 @@
 		// Unset the translate() transform introduced in Gutenberg.
 		// See: https://github.com/WordPress/gutenberg/pull/27377
 		transform: none;
+		left:0;
+		top:0;
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,11 +2,11 @@
 Contributors: woocommerce, automattic, woothemes, allendav, kellychoffman, jkudish, jeffstieler, nabsul, robobot3000, danreylop, mikeyarce, shaunkuschel, orangesareorange, pauldechov, dappermountain, radogeorgiev, bor0, royho, cshultz88, bartoszbudzanowski, harriswong, ferdev, superdav42
 Tags: shipping, stamps, usps, woocommerce, taxes, payment, dhl, labels
 Requires PHP: 7.4
-Requires at least: 6.4
+Requires at least: 6.5
 Requires Plugins: woocommerce
-Tested up to: 6.6
-WC requires at least: 8.8
-WC tested up to: 9.0
+Tested up to: 6.7
+WC requires at least: 9.1
+WC tested up to: 9.3
 Stable tag: 2.8.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -80,6 +80,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 6. Checking and exporting the label purchase reports
 
 == Changelog ==
+
+= 2.8.3 - 2024-xx-xx =
+* Tweak - WordPress 6.7 Compatibility.
 
 = 2.8.2 - 2024-09-23 =
 * Fix   - Keep live rates enabled for eligible stores when WCS&T is active alongside WooCommerce Shipping.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -630,7 +630,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		public function on_plugins_loaded() {
-			$this->load_textdomain();
+			add_action( 'after_setup_theme', array( $this, 'load_textdomain' ) );
 
 			/**
 			 * Allow third party logic to determine if this plugin should initiate its logic.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -9,10 +9,10 @@
  * Text Domain: woocommerce-services
  * Domain Path: /i18n/languages/
  * Version: 2.8.2
- * Requires at least: 6.4
- * Tested up to: 6.6
- * WC requires at least: 8.8
- * WC tested up to: 9.0
+ * Requires at least: 6.5
+ * Tested up to: 6.7
+ * WC requires at least: 9.1
+ * WC tested up to: 9.3
  *
  * Copyright (c) 2017-2023 Automattic
  *


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

### Description
Testing the plugin on WordPress 6.7 Beta to make sure its compatibility. Then bump the `Tested up to` version.
<!-- A brief description of what this PR does. Outline why these changes are important – what's the problem, and how does this PR address it. -->

### Testing Instructions
<!-- Add all the necessary steps to test this Pull Request. Your steps should allow anyone to test this as a user would. -->
1. Install [WordPress Beta Tester](https://wordpress.org/plugins/wordpress-beta-tester/) plugin.
2. Select the “Bleeding edge” channel and “Beta/RC Only” stream.
3. Test the plugin using WP 6.7 beta version.
4. Make sure no error listed in log file.

### Related issue(s)
Fixes #2822 
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

