### PR TITLE
fix: replaced spelling mistake in comment

### DIFF
--- a/classes/class-wc-connect-cart-validation.php
+++ b/classes/class-wc-connect-cart-validation.php
@@ -5,7 +5,7 @@
 class WC_Connect_Cart_Validation {
 
 	/**
-	 * Needed to keep track of the current package being proccessed.
+	 * Needed to keep track of the current package being processed.
 	 *
 	 * @var array
 	 */


### PR DESCRIPTION
This PR is to replace https://github.com/Automattic/woocommerce-services/pull/2614
Fixes https://github.com/Automattic/woocommerce-services/issues/2580
@Splagov Thanks for your contribution.
