### PR TITLE
Fix the build plugin jobs on Github workflow runner and fix manual runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,22 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
       - name: Install NPM dependencies
         run: npm ci
 
       - name: Build plugin zip
         run: npm run build
+
+      - name: Unzip woocommerce-services.zip
+        run: unzip woocommerce-services.zip -d woocommerce-services
+
+      - name: Re-zip woocommerce-services folder
+        run: zip -r woocommerce-services.zip woocommerce-services
 
       - name: Upload plugin zip
         uses: actions/upload-artifact@v4

--- a/.github/workflows/manual_qit.yml
+++ b/.github/workflows/manual_qit.yml
@@ -102,14 +102,14 @@ jobs:
       - run: npm run eslint
       - run: npm run test
 
-    php-tests:
-      if: contains(inputs.extension-tests, 'All') || contains(inputs.extension-tests, 'Unit')
-      name: PHP Tests
-      needs: find_latest_versions
-      uses: ./.github/workflows/unit_test_runner.yml
-      with:
-          wp_version: ${{ inputs.wp-version == 'latest' && fromJSON(needs.find_latest_versions.outputs.wp_versions)[0] || inputs.wp-version }}
-          wc_version: ${{ inputs.wc-version == 'latest' && fromJSON(needs.find_latest_versions.outputs.wc_versions)[0] || inputs.wc-version == 'rc' && needs.find_latest_versions.outputs.wc_rc_version || inputs.wc-version }}
+  php-tests:
+    if: contains(inputs.extension-tests, 'All') || contains(inputs.extension-tests, 'Unit')
+    name: PHP Tests
+    needs: find_latest_versions
+    uses: ./.github/workflows/unit_test_runner.yml
+    with:
+      wp_version: ${{ inputs.wp-version == 'latest' && fromJSON(needs.find_latest_versions.outputs.wp_versions)[0] || inputs.wp-version }}
+      wc_version: ${{ inputs.wc-version == 'latest' && fromJSON(needs.find_latest_versions.outputs.wc_versions)[0] || inputs.wc-version == 'rc' && needs.find_latest_versions.outputs.wc_rc_version || inputs.wc-version }}
 
   build_project:
     name: Package

--- a/.github/workflows/manual_qit.yml
+++ b/.github/workflows/manual_qit.yml
@@ -111,6 +111,7 @@ jobs:
     with:
       wp_version: ${{ inputs.wp-version == 'latest' && fromJSON(needs.find_latest_versions.outputs.wp_versions)[0] || inputs.wp-version }}
       wc_version: ${{ inputs.wc-version == 'latest' && fromJSON(needs.find_latest_versions.outputs.wc_versions)[0] || inputs.wc-version == 'rc' && needs.find_latest_versions.outputs.wc_rc_version || inputs.wc-version }}
+      php_version: ${{ inputs.php-version }}
 
   build_project:
     name: Package

--- a/.github/workflows/manual_qit.yml
+++ b/.github/workflows/manual_qit.yml
@@ -25,6 +25,7 @@ on:
           - 'Unit Tests'
           - 'All'
           - 'None'
+          - 'E2E'
       qit-tests:
         description: 'QIT Tests'
         type: choice

--- a/.github/workflows/unit_test_runner.yml
+++ b/.github/workflows/unit_test_runner.yml
@@ -9,6 +9,9 @@ on:
             wp_version:
                 required: true
                 type: string
+            php_version:
+                required: true
+                type: string
 
 jobs:
   php_lint:
@@ -43,31 +46,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: 7.4
-            wp_version: 6.2
-            wc_version: 8.2.3
-            wc_order_datastore: cpt
-          - php: 7.4
-            wp_version: ${{ inputs.wp_version }}
-            wc_version: ${{ inputs.wc_version }}
-            wc_order_datastore: cpt
-          - php: 8.0
-            wp_version: ${{ inputs.wp_version }}
-            wc_version: ${{ inputs.wc_version }}
-            wc_order_datastore: cpt
-          - php: 8.1
-            wp_version: ${{ inputs.wp_version }}
-            wc_version: ${{ inputs.wc_version }}
-            wc_order_datastore: cpt
-          - php: 8.2
-            wp_version: ${{ inputs.wp_version }}
-            wc_version: ${{ inputs.wc_version }}
-            wc_order_datastore: hpos
-          - php: 8.3
-            wp_version: ${{ inputs.wp_version }}
-            wc_version: ${{ inputs.wc_version }}
-            wc_order_datastore: hpos
-          - php: 8.4
+          - php: ${{ inputs.php_version }}
             wp_version: ${{ inputs.wp_version }}
             wc_version: ${{ inputs.wc_version }}
             wc_order_datastore: hpos
