### PR TITLE
WooCommerce 9.7 Compatibility

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.8.8 - 2025-xx-xx =
+* Tweak - WooCommerce 9.7 Compatibility.
+
 = 2.8.7 - 2025-01-20 =
 * Add   - Option to apply US Colorado Retail Delivery Fee tax by using `wc_services_apply_us_co_retail_delivery_fee` filter.
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 2.8.8 - 2025-xx-xx =
+* Tweak - WooCommerce 9.7 Compatibility.
+
 = 2.8.7 - 2025-01-20 =
 * Add   - Option to apply US Colorado Retail Delivery Fee tax by using `wc_services_apply_us_co_retail_delivery_fee` filter.
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,11 +2,11 @@
 Contributors: woocommerce, automattic, woothemes, allendav, kellychoffman, jkudish, jeffstieler, nabsul, robobot3000, danreylop, mikeyarce, shaunkuschel, orangesareorange, pauldechov, dappermountain, radogeorgiev, bor0, royho, cshultz88, bartoszbudzanowski, harriswong, ferdev, superdav42
 Tags: shipping, stamps, usps, woocommerce, taxes, payment, dhl, labels
 Requires PHP: 7.4
-Requires at least: 6.5
+Requires at least: 6.6
 Requires Plugins: woocommerce
 Tested up to: 6.7
-WC requires at least: 9.2
-WC tested up to: 9.4
+WC requires at least: 9.5
+WC tested up to: 9.7
 Stable tag: 2.8.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -9,10 +9,10 @@
  * Text Domain: woocommerce-services
  * Domain Path: /i18n/languages/
  * Version: 2.8.7
- * Requires at least: 6.5
+ * Requires at least: 6.6
  * Tested up to: 6.7
- * WC requires at least: 9.2
- * WC tested up to: 9.4
+ * WC requires at least: 9.5
+ * WC tested up to: 9.7
  *
  * Copyright (c) 2017-2023 Automattic
  *


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adding a changelog for WooCommerce 9.7 compatibility. This PR is connected with this [EPIC issue](https://github.com/Automattic/woocommerce-shipping-issues/issues/291).

### How to test the changes in this Pull Request:

1. Update WC version to 9.7
2. Test the extensions.
3. No warning or error is displayed on the log.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> * Tweak - WooCommerce 9.7 compatibility.
