### PR TITLE
Fixing the E2E tests

### DIFF
--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -7,7 +7,7 @@ permissions:
 jobs:
   qit_security:
     name: QIT Security Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       NO_COLOR: 1
       QIT_DISABLE_ONBOARDING: yes

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -373,7 +373,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			);
 
 			add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ) );
-			add_action( 'plugins_loaded', array( $this, 'jetpack_on_plugins_loaded' ), 1 );
+			add_action( 'after_setup_theme', array( $this, 'ensure_jetpack_connection' ), 1 );
 
 			/**
 			 * Used to let WC Tax know WCS&T will handle the plugin's coexistence.
@@ -620,13 +620,13 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			load_plugin_textdomain( 'woocommerce-services', false, dirname( plugin_basename( __FILE__ ) ) . '/i18n/languages' );
 		}
 
-		public function jetpack_on_plugins_loaded() {
+		public function ensure_jetpack_connection() {
 			$jetpack_config = new Automattic\Jetpack\Config();
 			$jetpack_config->ensure(
 				'connection',
 				array(
 					'slug' => WC_Connect_Jetpack::JETPACK_PLUGIN_SLUG,
-					'name' => __( 'WooCommerce Shipping & Tax', 'woocommerce-services' ),
+					'name' => _x( 'WooCommerce Shipping & Tax', 'The brand of WooCommerce Shipping and Tax', 'woocommerce-services' ),
 				)
 			);
 		}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Fixing the E2E tests by fixing the `Notice: Function _load_textdomain_just_in_time was called incorrectly.` error. It's fixed by moving the jetpack connection ensurance from `plugins_loaded` to `after_setup_theme`.
<!-- Explain the motivation for making this change -->

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

