### PR TITLE
Implement migration survey for WOOSHIP-1511

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Tax Changelog ***
 
 = 3.0.8 - 2025-xx-xx =
+* Add   - Migration survey to understand WooCommerce Shipping adoption blockers.
 * Fix   - Improves performance when WooCommerce Shipping is not active.
 * Tweak - WooCommerce 10.1 Compatibility.
 

--- a/classes/class-wc-connect-migration-survey.php
+++ b/classes/class-wc-connect-migration-survey.php
@@ -135,7 +135,7 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 				}
 			}
 
-			$this->track_event( 'survey_submitted', $track_properties );
+			$this->track_event( 'submitted', $track_properties );
 
 			wp_send_json_success();
 		}
@@ -150,7 +150,7 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 			}
 
 			// Track dismissal event
-			$this->track_event( 'survey_dismissed', array() );
+			$this->track_event( 'dismissed', array() );
 
 			wp_send_json_success();
 		}
@@ -171,7 +171,7 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 			update_user_meta( $user_id, 'wcs_migration_survey_last_shown', time() );
 
 			// Track survey display event
-			$this->track_event( 'survey_displayed', array() );
+			$this->track_event( 'displayed', array() );
 
 			wp_send_json_success();
 		}

--- a/classes/class-wc-connect-migration-survey.php
+++ b/classes/class-wc-connect-migration-survey.php
@@ -6,6 +6,8 @@
  * who haven't migrated from WCS&T to WooCommerce Shipping
  */
 