@@ -106,16 +85,16 @@ jobs:
           version: ${{ steps.get_wc_pnpm_version.outputs.WC_PNPM }}
       - uses: actions/setup-node@v3
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: '/tmp/woocommerce/.nvmrc'
       - name: Build WooCommerce essentials for running tests
         run: |
           cd /tmp/woocommerce/plugins/woocommerce
           composer install
           php bin/generate-feature-config.php
       - name: Setup WordPress
-        run: bash /tmp/woocommerce/plugins/woocommerce/tests/bin/install.sh wordpress_test root root 127.0.0.1 ${{ matrix.wp-version }}
+        run: bash /tmp/woocommerce/plugins/woocommerce/tests/bin/install.sh wordpress_test root root 127.0.0.1 ${{ env.WP_VERSION }}
       - name: Use PHPUnit v8 for WC < 7.7.0
-        if: contains(fromJSON('["7.5.1", "7.6.1"]'), matrix.wc-version)
+        if: contains(fromJSON('["7.5.1", "7.6.1"]'), env.WC_VERSION)
         run: composer require -W phpunit/phpunit:^8
       - name: Install Composer dependencies
         run: composer install

--- a/.github/workflows/unit_test_runner.yml
+++ b/.github/workflows/unit_test_runner.yml
@@ -85,7 +85,7 @@ jobs:
           version: ${{ steps.get_wc_pnpm_version.outputs.WC_PNPM }}
       - uses: actions/setup-node@v3
         with:
-          node-version-file: '/tmp/woocommerce/.nvmrc'
+          node-version: 'v20'
       - name: Build WooCommerce essentials for running tests
         run: |
           cd /tmp/woocommerce/plugins/woocommerce

--- a/.github/workflows/unit_test_runner.yml
+++ b/.github/workflows/unit_test_runner.yml
@@ -26,98 +26,98 @@ jobs:
       - name: Lint
         run: find . -type f -name "*.php" -exec php -l {} \;
 
