### PR TITLE
[WOOSHIP-1541] chore: fix failing e2e test in wc services repo

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 3.0.8 - 2025-xx-xx =
 * Fix   - Improves performance when WooCommerce Shipping is not active.
+* Fix   - Restore shipping label functionality for merchants with shipping features enabled.
 
 = 3.0.7 - 2025-07-21 =
 * Fix   - Missing release files.

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -224,7 +224,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 					continue;
 				}
 
-				$refunded_qty = $order->get_qty_refunded_for_item( $item->get_id() );
+				$refunded_qty       = $order->get_qty_refunded_for_item( $item->get_id() );
 				$remaining_quantity = $item['qty'] - absint( $refunded_qty );
 				/**
 				 * The threshold at which we will start batching items together.
@@ -238,31 +238,28 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				 */
 				$max_shipments = apply_filters( 'wc_connect_max_shipments_if_quantity_exceeds_threshold', 5 );
 
-				$weight_per_item = $item_data['weight'];
+				$weight_per_item      = $item_data['weight'];
 				$should_cap_shipments = $remaining_quantity > $threshold;
 
 				if ( $should_cap_shipments ) {
 					$quantity_per_shipment = floor( $remaining_quantity / $max_shipments );
-					for ( $i = 0; $i < $max_shipments; $i ++ ) {
+					for ( $i = 0; $i < $max_shipments; $i++ ) {
 						$remaining_quantity -= $quantity_per_shipment;
 
-						if( $remaining_quantity >= $quantity_per_shipment ) {
+						if ( $remaining_quantity >= $quantity_per_shipment ) {
 							$item_data['quantity'] = $quantity_per_shipment;
 						} else {
 							$item_data['quantity'] = $quantity_per_shipment + $remaining_quantity;
 						}
 
 						$item_data['weight'] = round( $item_data['quantity'] * $weight_per_item, 2 );
-						$items[] = $item_data;
+						$items[]             = $item_data;
 					}
 				} else {
-					for ( $i = 0; $i < $remaining_quantity; $i ++ ) {
+					for ( $i = 0; $i < $remaining_quantity; $i++ ) {
 						$items[] = $item_data;
 					}
 				}
-
-
-
 			}
 
 			return $items;
@@ -441,7 +438,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		public function is_dhl_express_available() {
 			$dhl_express = $this->service_schemas_store->get_service_schema_by_id( 'dhlexpress' );
 
-			return ! ! $dhl_express;
+			return (bool) $dhl_express;
 		}
 
 		public function is_order_dhl_express_eligible() {
@@ -533,7 +530,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		 */
 		public function is_shipping_label_enabled() {
 			// Check if this is a tax-only installation
-			if ( WC_Connect_Loader::instance()->has_only_tax_functionality() ) {
+			if ( WC_Connect_Loader::has_only_tax_functionality() ) {
 				return false;
 			}
 

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -529,17 +529,11 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		 * @return bool True if shipping label is enabled from the settings.
 		 */
 		public function is_shipping_label_enabled() {
-			$account_settings = $this->account_settings->get();
-
-			// If we have account settings with enabled=true, respect that over tax-only logic
-			if ( isset( $account_settings['formData']['enabled'] ) && $account_settings['formData']['enabled'] ) {
-				return true;
-			}
-
-			// Check if this is a tax-only installation
+			// For tax-only installations, shipping labels are disabled
 			if ( WC_Connect_Loader::has_only_tax_functionality() ) {
 				return false;
 			}
+			$account_settings = $this->account_settings->get();
 
 			if ( isset( $account_settings['formData']['enabled'] ) && is_bool( $account_settings['formData']['enabled'] ) ) {
 				return $account_settings['formData']['enabled'];

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -532,7 +532,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		 * @return bool True if shipping label is enabled from the settings.
 		 */
 		public function is_shipping_label_enabled() {
-			if ( ! WC_Connect_Loader::is_wc_shipping_activated() ) {
+			// Check if this is a tax-only installation
+			if ( WC_Connect_Loader::instance()->has_only_tax_functionality() ) {
 				return false;
 			}
 

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -529,12 +529,17 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		 * @return bool True if shipping label is enabled from the settings.
 		 */
 		public function is_shipping_label_enabled() {
+			$account_settings = $this->account_settings->get();
+
+			// If we have account settings with enabled=true, respect that over tax-only logic
+			if ( isset( $account_settings['formData']['enabled'] ) && $account_settings['formData']['enabled'] ) {
+				return true;
+			}
+
 			// Check if this is a tax-only installation
 			if ( WC_Connect_Loader::has_only_tax_functionality() ) {
 				return false;
 			}
-
-			$account_settings = $this->account_settings->get();
 
 			if ( isset( $account_settings['formData']['enabled'] ) && is_bool( $account_settings['formData']['enabled'] ) ) {
 				return $account_settings['formData']['enabled'];

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,7 @@ This plugin relies on the following external services:
 
 = 3.0.8 - 2025-xx-xx =
 * Fix   - Improves performance when WooCommerce Shipping is not active.
+* Fix   - Restore shipping label functionality for merchants with shipping features enabled.
 
 = 3.0.7 - 2025-07-21 =
 * Fix   - Missing release files.

--- a/tests/e2e/config/travis/wc-services-testing-helper.php
+++ b/tests/e2e/config/travis/wc-services-testing-helper.php
@@ -26,3 +26,10 @@ function wc_test_connect_jetpack_access_fake_token( $token ) {
 }
 
 add_filter( 'wc_connect_jetpack_access_token', 'wc_test_connect_jetpack_access_fake_token' );
+
+function wc_test_connect_override_tax_only_functionality( $is_tax_only ) {
+	// For e2e tests, always return false so shipping labels are enabled
+	return false;
+}
+
+add_filter( 'wc_connect_has_only_tax_functionality', 'wc_test_connect_override_tax_only_functionality' );

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1937,7 +1937,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 *
 		 * @return bool True if the store is configured for tax-only functionality, false otherwise.
 		 */
-		private function has_only_tax_functionality() {
+		public function has_only_tax_functionality() {
 			return ( WC_Connect_Jetpack::is_connected() && '1' === WC_Connect_Options::get_option( 'only_tax' ) ) ||
 			( ! WC_Connect_Jetpack::is_connected() && ! self::_has_any_labels_db_check() );
 		}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1188,7 +1188,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				$logger,
 				$this->shipping_label,
 				$this->payment_methods_store,
-				$this->has_only_tax_functionality()
+				self::has_only_tax_functionality()
 			);
 
 			$rest_shipping_label_eligibility_controller->register_routes();
@@ -1937,7 +1937,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 *
 		 * @return bool True if the store is configured for tax-only functionality, false otherwise.
 		 */
-		public function has_only_tax_functionality() {
+		public static function has_only_tax_functionality() {
 			return ( WC_Connect_Jetpack::is_connected() && '1' === WC_Connect_Options::get_option( 'only_tax' ) ) ||
 			( ! WC_Connect_Jetpack::is_connected() && ! self::_has_any_labels_db_check() );
 		}
@@ -1946,7 +1946,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$plugin_basename = 'woocommerce-services/woocommerce-services.php';
 
 			if ( isset( $plugins[ $plugin_basename ] ) ) {
-				if ( $this->has_only_tax_functionality() ) {
+				if ( self::has_only_tax_functionality() ) {
 					$plugins[ $plugin_basename ]['Name']        = $this->get_plugin_name_for_new_sites();
 					$plugins[ $plugin_basename ]['Description'] = $this->get_plugin_description_for_new_sites();
 				} else {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -1938,8 +1938,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * @return bool True if the store is configured for tax-only functionality, false otherwise.
 		 */
 		public static function has_only_tax_functionality() {
-			return ( WC_Connect_Jetpack::is_connected() && '1' === WC_Connect_Options::get_option( 'only_tax' ) ) ||
-			( ! WC_Connect_Jetpack::is_connected() && ! self::_has_any_labels_db_check() );
+			$result = ( WC_Connect_Jetpack::is_connected() && '1' === WC_Connect_Options::get_option( 'only_tax' ) ) ||
+						( ! WC_Connect_Jetpack::is_connected() && ! self::_has_any_labels_db_check() );
+
+			// Allow tests to override this functionality
+			return apply_filters( 'wc_connect_has_only_tax_functionality', $result );
 		}
 
 		public function maybe_rename_plugin( $plugins ) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
This PR fixes a regression introduced in #2856 where shipping label functionality was incorrectly blocked for merchants who should have access to it. The previous implementation checked if WooCommerce Shipping plugin was installed, but this breaks functionality for grandfathered merchants with existing shipping label. The fix replaces the `is_wc_shipping_activated()` check with `has_only_tax_functionality()`, which properly determines whether a merchant should have shipping features based on their configuration and existing labels.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Fixes [#WOOSHIP-1541](https://linear.app/a8c/issue/WOOSHIP-1541/fix-failing-e2e-test-in-wc-services-repo)

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
1. Verify the [e2e test result](https://github.com/Automattic/woocommerce-services/actions/runs/16569101401/job/46856335042) on the `trunk` of the repo are failing. 
2. Verify the same test's results in the PR that it passes.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

