### PR TITLE
Rename the plugin and updates the description in the Org store

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -17,10 +17,8 @@ We’re here to help with tax rates: collect accurate sales tax, automatically.
 
 Attention: Shipping features have moved to a new dedicated plugin. Download WooCommerce Shipping.
 
-WooCommerce Shipping & Tax makes basic eCommerce features like shipping more reliable by taking the burden off of your site’s infrastructure.
-
 Enable automated taxes
-That’s it! Once you update your tax settings, your store will collect sales tax at checkout based on the store address in your WooCommerce Settings.
+That's it! Once you update your tax settings, your store will collect sales tax at checkout based on the store address in your WooCommerce Settings.
 
 Eliminate the need to even think about sales taxes for your store
 Automatically calculate how much sales tax should be collected for WooCommerce orders — by city, country, or state — at checkout.

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
-=== WooCommerce Shipping & Tax ===
+=== WooCommerce Tax (formerly WooCommerce Shipping & Tax) ===
 Contributors: woocommerce, automattic, woothemes, allendav, kellychoffman, jkudish, jeffstieler, nabsul, robobot3000, danreylop, mikeyarce, shaunkuschel, orangesareorange, pauldechov, dappermountain, radogeorgiev, bor0, royho, cshultz88, bartoszbudzanowski, harriswong, ferdev, superdav42
-Tags: shipping, stamps, usps, woocommerce, taxes, payment, dhl, labels
+Tags: tax, vat, gst, woocommerce, payment
 Requires PHP: 7.4
 Requires at least: 6.6
 Requires Plugins: woocommerce
@@ -11,64 +11,59 @@ Stable tag: 3.0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-WooCommerce Shipping & Tax offers automated tax calculation, shipping label printing, smoother payment setup, and other hosted services for WooCommerce.
+We’re here to help with tax rates: collect accurate sales tax, automatically.
 
 == Description ==
 
-**Attention:** Shipping features have moved to a new dedicated plugin. [Download WooCommerce Shipping](https://wordpress.org/plugins/woocommerce-shipping/).
+Attention: Shipping features have moved to a new dedicated plugin. Download WooCommerce Shipping.
 
 WooCommerce Shipping & Tax makes basic eCommerce features like shipping more reliable by taking the burden off of your site’s infrastructure.
 
-With WooCommerce Shipping & Tax, critical services are hosted on Automattic’s best-in-class infrastructure, rather than relying on your store’s hosting. That means your store will be more stable and faster.
-To use the features, simply install this plugin and activate the ones you want directly in your dashboard. As we add more services, you’ll see more features available directly in WooCommerce – making setup simpler.
+Enable automated taxes
+That’s it! Once you update your tax settings, your store will collect sales tax at checkout based on the store address in your WooCommerce Settings.
 
-NOTE: This extension was previously referred to as WooCommerce Services.
-
-= Print USPS and DHL shipping labels and save up to 90% =
-Ship domestically and internationally right from your WooCommerce dashboard. Print USPS and DHL labels and instantly save up to 90%.
-
-= Collect accurate taxes at checkout =
-We've got taxes for you - no need to enter tax rates manually.
+Eliminate the need to even think about sales taxes for your store
+Automatically calculate how much sales tax should be collected for WooCommerce orders — by city, country, or state — at checkout.
 
 == Installation ==
 
 This section describes how to install the plugin and get it working.
 
-1. Upload the plugin files to the `/wp-content/plugins/plugin-name` directory, or install the plugin through the WordPress plugins screen directly.
-1. Activate the plugin through the 'Plugins' screen in WordPress
 1. Install and activate WooCommerce if you haven't already done so
-1. Install, activate and connect to your WordPress.com account if you haven't already done so
-1. Want to buy shipping labels? First, add your credit card to https://wordpress.com/me/purchases/billing and then print labels for orders right from the Edit Order page
-1. Enable automated taxes from WooCommerce > Settings > Tax (make sure "enable taxes" is checked in General settings first)
+2. Upload the plugin files to the `/wp-content/plugins/woocommerce-tax` directory, or install the plugin through the WordPress plugins screen directly.
+3. Activate the plugin through the 'Plugins' screen in WordPress
+4. Install, activate and connect to your WordPress.com account if you haven't already done so
+5. Enable automated taxes from WooCommerce > Settings > Tax (make sure "enable taxes" is checked in General settings first)
 
 == Frequently Asked Questions ==
 
 = Why is a WordPress.com account connection required? =
 
-We connect to your WordPress.com account to authenticate your site and user account so we can securely charge the payment method on file for any labels purchased.
-
-= What services are included? =
-
-* USPS and DHL label purchase/printing
-* Automated tax calculation
-* PayPal Checkout payment authorization
-
-= Can I buy and print shipping labels for US domestic and international packages? =
-
-Yes! You can buy and print USPS shipping labels for domestic destinations and USPS and DHL shipping labels for international destinations. Shipments need to originate from the U.S.
+A WordPress.com connection is required to securely access our tax APIs, and to avoid API abuse.
 
 = This works with WooCommerce, right? =
 
-Yep! WooCommerce version 3.0 or newer, please.
+Yep! We follow the L-2 policy, meaning if the latest version of WooCommerce is 8.7, we support back to WooCommerce version 8.5.
 
-= Are there Terms of Service and data usage policies? =
+= Are there Terms of Service? =
 
-Absolutely! You can read our Terms of Service [here](https://en.wordpress.com/tos) and our data policy [here](https://jetpack.com/support/what-data-does-jetpack-sync/).
+Absolutely! You can read our Terms of Service [here](https://wordpress.com/tos).
 
-= Where can I see the source code for this plugin? =
+== External services ==
 
-The source code is freely available [in GitHub](https://github.com/Automattic/woocommerce-services).
+This plugin relies on the following external services:
 
+1. WordPress.com connection:
+   - Description: The plugin makes requests to our own endpoints at WordPress.com (proxied via https://api.woocommerce.com) to fetch automated tax calculations.
+   - Website: https://wordpress.com/
+   - Terms of Service: https://wordpress.com/tos/
+   - Privacy Policy: https://automattic.com/privacy/
+
+2. Usage Tracking:
+   - Description: The plugin will send usage statistics to our own service, after the user has accepted our Terms of Service.
+   - Script: https://stats.wp.com/w.js
+   - Terms of Service: https://wordpress.com/tos/
+   - Privacy Policy: https://automattic.com/privacy/
 
 == Screenshots ==
 


### PR DESCRIPTION
-------

## Description
<!-- Explain the motivation for making this change -->
This PR renames the plugin to `WooCommerce Tax (formerly WooCommerce Shipping & Tax)` and also updates the tags and description in the WordPress.org plugin repository to reflect the new name and focus of the plugin.

### Related issue(s)

#WOOSHIP-1272

### Steps to reproduce & screenshots/GIFs

N/A

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [x] `readme.txt` entry added