### PR TITLE
Revert "woorelease: Product version bump update"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
-= 2.8.5 - 2024-12-10 =
+= 2.8.5 - 2024-xx-xx =
 * Fix   - Fixed an issue that prevented editing an order when automated tax is enabled.
 
 = 2.8.4 - 2024-12-09 =

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-services",
-  "version": "2.8.5",
+  "version": "2.8.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce-services",
-	"version": "2.8.5",
+	"version": "2.8.4",
 	"scripts": {
 		"start": "cross-env NODE_ENV=development CALYPSO_CLIENT=true webpack-dev-server --hot --inline --watch --content-base dist --port 8085 --host 0.0.0.0",
 		"watch": "cross-env NODE_ENV=development CALYPSO_CLIENT=true webpack --watch",

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Requires Plugins: woocommerce
 Tested up to: 6.7
 WC requires at least: 9.2
 WC tested up to: 9.4
-Stable tag: 2.8.5
+Stable tag: 2.8.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -81,7 +81,7 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
-= 2.8.5 - 2024-12-10 =
+= 2.8.5 - 2024-xx-xx =
 * Fix   - Fixed an issue that prevented editing an order when automated tax is enabled.
 
 = 2.8.4 - 2024-12-09 =

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -8,7 +8,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-services
  * Domain Path: /i18n/languages/
- * Version: 2.8.5
+ * Version: 2.8.4
  * Requires at least: 6.5
  * Tested up to: 6.7
  * WC requires at least: 9.2


### PR DESCRIPTION
This PR reverts the unfinished release as https://github.com/Automattic/woocommerce-services/actions/runs/12261576465 failed.