### PR TITLE
WordPress 6.8 & WooCommerce 9.8 Compatibility

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping & Tax Changelog ***
 
+= 2.8.9 - 2025-xx-xx =
+* Tweak - WordPress 6.8 & WooCommerce 9.8 Compatibility.
+
 = 2.8.8 - 2025-03-03 =
 * Tweak - WooCommerce 9.7 Compatibility.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,9 +4,9 @@ Tags: shipping, stamps, usps, woocommerce, taxes, payment, dhl, labels
 Requires PHP: 7.4
 Requires at least: 6.6
 Requires Plugins: woocommerce
-Tested up to: 6.7
-WC requires at least: 9.5
-WC tested up to: 9.7
+Tested up to: 6.8
+WC requires at least: 9.6
+WC tested up to: 9.8
 Stable tag: 2.8.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -80,6 +80,9 @@ The source code is freely available [in GitHub](https://github.com/Automattic/wo
 6. Checking and exporting the label purchase reports
 
 == Changelog ==
+
+= 2.8.9 - 2025-xx-xx =
+* Tweak - WordPress 6.8 & WooCommerce 9.8 Compatibility.
 
 = 2.8.8 - 2025-03-03 =
 * Tweak - WooCommerce 9.7 Compatibility.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -12,9 +12,9 @@
  * Requires Plugins: woocommerce
  * Requires PHP: 7.4
  * Requires at least: 6.6
- * Tested up to: 6.7
- * WC requires at least: 9.5
- * WC tested up to: 9.7
+ * Tested up to: 6.8
+ * WC requires at least: 9.6
+ * WC tested up to: 9.8
  *
  * Copyright (c) 2017-2023 Automattic
  *


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adding a changelog for WooCommerce 9.8 compatibility. This PR is connected with and resolves WOOSHIP-1223.

### How to test the changes in this Pull Request:

1. Update WP 6.8 RC version by following the steps [here](https://wpexperts.io/blog/wordpress-6-8-release/#scroll_to_9).
2. Update WC version to 9.8RC
3. Test the extensions.
4. No warning or error is displayed on the log.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> * Tweak - WordPress 6.8 & WooCommerce 9.8 Compatibility.
