### PR TITLE
Fix/issue wooship 1438 - Fix the Arizona Tax Calculation for the Order placed in Arizona

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Tax Changelog ***
 
 = 3.0.4 - 2025-xx-xx =
-* Fix   - Arizona tax calculation for the store located in Arizona and ship the product within Arizona.
+* Fix   - Corrected tax calculation for orders shipped within Arizona from stores based in Arizona.
 
 = 3.0.3 - 2025-06-12 =
 * Tweak - Update Org store screenshots.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.0.4 - 2025-xx-xx =
+* Fix   - Arizona tax calculation for the store located in Arizona and ship the product within Arizona.
+
 = 3.0.3 - 2025-06-12 =
 * Tweak - Update Org store screenshots.
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1008,6 +1008,12 @@ class WC_Connect_TaxJar_Integration {
 				'from_country' => 'US',
 				'from_state'   => 'CO',
 			),
+			'US-AZ' => array(
+				'to_country'   => 'US',
+				'to_state'     => 'AZ',
+				'from_country' => 'US',
+				'from_state'   => 'AZ',
+			),
 		);
 
 		foreach ( $cases as $case ) {

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.0.4 - 2025-xx-xx =
+* Fix   - Arizona tax calculation for the store located in Arizona and ship the product within Arizona.
+
 = 3.0.3 - 2025-06-12 =
 * Tweak - Update Org store screenshots.
 

--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,7 @@ This plugin relies on the following external services:
 == Changelog ==
 
 = 3.0.4 - 2025-xx-xx =
-* Fix   - Arizona tax calculation for the store located in Arizona and ship the product within Arizona.
+* Fix   - Corrected tax calculation for orders shipped within Arizona from stores based in Arizona.
 
 = 3.0.3 - 2025-06-12 =
 * Tweak - Update Org store screenshots.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Add one case ( for store located in AZ and ship the product to AZ ) for utilizing nexus address to calculate the tax. Because Arizona use destination-based tax calculation.
<!-- Explain the motivation for making this change -->

### Related issue(s)
Closes [WOOSHIP-1438](https://linear.app/a8c/issue/WOOSHIP-1438/wrong-tax-rate-being-returned-for-arizona-address).
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

1. Set the store location to Arizona address.
2. Enable the automated taxes : 
<img width="900" alt="Screenshot 2025-06-24 at 13 07 18" src="https://github.com/user-attachments/assets/4b9e6180-8ee6-463e-87f8-36b383294dd7" />

3. Add the product to the cart.
4. Go to checkout page.
5. Set the shipping address to : 
```
Street: 3948 W Butler Street
City: Chandler
State: Arizona
ZIP Code: 85226
```
6. New tax with correct percentage will be added : 
<img width="1310" alt="Screenshot 2025-06-24 at 13 04 40" src="https://github.com/user-attachments/assets/274ea531-384f-44a6-9bb9-c1ff43cd1759" />

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

