### PR TITLE
Fix/issue 2562 - Add Retail Delivery Fee for Colorado

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
-= 2.8.7 - 2024-xx-xx =
+= 2.9.0 - 2024-xx-xx =
 * Add   - Option to apply US Colorado Retail Delivery Fee tax by using `wc_services_apply_us_co_retail_delivery_fee` filter.
 
 = 2.8.6 - 2025-01-06 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
-= 2.9.0 - 2024-xx-xx =
+= 2.9.0 - 2025-xx-xx =
 * Add   - Option to apply US Colorado Retail Delivery Fee tax by using `wc_services_apply_us_co_retail_delivery_fee` filter.
 
 = 2.8.6 - 2025-01-06 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.8.6 - 2024-xx-xx =
+* Add   - Custom surcharge ( Retail Delivery Fee ) for shipment to Colorado, US.
+
 = 2.8.5 - 2024-12-10 =
 * Fix   - Fixed an issue that prevented editing an order when automated tax is enabled.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
 = 2.8.6 - 2024-xx-xx =
-* Add   - Custom surcharge ( Retail Delivery Fee ) for shipment to Colorado, US.
+* Add   - Option to apply US Colorado Retail Delivery Fee tax by using `wc_services_apply_us_co_retail_delivery_fee` filter.
 
 = 2.8.5 - 2024-12-10 =
 * Fix   - Fixed an issue that prevented editing an order when automated tax is enabled.

--- a/classes/class-wc-connect-custom-surcharge.php
+++ b/classes/class-wc-connect-custom-surcharge.php
@@ -23,11 +23,22 @@ if ( ! class_exists( 'WC_Connect_Custom_Surcharge' ) ) {
 		 * @return boolean.
 		 */
 		public static function get_us_co_eligibility( $cart = null ) {
-			if ( $cart instanceof WC_Cart ) {
-				return true;
+			if ( false === ( $cart instanceof WC_Cart ) ) {
+				return false;
 			}
 
-			return false;
+			$has_taxable_product = false;
+
+			foreach ( $cart->get_cart() as $cart_item ) {
+				if ( $cart_item['data']->is_taxable() ) {
+					$has_taxable_product = true;
+					break;
+				}
+			}
+
+			$content_taxes = $cart->get_cart_contents_taxes();
+
+			return $has_taxable_product && ! empty( $content_taxes );
 		}
 	}
 }

--- a/classes/class-wc-connect-custom-surcharge.php
+++ b/classes/class-wc-connect-custom-surcharge.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * A class for working around the quirks and different versions of WordPress/WooCommerce
+ * This is for versions higher than 2.6 (3.0 and higher)
+ */
+
+// No direct access please.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'WC_Connect_Custom_Surcharge' ) ) {
+	/**
+	 * WC_Connect_Compatibility class.
+	 */
+	class WC_Connect_Custom_Surcharge {
+
+		/**
+		 * Get US Colorado custom surcharge eligibility.
+		 *
+		 * @param WC_Cart|null $cart Cart object or null.
+		 *
+		 * @return boolean.
+		 */
+		public static function get_us_co_eligibility( $cart = null ) {
+			if ( $cart instanceof WC_Cart ) {
+				return true;
+			}
+
+			return false;
+		}
+	}
+}

