### PR TITLE
[WOOSHIP-1512] Include `src` folder as part of the release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.0.7 - 2025-xx-xx =
+* Fix   - Missing release files.
+
 = 3.0.6 - 2025-07-21 =
 * Add   - Support for Itemized tax rates.
 * Fix   - TaxJar error notices displaying incorrectly on block cart and checkout.

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.0.7 - 2025-xx-xx =
+* Fix   - Missing release files.
+
 = 3.0.6 - 2025-07-21 =
 * Add   - Support for Itemized tax rates.
 * Fix   - TaxJar error notices displaying incorrectly on block cart and checkout.

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -16,6 +16,7 @@ const dirsToCopy = [
 	'i18n',
 	'images',
 	'vendor',
+	'src',
 ];
 
 confirm( chalk.cyan( 'Howdy! This script is going to create a release folder with a compiled ' +


### PR DESCRIPTION
## Description
Include `src` folder in the release as a temporary fix to the latest release incident (p1753106419203499-slack-C022B9ALCQ3)
Fixes WOOSHIP-1512
### Checklist

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added