### PR TITLE
Check HPOS feauture before quering DB for labels report

### DIFF
--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -25,6 +25,13 @@ jobs:
         run: npm ci
       - name: Build plugin zip
         run: npm run build
+
+      - name: Unzip woocommerce-services.zip
+        run: unzip woocommerce-services.zip -d woocommerce-services
+
+      - name: Re-zip woocommerce-services folder
+        run: zip -r woocommerce-services.zip woocommerce-services
+
       - name: Require woocommerce/qit-cli
         run: composer require woocommerce/qit-cli
       - name: Add Partner

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -25,8 +25,8 @@ jobs:
         run: npm ci
       - name: Build plugin zip
         run: npm run build
-      - name: Install composer dependencies
-        run: composer install
+      - name: Require woocommerce/qit-cli
+        run: composer require woocommerce/qit-cli
       - name: Add Partner
         run: ./vendor/bin/qit partner:add --user='${{ secrets.PARTNER_USER }}' --application_password='${{ secrets.PARTNER_SECRET }}'
       - name: Create results dir

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.8.4 - 2024-xx-xx =
+* Fix   - Support High-Performance Order Storage in shipping label reports.
+
 = 2.8.3 - 2024-10-29 =
 * Tweak - WordPress 6.7 Compatibility.
 

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -197,7 +197,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 						<?php foreach ( $labels as $label ) : ?>
 							<tr>
 								<th scope="row">
-									<?php echo esc_html( get_date_from_gmt( date( 'Y-m-d H:i:s', $label['created'] / 1000 ) ) ); ?>
+									<?php echo esc_html( get_date_from_gmt( date( 'Y-m-d H:i:s', intval( $label['created'] / 1000 ) ) ) ); ?>
 								</th>
 								<td>
 									<?php

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
 if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 	include_once WC()->plugin_path() . '/includes/admin/reports/class-wc-admin-report.php';
 
@@ -36,13 +38,18 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 		private function get_all_labels() {
 			global $wpdb;
 
+			$table_name = OrderUtil::get_table_for_order_meta();
+			$id_column  = OrderUtil::custom_orders_table_usage_is_enabled() ? 'order_id' : 'post_id';
 			$db_results = $wpdb->get_results(
 				$wpdb->prepare(
-					"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s",
+					'SELECT %i, meta_value FROM %i WHERE meta_key = %s',
+					$id_column,
+					$table_name,
 					'wc_connect_labels'
 				)
 			);
-			$results    = array();
+
+			$results = array();
 
 			foreach ( $db_results as $meta ) {
 				$labels = maybe_unserialize( $meta->meta_value );
@@ -56,7 +63,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 				}
 
 				foreach ( $labels as $label ) {
-					$results[] = array_merge( $label, array( 'order_id' => $meta->post_id ) );
+					$results[] = array_merge( $label, array( 'order_id' => $meta->{$id_column} ) );
 				}
 			}
 

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -79,9 +79,15 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 				set_transient( self::LABELS_TRANSIENT_KEY, $all_labels, 1800 );
 			}
 
-			// translate timestamps to JS timestapms
-			$start_date = $this->start_date * 1000;
-			$end_date   = $this->end_date * 1000;
+			/**
+			 * Translate timestamps to JS timestamps.
+			 *
+			 * The start_date is set to the beginning of the day (midnight) of the start_date property, converted to milliseconds.
+			 * The end_date is set to the end of the day (one millisecond before midnight) of the end_date property, converted to milliseconds.
+			 * This ensures that the date range includes the entire days specified by start_date and end_date.
+			 */
+			$start_date = strtotime( 'midnight', $this->start_date ) * 1000;
+			$end_date   = strtotime( 'tomorrow', $this->end_date ) * 1000 - 1;
 
 			$results = array();
 			foreach ( $all_labels as $label ) {

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 2.8.4 - 2024-xx-xx =
+* Fix   - Support High-Performance Order Storage in shipping label reports.
+
 = 2.8.3 - 2024-10-29 =
 * Tweak - WordPress 6.7 Compatibility.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
This PR adds support for HPOS in shipping labels report.
It also fixes a bug that prevented the query to include the whole days on the borders of the query range.

### Related issue(s)
https://github.com/woocommerce/woocommerce-shipping/issues/923

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
- With trunk of this repo, make a label purchase while your [test shop is using HPOS](https://woocommerce.com/document/high-performance-order-storage/#how-to-enable-high-performance-order-storage).
- Visit {site-domain}/wp-admin/admin.php?page=wc-reports&tab=wcs_labels and verify you can't see the recently purchase label in the report table.
- Now build and use this branch, visit the report page and verify the recently purchase label is viewable on the report table.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