--- a/classes/class-wc-connect-custom-surcharge.php
+++ b/classes/class-wc-connect-custom-surcharge.php
@@ -23,8 +23,20 @@ if ( ! class_exists( 'WC_Connect_Custom_Surcharge' ) ) {
 		 * @return boolean.
 		 */
 		public static function get_us_co_eligibility( $cart = null ) {
+			$fee_info = array();
+
 			if ( false === ( $cart instanceof WC_Cart ) ) {
-				return false;
+				return $fee_info;
+			}
+
+			// Do not apply the fee if all products are virtual.
+			if ( WC_Connect_Utils::is_all_products_are_virtual( $cart ) ) {
+				return $fee_info;
+			}
+	
+			// Do not apply the fee if all shipping methods use Local Pickup.
+			if ( 0 === count( array_diff( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) ) {
+				return $fee_info;
 			}
 
 			$has_taxable_product = false;
@@ -38,7 +50,14 @@ if ( ! class_exists( 'WC_Connect_Custom_Surcharge' ) ) {
 
 			$content_taxes = $cart->get_cart_contents_taxes();
 
-			return $has_taxable_product && ! empty( $content_taxes );
+			if ( $has_taxable_product && ! empty( $content_taxes ) ) {
+				$fee_info = array(
+					'fee'      => 0.27,
+					'fee_text' => __( 'Retail Delivery Fee', 'woocommerce_services' ),
+				);
+			}
+			
+			return $fee_info;
 		}
 	}
 }

--- a/classes/class-wc-connect-custom-surcharge.php
+++ b/classes/class-wc-connect-custom-surcharge.php
@@ -20,7 +20,7 @@ if ( ! class_exists( 'WC_Connect_Custom_Surcharge' ) ) {
 		 *
 		 * @param WC_Cart|null $cart Cart object or null.
 		 *
-		 * @return boolean.
+		 * @return array|false.
 		 */
 		public static function add_us_co_rdf( $cart = null ) {
 			if ( false === ( $cart instanceof WC_Cart ) ) {
@@ -42,7 +42,7 @@ if ( ! class_exists( 'WC_Connect_Custom_Surcharge' ) ) {
 			}
 			
 			return array(
-				'fee'      => 0.27,
+				'fee'      => 0.29,
 				'fee_text' => __( 'Retail Delivery Fee', 'woocommerce_services' ),
 			);
 		}

--- a/classes/class-wc-connect-custom-surcharge.php
+++ b/classes/class-wc-connect-custom-surcharge.php
@@ -13,24 +13,42 @@ if ( ! class_exists( 'WC_Connect_Custom_Surcharge' ) ) {
 	 * WC_Connect_Custom_Surcharge class.
 	 */
 	class WC_Connect_Custom_Surcharge {
+
 		/**
-		 * Add a 29 cent surcharge to your cart / checkout based on delivery US Colorado
-		 * Taxes, shipping costs and order subtotal are all included in the surcharge amount
-		 *
-		 * Fee won't be added if all products in the cart are virtual.
-		 * 
-		 * This fee is being DISABLED by default because there is a lot of consideration for this fee to be applied.
-		 * 
-		 * If the user wish to use this fee, they can enable it by using `wc_services_apply_us_co_retail_delivery_fee` filter.
-		 * Change the 'enabled' value from `false` to `true`. See the example below:
-		 * 
-		 * `add_filter( 'wc_services_apply_us_co_retail_delivery_fee', function( $fee_info, $cart ) { $fee_info['enabled'] = true; return $fee_info; }, 10, 2 );`
-		 *
-		 * Uses the WooCommerce fees API
-		 *
-		 * @param WC_Cart|null $cart WooCommerce Cart object.
+		 * Initialize the class and set up action hooks.
 		 */
-		public static function add_us_co_rdf( $cart = null ) {
+		public static function init() {
+			add_action( 'woocommerce_cart_calculate_fees', array( static::class, 'add_us_co_retail_delivery_fee' ), 10 );
+		}
+		/**
+		 * Add US Colorado Retail Delivery Fee Tax.
+		 * Uses the WooCommerce fees API `$cart->add_fee()`.
+		 *
+		 * Colorado Retail Delivery Fee Tax:
+		 * https://www.avalara.com/blog/en/north-america/2022/10/what-you-need-to-know-about-the-colorado-retail-delivery-fee-now.html
+		 *
+		 * RDF fee is DISABLED by default - not all business are required to charge the fee.
+		 * To apply the fee use `wc_services_apply_us_co_retail_delivery_fee` filter.
+		 * Change boolian flag to `true`
+		 * Example: `add_filter( 'wc_services_apply_us_co_retail_delivery_fee', '__return_true' );`
+		 *
+		 * @param WC_Cart $cart WooCommerce Cart object.
+		 */
+		public static function add_us_co_retail_delivery_fee( $cart ) {
+
+			/**
+			 * Filter should Retail Delivery Fee be applied.
+			 * Default: false.
+			 *
+			 * @since 2.8.6
+			 *
+			 * @param bool    Should the Retail Delivery Fee be applied.
+			 * @param WC_Cart WooCommerce cart object.
+			 */
+			if ( ! apply_filters( 'wc_services_apply_us_co_retail_delivery_fee', false, $cart ) ) {
+				return;
+			}
+
 			if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
 				return;
 			}
@@ -39,50 +57,48 @@ if ( ! class_exists( 'WC_Connect_Custom_Surcharge' ) ) {
 				return;
 			}
 
-			if ( ! is_array( $cart->get_cart_contents_taxes() ) || 0 === count( $cart->get_cart_contents_taxes() ) ) {
+			// Do not apply RDF if the customer is not in US Colorado.
+			if (
+				'US' !== WC()->customer->get_shipping_country()
+				|| 'CO' !== WC()->customer->get_shipping_state()
+			) {
 				return;
 			}
 
-			// Do not apply the fee if all products are virtual.
+			// Do not apply RDF when every item in order is exempt from Colorado sales tax.
+			if (
+				! is_array( $cart->get_cart_contents_taxes() )
+				|| 0 === count( $cart->get_cart_contents_taxes() )
+			) {
+				return;
+			}
+
+			// Do not apply RDF if all shipping methods use Local Pickup.
+			if ( 0 === count(
+				array_diff(
+					wc_get_chosen_shipping_method_ids(),
+					/**
+					 * Filters local pickup shipping methods.
+					 * Copied from WooCommerce core to maintain compatability.
+					 *
+					 * @since 6.8.0
+					 * @param string[] $local_pickup_methods Local pickup shipping method IDs.
+					 */
+					apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) )
+				)
+			) ) {
+				return;
+			}
+
+			// Do not apply RDF if all products are virtual.
 			if ( ! $cart->needs_shipping() ) {
 				return;
 			}
-	
-			// Do not apply the fee if all shipping methods use Local Pickup.
-			if ( 0 === count( array_diff( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) ) {
-				return;
-			}
 
-			if ( 'US' !== WC()->customer->get_shipping_country() || 'CO' !== WC()->customer->get_shipping_state() ) {
-				return;
-			}
-
-			/**
-			 * Filter for manipulate the custom surcharge.
-			 * Set the 'enabled' key to `false` to disable the custom surcharge.
-			 *
-			 * @since 2.8.6
-			 *
-			 * @param array   Custom surcharge info.
-			 * @param WC_Cart WooCommerce cart object.
-			 */
-			$fee_info = apply_filters(
-				'wc_services_apply_us_co_retail_delivery_fee',
-				array(
-					'enabled' => false,
-					'value'   => 0.29,
-					'text'    => __( 'Retail Delivery Fee', 'woocommerce_services' ),
-				),
-				$cart
-			);
-			
-			if (
-				isset( $fee_info['enabled'] ) && true === $fee_info['enabled'] &&
-				isset( $fee_info['text'] ) &&
-				isset( $fee_info['value'] ) && is_numeric( $fee_info['value'] )
-			) {
-				$cart->add_fee( $fee_info['text'], floatval( $fee_info['value'] ), true, 'standard' );
-			}
+			// As of July 1, 2024 till June 30, 2025 RDF is 29 cents per order
+			// RDF is subject to sales tax.
+			// https://www.avalara.com/blog/en/north-america/2022/10/what-you-need-to-know-about-the-colorado-retail-delivery-fee-now.html.
+			$cart->add_fee( __( 'Retail Delivery Fee', 'woocommerce_services' ), 0.29, true, 'standard' );
 		}
 	}
 }

--- a/classes/class-wc-connect-custom-surcharge.php
+++ b/classes/class-wc-connect-custom-surcharge.php
@@ -16,48 +16,35 @@ if ( ! class_exists( 'WC_Connect_Custom_Surcharge' ) ) {
 	class WC_Connect_Custom_Surcharge {
 
 		/**
-		 * Get US Colorado custom surcharge eligibility.
+		 * Add US Colorado "Retail Delivery Fee" Tax.
 		 *
 		 * @param WC_Cart|null $cart Cart object or null.
 		 *
 		 * @return boolean.
 		 */
-		public static function get_us_co_eligibility( $cart = null ) {
-			$fee_info = array();
-
+		public static function add_us_co_rdf( $cart = null ) {
 			if ( false === ( $cart instanceof WC_Cart ) ) {
-				return $fee_info;
+				return false;
+			}
+
+			if ( ! is_array( $cart->get_cart_contents_taxes() ) || 0 === count( $cart->get_cart_contents_taxes() ) ) {
+				return false;
 			}
 
 			// Do not apply the fee if all products are virtual.
-			if ( WC_Connect_Utils::is_all_products_are_virtual( $cart ) ) {
-				return $fee_info;
+			if ( ! $cart->needs_shipping() ) {
+				return false;
 			}
 	
 			// Do not apply the fee if all shipping methods use Local Pickup.
 			if ( 0 === count( array_diff( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) ) {
-				return $fee_info;
-			}
-
-			$has_taxable_product = false;
-
-			foreach ( $cart->get_cart() as $cart_item ) {
-				if ( $cart_item['data']->is_taxable() ) {
-					$has_taxable_product = true;
-					break;
-				}
-			}
-
-			$content_taxes = $cart->get_cart_contents_taxes();
-
-			if ( $has_taxable_product && ! empty( $content_taxes ) ) {
-				$fee_info = array(
-					'fee'      => 0.27,
-					'fee_text' => __( 'Retail Delivery Fee', 'woocommerce_services' ),
-				);
+				return false;
 			}
 			
-			return $fee_info;
+			return array(
+				'fee'      => 0.27,
+				'fee_text' => __( 'Retail Delivery Fee', 'woocommerce_services' ),
+			);
 		}
 	}
 }

--- a/classes/class-wc-connect-custom-surcharge.php
+++ b/classes/class-wc-connect-custom-surcharge.php
@@ -40,12 +40,12 @@ if ( ! class_exists( 'WC_Connect_Custom_Surcharge' ) ) {
 			 * Filter should Retail Delivery Fee be applied.
 			 * Default: false.
 			 *
-			 * @since 2.8.6
+			 * @since 2.9.0
 			 *
 			 * @param bool    Should the Retail Delivery Fee be applied.
 			 * @param WC_Cart WooCommerce cart object.
 			 */
-			if ( ! apply_filters( 'wc_services_apply_us_co_retail_delivery_fee', false, $cart ) ) {
+			if ( ! apply_filters( 'wc_services_enable_us_co_retail_delivery_fee', false, $cart ) ) {
 				return;
 			}
 
@@ -95,10 +95,33 @@ if ( ! class_exists( 'WC_Connect_Custom_Surcharge' ) ) {
 				return;
 			}
 
-			// As of July 1, 2024 till June 30, 2025 RDF is 29 cents per order
-			// RDF is subject to sales tax.
-			// https://www.avalara.com/blog/en/north-america/2022/10/what-you-need-to-know-about-the-colorado-retail-delivery-fee-now.html.
-			$cart->add_fee( __( 'Retail Delivery Fee', 'woocommerce_services' ), 0.29, true, 'standard' );
+			/**
+			 * Filter for manipulate the custom surcharge.
+			 * 
+			 * As of July 1, 2024 till June 30, 2025 RDF is 29 cents per order
+			 * RDF is subject to sales tax.
+			 * https://www.avalara.com/blog/en/north-america/2022/10/what-you-need-to-know-about-the-colorado-retail-delivery-fee-now.html.
+			 *
+			 * @since 2.9.0
+			 *
+			 * @param array   Custom surcharge info.
+			 * @param WC_Cart WooCommerce cart object.
+			 */
+			$fee_info = apply_filters(
+				'wc_services_apply_us_co_retail_delivery_fee',
+				array(
+					'value' => 0.29,
+					'text'  => __( 'Retail Delivery Fee', 'woocommerce_services' ),
+				),
+				$cart
+			);
+
+			if (
+				! empty( $fee_info['text'] ) &&
+				isset( $fee_info['value'] ) && is_numeric( $fee_info['value'] )
+			) {
+				$cart->add_fee( $fee_info['text'], floatval( $fee_info['value'] ), true, 'standard' );
+			}
 		}
 	}
 }

--- a/classes/class-wc-connect-custom-surcharge.php
+++ b/classes/class-wc-connect-custom-surcharge.php
@@ -1,7 +1,6 @@
 <?php
 /**
- * A class for working around the quirks and different versions of WordPress/WooCommerce
- * This is for versions higher than 2.6 (3.0 and higher)
+ * A class for custom surcharge.
  */
 
 // No direct access please.
@@ -11,40 +10,79 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! class_exists( 'WC_Connect_Custom_Surcharge' ) ) {
 	/**
-	 * WC_Connect_Compatibility class.
+	 * WC_Connect_Custom_Surcharge class.
 	 */
 	class WC_Connect_Custom_Surcharge {
-
 		/**
-		 * Add US Colorado "Retail Delivery Fee" Tax.
+		 * Add a 29 cent surcharge to your cart / checkout based on delivery US Colorado
+		 * Taxes, shipping costs and order subtotal are all included in the surcharge amount
 		 *
-		 * @param WC_Cart|null $cart Cart object or null.
+		 * Fee won't be added if all products in the cart are virtual.
+		 * 
+		 * This fee is being DISABLED by default because there is a lot of consideration for this fee to be applied.
+		 * 
+		 * If the user wish to use this fee, they can enable it by using `wc_services_apply_us_co_retail_delivery_fee` filter.
+		 * Change the 'enabled' value from `false` to `true`. See the example below:
+		 * 
+		 * `add_filter( 'wc_services_apply_us_co_retail_delivery_fee', function( $fee_info, $cart ) { $fee_info['enabled'] = true; return $fee_info; }, 10, 2 );`
 		 *
-		 * @return array|false.
+		 * Uses the WooCommerce fees API
+		 *
+		 * @param WC_Cart|null $cart WooCommerce Cart object.
 		 */
 		public static function add_us_co_rdf( $cart = null ) {
+			if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
+				return;
+			}
+
 			if ( false === ( $cart instanceof WC_Cart ) ) {
-				return false;
+				return;
 			}
 
 			if ( ! is_array( $cart->get_cart_contents_taxes() ) || 0 === count( $cart->get_cart_contents_taxes() ) ) {
-				return false;
+				return;
 			}
 
 			// Do not apply the fee if all products are virtual.
 			if ( ! $cart->needs_shipping() ) {
-				return false;
+				return;
 			}
 	
 			// Do not apply the fee if all shipping methods use Local Pickup.
 			if ( 0 === count( array_diff( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) ) {
-				return false;
+				return;
 			}
-			
-			return array(
-				'fee'      => 0.29,
-				'fee_text' => __( 'Retail Delivery Fee', 'woocommerce_services' ),
+
+			if ( 'US' !== WC()->customer->get_shipping_country() || 'CO' !== WC()->customer->get_shipping_state() ) {
+				return;
+			}
+
+			/**
+			 * Filter for manipulate the custom surcharge.
+			 * Set the 'enabled' key to `false` to disable the custom surcharge.
+			 *
+			 * @since 2.8.6
+			 *
+			 * @param array   Custom surcharge info.
+			 * @param WC_Cart WooCommerce cart object.
+			 */
+			$fee_info = apply_filters(
+				'wc_services_apply_us_co_retail_delivery_fee',
+				array(
+					'enabled' => false,
+					'value'   => 0.29,
+					'text'    => __( 'Retail Delivery Fee', 'woocommerce_services' ),
+				),
+				$cart
 			);
+			
+			if (
+				isset( $fee_info['enabled'] ) && true === $fee_info['enabled'] &&
+				isset( $fee_info['text'] ) &&
+				isset( $fee_info['value'] ) && is_numeric( $fee_info['value'] )
+			) {
+				$cart->add_fee( $fee_info['text'], floatval( $fee_info['value'] ), true, 'standard' );
+			}
 		}
 	}
 }

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -90,12 +90,12 @@ class WC_Connect_TaxJar_Integration {
 		// for a list of possible attributes in the `jurisdictions` attribute, see:
 		// https://developers.taxjar.com/api/reference/#post-calculate-sales-tax-for-an-order
 		$jurisdiction_pieces = array_merge(
-			[
+			array(
 				'city'    => '',
 				'county'  => '',
 				'state'   => $to_state,
 				'country' => $to_country,
-			],
+			),
 			(array) $taxjar_response->jurisdictions
 		);
 
@@ -107,7 +107,7 @@ class WC_Connect_TaxJar_Integration {
 		return join(
 			'-',
 			array_filter(
-				[
+				array(
 					// the `$jurisdiction_pieces` is not really sorted
 					// so let's sort it with COUNTRY-STATE-COUNTY-CITY
 					// `array_filter` will take care of filtering out the "falsy" entries
@@ -115,7 +115,7 @@ class WC_Connect_TaxJar_Integration {
 					$jurisdiction_pieces['state'],
 					$jurisdiction_pieces['county'],
 					$jurisdiction_pieces['city'],
-				]
+				)
 			)
 		);
 	}
@@ -170,7 +170,8 @@ class WC_Connect_TaxJar_Integration {
 
 		add_filter( 'woocommerce_calc_tax', array( $this, 'override_woocommerce_tax_rates' ), 10, 3 );
 		add_filter( 'woocommerce_matched_rates', array( $this, 'allow_street_address_for_matched_rates' ), 10, 2 );
-		add_action( 'woocommerce_cart_calculate_fees', array( $this, 'maybe_add_custom_fee' ), 10 );
+
+		WC_Connect_Custom_Surcharge::init();
 	}
 
 	/**
@@ -212,11 +213,11 @@ class WC_Connect_TaxJar_Integration {
 
 		$automated_taxes_description = join(
 			'',
-			$enabled ? [
+			$enabled ? array(
 				$powered_by_wct_notice,
 				$backup_notice,
 				$tax_nexus_notice,
-			] : [ $desctructive_action_notice, $desctructive_backup_notice, $tax_nexus_notice ]
+			) : array( $desctructive_action_notice, $desctructive_backup_notice, $tax_nexus_notice )
 		);
 		$automated_taxes             = array(
 			'title'    => __( 'Automated taxes', 'woocommerce-services' ),
@@ -599,14 +600,12 @@ class WC_Connect_TaxJar_Integration {
 					$item_tax->save();
 				}
 			}
-		} else { // Recalculate tax for Woo 2.6 to apply new tax rates
-			if ( class_exists( 'WC_AJAX' ) ) {
+		} elseif ( class_exists( 'WC_AJAX' ) ) { // Recalculate tax for Woo 2.6 to apply new tax rates
 				remove_action( 'woocommerce_before_save_order_items', array( $this, 'calculate_backend_totals' ), 20 );
-				if ( check_ajax_referer( 'calc-totals', 'security', false ) ) {
-					WC_AJAX::calc_line_taxes();
-				}
-				add_action( 'woocommerce_before_save_order_items', array( $this, 'calculate_backend_totals' ), 20 );
+			if ( check_ajax_referer( 'calc-totals', 'security', false ) ) {
+				WC_AJAX::calc_line_taxes();
 			}
+				add_action( 'woocommerce_before_save_order_items', array( $this, 'calculate_backend_totals' ), 20 );
 		}
 	}
 
@@ -677,10 +676,8 @@ class WC_Connect_TaxJar_Integration {
 			if ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
 				$tax_based_on = 'base';
 			}
-		} else {
-			if ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( WC()->session->get( 'chosen_shipping_methods', array() ), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
+		} elseif ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( WC()->session->get( 'chosen_shipping_methods', array() ), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
 				$tax_based_on = 'base';
-			}
 		}
 
 		if ( 'base' === $tax_based_on ) {
@@ -914,10 +911,8 @@ class WC_Connect_TaxJar_Integration {
 			if ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
 				$tax_based_on = 'base';
 			}
-		} else {
-			if ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( WC()->session->get( 'chosen_shipping_methods', array() ), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
+		} elseif ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( WC()->session->get( 'chosen_shipping_methods', array() ), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
 				$tax_based_on = 'base';
-			}
 		}
 
 		if ( 'base' == $tax_based_on ) {
@@ -957,7 +952,7 @@ class WC_Connect_TaxJar_Integration {
 
 		if ( ! empty( $taxjar_resp_tax->breakdown->line_items ) ) {
 			$taxjar_resp_tax->breakdown->line_items = array_map(
-				function( $line_item ) use ( $new_tax_rate ) {
+				function ( $line_item ) use ( $new_tax_rate ) {
 					$line_item->combined_tax_rate       = $new_tax_rate;
 					$line_item->country_tax_rate        = $new_tax_rate;
 					$line_item->country_tax_collectable = $line_item->country_taxable_amount * $new_tax_rate;
@@ -1194,10 +1189,8 @@ class WC_Connect_TaxJar_Integration {
 
 				if ( $product ) {
 					$tax_class = $product->get_tax_class();
-				} else {
-					if ( isset( $this->backend_tax_classes[ $product_id ] ) ) {
+				} elseif ( isset( $this->backend_tax_classes[ $product_id ] ) ) {
 						$tax_class = $this->backend_tax_classes[ $product_id ];
-					}
 				}
 
 				if ( $line_item->combined_tax_rate ) {
@@ -1499,31 +1492,5 @@ class WC_Connect_TaxJar_Integration {
 		}
 		// Load Javascript for WooCommerce new order page
 		wp_enqueue_script( 'wc-taxjar-order', $this->wc_connect_base_url . 'woocommerce-services-new-order-taxjar-' . WC_Connect_Loader::get_wcs_version() . '.js', array( 'jquery' ), null, true );
-	}
-
-	public function maybe_add_custom_fee( $cart ) {
-		/**
-		 * Filter to manipulate the custom surcharge methods.
-		 *
-		 * @since 2.8.6
-		 *
-		 * @param array List of custom surcharge methods.
-		 */
-		$surcharge_funcs = apply_filters(
-			'wc_services_custom_surcharge_methods',
-			array(
-				array( 'WC_Connect_Custom_Surcharge', 'add_us_co_rdf' ),
-			)
-		);
-
-		foreach ( $surcharge_funcs as $function_rule ) {
-			if ( ! is_callable( $function_rule ) ) {
-				$callback_string = is_array( $function_rule ) ? implode( '::', $function_rule ) : $function_rule;
-				$this->_log( 'This surcharge rule cannot be called: ' . $callback_string );
-				continue;
-			}
-
-			call_user_func( $function_rule, $cart );
-		}
 	}
 }

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1528,19 +1528,20 @@ class WC_Connect_TaxJar_Integration {
 			return;
 		}
 
-		if ( ! is_array( $this->get_custom_surcharges() ) ) {
+		$surcharges = $this->get_custom_surcharges();
+
+		if ( ! is_array( $surcharges ) ) {
 			return;
 		}
 
-		$custom_surcharges = $this->get_custom_surcharges();
-		$customer          = WC()->customer;
-		$key               = $customer->get_shipping_country() . ':' . $customer->get_shipping_state();
+		$customer = WC()->customer;
+		$key      = $customer->get_shipping_country() . ':' . $customer->get_shipping_state();
 
-		if ( ! isset( $custom_surcharges[ $key ] ) || ! is_array( $custom_surcharges[ $key ] ) )  {
+		if ( ! isset( $surcharges[ $key ] ) || ! is_array( $surcharges[ $key ] ) )  {
 			return;
 		}
 
-		foreach ( $custom_surcharges[ $key ] as $function_rule ) {
+		foreach ( $surcharges[ $key ] as $function_rule ) {
 			$fee_info = call_user_func( $function_rule, $cart );
 
 			/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1528,7 +1528,7 @@ class WC_Connect_TaxJar_Integration {
 			return;
 		}
 		
-		if( $this->maybe_all_products_are_virtual( $cart ) ) {
+		if ( $this->maybe_all_products_are_virtual( $cart ) ) {
 			return;
 		}
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -171,8 +171,7 @@ class WC_Connect_TaxJar_Integration {
 		add_filter( 'woocommerce_calc_tax', array( $this, 'override_woocommerce_tax_rates' ), 10, 3 );
 		add_filter( 'woocommerce_matched_rates', array( $this, 'allow_street_address_for_matched_rates' ), 10, 2 );
 		
-		// Add custom state surcharge.
-		add_action( 'woocommerce_cart_calculate_fees', array( $this, 'add_custom_state_surcharge_fee' ), 10 );
+		add_action( 'woocommerce_cart_calculate_fees', array( $this, 'maybe_add_custom_state_surcharge_fee' ), 10 );
 	}
 
 	/**
@@ -1523,7 +1522,7 @@ class WC_Connect_TaxJar_Integration {
 	 *
 	 * @param WC_Cart $cart WooCommerce Cart object.
 	 */
-	public function add_custom_state_surcharge_fee( $cart ) {
+	public function maybe_add_custom_state_surcharge_fee( $cart ) {
 		if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
 			return;
 		}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1549,7 +1549,19 @@ class WC_Connect_TaxJar_Integration {
 				continue;
 			}
 
-			$cart->add_fee( $custom_info['fee_text'], $custom_info['fee'], true, 'standard' );
+			/**
+			 * Filter for toggling whether apply the custom surcharge or not.
+			 * Set to `false` to disable the custom surcharge.
+			 *
+			 * @since 2.8.6
+			 *
+			 * @param boolean Custom surcharge toggle.
+			 * @param array   Custom surcharge info.
+			 * @param WC_Cart WooCommerce cart object.
+			 */
+			if ( true === apply_filters( 'wc_services_apply_custom_surcharge_fee', true, $custom_info, $cart ) ) {
+				$cart->add_fee( $custom_info['fee_text'], $custom_info['fee'], true, 'standard' );	
+			}
 		}
 	}
 
@@ -1559,6 +1571,13 @@ class WC_Connect_TaxJar_Integration {
 	 * @return array.
 	 */
 	public function get_custom_surcharges() {
+		/**
+		 * Filter to manipulate the custom surcharge info.
+		 *
+		 * @since 2.8.6
+		 *
+		 * @param array List of custom surcharge info.
+		 */
 		return apply_filters(
 			'wc_services_custom_surcharges',
 			array(

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1556,8 +1556,8 @@ class WC_Connect_TaxJar_Integration {
 			 */
 			$fee_info = apply_filters( 'wc_services_apply_custom_surcharge_fee', $fee_info, $key, $function_rule, $cart );
 			
-			if ( isset( $fee_info['fee_text'] ) && isset( $fee_info['fee'] ) && is_float( $fee_info['fee'] ) ) {
-				$cart->add_fee( $fee_info['fee_text'], $fee_info['fee'], true, 'standard' );
+			if ( isset( $fee_info['fee_text'] ) && isset( $fee_info['fee'] ) && is_numeric( $fee_info['fee'] ) ) {
+				$cart->add_fee( $fee_info['fee_text'], floatval( $fee_info['fee'] ), true, 'standard' );
 			}
 		}
 	}
@@ -1579,7 +1579,7 @@ class WC_Connect_TaxJar_Integration {
 			'wc_services_custom_surcharges',
 			array(
 				'US:CO' => array(
-					array( 'WC_Connect_Custom_Surcharge', 'get_us_co_eligibility' ),
+					array( 'WC_Connect_Custom_Surcharge', 'add_us_co_rdf' ),
 				)
 			)
 		);

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1532,8 +1532,8 @@ class WC_Connect_TaxJar_Integration {
 			return;
 		}
 
-		/** Checks if Local Pickup is selected to not apply the fee */
-		if ( count( array_intersect( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
+		/** Do not apply the fee if all shipping methods use Local Pickup */
+		if ( 0 === count( array_diff( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) ) {
 			return;
 		}
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -170,8 +170,7 @@ class WC_Connect_TaxJar_Integration {
 
 		add_filter( 'woocommerce_calc_tax', array( $this, 'override_woocommerce_tax_rates' ), 10, 3 );
 		add_filter( 'woocommerce_matched_rates', array( $this, 'allow_street_address_for_matched_rates' ), 10, 2 );
-		
-		add_action( 'woocommerce_cart_calculate_fees', array( $this, 'maybe_add_custom_state_surcharge_fee' ), 10 );
+		add_action( 'woocommerce_cart_calculate_fees', array( $this, 'maybe_add_custom_fee' ), 10 );
 	}
 
 	/**
@@ -1502,92 +1501,29 @@ class WC_Connect_TaxJar_Integration {
 		wp_enqueue_script( 'wc-taxjar-order', $this->wc_connect_base_url . 'woocommerce-services-new-order-taxjar-' . WC_Connect_Loader::get_wcs_version() . '.js', array( 'jquery' ), null, true );
 	}
 
-	/**
-	 * Add a 27 cent surcharge to your cart / checkout based on delivery country & state
-	 * Taxes, shipping costs and order subtotal are all included in the surcharge amount
-	 *
-	 * Fee won't be added if all products in the cart are virtual
-	 * 
-	 * Change $fee to set the surcharge to a value to suit
-	 *
-	 * 
-	 * Change $country to set the country
-	 * http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes for available alpha-2 country codes
-	 *
-	 * Change $state to set the state
-	 * Example: The state code for Colorado would be 'CO'
-	 * https://en.wikipedia.org/wiki/ISO_3166-2:US
-	 *
-	 * Uses the WooCommerce fees API
-	 *
-	 * @param WC_Cart $cart WooCommerce Cart object.
-	 */
-	public function maybe_add_custom_state_surcharge_fee( $cart ) {
-		if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
-			return;
-		}
+	public function maybe_add_custom_fee( $cart ) {
+		/**
+		 * Filter to manipulate the custom surcharge methods.
+		 *
+		 * @since 2.8.6
+		 *
+		 * @param array List of custom surcharge methods.
+		 */
+		$surcharge_funcs = apply_filters(
+			'wc_services_custom_surcharge_methods',
+			array(
+				array( 'WC_Connect_Custom_Surcharge', 'add_us_co_rdf' ),
+			)
+		);
 
-		$surcharges = $this->get_custom_surcharges();
-
-		if ( ! is_array( $surcharges ) ) {
-			return;
-		}
-
-		$customer = WC()->customer;
-		$key      = $customer->get_shipping_country() . ':' . $customer->get_shipping_state();
-
-		if ( ! isset( $surcharges[ $key ] ) || ! is_array( $surcharges[ $key ] ) )  {
-			return;
-		}
-
-		foreach ( $surcharges[ $key ] as $function_rule ) {
+		foreach ( $surcharge_funcs as $function_rule ) {
 			if ( ! is_callable( $function_rule ) ) {
 				$callback_string = is_array( $function_rule ) ? implode( '::', $function_rule ) : $function_rule;
 				$this->_log( 'This surcharge rule cannot be called: ' . $callback_string );
 				continue;
 			}
 
-			$fee_info = call_user_func( $function_rule, $cart );
-
-			/**
-			 * Filter for toggling whether apply the custom surcharge or not.
-			 * Set to `false` to disable the custom surcharge.
-			 *
-			 * @since 2.8.6
-			 *
-			 * @param array   Custom surcharge info.
-			 * @param string  Custom surcharge area string. Example: "US-CO".
-			 * @param array   Custom surcharge function or method.
-			 * @param WC_Cart WooCommerce cart object.
-			 */
-			$fee_info = apply_filters( 'wc_services_apply_custom_surcharge_fee', $fee_info, $key, $function_rule, $cart );
-			
-			if ( isset( $fee_info['fee_text'] ) && isset( $fee_info['fee'] ) && is_numeric( $fee_info['fee'] ) ) {
-				$cart->add_fee( $fee_info['fee_text'], floatval( $fee_info['fee'] ), true, 'standard' );
-			}
+			call_user_func( $function_rule, $cart );
 		}
-	}
-
-	/**
-	 * Get list of custom surcharges.
-	 *
-	 * @return array.
-	 */
-	public function get_custom_surcharges() {
-		/**
-		 * Filter to manipulate the custom surcharge info.
-		 *
-		 * @since 2.8.6
-		 *
-		 * @param array List of custom surcharge info.
-		 */
-		return apply_filters(
-			'wc_services_custom_surcharges',
-			array(
-				'US:CO' => array(
-					array( 'WC_Connect_Custom_Surcharge', 'add_us_co_rdf' ),
-				)
-			)
-		);
 	}
 }

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1541,6 +1541,12 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		foreach ( $surcharges[ $key ] as $function_rule ) {
+			if ( ! is_callable( $function_rule ) ) {
+				$callback_string = is_array( $function_rule ) ? implode( '::', $function_rule ) : $function_rule;
+				$this->_log( 'This surcharge rule cannot be called: ' . $callback_string );
+				continue;
+			}
+
 			$fee_info = call_user_func( $function_rule, $cart );
 
 			/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1527,33 +1527,21 @@ class WC_Connect_TaxJar_Integration {
 		if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
 			return;
 		}
-		
-		if ( $this->maybe_all_products_are_virtual( $cart ) ) {
-			return;
-		}
-
-		/** Do not apply the fee if all shipping methods use Local Pickup */
-		if ( 0 === count( array_diff( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) ) {
-			return;
-		}
 
 		if ( ! is_array( $this->get_custom_surcharges() ) ) {
 			return;
 		}
 
-		$customer = WC()->customer;
+		$custom_surcharges = $this->get_custom_surcharges();
+		$customer          = WC()->customer;
+		$key               = $customer->get_shipping_country() . ':' . $customer->get_shipping_state();
 
-		foreach ( $this->get_custom_surcharges() as $key => $custom_info ) {
-			if ( $customer->get_shipping_country() . '-' . $customer->get_shipping_state() !== $key ) {
-				continue;
-			}
+		if ( ! isset( $custom_surcharges[ $key ] ) || ! is_array( $custom_surcharges[ $key ] ) )  {
+			return;
+		}
 
-			// Making sure all info is not empty.
-			if ( ! isset( $custom_info['function'] ) || ! isset( $custom_info['fee'] ) || ! isset( $custom_info['fee_text'] ) || ! is_float( $custom_info['fee'] ) || ! is_callable( $custom_info['function'] ) ) {
-				continue;
-			}
-
-			$eligible_to_add_fee = call_user_func( $custom_info['function'], $cart );
+		foreach ( $custom_surcharges[ $key ] as $function_rule ) {
+			$fee_info = call_user_func( $function_rule, $cart );
 
 			/**
 			 * Filter for toggling whether apply the custom surcharge or not.
@@ -1561,13 +1549,15 @@ class WC_Connect_TaxJar_Integration {
 			 *
 			 * @since 2.8.6
 			 *
-			 * @param boolean Custom surcharge toggle.
-			 * @param string  Custom surcharge area string. Example: "US-CO".
 			 * @param array   Custom surcharge info.
+			 * @param string  Custom surcharge area string. Example: "US-CO".
+			 * @param array   Custom surcharge function or method.
 			 * @param WC_Cart WooCommerce cart object.
 			 */
-			if ( true === apply_filters( 'wc_services_apply_custom_surcharge_fee', $eligible_to_add_fee, $key, $custom_info, $cart ) ) {
-				$cart->add_fee( $custom_info['fee_text'], $custom_info['fee'], true, 'standard' );
+			$fee_info = apply_filters( 'wc_services_apply_custom_surcharge_fee', $fee_info, $key, $function_rule, $cart );
+			
+			if ( isset( $fee_info['fee_text'] ) && isset( $fee_info['fee'] ) && is_float( $fee_info['fee'] ) ) {
+				$cart->add_fee( $fee_info['fee_text'], $fee_info['fee'], true, 'standard' );
 			}
 		}
 	}
@@ -1588,29 +1578,10 @@ class WC_Connect_TaxJar_Integration {
 		return apply_filters(
 			'wc_services_custom_surcharges',
 			array(
-				'US-CO' => array(
-					'function' => array( 'WC_Connect_Custom_Surcharge', 'get_us_co_eligibility' ),
-					'fee'      => 0.27,
-					'fee_text' => __( 'Retail Delivery Fee', 'woocommerce_services' ),
+				'US:CO' => array(
+					array( 'WC_Connect_Custom_Surcharge', 'get_us_co_eligibility' ),
 				)
 			)
 		);
-	}
-
-	/**
-	 * Check if all products are virtual or not.
-	 *
-	 * @param WC_Cart $cart WooCommerce Cart object.
-	 *
-	 * @return boolean.
-	 */
-	public function maybe_all_products_are_virtual( $cart ) {
-		foreach ( $cart->get_cart() as $cart_item ) {
-			if ( ! $cart_item['data']->is_virtual() ) {
-				return false;
-			}
-		}
-
-		return true;
 	}
 }

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -170,6 +170,9 @@ class WC_Connect_TaxJar_Integration {
 
 		add_filter( 'woocommerce_calc_tax', array( $this, 'override_woocommerce_tax_rates' ), 10, 3 );
 		add_filter( 'woocommerce_matched_rates', array( $this, 'allow_street_address_for_matched_rates' ), 10, 2 );
+		
+		// Add custom state surcharge.
+		add_action( 'woocommerce_cart_calculate_fees', array( $this, 'add_custom_state_surcharge_fee' ), 10 );
 	}
 
 	/**
@@ -1498,5 +1501,91 @@ class WC_Connect_TaxJar_Integration {
 		}
 		// Load Javascript for WooCommerce new order page
 		wp_enqueue_script( 'wc-taxjar-order', $this->wc_connect_base_url . 'woocommerce-services-new-order-taxjar-' . WC_Connect_Loader::get_wcs_version() . '.js', array( 'jquery' ), null, true );
+	}
+
+	/**
+	 * Add a 27 cent surcharge to your cart / checkout based on delivery country & state
+	 * Taxes, shipping costs and order subtotal are all included in the surcharge amount
+	 *
+	 * Fee won't be added if all products in the cart are virtual
+	 * 
+	 * Change $fee to set the surcharge to a value to suit
+	 *
+	 * 
+	 * Change $country to set the country
+	 * http://en.wikipedia.org/wiki/ISO_3166-1#Current_codes for available alpha-2 country codes
+	 *
+	 * Change $state to set the state
+	 * Example: The state code for Colorado would be 'CO'
+	 * https://en.wikipedia.org/wiki/ISO_3166-2:US
+	 *
+	 * Uses the WooCommerce fees API
+	 *
+	 * @param WC_Cart $cart WooCommerce Cart object.
+	 */
+	public function add_custom_state_surcharge_fee( $cart ) {
+		if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
+			return;
+		}
+		
+		if( $this->maybe_all_products_are_virtual( $cart ) ) {
+			return;
+		}
+
+		/** Checks if Local Pickup is selected to not apply the fee */
+		if ( count( array_intersect( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
+			return;
+		}
+
+		$customer = WC()->customer;
+
+		foreach ( $this->get_custom_surcharges() as $custom_info ) {
+			// Making sure all info is not empty.
+			if ( ! isset( $custom_info['country'] ) || ! isset( $custom_info['state'] ) || ! isset( $custom_info['fee'] ) || ! isset( $custom_info['fee_text'] ) || ! is_float( $custom_info['fee'] ) ) {
+				continue;
+			}
+
+			if ( $customer->get_shipping_country() !== $custom_info['country'] || $customer->get_shipping_state() !== $custom_info['state'] ) {	
+				continue;
+			}
+
+			$cart->add_fee( $custom_info['fee_text'], $custom_info['fee'], true, 'standard' );
+		}
+	}
+
+	/**
+	 * Get list of custom surcharges.
+	 *
+	 * @return array.
+	 */
+	public function get_custom_surcharges() {
+		return apply_filters(
+			'wc_services_custom_surcharges',
+			array(
+				array(
+					'country'  => 'US',
+					'state'    => 'CO',
+					'fee'      => 0.27,
+					'fee_text' => __( 'Retail Delivery Fee', 'woocommerce_services' ),
+				)
+			)
+		);
+	}
+
+	/**
+	 * Check if all products are virtual or not.
+	 *
+	 * @param WC_Cart $cart WooCommerce Cart object.
+	 *
+	 * @return boolean.
+	 */
+	public function maybe_all_products_are_virtual( $cart ) {
+		foreach ( $cart->get_cart() as $cart_item ) {
+			if ( ! $cart_item['data']->is_virtual() ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1544,12 +1544,12 @@ class WC_Connect_TaxJar_Integration {
 		$customer = WC()->customer;
 
 		foreach ( $this->get_custom_surcharges() as $key => $custom_info ) {
-			if ( $customer->get_shipping_country() . ':' . $customer->get_shipping_state() !== $key ) {
+			if ( $customer->get_shipping_country() . '-' . $customer->get_shipping_state() !== $key ) {
 				continue;
 			}
 
 			// Making sure all info is not empty.
-			if ( ! isset( $custom_info['function'] ) || ! isset( $custom_info['fee'] ) || ! isset( $custom_info['fee_text'] ) || ! is_float( $custom_info['fee'] ) || ! is_callable( $custom_info['function'], true ) ) {
+			if ( ! isset( $custom_info['function'] ) || ! isset( $custom_info['fee'] ) || ! isset( $custom_info['fee_text'] ) || ! is_float( $custom_info['fee'] ) || ! is_callable( $custom_info['function'] ) ) {
 				continue;
 			}
 
@@ -1562,11 +1562,12 @@ class WC_Connect_TaxJar_Integration {
 			 * @since 2.8.6
 			 *
 			 * @param boolean Custom surcharge toggle.
+			 * @param string  Custom surcharge area string. Example: "US-CO".
 			 * @param array   Custom surcharge info.
 			 * @param WC_Cart WooCommerce cart object.
 			 */
-			if ( true === apply_filters( 'wc_services_apply_custom_surcharge_fee', $eligible_to_add_fee, $custom_info, $cart ) ) {
-				$cart->add_fee( $custom_info['fee_text'], $custom_info['fee'], true, 'standard' );	
+			if ( true === apply_filters( 'wc_services_apply_custom_surcharge_fee', $eligible_to_add_fee, $key, $custom_info, $cart ) ) {
+				$cart->add_fee( $custom_info['fee_text'], $custom_info['fee'], true, 'standard' );
 			}
 		}
 	}
@@ -1588,7 +1589,7 @@ class WC_Connect_TaxJar_Integration {
 			'wc_services_custom_surcharges',
 			array(
 				'US-CO' => array(
-					'function' => array( 'WC_Connect_Custom_Surcharge', 'get_us_co_custom_surcharge' ),
+					'function' => array( 'WC_Connect_Custom_Surcharge', 'get_us_co_eligibility' ),
 					'fee'      => 0.27,
 					'fee_text' => __( 'Retail Delivery Fee', 'woocommerce_services' ),
 				)

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1537,17 +1537,23 @@ class WC_Connect_TaxJar_Integration {
 			return;
 		}
 
+		if ( ! is_array( $this->get_custom_surcharges() ) ) {
+			return;
+		}
+
 		$customer = WC()->customer;
 
-		foreach ( $this->get_custom_surcharges() as $custom_info ) {
-			// Making sure all info is not empty.
-			if ( ! isset( $custom_info['country'] ) || ! isset( $custom_info['state'] ) || ! isset( $custom_info['fee'] ) || ! isset( $custom_info['fee_text'] ) || ! is_float( $custom_info['fee'] ) ) {
+		foreach ( $this->get_custom_surcharges() as $key => $custom_info ) {
+			if ( $customer->get_shipping_country() . ':' . $customer->get_shipping_state() !== $key ) {
 				continue;
 			}
 
-			if ( $customer->get_shipping_country() !== $custom_info['country'] || $customer->get_shipping_state() !== $custom_info['state'] ) {	
+			// Making sure all info is not empty.
+			if ( ! isset( $custom_info['function'] ) || ! isset( $custom_info['fee'] ) || ! isset( $custom_info['fee_text'] ) || ! is_float( $custom_info['fee'] ) || ! is_callable( $custom_info['function'], true ) ) {
 				continue;
 			}
+
+			$eligible_to_add_fee = call_user_func( $custom_info['function'], $cart );
 
 			/**
 			 * Filter for toggling whether apply the custom surcharge or not.
@@ -1559,7 +1565,7 @@ class WC_Connect_TaxJar_Integration {
 			 * @param array   Custom surcharge info.
 			 * @param WC_Cart WooCommerce cart object.
 			 */
-			if ( true === apply_filters( 'wc_services_apply_custom_surcharge_fee', true, $custom_info, $cart ) ) {
+			if ( true === apply_filters( 'wc_services_apply_custom_surcharge_fee', $eligible_to_add_fee, $custom_info, $cart ) ) {
 				$cart->add_fee( $custom_info['fee_text'], $custom_info['fee'], true, 'standard' );	
 			}
 		}
@@ -1581,9 +1587,8 @@ class WC_Connect_TaxJar_Integration {
 		return apply_filters(
 			'wc_services_custom_surcharges',
 			array(
-				array(
-					'country'  => 'US',
-					'state'    => 'CO',
+				'US-CO' => array(
+					'function' => array( 'WC_Connect_Custom_Surcharge', 'get_us_co_custom_surcharge' ),
 					'fee'      => 0.27,
 					'fee_text' => __( 'Retail Delivery Fee', 'woocommerce_services' ),
 				)

--- a/classes/class-wc-connect-utils.php
+++ b/classes/class-wc-connect-utils.php
@@ -104,22 +104,5 @@ if ( ! class_exists( 'WC_Connect_Utils' ) ) {
 
 			return false;
 		}
-
-		/**
-		 * Check if all products are virtual or not.
-		 *
-		 * @param WC_Cart $cart WooCommerce Cart object.
-		 *
-		 * @return boolean.
-		 */
-		public static function is_all_products_are_virtual( $cart ) {
-			foreach ( $cart->get_cart() as $cart_item ) {
-				if ( ! $cart_item['data']->is_virtual() ) {
-					return false;
-				}
-			}
-
-			return true;
-		}
 	}
 }

--- a/classes/class-wc-connect-utils.php
+++ b/classes/class-wc-connect-utils.php
@@ -104,5 +104,22 @@ if ( ! class_exists( 'WC_Connect_Utils' ) ) {
 
 			return false;
 		}
+
+		/**
+		 * Check if all products are virtual or not.
+		 *
+		 * @param WC_Cart $cart WooCommerce Cart object.
+		 *
+		 * @return boolean.
+		 */
+		public static function is_all_products_are_virtual( $cart ) {
+			foreach ( $cart->get_cart() as $cart_item ) {
+				if ( ! $cart_item['data']->is_virtual() ) {
+					return false;
+				}
+			}
+
+			return true;
+		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 2.8.6 - 2024-xx-xx =
+* Add   - Custom surcharge ( Retail Delivery Fee ) for shipment to Colorado, US.
+
 = 2.8.5 - 2024-12-10 =
 * Fix   - Fixed an issue that prevented editing an order when automated tax is enabled.
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,7 +81,7 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
-= 2.8.7 - 2024-xx-xx =
+= 2.9.0 - 2024-xx-xx =
 * Add   - Option to apply US Colorado Retail Delivery Fee tax by using `wc_services_apply_us_co_retail_delivery_fee` filter.
 
 = 2.8.6 - 2025-01-06 =

--- a/readme.txt
+++ b/readme.txt
@@ -82,7 +82,7 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 == Changelog ==
 
 = 2.8.6 - 2024-xx-xx =
-* Add   - Custom surcharge ( Retail Delivery Fee ) for shipment to Colorado, US.
+* Add   - Option to apply US Colorado Retail Delivery Fee tax by using `wc_services_apply_us_co_retail_delivery_fee` filter.
 
 = 2.8.5 - 2024-12-10 =
 * Fix   - Fixed an issue that prevented editing an order when automated tax is enabled.

--- a/readme.txt
+++ b/readme.txt
@@ -81,7 +81,7 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
-= 2.9.0 - 2024-xx-xx =
+= 2.9.0 - 2025-xx-xx =
 * Add   - Option to apply US Colorado Retail Delivery Fee tax by using `wc_services_apply_us_co_retail_delivery_fee` filter.
 
 = 2.8.6 - 2025-01-06 =

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -767,6 +767,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			require_once __DIR__ . '/classes/class-wc-connect-logger.php';
 			require_once __DIR__ . '/classes/class-wc-connect-service-schemas-validator.php';
 			require_once __DIR__ . '/classes/class-wc-connect-taxjar-integration.php';
+			require_once __DIR__ . '/classes/class-wc-connect-custom-surcharge.php';
 			require_once __DIR__ . '/classes/class-wc-connect-error-notice.php';
 			require_once __DIR__ . '/classes/class-wc-connect-compatibility.php';
 			require_once __DIR__ . '/classes/class-wc-connect-compatibility-wcshipping-packages.php';


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Adding a function for custom surcharge ( retail delivery fee ) for Colorado state. This changes also introduce a new filter hook that the user can use to disable the custom surcharge addition.
<!-- Explain the motivation for making this change -->

### Related issue(s)
Fixes #2562 
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
1. Add product to the cart.
2. Use any Colorado address for the shipping address.
3. The Retail Delivery Fee will be displayed as a free on the cart.
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

