### PR TITLE
Fix/issue 2824 - Making sure the data is string before parsing into JSON in order edit page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.8.5 - 2024-xx-xx =
+* Fix   - Adding Product Add-Ons on order edit page is stucked when automated tax is enabled.
+
 = 2.8.4 - 2024-12-09 =
 * Fix   - Support High-Performance Order Storage in shipping label reports.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 2.8.5 - 2024-xx-xx =
-* Fix   - Adding Product Add-Ons on order edit page is stucked when automated tax is enabled.
+* Fix   - Fixed an issue that prevented editing an order when automated tax is enabled.
 
 = 2.8.4 - 2024-12-09 =
 * Fix   - Support High-Performance Order Storage in shipping label reports.

--- a/client/new-order-taxjar.js
+++ b/client/new-order-taxjar.js
@@ -11,7 +11,7 @@ jQuery( document ).ready( function() {
 	const TaxJarOrder = function( $ ){ // eslint-disable-line no-unused-vars
 		$( document ).ajaxSend( function( event, request, settings ) {
 			// Making sure it's a recalculate event by checking `woocommerce_calc_line_taxes` before parsing to JSON.
-			if ( settings.data && settings.data.indexOf( 'woocommerce_calc_line_taxes' ) > 0 ) {
+			if ( settings.data && typeof settings.data === 'string' && settings.data.indexOf( 'woocommerce_calc_line_taxes' ) > 0 ) {
 				const data = JSON.parse( '{"' + decodeURIComponent( settings.data.replace( /&/g, '","' ).replace( /=/g, '":"' ) ) + '"}' );
  				if ( 'woocommerce_calc_line_taxes' === data.action ) {
 					let street = '';

--- a/readme.txt
+++ b/readme.txt
@@ -82,7 +82,7 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 == Changelog ==
 
 = 2.8.5 - 2024-xx-xx =
-* Fix   - Adding Product Add-Ons on order edit page is stucked when automated tax is enabled.
+* Fix   - Fixed an issue that prevented editing an order when automated tax is enabled.
 
 = 2.8.4 - 2024-12-09 =
 * Fix   - Support High-Performance Order Storage in shipping label reports.

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Requires PHP: 7.4
 Requires at least: 6.5
 Requires Plugins: woocommerce
 Tested up to: 6.7
-WC requires at least: 9.1
-WC tested up to: 9.3
+WC requires at least: 9.2
+WC tested up to: 9.4
 Stable tag: 2.8.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 2.8.5 - 2024-xx-xx =
+* Fix   - Adding Product Add-Ons on order edit page is stucked when automated tax is enabled.
+
 = 2.8.4 - 2024-12-09 =
 * Fix   - Support High-Performance Order Storage in shipping label reports.
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -11,8 +11,8 @@
  * Version: 2.8.4
  * Requires at least: 6.5
  * Tested up to: 6.7
- * WC requires at least: 9.1
- * WC tested up to: 9.3
+ * WC requires at least: 9.2
+ * WC tested up to: 9.4
  *
  * Copyright (c) 2017-2023 Automattic
  *


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Making sure the data is string before parsing into JSON in order edit page. It needs to be done this way to make sure that the `indexOf()` function is not called.
<!-- Explain the motivation for making this change -->

### Related issue(s)
- Fixes #2824 
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
1. Install [Product Add-Ons plugin](https://woocommerce.com/products/product-add-ons/) is installed.
2. Create one product add-ons.
3. Go to **WooCommerce > Settings > Tax** and enable "Automated taxes."
4. Go to **WooCommerce > Orders > Add New**, add a line item, then click on the "Configure" button.
![image](https://github.com/user-attachments/assets/52866a51-7cc0-4c71-a41a-26a119284084)

5. Fill in the addon field in the popup, click "Done".
6. The product add ons will be added successfully.
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

