### PR TITLE
Add option to disable legacy shipping features

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -495,6 +495,11 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				return false;
 			}
 
+			$disable_shipping = get_option( 'wc_connect_disable_shipping', 'no' );
+			if ( $disable_shipping === 'yes' ) {
+				return false;
+			}
+
 			// If the shipping label is disabled, will remove the meta box.
 			if ( ! $this->is_shipping_label_enabled() ) {
 				return false;
@@ -532,6 +537,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		 * @return bool True if shipping label is enabled from the settings.
 		 */
 		public function is_shipping_label_enabled() {
+			if ( get_option( 'wc_connect_disable_shipping' ) === 'yes' ) {
+				return false;
+			}
+			
 			$account_settings = $this->account_settings->get();
 
 			if ( isset( $account_settings['formData']['enabled'] ) && is_bool( $account_settings['formData']['enabled'] ) ) {

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -495,11 +495,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				return false;
 			}
 
-			$disable_shipping = get_option( 'wc_connect_disable_shipping', 'no' );
-			if ( $disable_shipping === 'yes' ) {
-				return false;
-			}
-
 			// If the shipping label is disabled, will remove the meta box.
 			if ( ! $this->is_shipping_label_enabled() ) {
 				return false;
@@ -540,7 +535,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			if ( get_option( 'wc_connect_disable_shipping' ) === 'yes' ) {
 				return false;
 			}
-			
+
 			$account_settings = $this->account_settings->get();
 
 			if ( isset( $account_settings['formData']['enabled'] ) && is_bool( $account_settings['formData']['enabled'] ) ) {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -236,6 +236,17 @@ class WC_Connect_TaxJar_Integration {
 		// Insert the "automated taxes" setting at the top (under the section title)
 		array_splice( $tax_settings, 1, 0, array( $automated_taxes ) );
 
+		// Insert Disable Shipping Features setting right after
+		$disable_shipping_setting = array(
+			'title'    => __( 'Disable Legacy Shipping Features in WooCommerce Tax', 'woocommerce-services' ),
+			'desc'     => __( 'Enabling this option will turn off the shipping features on the Edit Order pages and will improve overall performance.', 'woocommerce-services' ),
+			'id'       => 'wc_connect_disable_shipping',
+			'default'  => 'no',
+			'type'     => 'checkbox',
+			'desc_tip' => true,
+		);
+		array_splice( $tax_settings, 2, 0, array( $disable_shipping_setting ) );
+
 		if ( $enabled ) {
 			// If the automated taxes are enabled, disable the settings that would be reverted in the original plugin
 			foreach ( $tax_settings as $index => $tax_setting ) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
This pull request adds an option in the admin panel to turn off the legacy shipping features in this plugin which add the shipping meta boxes on the Edit Order page. Since this plugin is heading in the direction of deprecating these features, I figure it may be useful to allow users to turn off these features.

After installing this plugin, I noticed these meta boxes cause a number of API requests to run on every load of the Edit Order page, amounting to a 2-4 second impact of load time, even when these boxes are set to hidden in the UI.

This option cuts off the loading of the meta boxes during the evaluation of `calculate_should_show_meta_box`.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

#### API Calls of the Edit Order page after a typical install of this plugin:

<img width="1317" alt="Screenshot 2025-06-24 at 11 21 42 PM" src="https://github.com/user-attachments/assets/29e39604-d5ed-4057-a8a9-4a36c8894ebc" />


#### API Calls of the Edit Order page after enabling the new option to turn off the legacy shipping features:

<img width="1318" alt="Screenshot 2025-06-24 at 11 20 00 PM" src="https://github.com/user-attachments/assets/e84972af-baa0-445c-af02-93484ba13dc0" />


#### Screenshot of the new setting:

<img width="991" alt="Screenshot 2025-06-25 at 12 16 23 AM" src="https://github.com/user-attachments/assets/5b1deb3d-9da9-4e42-a639-838d860edf77" />


<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