+use Automattic\WCServices\Utils;
+
 if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 
 	class WC_Connect_Migration_Survey {
@@ -102,7 +104,7 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 		 */
 		public function handle_survey_submission() {
 			// Verify nonce
-			if ( ! wp_verify_nonce( $_POST['nonce'], 'wcs_migration_survey' ) ) {
+			if ( ! wp_verify_nonce( Utils::get_sanitized_request_data( 'nonce' ), 'wcs_migration_survey' ) ) {
 				wp_die( 'Security check failed' );
 			}
 
@@ -143,7 +145,7 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 		 */
 		public function handle_survey_dismissal() {
 			// Verify nonce
-			if ( ! wp_verify_nonce( $_POST['nonce'], 'wcs_migration_survey' ) ) {
+			if ( ! wp_verify_nonce( Utils::get_sanitized_request_data( 'nonce' ), 'wcs_migration_survey' ) ) {
 				wp_die( 'Security check failed' );
 			}
 
@@ -158,7 +160,7 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 		 */
 		public function handle_survey_display_tracking() {
 			// Verify nonce
-			if ( ! wp_verify_nonce( $_POST['nonce'], 'wcs_migration_survey' ) ) {
+			if ( ! wp_verify_nonce( Utils::get_sanitized_request_data( 'nonce' ), 'wcs_migration_survey' ) ) {
 				wp_die( 'Security check failed' );
 			}
 

--- a/classes/class-wc-connect-migration-survey.php
+++ b/classes/class-wc-connect-migration-survey.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Migration Survey Class
+ * 
+ * Handles the display and submission of migration survey for users
+ * who haven't migrated from WCS&T to WooCommerce Shipping
+ */
+
+if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
+
+	class WC_Connect_Migration_Survey {
+
+
+		/**
+		 * Maximum number of times to show the survey
+		 */
+		const MAX_DISPLAY_COUNT = 2;
+
+		/**
+		 * Cooldown period between survey displays (in seconds)
+		 */
+		const COOLDOWN_PERIOD = 259200; // 3 days
+
+		/**
+		 * Initialize the migration survey
+		 */
+		public function __construct() {
+			// Hook into script enqueue action
+			add_action( 'enqueue_wc_connect_script', array( $this, 'add_survey_data_to_script' ), 10, 2 );
+			
+			// AJAX handlers
+			add_action( 'wp_ajax_wcs_migration_survey_submit', array( $this, 'handle_survey_submission' ) );
+			add_action( 'wp_ajax_wcs_migration_survey_dismiss', array( $this, 'handle_survey_dismissal' ) );
+			add_action( 'wp_ajax_wcs_migration_survey_track_display', array( $this, 'handle_survey_display_tracking' ) );
+		}
+
+		/**
+		 * Check if survey should be shown to current user
+		 */
+		public function should_show_survey() {
+			// Force survey to show for testing/debugging
+			if ( isset( $_GET['force_survey'] ) ) {
+				return true;
+			}
+
+			// Don't show if WooCommerce Shipping is already active
+			if ( WC_Connect_Loader::is_wc_shipping_activated() ) {
+				return false;
+			}
+
+			// Check if user has already been shown the survey max times
+			$user_id = get_current_user_id();
+			$display_count = get_user_meta( $user_id, 'wcs_migration_survey_count', true );
+			
+			if ( $display_count >= self::MAX_DISPLAY_COUNT ) {
+				return false;
+			}
+
+			// Check cooldown period
+			$last_shown = get_user_meta( $user_id, 'wcs_migration_survey_last_shown', true );
+			if ( $last_shown && ( time() - $last_shown ) < self::COOLDOWN_PERIOD ) {
+				return false;
+			}
+
+			// Check if user has already completed the survey
+			if ( get_user_meta( $user_id, 'wcs_migration_survey_completed', true ) ) {
+				return false;
+			}
+
+			return true;
+		}
+
+
+		/**
+		 * Add survey data to shipping label script localization
+		 */
+		public function add_survey_data_to_script( $root_view, $payload ) {
+			// Only add survey data to shipping label context
+			if ( 'wc-connect-create-shipping-label' !== $root_view ) {
+				return;
+			}
+
+			$should_show = $this->should_show_survey();
+			
+			if ( ! $should_show ) {
+				return;
+			}
+
+			// Add survey data via separate localize_script call
+			// NOTE: We don't update user meta here - only when survey is actually displayed in frontend
+			$survey_data = array(
+				'shouldShow' => true,
+				'nonce' => wp_create_nonce( 'wcs_migration_survey' ),
+				'ajaxUrl' => admin_url( 'admin-ajax.php' )
+			);
+
+			wp_localize_script( 'wc_connect_admin', 'wcsMigrationSurvey', $survey_data );
+		}
+
+		/**
+		 * Handle survey submission via AJAX
+		 */
+		public function handle_survey_submission() {
+			// Verify nonce
+			if ( ! wp_verify_nonce( $_POST['nonce'], 'wcs_migration_survey' ) ) {
+				wp_die( 'Security check failed' );
+			}
+
+			// Get survey data
+			$survey_data = json_decode( stripslashes( $_POST['survey_data'] ), true );
+			
+			if ( ! $survey_data ) {
+				wp_send_json_error( 'Invalid survey data' );
+			}
+
+			// Mark survey as completed for this user
+			$user_id = get_current_user_id();
+			update_user_meta( $user_id, 'wcs_migration_survey_completed', true );
+
+			// Track submission event with detailed properties
+			$track_properties = array(
+				'primary_reason' => sanitize_text_field( $survey_data['primary'] )
+			);
+			
+			// Add followup responses to tracking (flatten the array)
+			if ( ! empty( $survey_data['followup'] ) ) {
+				foreach ( $survey_data['followup'] as $key => $value ) {
+					if ( is_bool( $value ) ) {
+						$track_properties['followup_' . $key] = $value ? 'true' : 'false';
+					} else {
+						$track_properties['followup_' . $key] = sanitize_text_field( $value );
+					}
+				}
+			}
+			
+			$this->track_event( 'survey_submitted', $track_properties );
+
+			wp_send_json_success();
+		}
+
+		/**
+		 * Handle survey dismissal
+		 */
+		public function handle_survey_dismissal() {
+			// Verify nonce
+			if ( ! wp_verify_nonce( $_POST['nonce'], 'wcs_migration_survey' ) ) {
+				wp_die( 'Security check failed' );
+			}
+
+			// Track dismissal event
+			$this->track_event( 'survey_dismissed', array() );
+
+			wp_send_json_success();
+		}
+
+		/**
+		 * Handle survey display tracking (update user meta when survey is actually shown)
+		 */
+		public function handle_survey_display_tracking() {
+			// Verify nonce
+			if ( ! wp_verify_nonce( $_POST['nonce'], 'wcs_migration_survey' ) ) {
+				wp_die( 'Security check failed' );
+			}
+
+			// Update user meta to track that survey was displayed
+			$user_id = get_current_user_id();
+			$display_count = get_user_meta( $user_id, 'wcs_migration_survey_count', true );
+			update_user_meta( $user_id, 'wcs_migration_survey_count', intval( $display_count ) + 1 );
+			update_user_meta( $user_id, 'wcs_migration_survey_last_shown', time() );
+
+			// Track survey display event
+			$this->track_event( 'survey_displayed', array() );
+
+			wp_send_json_success();
+		}
+
+		/**
+		 * Track survey events
+		 */
+		private function track_event( $event_name, $properties = array() ) {
+			if ( class_exists( 'WC_Connect_Tracks' ) && class_exists( 'WC_Connect_Logger' ) && function_exists( 'wc_get_logger' ) ) {
+				try {
+					$wc_logger = wc_get_logger();
+					$logger = new WC_Connect_Logger( $wc_logger );
+					$tracks = new WC_Connect_Tracks( $logger, WCSERVICES_PLUGIN_FILE );
+					$tracks->record_user_event( 'migration_survey_' . $event_name, $properties );
+				} catch ( Exception $e ) {
+					// Silently fail if tracking doesn't work
+					error_log( 'Migration Survey: Failed to track event: ' . $e->getMessage() );
+				}
+			}
+		}
+
+	}
+}

--- a/classes/class-wc-connect-migration-survey.php
+++ b/classes/class-wc-connect-migration-survey.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Migration Survey Class
- * 
+ *
  * Handles the display and submission of migration survey for users
  * who haven't migrated from WCS&T to WooCommerce Shipping
  */
@@ -27,7 +27,7 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 		public function __construct() {
 			// Hook into script enqueue action
 			add_action( 'enqueue_wc_connect_script', array( $this, 'add_survey_data_to_script' ), 10, 2 );
-			
+
 			// AJAX handlers
 			add_action( 'wp_ajax_wcs_migration_survey_submit', array( $this, 'handle_survey_submission' ) );
 			add_action( 'wp_ajax_wcs_migration_survey_dismiss', array( $this, 'handle_survey_dismissal' ) );
@@ -49,9 +49,9 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 			}
 
 			// Check if user has already been shown the survey max times
-			$user_id = get_current_user_id();
+			$user_id       = get_current_user_id();
 			$display_count = get_user_meta( $user_id, 'wcs_migration_survey_count', true );
-			
+
 			if ( $display_count >= self::MAX_DISPLAY_COUNT ) {
 				return false;
 			}
@@ -81,7 +81,7 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 			}
 
 			$should_show = $this->should_show_survey();
-			
+
 			if ( ! $should_show ) {
 				return;
 			}
@@ -90,8 +90,8 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 			// NOTE: We don't update user meta here - only when survey is actually displayed in frontend
 			$survey_data = array(
 				'shouldShow' => true,
-				'nonce' => wp_create_nonce( 'wcs_migration_survey' ),
-				'ajaxUrl' => admin_url( 'admin-ajax.php' )
+				'nonce'      => wp_create_nonce( 'wcs_migration_survey' ),
+				'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
 			);
 
 			wp_localize_script( 'wc_connect_admin', 'wcsMigrationSurvey', $survey_data );
@@ -108,7 +108,7 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 
 			// Get survey data
 			$survey_data = json_decode( stripslashes( $_POST['survey_data'] ), true );
-			
+
 			if ( ! $survey_data ) {
 				wp_send_json_error( 'Invalid survey data' );
 			}
@@ -119,20 +119,20 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 
 			// Track submission event with detailed properties
 			$track_properties = array(
-				'primary_reason' => sanitize_text_field( $survey_data['primary'] )
+				'primary_reason' => sanitize_text_field( $survey_data['primary'] ),
 			);
-			
+
 			// Add followup responses to tracking (flatten the array)
 			if ( ! empty( $survey_data['followup'] ) ) {
 				foreach ( $survey_data['followup'] as $key => $value ) {
 					if ( is_bool( $value ) ) {
-						$track_properties['followup_' . $key] = $value ? 'true' : 'false';
+						$track_properties[ 'followup_' . $key ] = $value ? 'true' : 'false';
 					} else {
-						$track_properties['followup_' . $key] = sanitize_text_field( $value );
+						$track_properties[ 'followup_' . $key ] = sanitize_text_field( $value );
 					}
 				}
 			}
-			
+
 			$this->track_event( 'survey_submitted', $track_properties );
 
 			wp_send_json_success();
@@ -163,7 +163,7 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 			}
 
 			// Update user meta to track that survey was displayed
-			$user_id = get_current_user_id();
+			$user_id       = get_current_user_id();
 			$display_count = get_user_meta( $user_id, 'wcs_migration_survey_count', true );
 			update_user_meta( $user_id, 'wcs_migration_survey_count', intval( $display_count ) + 1 );
 			update_user_meta( $user_id, 'wcs_migration_survey_last_shown', time() );
@@ -178,18 +178,10 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 		 * Track survey events
 		 */
 		private function track_event( $event_name, $properties = array() ) {
-			if ( class_exists( 'WC_Connect_Tracks' ) && class_exists( 'WC_Connect_Logger' ) && function_exists( 'wc_get_logger' ) ) {
-				try {
-					$wc_logger = wc_get_logger();
-					$logger = new WC_Connect_Logger( $wc_logger );
-					$tracks = new WC_Connect_Tracks( $logger, WCSERVICES_PLUGIN_FILE );
-					$tracks->record_user_event( 'migration_survey_' . $event_name, $properties );
-				} catch ( Exception $e ) {
-					// Silently fail if tracking doesn't work
-					error_log( 'Migration Survey: Failed to track event: ' . $e->getMessage() );
-				}
-			}
+			$wc_logger = wc_get_logger();
+			$logger    = new WC_Connect_Logger( $wc_logger );
+			$tracks    = new WC_Connect_Tracks( $logger, WCSERVICES_PLUGIN_FILE );
+			$tracks->record_user_event( 'migration_survey_' . $event_name, $properties );
 		}
-
 	}
 }

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -532,10 +532,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		 * @return bool True if shipping label is enabled from the settings.
 		 */
 		public function is_shipping_label_enabled() {
-			if ( ! WC_Connect_Loader::is_wc_shipping_activated() ) {
-				return false;
-			}
-
 			$account_settings = $this->account_settings->get();
 
 			if ( isset( $account_settings['formData']['enabled'] ) && is_bool( $account_settings['formData']['enabled'] ) ) {

--- a/client/components/migration-survey/modal.js
+++ b/client/components/migration-survey/modal.js
@@ -1,0 +1,206 @@
+/**
+ * External dependencies
+ */
+import React, { useState } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Migration Survey Modal Component
+ * 
+ * For users with WCS&T version >= 3.0.0
+ */
+
+const MigrationSurveyModal = ( { isVisible, onClose, onSubmit, translate } ) => {
+	const [ primaryAnswer, setPrimaryAnswer ] = useState( '' );
+	const [ followupAnswers, setFollowupAnswers ] = useState( {} );
+	const [ showFollowup, setShowFollowup ] = useState( false );
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const [ isSubmitted, setIsSubmitted ] = useState( false );
+
+	const primaryQuestions = [
+		{ value: 'missing_features', label: translate( 'The new plugin is missing a feature I rely on.' ) },
+		{ value: 'disruption_concerns', label: translate( 'I\'m concerned switching will be difficult or disrupt my current workflow.' ) },
+		{ value: 'tried_had_issues', label: translate( 'I tried the new WooCommerce Shipping before and had a problem or found it confusing.' ) },
+		{ value: 'unaware', label: translate( 'I wasn\'t aware there was a new WooCommerce Shipping plugin.' ) },
+		{ value: 'unsure_benefits', label: translate( 'I\'m not sure what the benefits of switching are.' ) },
+		{ value: 'no_time', label: translate( 'I just haven\'t had time to look into it.' ) },
+		{ value: 'other', label: translate( 'Other' ) }
+	];
+
+	const followupQuestions = {
+		missing_features: {
+			type: 'textarea',
+			label: translate( 'Could you tell us which feature is most important to you? Your feedback directly helps us prioritize what to build next.' )
+		},
+		disruption_concerns: {
+			type: 'textarea', 
+			label: translate( 'What is your biggest concern about the switching process? This will help us make sure you can migrate with confidence and ease.' )
+		},
+		tried_had_issues: {
+			type: 'textarea',
+			label: translate( 'Could you briefly describe the problem you ran into? This helps us fix bugs and improve the design.' )
+		},
+		unsure_benefits: {
+			type: 'textarea',
+			label: translate( 'What\'s the most important thing to you when it comes to shipping? (e.g. saving money, saving time, carrier options)' )
+		},
+		unaware: {
+			type: 'textarea',
+			label: translate( 'What\'s the most important thing to you when it comes to shipping? (e.g. saving money, saving time, carrier options)' )
+		},
+		no_time: {
+			type: 'textarea',
+			label: translate( 'Knowing the switch takes less than five minutes, what\'s one thing that would convince you to try it?' )
+		},
+		other: {
+			type: 'textarea',
+			label: translate( 'We\'d love to hear more. Could you please share your reason with us?' )
+		}
+	};
+
+	const handlePrimaryChange = ( value ) => {
+		setPrimaryAnswer( value );
+		setFollowupAnswers( {} );
+		setShowFollowup( true ); // Always show followup for any primary answer
+	};
+
+
+	const handleTextChange = ( questionValue, text ) => {
+		setFollowupAnswers( prev => ( {
+			...prev,
+			[ questionValue ]: text
+		} ) );
+	};
+
+	const handleSubmit = async () => {
+		if ( ! primaryAnswer ) return;
+
+		setIsSubmitting( true );
+
+		try {
+			await onSubmit( {
+				primary: primaryAnswer,
+				followup: followupAnswers
+			} );
+			setIsSubmitted( true );
+		} catch ( error ) {
+			// Failed to submit survey
+			setIsSubmitting( false );
+		}
+	};
+
+	const handleSkip = () => {
+		onSubmit( { primary: 'skipped', followup: {} } );
+		onClose();
+	};
+
+	if ( ! isVisible ) {
+		return null;
+	}
+
+	// Show confirmation message after submission
+	if ( isSubmitted ) {
+		return (
+			<div className="migration-survey__modal-backdrop">
+				<div className="migration-survey__modal">
+					<div className="migration-survey__modal-header">
+						<h3>{ translate( 'Thank you!' ) }</h3>
+						<button 
+							className="migration-survey__modal-close"
+							onClick={ onClose }
+							aria-label={ translate( 'Close' ) }
+						>
+							×
+						</button>
+					</div>
+					<div className="migration-survey__modal-content">
+						<p>{ translate( 'Your feedback is incredibly valuable. We want to make sure the new WooCommerce Shipping is an excellent replacement for you before we officially retire the shipping functionality in this plugin.' ) }</p>
+						<p>{ translate( 'P.S. While we work on improvements, did you know the new WooCommerce Shipping includes discounted UPS rates? You can print USPS, DHL, and now UPS labels right from your dashboard – no separate accounts needed. Want to see how easy it is?' ) } <a href="https://woocommerce.com/document/migrating-from-woocommerce-services-to-woocommerce-shipping/" target="_blank" rel="noopener noreferrer">{ translate( 'Read the step-by-step migration guide.' ) }</a></p>
+					</div>
+					<div className="migration-survey__modal-footer">
+						<button 
+							className="migration-survey__button migration-survey__button-primary"
+							onClick={ onClose }
+						>
+							{ translate( 'Close' ) }
+						</button>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="migration-survey__modal-backdrop">
+			<div className="migration-survey__modal">
+				<div className="migration-survey__modal-header">
+					<h3>{ translate( 'A Quick Question About Shipping' ) }</h3>
+					<button 
+						className="migration-survey__modal-close"
+						onClick={ onClose }
+						aria-label={ translate( 'Close survey' ) }
+					>
+						×
+					</button>
+				</div>
+
+				<div className="migration-survey__modal-content">
+					<p>{ translate( 'Thanks for shipping with Woo! We are preparing to transition to the new WooCommerce Shipping plugin as our single officially supported shipping solution. To help us make it a great experience for you, could you answer one quick question?' ) }</p>
+
+					<div className="migration-survey__question">
+						<h4>{ translate( 'What\'s the main reason you\'re still using WooCommerce Shipping & Tax as your shipping tool?' ) }</h4>
+						{ primaryQuestions.map( question => (
+							<label key={ question.value } className="migration-survey__option">
+								<input
+									className="migration-survey__radio"
+									type="radio"
+									name="primary_reason"
+									value={ question.value }
+									checked={ primaryAnswer === question.value }
+									onChange={ () => handlePrimaryChange( question.value ) }
+								/>
+								<span>{ question.label }</span>
+							</label>
+						) ) }
+					</div>
+
+					{ showFollowup && followupQuestions[ primaryAnswer ] && (
+						<div className="migration-survey__question migration-survey__followup">
+							<div className="migration-survey__option">
+								<div>
+									<label htmlFor="followup_textarea">{ followupQuestions[ primaryAnswer ].label }</label>
+									<textarea
+										id="followup_textarea"
+										value={ followupAnswers.text || '' }
+										onChange={ ( e ) => handleTextChange( 'text', e.target.value ) }
+										rows="3"
+										className="migration-survey__textarea"
+									/>
+								</div>
+							</div>
+						</div>
+					) }
+				</div>
+
+				<div className="migration-survey__modal-footer">
+					<button 
+						className="migration-survey__button migration-survey__button-secondary"
+						onClick={ handleSkip }
+						disabled={ isSubmitting }
+					>
+						{ translate( 'Skip' ) }
+					</button>
+					<button 
+						className="migration-survey__button migration-survey__button-primary"
+						onClick={ handleSubmit }
+						disabled={ ! primaryAnswer || isSubmitting }
+					>
+						{ isSubmitting ? translate( 'Submitting…' ) : translate( 'Submit Feedback' ) }
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default localize( MigrationSurveyModal );

--- a/client/components/migration-survey/modal.js
+++ b/client/components/migration-survey/modal.js
@@ -149,22 +149,19 @@ const MigrationSurveyModal = ( { isVisible, onClose, onSubmit, translate } ) => 
 
 					<div className="migration-survey__question">
 						<h4>{ translate( 'What\'s the main reason you\'re still using WooCommerce Shipping & Tax as your shipping tool?' ) }</h4>
-						<div style={{ paddingLeft: '50px', paddingRight: '50px' }}>
-							{ primaryQuestions.map( question => (
-								<label key={ question.value } className="migration-survey__option" style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'flex-start', marginBottom: '12px', cursor: 'pointer' }}>
-									<input
-										className="migration-survey__radio"
-										type="radio"
-										name="primary_reason"
-										value={ question.value }
-										checked={ primaryAnswer === question.value }
-										onChange={ () => handlePrimaryChange( question.value ) }
-										style={{ marginRight: '8px', marginTop: '2px', flexShrink: 0 }}
-									/>
-									<span style={{ lineHeight: '1.4', color: '#1e1e1e', marginLeft: '0 !important', margin: '0' }}>{ question.label }</span>
-								</label>
-							) ) }
-						</div>
+						{ primaryQuestions.map( question => (
+							<label key={ question.value } className="migration-survey__option">
+								<input
+									className="migration-survey__radio"
+									type="radio"
+									name="primary_reason"
+									value={ question.value }
+									checked={ primaryAnswer === question.value }
+									onChange={ () => handlePrimaryChange( question.value ) }
+								/>
+								<span>{ question.label }</span>
+							</label>
+						) ) }
 					</div>
 
 					{ showFollowup && followupQuestions[ primaryAnswer ] && (

--- a/client/components/migration-survey/modal.js
+++ b/client/components/migration-survey/modal.js
@@ -149,19 +149,22 @@ const MigrationSurveyModal = ( { isVisible, onClose, onSubmit, translate } ) => 
 
 					<div className="migration-survey__question">
 						<h4>{ translate( 'What\'s the main reason you\'re still using WooCommerce Shipping & Tax as your shipping tool?' ) }</h4>
-						{ primaryQuestions.map( question => (
-							<label key={ question.value } className="migration-survey__option">
-								<input
-									className="migration-survey__radio"
-									type="radio"
-									name="primary_reason"
-									value={ question.value }
-									checked={ primaryAnswer === question.value }
-									onChange={ () => handlePrimaryChange( question.value ) }
-								/>
-								<span>{ question.label }</span>
-							</label>
-						) ) }
+						<div style={{ paddingLeft: '50px', paddingRight: '50px' }}>
+							{ primaryQuestions.map( question => (
+								<label key={ question.value } className="migration-survey__option" style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'flex-start', marginBottom: '12px', cursor: 'pointer' }}>
+									<input
+										className="migration-survey__radio"
+										type="radio"
+										name="primary_reason"
+										value={ question.value }
+										checked={ primaryAnswer === question.value }
+										onChange={ () => handlePrimaryChange( question.value ) }
+										style={{ marginRight: '8px', marginTop: '2px', flexShrink: 0 }}
+									/>
+									<span style={{ lineHeight: '1.4', color: '#1e1e1e', marginLeft: '0 !important', margin: '0' }}>{ question.label }</span>
+								</label>
+							) ) }
+						</div>
 					</div>
 
 					{ showFollowup && followupQuestions[ primaryAnswer ] && (

--- a/client/components/migration-survey/modal.js
+++ b/client/components/migration-survey/modal.js
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
  * For users with WCS&T version >= 3.0.0
  */
 
-const MigrationSurveyModal = ( { isVisible, onClose, onSubmit, translate } ) => {
+const MigrationSurveyModal = ( { isVisible, onClose, translate } ) => {
 	const [ primaryAnswer, setPrimaryAnswer ] = useState( '' );
 	const [ followupAnswers, setFollowupAnswers ] = useState( {} );
 	const [ showFollowup, setShowFollowup ] = useState( false );
@@ -72,13 +72,55 @@ const MigrationSurveyModal = ( { isVisible, onClose, onSubmit, translate } ) => 
 		} ) );
 	};
 
+	const trackSurveyDisplay = async () => {
+		try {
+			await fetch( window.wcsMigrationSurvey.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams( {
+					action: 'wcs_migration_survey_track_display',
+					nonce: window.wcsMigrationSurvey.nonce,
+				} ),
+			} );
+		} catch ( error ) {
+			// Silently fail tracking
+		}
+	};
+
+	const handleSurveySubmit = async ( surveyData ) => {
+		try {
+			await fetch( window.wcsMigrationSurvey.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams( {
+					action: 'wcs_migration_survey_submit',
+					nonce: window.wcsMigrationSurvey.nonce,
+					survey_data: JSON.stringify( surveyData ),
+				} ),
+			} );
+		} catch ( error ) {
+			// Silently fail submission
+		}
+	};
+
+	// Track when survey is displayed
+	React.useEffect( () => {
+		if ( isVisible && window.wcsMigrationSurvey ) {
+			trackSurveyDisplay();
+		}
+	}, [ isVisible ] );
+
 	const handleSubmit = async () => {
 		if ( ! primaryAnswer ) return;
 
 		setIsSubmitting( true );
 
 		try {
-			await onSubmit( {
+			await handleSurveySubmit( {
 				primary: primaryAnswer,
 				followup: followupAnswers
 			} );
@@ -90,7 +132,7 @@ const MigrationSurveyModal = ( { isVisible, onClose, onSubmit, translate } ) => 
 	};
 
 	const handleSkip = () => {
-		onSubmit( { primary: 'skipped', followup: {} } );
+		handleSurveySubmit( { primary: 'skipped', followup: {} } );
 		onClose();
 	};
 

--- a/client/components/migration-survey/modal.js
+++ b/client/components/migration-survey/modal.js
@@ -131,8 +131,22 @@ const MigrationSurveyModal = ( { isVisible, onClose, translate } ) => {
 		}
 	};
 
-	const handleSkip = () => {
-		handleSurveySubmit( { primary: 'skipped', followup: {} } );
+	const handleSkip = async () => {
+
+		try {
+			await fetch( window.wcsMigrationSurvey.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams( {
+					action: 'wcs_migration_survey_dismiss',
+					nonce: window.wcsMigrationSurvey.nonce,
+				} ),
+			} );
+		} catch ( error ) {
+			// Silently fail submission
+		}
 		onClose();
 	};
 
@@ -161,7 +175,7 @@ const MigrationSurveyModal = ( { isVisible, onClose, translate } ) => {
 					</div>
 					<div className="migration-survey__modal-footer">
 						<button 
-							className="migration-survey__button migration-survey__button-primary"
+							className="migration-survey__button button is-primary"
 							onClick={ onClose }
 						>
 							{ translate( 'Close' ) }
@@ -226,16 +240,20 @@ const MigrationSurveyModal = ( { isVisible, onClose, translate } ) => {
 
 				<div className="migration-survey__modal-footer">
 					<button 
-						className="migration-survey__button migration-survey__button-secondary"
+						className="migration-survey__button button is-secondary"
 						onClick={ handleSkip }
 						disabled={ isSubmitting }
+						type="button" // Prevent form submission as it's being rendered in the order form
+						aria-label={ translate( 'Skip' ) }
 					>
 						{ translate( 'Skip' ) }
 					</button>
 					<button 
-						className="migration-survey__button migration-survey__button-primary"
+						className="migration-survey__button button is-primary"
 						onClick={ handleSubmit }
 						disabled={ ! primaryAnswer || isSubmitting }
+						type="button" // Prevent form submission as it's being rendered in the order form
+						aria-label={ isSubmitting ? translate( 'Submitting…' ) : translate( 'Submit Feedback' ) }
 					>
 						{ isSubmitting ? translate( 'Submitting…' ) : translate( 'Submit Feedback' ) }
 					</button>

--- a/client/components/migration-survey/modal.js
+++ b/client/components/migration-survey/modal.js
@@ -177,6 +177,7 @@ const MigrationSurveyModal = ( { isVisible, onClose, translate } ) => {
 						<button 
 							className="migration-survey__button button is-primary"
 							onClick={ onClose }
+							aria-label={ translate( 'Close after submitting feedback' ) }
 						>
 							{ translate( 'Close' ) }
 						</button>
@@ -193,7 +194,8 @@ const MigrationSurveyModal = ( { isVisible, onClose, translate } ) => {
 					<h3>{ translate( 'A Quick Question About Shipping' ) }</h3>
 					<button 
 						className="migration-survey__modal-close"
-						onClick={ onClose }
+						onClick={ handleSkip }
+						type="button" // Prevent form submission as it's being rendered in the order form
 						aria-label={ translate( 'Close survey' ) }
 					>
 						×

--- a/client/components/migration-survey/style.scss
+++ b/client/components/migration-survey/style.scss
@@ -153,7 +153,7 @@
 	padding: 16px 24px 24px;
 	border-top: 1px solid #e0e0e0;
 	display: flex;
-	justify-content: flex-start;
+	justify-content: space-between;
 	gap: 12px;
 	text-align: left;
 

--- a/client/components/migration-survey/style.scss
+++ b/client/components/migration-survey/style.scss
@@ -13,9 +13,9 @@
 }
 
 .migration-survey__modal {
-	background: white;
+	background: var( --color-white );
 	border-radius: 4px;
-	box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+	box-shadow: rgba(151,150,150,.5) 2px 2px 7px;
 	max-width: 600px;
 	width: 90%;
 	max-height: 80vh;
@@ -28,7 +28,7 @@
 	justify-content: space-between;
 	align-items: center;
 	padding: 20px 24px 0;
-	border-bottom: 1px solid #e0e0e0;
+	border-bottom: 1px solid var( --color-neutral-100 );
 	margin-bottom: 20px;
 	text-align: left;
 
@@ -36,7 +36,7 @@
 		margin: 0 0 20px 0;
 		font-size: 20px;
 		font-weight: 600;
-		color: #1e1e1e;
+		color: var( --color-text );
 		text-align: left;
 	}
 }
@@ -46,7 +46,7 @@
 	border: none;
 	font-size: 24px;
 	cursor: pointer;
-	color: #666;
+	color: var( --color-neutral-400 );
 	position: absolute;
 	top: 16px;
 	right: 20px;
@@ -57,7 +57,7 @@
 	justify-content: center;
 	
 	&:hover {
-		color: #000;
+		color: var( --color-text );
 	}
 }
 
@@ -66,7 +66,7 @@
 	text-align: left;
 
 	> p {
-		color: #666;
+		color: var( --color-text-subtle );
 		margin-bottom: 24px;
 		line-height: 1.5;
 		text-align: left;
@@ -81,16 +81,16 @@
 		margin: 0 0 16px 0;
 		font-size: 16px;
 		font-weight: 600;
-		color: #1e1e1e;
+		color: var( --color-text );
 		text-align: left;
 	}
 }
 
 .migration-survey__followup {
-	background: #f9f9f9;
+	background: var( --color-neutral-0 );
 	padding: 16px;
 	border-radius: 4px;
-	border-left: 4px solid #0073aa;
+	border-left: 4px solid var( --color-primary );
 }
 
 .migration-survey__option {
@@ -109,13 +109,13 @@
 
 	span {
 		line-height: 1.4;
-		color: #1e1e1e;
+		color: var( --color-text );
 		flex: 1;
 		margin-left: 0 !important;
 	}
 
 	&:hover span {
-		color: #0073aa;
+		color: var( --color-primary );
 	}
 
 	// For textarea options
@@ -126,7 +126,7 @@
 			display: block;
 			margin-bottom: 8px;
 			font-weight: 500;
-			color: #1e1e1e;
+			color: var( --color-text );
 		}
 	}
 }
@@ -135,7 +135,7 @@
 	width: 100%;
 	min-height: 80px;
 	padding: 8px 12px;
-	border: 1px solid #ccd0d4;
+	border: 1px solid var( --color-neutral-200 );
 	border-radius: 4px;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 14px;
@@ -144,14 +144,14 @@
 
 	&:focus {
 		outline: none;
-		border-color: #0073aa;
-		box-shadow: 0 0 0 1px #0073aa;
+		border-color: var( --color-primary );
+		box-shadow: 0 0 0 1px var( --color-primary );
 	}
 }
 
 .migration-survey__modal-footer {
 	padding: 16px 24px 24px;
-	border-top: 1px solid #e0e0e0;
+	border-top: 1px solid var( --color-neutral-100 );
 	display: flex;
 	justify-content: space-between;
 	gap: 12px;

--- a/client/components/migration-survey/style.scss
+++ b/client/components/migration-survey/style.scss
@@ -94,9 +94,7 @@
 	margin-bottom: 12px;
 	cursor: pointer;
 	position: relative;
-	max-width: 500px;
-	margin-left: auto;
-	margin-right: auto;
+	justify-content: center;
 
 	input[type="radio"],
 	input[type="checkbox"] {
@@ -108,7 +106,7 @@
 	span {
 		line-height: 1.4;
 		color: #1e1e1e;
-		flex: 1;
+		flex-shrink: 0;
 		text-align: left;
 	}
 
@@ -119,6 +117,7 @@
 	// For textarea options
 	> div {
 		width: 100%;
+		max-width: 500px;
 		
 		label {
 			display: block;

--- a/client/components/migration-survey/style.scss
+++ b/client/components/migration-survey/style.scss
@@ -98,6 +98,7 @@
 	align-items: flex-start;
 	margin-bottom: 12px;
 	cursor: pointer;
+	text-align: left;
 
 	input[type="radio"],
 	input[type="checkbox"] {
@@ -110,6 +111,7 @@
 		line-height: 1.4;
 		color: #1e1e1e;
 		flex: 1;
+		margin-left: 0 !important;
 	}
 
 	&:hover span {

--- a/client/components/migration-survey/style.scss
+++ b/client/components/migration-survey/style.scss
@@ -1,0 +1,185 @@
+/* Migration Survey Modal Styles */
+.migration-survey__modal-backdrop {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: rgba(0, 0, 0, 0.7);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 100000;
+}
+
+.migration-survey__modal {
+	background: white;
+	border-radius: 4px;
+	box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+	max-width: 600px;
+	width: 90%;
+	max-height: 80vh;
+	overflow-y: auto;
+	position: relative;
+}
+
+.migration-survey__modal-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 20px 24px 0;
+	border-bottom: 1px solid #e0e0e0;
+	margin-bottom: 20px;
+
+	h3 {
+		margin: 0 0 20px 0;
+		font-size: 20px;
+		font-weight: 600;
+		color: #1e1e1e;
+	}
+}
+
+.migration-survey__modal-close {
+	background: none;
+	border: none;
+	font-size: 24px;
+	cursor: pointer;
+	color: #666;
+	position: absolute;
+	top: 16px;
+	right: 20px;
+	width: 30px;
+	height: 30px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	
+	&:hover {
+		color: #000;
+	}
+}
+
+.migration-survey__modal-content {
+	padding: 0 24px 20px;
+
+	> p {
+		color: #666;
+		margin-bottom: 24px;
+		line-height: 1.5;
+	}
+}
+
+.migration-survey__question {
+	margin-bottom: 24px;
+
+	h4 {
+		margin: 0 0 16px 0;
+		font-size: 16px;
+		font-weight: 600;
+		color: #1e1e1e;
+	}
+}
+
+.migration-survey__followup {
+	background: #f9f9f9;
+	padding: 16px;
+	border-radius: 4px;
+	border-left: 4px solid #0073aa;
+}
+
+.migration-survey__option {
+	display: flex;
+	align-items: flex-start;
+	margin-bottom: 12px;
+	cursor: pointer;
+	position: relative;
+
+	input[type="radio"],
+	input[type="checkbox"] {
+		margin-right: 8px;
+		margin-top: 2px;
+		flex-shrink: 0;
+	}
+
+	span {
+		line-height: 1.4;
+		color: #1e1e1e;
+		flex: 1;
+	}
+
+	&:hover span {
+		color: #0073aa;
+	}
+
+	// For textarea options
+	> div {
+		label {
+			display: block;
+			margin-bottom: 8px;
+			font-weight: 500;
+			color: #1e1e1e;
+		}
+	}
+}
+
+.migration-survey__textarea {
+	width: 100%;
+	min-height: 80px;
+	padding: 8px 12px;
+	border: 1px solid #ccd0d4;
+	border-radius: 4px;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 14px;
+	line-height: 1.4;
+	resize: vertical;
+
+	&:focus {
+		outline: none;
+		border-color: #0073aa;
+		box-shadow: 0 0 0 1px #0073aa;
+	}
+}
+
+.migration-survey__modal-footer {
+	padding: 16px 24px 24px;
+	border-top: 1px solid #e0e0e0;
+	display: flex;
+	justify-content: flex-end;
+	gap: 12px;
+
+	.button {
+		min-width: 80px;
+		
+		&:disabled {
+			opacity: 0.6;
+			cursor: not-allowed;
+		}
+	}
+}
+
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+	.migration-survey__modal {
+		width: 95%;
+		max-height: 90vh;
+	}
+
+	.migration-survey__modal-header,
+	.migration-survey__modal-content,
+	.migration-survey__modal-footer {
+		padding-left: 16px;
+		padding-right: 16px;
+	}
+
+	.migration-survey__notice-actions {
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 8px;
+
+		.button {
+			width: 100%;
+			text-align: center;
+		}
+	}
+}

--- a/client/components/migration-survey/style.scss
+++ b/client/components/migration-survey/style.scss
@@ -89,25 +89,25 @@
 }
 
 .migration-survey__option {
-	display: flex;
-	align-items: flex-start;
 	margin-bottom: 12px;
 	cursor: pointer;
-	position: relative;
-	justify-content: center;
+	text-align: center;
 
+	// Create an inline container for radio + text
 	input[type="radio"],
 	input[type="checkbox"] {
-		margin-right: 10px;
-		margin-top: 2px;
-		flex-shrink: 0;
+		margin-right: 8px;
+		margin-top: 0;
+		vertical-align: top;
 	}
 
 	span {
 		line-height: 1.4;
 		color: #1e1e1e;
-		flex-shrink: 0;
+		display: inline-block;
+		vertical-align: top;
 		text-align: left;
+		max-width: 400px;
 	}
 
 	&:hover span {
@@ -116,15 +116,15 @@
 
 	// For textarea options
 	> div {
-		width: 100%;
-		max-width: 500px;
+		text-align: center;
 		
 		label {
-			display: block;
+			display: inline-block;
 			margin-bottom: 8px;
 			font-weight: 500;
 			color: #1e1e1e;
 			text-align: left;
+			max-width: 400px;
 		}
 	}
 }

--- a/client/components/migration-survey/style.scss
+++ b/client/components/migration-survey/style.scss
@@ -30,12 +30,14 @@
 	padding: 20px 24px 0;
 	border-bottom: 1px solid #e0e0e0;
 	margin-bottom: 20px;
+	text-align: left;
 
 	h3 {
 		margin: 0 0 20px 0;
 		font-size: 20px;
 		font-weight: 600;
 		color: #1e1e1e;
+		text-align: left;
 	}
 }
 
@@ -61,28 +63,26 @@
 
 .migration-survey__modal-content {
 	padding: 0 24px 20px;
+	text-align: left;
 
 	> p {
 		color: #666;
 		margin-bottom: 24px;
 		line-height: 1.5;
+		text-align: left;
 	}
 }
 
 .migration-survey__question {
 	margin-bottom: 24px;
+	text-align: left;
 
 	h4 {
 		margin: 0 0 16px 0;
 		font-size: 16px;
 		font-weight: 600;
 		color: #1e1e1e;
-	}
-	
-	// Add padding to the options container to center the block
-	> label {
-		padding-left: 20%;
-		padding-right: 20%;
+		text-align: left;
 	}
 }
 
@@ -153,8 +153,9 @@
 	padding: 16px 24px 24px;
 	border-top: 1px solid #e0e0e0;
 	display: flex;
-	justify-content: flex-end;
+	justify-content: flex-start;
 	gap: 12px;
+	text-align: left;
 
 	.button {
 		min-width: 80px;

--- a/client/components/migration-survey/style.scss
+++ b/client/components/migration-survey/style.scss
@@ -157,11 +157,10 @@
 	gap: 12px;
 	text-align: left;
 
-	.button {
+	button {
 		min-width: 80px;
 		
 		&:disabled {
-			opacity: 0.6;
 			cursor: not-allowed;
 		}
 	}

--- a/client/components/migration-survey/style.scss
+++ b/client/components/migration-survey/style.scss
@@ -77,7 +77,12 @@
 		font-size: 16px;
 		font-weight: 600;
 		color: #1e1e1e;
-		text-align: center;
+	}
+	
+	// Add padding to the options container to center the block
+	> label {
+		padding-left: 20%;
+		padding-right: 20%;
 	}
 }
 
@@ -89,25 +94,22 @@
 }
 
 .migration-survey__option {
+	display: flex;
+	align-items: flex-start;
 	margin-bottom: 12px;
 	cursor: pointer;
-	text-align: center;
 
-	// Create an inline container for radio + text
 	input[type="radio"],
 	input[type="checkbox"] {
 		margin-right: 8px;
-		margin-top: 0;
-		vertical-align: top;
+		margin-top: 2px;
+		flex-shrink: 0;
 	}
 
 	span {
 		line-height: 1.4;
 		color: #1e1e1e;
-		display: inline-block;
-		vertical-align: top;
-		text-align: left;
-		max-width: 400px;
+		flex: 1;
 	}
 
 	&:hover span {
@@ -116,15 +118,13 @@
 
 	// For textarea options
 	> div {
-		text-align: center;
+		width: 100%;
 		
 		label {
-			display: inline-block;
+			display: block;
 			margin-bottom: 8px;
 			font-weight: 500;
 			color: #1e1e1e;
-			text-align: left;
-			max-width: 400px;
 		}
 	}
 }

--- a/client/components/migration-survey/style.scss
+++ b/client/components/migration-survey/style.scss
@@ -77,6 +77,7 @@
 		font-size: 16px;
 		font-weight: 600;
 		color: #1e1e1e;
+		text-align: center;
 	}
 }
 
@@ -93,10 +94,13 @@
 	margin-bottom: 12px;
 	cursor: pointer;
 	position: relative;
+	max-width: 500px;
+	margin-left: auto;
+	margin-right: auto;
 
 	input[type="radio"],
 	input[type="checkbox"] {
-		margin-right: 8px;
+		margin-right: 10px;
 		margin-top: 2px;
 		flex-shrink: 0;
 	}
@@ -105,6 +109,7 @@
 		line-height: 1.4;
 		color: #1e1e1e;
 		flex: 1;
+		text-align: left;
 	}
 
 	&:hover span {
@@ -113,11 +118,14 @@
 
 	// For textarea options
 	> div {
+		width: 100%;
+		
 		label {
 			display: block;
 			margin-bottom: 8px;
 			font-weight: 500;
 			color: #1e1e1e;
+			text-align: left;
 		}
 	}
 }

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -887,6 +887,9 @@ const handlePrintFinished = ( orderId, siteId, dispatch, getState, hasError, lab
 	if ( hasError ) {
 		return;
 	}
+	
+	// Trigger survey after successful label purchase/print
+	window.dispatchEvent(new CustomEvent('wcs-label-purchase-completed'));
 
 	if ( shouldEmailDetails( getState(), orderId, siteId ) ) {
 		dispatch(

--- a/client/extensions/woocommerce/woocommerce-services/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/style.scss
@@ -5,7 +5,7 @@
 @import 'components/settings-group-card/style';
 @import 'components/text/style';
 @import 'components/text-field/style';
-@import '../../../components/migration-survey/style';
+@import 'components/migration-survey/style';
 @import 'views/label-settings/style';
 @import 'views/carrier-accounts/style';
 @import 'views/live-rates-carriers-list/style';

--- a/client/extensions/woocommerce/woocommerce-services/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/style.scss
@@ -5,6 +5,7 @@
 @import 'components/settings-group-card/style';
 @import 'components/text/style';
 @import 'components/text-field/style';
+@import '../../../components/migration-survey/style';
 @import 'views/label-settings/style';
 @import 'views/carrier-accounts/style';
 @import 'views/live-rates-carriers-list/style';

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
@@ -18,6 +18,7 @@ import PackagesStep from './packages-step';
 import CustomsStep from './customs-step';
 import RatesStep from './rates-step';
 import Sidebar from './sidebar';
+import MigrationSurveyModal from 'components/migration-survey/modal';
 import { exitPrintingFlow } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
 import {
 	getShippingLabel, isLoaded, isCustomsFormRequired,
@@ -26,45 +27,118 @@ import FeatureAnnouncement from 'components/migration/feature-announcement';
 
 const LabelPurchaseModal = props => {
 	const { loaded, translate, showPurchaseDialog } = props;
+	const [ showSurveyModal, setShowSurveyModal ] = React.useState( false );
+	const [ purchaseDialogWasShown, setPurchaseDialogWasShown ] = React.useState( false );
 
 	if ( !loaded ) {
 		return null;
 	}
 
+	// Track when purchase dialog is shown
+	React.useEffect( () => {
+		if ( loaded && showPurchaseDialog ) {
+			setPurchaseDialogWasShown( true );
+		}
+	}, [ loaded, showPurchaseDialog ] );
+
+	// Show survey when purchase dialog is closed (after it was actually shown)
+	React.useEffect( () => {
+		// Only show survey if purchase dialog was previously shown AND is now closed
+		if ( loaded && 
+			 purchaseDialogWasShown && 
+			 !showPurchaseDialog && 
+			 window.wcsMigrationSurvey && 
+			 window.wcsMigrationSurvey.shouldShow ) {
+			
+			// Add a small delay to ensure any print dialogs have also closed
+			setTimeout( () => {
+				setShowSurveyModal( true );
+				
+				// Track that survey is being displayed (update user meta via AJAX)
+				trackSurveyDisplay();
+			}, 500 ); // 500ms delay to allow print dialogs to close
+		}
+	}, [ loaded, showPurchaseDialog, purchaseDialogWasShown ] );
+
 	const onClose = () => props.exitPrintingFlow(props.orderId, props.siteId, false);
 
-	return showPurchaseDialog ? (<><Modal
-		className="woocommerce label-purchase-modal wcc-root"
-		shouldCloseOnClickOutside={false}
-		onRequestClose={onClose}
-		title={translate('Create shipping label',
-			'Create shipping labels',
-			{ count: Object.keys(props.form.packages.selected).length }
-		)}
-	>
-		<div className="label-purchase-modal__content">
-			<div className="label-purchase-modal__main-section">
-				<AddressStep
-					type="origin"
-					title={translate('Origin address')}
-					siteId={props.siteId}
-					orderId={props.orderId}
-				/>
-				<AddressStep
-					type="destination"
-					title={translate('Destination address')}
-					siteId={props.siteId}
-					orderId={props.orderId}
-				/>
-				<PackagesStep siteId={props.siteId} orderId={props.orderId}/>
-				{props.isCustomsFormRequired && (<CustomsStep siteId={props.siteId} orderId={props.orderId}/>)}
-				<RatesStep siteId={props.siteId} orderId={props.orderId}/>
-			</div>
-			<Sidebar siteId={props.siteId} orderId={props.orderId}/>
-		</div>
-	</Modal>
+	const trackSurveyDisplay = async () => {
+		try {
+			await fetch( window.wcsMigrationSurvey.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams( {
+					action: 'wcs_migration_survey_track_display',
+					nonce: window.wcsMigrationSurvey.nonce,
+				} ),
+			} );
+		} catch ( error ) {
+			console.error( 'Failed to track survey display:', error );
+		}
+	};
+
+	const handleSurveySubmit = async ( surveyData ) => {
+		try {
+			await fetch( window.wcsMigrationSurvey.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams( {
+					action: 'wcs_migration_survey_submit',
+					nonce: window.wcsMigrationSurvey.nonce,
+					survey_data: JSON.stringify( surveyData ),
+				} ),
+			} );
+		} catch ( error ) {
+			console.error( 'Failed to submit survey:', error );
+		}
+	};
+
+	return (<>
+		{ showPurchaseDialog && (
+			<Modal
+				className="woocommerce label-purchase-modal wcc-root"
+				shouldCloseOnClickOutside={false}
+				onRequestClose={onClose}
+				title={translate('Create shipping label',
+					'Create shipping labels',
+					{ count: Object.keys(props.form.packages.selected).length }
+				)}
+			>
+				<div className="label-purchase-modal__content">
+					<div className="label-purchase-modal__main-section">
+						<AddressStep
+							type="origin"
+							title={translate('Origin address')}
+							siteId={props.siteId}
+							orderId={props.orderId}
+						/>
+						<AddressStep
+							type="destination"
+							title={translate('Destination address')}
+							siteId={props.siteId}
+							orderId={props.orderId}
+						/>
+						<PackagesStep siteId={props.siteId} orderId={props.orderId}/>
+						{props.isCustomsFormRequired && (<CustomsStep siteId={props.siteId} orderId={props.orderId}/>)}
+						<RatesStep siteId={props.siteId} orderId={props.orderId}/>
+					</div>
+					<Sidebar siteId={props.siteId} orderId={props.orderId}/>
+				</div>
+			</Modal>
+		) }
 		<FeatureAnnouncement siteId={props.siteId} orderId={props.orderId}/>
-	</>) : null;
+		{ showSurveyModal && (
+			<MigrationSurveyModal
+				isVisible={ showSurveyModal }
+				onClose={ () => setShowSurveyModal( false ) }
+				onSubmit={ handleSurveySubmit }
+			/>
+		) }
+	</>);
 };
 
 LabelPurchaseModal.propTypes = {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
@@ -28,74 +28,55 @@ import FeatureAnnouncement from 'components/migration/feature-announcement';
 const LabelPurchaseModal = props => {
 	const { loaded, translate, showPurchaseDialog } = props;
 	const [ showSurveyModal, setShowSurveyModal ] = React.useState( false );
-	const [ purchaseDialogWasShown, setPurchaseDialogWasShown ] = React.useState( false );
+	const [ dialogWasShown, setDialogWasShown ] = React.useState( false );
 
 	if ( !loaded ) {
 		return null;
 	}
 
-	// Track when purchase dialog is shown
+	// Track when dialog is shown
 	React.useEffect( () => {
-		if ( loaded && showPurchaseDialog ) {
-			setPurchaseDialogWasShown( true );
+		if ( showPurchaseDialog ) {
+			setDialogWasShown( true );
 		}
-	}, [ loaded, showPurchaseDialog ] );
+	}, [ showPurchaseDialog ] );
 
-	// Show survey when purchase dialog is closed (after it was actually shown)
+	// Listen for successful label purchase/print completion
 	React.useEffect( () => {
-		// Only show survey if purchase dialog was previously shown AND is now closed
-		if ( loaded && 
-			 purchaseDialogWasShown && 
-			 !showPurchaseDialog && 
-			 window.wcsMigrationSurvey && 
-			 window.wcsMigrationSurvey.shouldShow ) {
+		const handleSurveyTrigger = () => {
+			const shouldShow = window.wcsMigrationSurvey && window.wcsMigrationSurvey.shouldShow;
+			const isForced = new URLSearchParams(window.location.search).get('force_survey') !== null;
 			
-			// Add a small delay to ensure any print dialogs have also closed
-			setTimeout( () => {
-				setShowSurveyModal( true );
-				
-				// Track that survey is being displayed (update user meta via AJAX)
-				trackSurveyDisplay();
-			}, 500 ); // 500ms delay to allow print dialogs to close
-		}
-	}, [ loaded, showPurchaseDialog, purchaseDialogWasShown ] );
+			// Show survey if conditions are met and dialog was shown (or forced)
+			if ( shouldShow && (dialogWasShown || isForced) ) {
+				setTimeout( () => {
+					setShowSurveyModal( true );
+				}, 500 ); // Small delay to ensure print dialogs have closed
+			}
+		};
 
-	const onClose = () => props.exitPrintingFlow(props.orderId, props.siteId, false);
+		// Listen for custom event that we'll dispatch on successful completion
+		window.addEventListener('wcs-label-purchase-completed', handleSurveyTrigger);
+		
+		return () => {
+			window.removeEventListener('wcs-label-purchase-completed', handleSurveyTrigger);
+		};
+	}, [ dialogWasShown ] );
 
-	const trackSurveyDisplay = async () => {
-		try {
-			await fetch( window.wcsMigrationSurvey.ajaxUrl, {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/x-www-form-urlencoded',
-				},
-				body: new URLSearchParams( {
-					action: 'wcs_migration_survey_track_display',
-					nonce: window.wcsMigrationSurvey.nonce,
-				} ),
-			} );
-		} catch ( error ) {
-			console.error( 'Failed to track survey display:', error );
+	// Handle force_survey - simulate successful purchase when modal closes
+	React.useEffect( () => {
+		const isForced = new URLSearchParams(window.location.search).get('force_survey') !== null;
+		
+		if ( isForced && !showPurchaseDialog && dialogWasShown ) {
+			// Dialog was shown and now closed with force_survey - simulate successful completion
+			window.dispatchEvent(new CustomEvent('wcs-label-purchase-completed'));
 		}
+	}, [ showPurchaseDialog, dialogWasShown ] );
+
+	const onClose = () => {
+		props.exitPrintingFlow(props.orderId, props.siteId, false);
 	};
 
-	const handleSurveySubmit = async ( surveyData ) => {
-		try {
-			await fetch( window.wcsMigrationSurvey.ajaxUrl, {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/x-www-form-urlencoded',
-				},
-				body: new URLSearchParams( {
-					action: 'wcs_migration_survey_submit',
-					nonce: window.wcsMigrationSurvey.nonce,
-					survey_data: JSON.stringify( surveyData ),
-				} ),
-			} );
-		} catch ( error ) {
-			console.error( 'Failed to submit survey:', error );
-		}
-	};
 
 	return (<>
 		{ showPurchaseDialog && (
@@ -135,7 +116,6 @@ const LabelPurchaseModal = props => {
 			<MigrationSurveyModal
 				isVisible={ showSurveyModal }
 				onClose={ () => setShowSurveyModal( false ) }
-				onSubmit={ handleSurveySubmit }
 			/>
 		) }
 	</>);

--- a/readme.txt
+++ b/readme.txt
@@ -71,6 +71,7 @@ This plugin relies on the following external services:
 == Changelog ==
 
 = 3.0.8 - 2025-xx-xx =
+* Add   - Migration survey to understand WooCommerce Shipping adoption blockers.
 * Fix   - Improves performance when WooCommerce Shipping is not active.
 * Tweak - WooCommerce 10.1 Compatibility.
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -58,4 +58,15 @@ class Utils {
 
 		return self::get_wcservices_version();
 	}
+
+	/**
+	 * Get sanitized request data.
+	 *
+	 * @param string $key     The key to get the data for.
+	 * @param string $default The default value to return if the key is not set.
+	 * @return string The sanitized data as a string.
+	 */
+	public static function get_sanitized_request_data( string $key, string $default = '' ): string {
+		return sanitize_text_field( wp_unslash( $_REQUEST[ $key ] ?? $default ) );
+	}
 }

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -873,13 +873,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$tracks                 = new WC_Connect_Tracks( $logger, __FILE__ );
 			$shipping_label         = new WC_Connect_Shipping_Label( $api_client, $settings_store, $schemas_store, $payment_methods_store );
 			$nux                    = new WC_Connect_Nux( $tracks, $shipping_label );
-			$store_notices_notifier = class_exists( 'Automattic\WCServices\StoreNotices\StoreNoticesNotifier' )
-				? new StoreNoticesNotifier( $taxes_logger->is_debug_enabled() )
-				: null;
+			$store_notices_notifier = new StoreNoticesNotifier( $taxes_logger->is_debug_enabled() );
 			$taxjar                 = new WC_Connect_TaxJar_Integration( $api_client, $taxes_logger, $this->wc_connect_base_url, $store_notices_notifier );
-			if ( $store_notices_notifier ) {
-				$this->set_store_notices_notifier( $store_notices_notifier );
-			}
+			$this->set_store_notices_notifier( $store_notices_notifier );
 			$paypal_ec     = new WC_Connect_PayPal_EC( $api_client, $nux );
 			$label_reports = new WC_Connect_Label_Reports( $settings_store );
 
@@ -970,23 +966,13 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * Init WC Store Notices.
 		 */
 		public function init_store_notices() {
-			$notifier = $this->get_store_notices_notifier();
-			if ( $notifier ) {
-				new StoreNoticesController( $notifier );
-			}
+			new StoreNoticesController( $this->get_store_notices_notifier() );
 		}
 
 		/**
 		 * Extend the Store API.
 		 */
 		public function extend_store_api() {
-			// Check if Store API classes are available before instantiating
-			if ( ! class_exists( 'Automattic\WCServices\StoreApi\StoreApiExtendSchema' ) ||
-				! class_exists( 'Automattic\WCServices\StoreApi\StoreApiExtensionController' ) ||
-				! class_exists( 'Automattic\WCServices\StoreApi\Extensions\StoreNoticesExtension' ) ) {
-				return;
-			}
-
 			$store_api_extend_schema        = StoreApiExtendSchema::instance();
 			$store_api_extension_controller = new StoreApiExtensionController( $store_api_extend_schema );
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -873,9 +873,13 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$tracks                 = new WC_Connect_Tracks( $logger, __FILE__ );
 			$shipping_label         = new WC_Connect_Shipping_Label( $api_client, $settings_store, $schemas_store, $payment_methods_store );
 			$nux                    = new WC_Connect_Nux( $tracks, $shipping_label );
-			$store_notices_notifier = new StoreNoticesNotifier( $taxes_logger->is_debug_enabled() );
+			$store_notices_notifier = class_exists( 'Automattic\WCServices\StoreNotices\StoreNoticesNotifier' ) 
+				? new StoreNoticesNotifier( $taxes_logger->is_debug_enabled() )
+				: null;
 			$taxjar                 = new WC_Connect_TaxJar_Integration( $api_client, $taxes_logger, $this->wc_connect_base_url, $store_notices_notifier );
-			$this->set_store_notices_notifier( $store_notices_notifier );
+			if ( $store_notices_notifier ) {
+				$this->set_store_notices_notifier( $store_notices_notifier );
+			}
 			$paypal_ec     = new WC_Connect_PayPal_EC( $api_client, $nux );
 			$label_reports = new WC_Connect_Label_Reports( $settings_store );
 
@@ -966,13 +970,23 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * Init WC Store Notices.
 		 */
 		public function init_store_notices() {
-			new StoreNoticesController( $this->get_store_notices_notifier() );
+			$notifier = $this->get_store_notices_notifier();
+			if ( $notifier ) {
+				new StoreNoticesController( $notifier );
+			}
 		}
 
 		/**
 		 * Extend the Store API.
 		 */
 		public function extend_store_api() {
+			// Check if Store API classes are available before instantiating
+			if ( ! class_exists( 'Automattic\WCServices\StoreApi\StoreApiExtendSchema' ) ||
+				 ! class_exists( 'Automattic\WCServices\StoreApi\StoreApiExtensionController' ) ||
+				 ! class_exists( 'Automattic\WCServices\StoreApi\Extensions\StoreNoticesExtension' ) ) {
+				return;
+			}
+
 			$store_api_extend_schema        = StoreApiExtendSchema::instance();
 			$store_api_extension_controller = new StoreApiExtensionController( $store_api_extend_schema );
 
@@ -990,6 +1004,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 */
 		public function init_shipping_labels() {
 			add_filter( 'woocommerce_admin_reports', array( $this, 'reports_tabs' ) );
+
+			// Initialize migration survey
+			require_once __DIR__ . '/classes/class-wc-connect-migration-survey.php';
+			new WC_Connect_Migration_Survey();
 
 			// Changing the postcode, currency, weight or dimension units affect the returned schema from the server.
 			// Make sure to update the service schemas when these options change.


### PR DESCRIPTION
## Description

  This PR implements WOOSHIP-1511: a migration survey to understand why WCS&T users haven't migrated to WooCommerce Shipping. The survey appears after users complete a shipping label
  purchase to capture feedback on migration blockers.

  ### Related issue(s)

  Implements WOOSHIP-1511: https://linear.app/a8c/issue/WOOSHIP-1511/implement-survey-in-wcsandt-for-migration-blockers

  ### Key Features Implemented

  - **Backend Survey Logic**: PHP class handling survey eligibility, display limits, and tracking
  - **Frontend Modal Component**: React modal with primary/followup questions matching Linear spec
  - **Post-Purchase Timing**: Survey displays after label purchase completion (not during)
  - **Display Control**: Maximum 2 displays per user with 3-day cooldown period
  - **Analytics Integration**: Tracks survey events via WooCommerce Services Tracks
  - **Responsive Design**: Mobile-friendly modal with proper styling

  ### Survey Flow

  1. User completes shipping label purchase
  2. Survey appears after purchase dialog closes (500ms delay for print dialogs)
  3. Primary question with 7 predefined options
  4. Conditional followup textarea based on selection
  5. Submit or skip options with proper tracking
  6. Confirmation message with migration guidance

  ### Display Logic

  - **Eligibility**: Only shown if WooCommerce Shipping is not active
  - **Frequency**: Maximum 2 times per user with 3-day cooldown
  - **Completion**: Never shows again after user submits feedback
  - **Testing**: `?force_survey=1` parameter for development/testing

  ### Steps to reproduce & screenshots/GIFs

  **Testing Steps:**
  1. Go to WP Admin → Orders → Edit any order
  2. Add `?force_survey=1` to URL to force survey display
  3. Create a shipping label (or use existing label creation flow)
  4. Complete the purchase process
  5. Survey modal should appear after purchase completion
  6. Test both primary questions and followup responses
  7. Verify tracking in browser dev tools (AJAX calls to track display/submission)

  **Track Events to Monitor:**

  When testing, verify these events are properly fired in browser dev tools (Network tab → XHR requests) or analytics dashboard:

  1. **`migration_survey_survey_displayed`**
     - Fired when: Survey modal appears to user
     - Properties: None
     - Expected: Once per survey display

  2. **`migration_survey_survey_submitted`**
     - Fired when: User completes and submits survey
     - Properties:
       - `primary_reason`: Selected option from dropdown
       - `followup_*`: Any followup question responses (prefixed with `followup_`)
     - Expected: Once per successful submission

  3. **`migration_survey_survey_dismissed`**
     - Fired when: User clicks "Skip" or closes survey
     - Properties: None
     - Expected: Once per dismissal action

  ### Checklist

  - [ ] unit tests
  - [x] `changelog.txt` entry added
  - [x] `readme.txt` entry added