-    php_build_and_test:
-      name: PHP Tests (WP ${{ matrix.wp_version }} WC ${{ matrix.wc_version }})
-      runs-on: ubuntu-latest
-      services:
-        mariadb:
-          image: mariadb:10.9
-          ports:
-            - 3306:3306
-          env:
-            MYSQL_USER: wp_test
-            MYSQL_PASSWORD: wp_test
-            MYSQL_DATABASE: wordpress_default
-            MYSQL_ROOT_PASSWORD: root
-          options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-      strategy:
-        matrix:
-          include:
-            - php: 7.4
-              wp_version: 6.2
-              wc_version: 8.2.3
-              wc_order_datastore: cpt
-            - php: 7.4
-              wp_version: ${{ inputs.wp_version }}
-              wc_version: ${{ inputs.wc_version }}
-              wc_order_datastore: cpt
-            - php: 8.0
-              wp_version: ${{ inputs.wp_version }}
-              wc_version: ${{ inputs.wc_version }}
-              wc_order_datastore: cpt
-            - php: 8.1
-              wp_version: ${{ inputs.wp_version }}
-              wc_version: ${{ inputs.wc_version }}
-              wc_order_datastore: cpt
-            - php: 8.2
-              wp_version: ${{ inputs.wp_version }}
-              wc_version: ${{ inputs.wc_version }}
-              wc_order_datastore: hpos
-            - php: 8.3
-              wp_version: ${{ inputs.wp_version }}
-              wc_version: ${{ inputs.wc_version }}
-              wc_order_datastore: hpos
-            - php: 8.4
-              wp_version: ${{ inputs.wp_version }}
-              wc_version: ${{ inputs.wc_version }}
-              wc_order_datastore: hpos
-      env:
-        WP_VERSION: ${{ matrix.wp_version }}
-        WC_VERSION: ${{ matrix.wc_version }}
-        PHP_VERSION: ${{ matrix.php }}
-        RUN_UNIT_TESTS: 1
-        WC_ORDER_DATASTORE: ${{ matrix.wc_order_datastore }}
-      steps:
-        - name: Install SVN if not already installed
-          run: |
-            if ! svn --version &> /dev/null
-            then
-              echo "SVN is not installed. Installing SVN..."
-              sudo apt-get update && sudo apt-get install -y subversion
-            else
-              echo "SVN is already installed."
-            fi
-        - name: Checkout WCS&T
-          uses: actions/checkout@v4
-          with:
-            submodules: recursive
-        - name: Checkout WooCommerce
-          run: git clone --depth=1 --branch=${{ env.WC_VERSION }} https://github.com/woocommerce/woocommerce.git /tmp/woocommerce
-        - name: Setup PHP
-          uses: shivammathur/setup-php@v2
-          with:
-            php-version: ${{ env.PHP_VERSION }}
-        - name: Get WC pinned pnpm version
-          id: get_wc_pnpm_version
-          run: echo "WC_PNPM=$( grep packageManager /tmp/woocommerce/package.json | sed -nr 's/.+packageManager.+pnpm@([[:digit:].]+).+/\1/p' )" >> "$GITHUB_OUTPUT"
-        - name: Setup PNPM
-          uses: pnpm/action-setup@v2
-          with:
-            version: ${{ steps.get_wc_pnpm_version.outputs.WC_PNPM }}
-        - uses: actions/setup-node@v3
-          with:
-            node-version-file: '.nvmrc'
-        - name: Build WooCommerce essentials for running tests
-          run: |
-            cd /tmp/woocommerce/plugins/woocommerce
-            composer install
-            php bin/generate-feature-config.php
-        - name: Setup WordPress
-          run: bash /tmp/woocommerce/plugins/woocommerce/tests/bin/install.sh wordpress_test root root 127.0.0.1 ${{ matrix.wp-version }}
-        - name: Use PHPUnit v8 for WC < 7.7.0
-          if: contains(fromJSON('["7.5.1", "7.6.1"]'), matrix.wc-version)
-          run: composer require -W phpunit/phpunit:^8
-        - name: Install Composer dependencies
-          run: composer install
-        - name: Run PHPUnit tests
-          run: ./vendor/bin/phpunit -c phpunit.xml.dist
+  php_build_and_test:
+    name: PHP Tests (WP ${{ matrix.wp_version }} WC ${{ matrix.wc_version }})
+    runs-on: ubuntu-latest
+    services:
+      mariadb:
+        image: mariadb:10.9
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_USER: wp_test
+          MYSQL_PASSWORD: wp_test
+          MYSQL_DATABASE: wordpress_default
+          MYSQL_ROOT_PASSWORD: root
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+    strategy:
+      matrix:
+        include:
+          - php: 7.4
+            wp_version: 6.2
+            wc_version: 8.2.3
+            wc_order_datastore: cpt
+          - php: 7.4
+            wp_version: ${{ inputs.wp_version }}
+            wc_version: ${{ inputs.wc_version }}
+            wc_order_datastore: cpt
+          - php: 8.0
+            wp_version: ${{ inputs.wp_version }}
+            wc_version: ${{ inputs.wc_version }}
+            wc_order_datastore: cpt
+          - php: 8.1
+            wp_version: ${{ inputs.wp_version }}
+            wc_version: ${{ inputs.wc_version }}
+            wc_order_datastore: cpt
+          - php: 8.2
+            wp_version: ${{ inputs.wp_version }}
+            wc_version: ${{ inputs.wc_version }}
+            wc_order_datastore: hpos
+          - php: 8.3
+            wp_version: ${{ inputs.wp_version }}
+            wc_version: ${{ inputs.wc_version }}
+            wc_order_datastore: hpos
+          - php: 8.4
+            wp_version: ${{ inputs.wp_version }}
+            wc_version: ${{ inputs.wc_version }}
+            wc_order_datastore: hpos
+    env:
+      WP_VERSION: ${{ matrix.wp_version }}
+      WC_VERSION: ${{ matrix.wc_version }}
+      PHP_VERSION: ${{ matrix.php }}
+      RUN_UNIT_TESTS: 1
+      WC_ORDER_DATASTORE: ${{ matrix.wc_order_datastore }}
+    steps:
+      - name: Install SVN if not already installed
+        run: |
+          if ! svn --version &> /dev/null
+          then
+            echo "SVN is not installed. Installing SVN..."
+            sudo apt-get update && sudo apt-get install -y subversion
+          else
+            echo "SVN is already installed."
+          fi
+      - name: Checkout WCS&T
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Checkout WooCommerce
+        run: git clone --depth=1 --branch=${{ env.WC_VERSION }} https://github.com/woocommerce/woocommerce.git /tmp/woocommerce
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ env.PHP_VERSION }}
+      - name: Get WC pinned pnpm version
+        id: get_wc_pnpm_version
+        run: echo "WC_PNPM=$( grep packageManager /tmp/woocommerce/package.json | sed -nr 's/.+packageManager.+pnpm@([[:digit:].]+).+/\1/p' )" >> "$GITHUB_OUTPUT"
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v2
+        with:
+          version: ${{ steps.get_wc_pnpm_version.outputs.WC_PNPM }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+      - name: Build WooCommerce essentials for running tests
+        run: |
+          cd /tmp/woocommerce/plugins/woocommerce
+          composer install
+          php bin/generate-feature-config.php
+      - name: Setup WordPress
+        run: bash /tmp/woocommerce/plugins/woocommerce/tests/bin/install.sh wordpress_test root root 127.0.0.1 ${{ matrix.wp-version }}
+      - name: Use PHPUnit v8 for WC < 7.7.0
+        if: contains(fromJSON('["7.5.1", "7.6.1"]'), matrix.wc-version)
+        run: composer require -W phpunit/phpunit:^8
+      - name: Install Composer dependencies
+        run: composer install
+      - name: Run PHPUnit tests
+        run: ./vendor/bin/phpunit -c phpunit.xml.dist

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -31,7 +31,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @return object|array
 		 */
 		public function get_store_options() {
-			// ENT_COMPAT is explicitly set for cross-version compatibility as it was the default prior to PHP v8.1
+			// ENT_COMPAT is explicitly set for cross-version compatibility as it was the default prior to PHP v8.1.
 			$currency_symbol = sanitize_text_field( html_entity_decode( get_woocommerce_currency_symbol(), ENT_COMPAT ) );
 			$dimension_unit  = sanitize_text_field( strtolower( get_option( 'woocommerce_dimension_unit' ) ) );
 			$weight_unit     = sanitize_text_field( strtolower( get_option( 'woocommerce_weight_unit' ) ) );

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -31,7 +31,8 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @return object|array
 		 */
 		public function get_store_options() {
-			$currency_symbol = sanitize_text_field( html_entity_decode( get_woocommerce_currency_symbol() ) );
+			// ENT_COMPAT is explicitly set for cross-version compatibility as it was the default prior to PHP v8.1
+			$currency_symbol = sanitize_text_field( html_entity_decode( get_woocommerce_currency_symbol(), ENT_COMPAT ) );
 			$dimension_unit  = sanitize_text_field( strtolower( get_option( 'woocommerce_dimension_unit' ) ) );
 			$weight_unit     = sanitize_text_field( strtolower( get_option( 'woocommerce_weight_unit' ) ) );
 			$base_location   = wc_get_base_location();

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -611,7 +611,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 		public static function format_rate_title( $rate_title ) {
 			$formatted_title = wp_kses(
-				html_entity_decode( $rate_title ),
+				html_entity_decode( $rate_title, ENT_COMPAT ),
 				array(
 					'sup'    => array(),
 					'del'    => array(),

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -611,7 +611,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 		public static function format_rate_title( $rate_title ) {
 			$formatted_title = wp_kses(
-				html_entity_decode( $rate_title, ENT_COMPAT ),
+				html_entity_decode( $rate_title, ENT_COMPAT ), // ENT_COMPAT is explicitly set for cross-version compatibility as it was the default prior to PHP v8.1.
 				array(
 					'sup'    => array(),
 					'del'    => array(),


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fix the Build plugin jobs on the github workflow. This PR also fix the manual runner.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes [WOOSHIP-1473](https://linear.app/a8c/issue/WOOSHIP-1473/qit-activation-test-is-failing)
### How to test the changes in this Pull Request:

1. It needs to be tested on the trunk branch.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->
