### PR TITLE
Pass through settings with proxy requests as well

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.8.10 - 2025-xx-xx =
+* Tweak - Improve tax tracking.
+
 = 2.8.9 - 2025-04-07 =
 * Tweak - WordPress 6.8 & WooCommerce 9.8 Compatibility.
 

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -29,7 +29,6 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 
 			$this->validator         = $validator;
 			$this->wc_connect_loader = $wc_connect_loader;
-
 		}
 
 		/**
@@ -437,7 +436,8 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			if ( is_wp_error( $authorization ) ) {
 				return $authorization;
 			}
-			$args['headers']['Authorization'] = $authorization;
+			$args['headers']['Authorization']  = $authorization;
+			$args['headers']['X-Woo-Settings'] = $this->get_request_additional_header();
 
 			$http_timeout = 60; // 1 minute
 
@@ -450,6 +450,44 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			$response = wp_remote_request( $proxy_url, $args );
 
 			return $response;
+		}
+
+		/**
+		 * Get useful settings values for use in a requests
+		 *
+		 * @return array
+		 */
+		protected function get_settings_values() {
+			return array(
+				'store_guid'           => $this->get_guid(),
+				'base_city'            => WC()->countries->get_base_city(),
+				'base_country'         => WC()->countries->get_base_country(),
+				'base_state'           => WC()->countries->get_base_state(),
+				'base_postcode'        => WC()->countries->get_base_postcode(),
+				'currency'             => get_woocommerce_currency(),
+				'dimension_unit'       => strtolower( get_option( 'woocommerce_dimension_unit' ) ),
+				'weight_unit'          => strtolower( get_option( 'woocommerce_weight_unit' ) ),
+				'wcs_version'          => WC_Connect_Loader::get_wcs_version(),
+				'jetpack_version'      => 'embed-' . WC_Connect_Jetpack::get_jetpack_connection_package_version(),
+				'is_atomic'            => WC_Connect_Jetpack::is_atomic_site(),
+				'wc_version'           => WC()->version,
+				'wp_version'           => get_bloginfo( 'version' ),
+				'last_services_update' => WC_Connect_Options::get_option( 'services_last_update', 0 ),
+				'last_heartbeat'       => WC_Connect_Options::get_option( 'last_heartbeat', 0 ),
+				'last_rate_request'    => WC_Connect_Options::get_option( 'last_rate_request', 0 ),
+				'active_services'      => $this->wc_connect_loader->get_active_services(),
+				'disable_stats'        => WC_Connect_Jetpack::is_staging_site(),
+				'taxes_enabled'        => wc_tax_enabled() && 'yes' === get_option( 'wc_connect_taxes_enabled' ),
+			);
+		}
+
+		/**
+		 * Add useful WP/WC/WCC information for use in a request header
+		 *
+		 * @return json
+		 */
+		protected function get_request_additional_header() {
+			return json_encode( $this->get_settings_values() );
 		}
 
 		/**
@@ -467,27 +505,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			// Add interesting fields to the body of each request
 			$body['settings'] = wp_parse_args(
 				$body['settings'],
-				array(
-					'store_guid'           => $this->get_guid(),
-					'base_city'            => WC()->countries->get_base_city(),
-					'base_country'         => WC()->countries->get_base_country(),
-					'base_state'           => WC()->countries->get_base_state(),
-					'base_postcode'        => WC()->countries->get_base_postcode(),
-					'currency'             => get_woocommerce_currency(),
-					'dimension_unit'       => strtolower( get_option( 'woocommerce_dimension_unit' ) ),
-					'weight_unit'          => strtolower( get_option( 'woocommerce_weight_unit' ) ),
-					'wcs_version'          => WC_Connect_Loader::get_wcs_version(),
-					'jetpack_version'      => 'embed-' . WC_Connect_Jetpack::get_jetpack_connection_package_version(),
-					'is_atomic'            => WC_Connect_Jetpack::is_atomic_site(),
-					'wc_version'           => WC()->version,
-					'wp_version'           => get_bloginfo( 'version' ),
-					'last_services_update' => WC_Connect_Options::get_option( 'services_last_update', 0 ),
-					'last_heartbeat'       => WC_Connect_Options::get_option( 'last_heartbeat', 0 ),
-					'last_rate_request'    => WC_Connect_Options::get_option( 'last_rate_request', 0 ),
-					'active_services'      => $this->wc_connect_loader->get_active_services(),
-					'disable_stats'        => WC_Connect_Jetpack::is_staging_site(),
-					'taxes_enabled'        => wc_tax_enabled() && 'yes' === get_option( 'wc_connect_taxes_enabled' ),
-				)
+				$this->get_settings_values()
 			);
 
 			return $body;

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 
 == Changelog ==
 
+= 2.8.10 - 2025-xx-xx =
+* Tweak - Improve tax tracking.
+
 = 2.8.9 - 2025-04-07 =
 * Tweak - WordPress 6.8 & WooCommerce 9.8 Compatibility.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
When we make requests to api.woocommerce.com we include key settings to help us determine certain things on the server, when making proxy requests for taxes, we cannot include these as part of the body, so instead we should include this in another way.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
- Check out this branch and build the plugin
- Enable automated taxes and ensure your store is set to US origin for testing
- Put an error log and die command [here](https://github.com/Automattic/woocommerce-services/blob/147ad8ffdd9253bdefb0f77597b8ec0a324dd64d/classes/class-wc-connect-api-client.php#L449)
```
print_r( $args );
die();
```
- Now go to the store frontend and and try and checkout with a US address
- It should show the request args and as part of that it should include a new `x-woo-settings` header containing things like the wc_version, wp_version, store_guid, etc in json format.

<img width="909" alt="Screenshot 2025-04-01 at 16 34 25" src="https://github.com/user-attachments/assets/3aa3248c-89de-4df1-9e6a-336a9422ee19" />


### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

