### PR TITLE
Fix WOOSHIP-1535 - Don't load shipping settings if WC shipping or tax-only is enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.1.1 - 2025-xx-xx =
+* Fix   - Exclude shipping-related admin components when shipping functionality is disabled.
+
 = 3.1.0 - 2025-09-16 =
 * Add   - Increase cache time for address validation errors.
 * Tweak - WooCommerce 10.2 Compatibility.
@@ -12,7 +15,6 @@
 
 = 3.0.9 - 2025-08-26 =
 * Add   - Migration survey to understand WooCommerce Shipping adoption blockers.
-* Fix   - Exclude shipping-related admin components when shipping functionality is disabled.
 
 = 3.0.8 - 2025-08-13 =
 * Fix   - Improves performance when WooCommerce Shipping is not active.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.0.9 - 2025-xx-xx =
+* Fix   - Exclude shipping-related admin components when shipping functionality is disabled.
+
 = 3.0.8 - 2025-08-13 =
 * Fix   - Improves performance when WooCommerce Shipping is not active.
 * Fix   - Restore shipping label functionality for merchants with shipping features enabled.

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -297,15 +297,18 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 				)
 			);
 
-			do_action(
-				'enqueue_wc_connect_script',
-				'wc-connect-admin-test-print',
-				array(
-					'isShippingLoaded' => $this->is_shipping_loaded(),
-					'storeOptions'     => $this->service_settings_store->get_store_options(),
-					'paperSize'        => $this->service_settings_store->get_preferred_paper_size(),
-				)
-			);
+			// Shipping related.
+			if ( ! WC_Connect_Loader::is_wc_shipping_activated() && '1' !== WC_Connect_Options::get_option( 'only_tax' ) ) {
+				do_action(
+					'enqueue_wc_connect_script',
+					'wc-connect-admin-test-print',
+					array(
+						'isShippingLoaded' => $this->is_shipping_loaded(),
+						'storeOptions'     => $this->service_settings_store->get_store_options(),
+						'paperSize'        => $this->service_settings_store->get_preferred_paper_size(),
+					)
+				);
+			}
 		}
 
 		/**

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.0.9 - 2025-xx-xx =
+* Fix   - Exclude shipping-related admin components when shipping functionality is disabled.
+
 = 3.0.8 - 2025-08-13 =
 * Fix   - Improves performance when WooCommerce Shipping is not active.
 * Fix   - Restore shipping label functionality for merchants with shipping features enabled.

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.1.1 - 2025-xx-xx =
+* Fix   - Exclude shipping-related admin components when shipping functionality is disabled.
+
 = 3.1.0 - 2025-09-16 =
 * Add   - Increase cache time for address validation errors.
 * Tweak - WooCommerce 10.2 Compatibility.
@@ -82,7 +85,6 @@ This plugin relies on the following external services:
 
 = 3.0.9 - 2025-08-26 =
 * Add   - Migration survey to understand WooCommerce Shipping adoption blockers.
-* Fix   - Exclude shipping-related admin components when shipping functionality is disabled.
 
 = 3.0.8 - 2025-08-13 =
 * Fix   - Improves performance when WooCommerce Shipping is not active.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -914,15 +914,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'admin_notices', array( WC_Connect_Error_Notice::instance(), 'render_notice' ) );
 			add_action( 'admin_notices', array( $this, 'render_schema_notices' ) );
 
-			/**
-			 * Don't load shipping settings and notices when:
-			 * 1. WC Shipping plugin is active (it handles its own settings).
-			 * 2. Plugin is in tax-only mode (shipping features are disabled).
-			 */
-			if ( self::is_wc_shipping_activated() || '1' === WC_Connect_Options::get_option( 'only_tax' ) ) {
-				return;
-			}
-
 			// We only use the settings page for shipping since tax settings are part of
 			// the core "WooCommerce > Settings > Tax" tab.
 			require_once __DIR__ . '/classes/class-wc-connect-settings-pages.php';
@@ -930,7 +921,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->set_settings_pages( $settings_pages );
 
 			// Add WC Admin Notices.
-			if ( self::can_add_wc_admin_notice() ) {
+			if ( ! self::is_wc_shipping_activated() && self::can_add_wc_admin_notice() ) {
 				require_once __DIR__ . '/classes/class-wc-connect-note-dhl-live-rates-available.php';
 				WC_Connect_Note_DHL_Live_Rates_Available::init( $schema );
 			}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -914,6 +914,15 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'admin_notices', array( WC_Connect_Error_Notice::instance(), 'render_notice' ) );
 			add_action( 'admin_notices', array( $this, 'render_schema_notices' ) );
 
+			/**
+			 * Don't load shipping settings and notices when:
+			 * 1. WC Shipping plugin is active (it handles its own settings).
+			 * 2. Plugin is in tax-only mode (shipping features are disabled).
+			 */
+			if ( self::is_wc_shipping_activated() || '1' === WC_Connect_Options::get_option( 'only_tax' ) ) {
+				return;
+			}
+
 			// We only use the settings page for shipping since tax settings are part of
 			// the core "WooCommerce > Settings > Tax" tab.
 			require_once __DIR__ . '/classes/class-wc-connect-settings-pages.php';
@@ -921,7 +930,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->set_settings_pages( $settings_pages );
 
 			// Add WC Admin Notices.
-			if ( ! self::is_wc_shipping_activated() && self::can_add_wc_admin_notice() ) {
+			if ( self::can_add_wc_admin_notice() ) {
 				require_once __DIR__ . '/classes/class-wc-connect-note-dhl-live-rates-available.php';
 				WC_Connect_Note_DHL_Live_Rates_Available::init( $schema );
 			}

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -914,6 +914,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'admin_notices', array( WC_Connect_Error_Notice::instance(), 'render_notice' ) );
 			add_action( 'admin_notices', array( $this, 'render_schema_notices' ) );
 
+			// Don't register settings if only_tax mode.
+			if ( '1' === WC_Connect_Options::get_option( 'only_tax' ) ) {
+				return;
+			}
+
 			// We only use the settings page for shipping since tax settings are part of
 			// the core "WooCommerce > Settings > Tax" tab.
 			require_once __DIR__ . '/classes/class-wc-connect-settings-pages.php';


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
* Fix   - Exclude shipping-related admin components when shipping functionality is disabled.

### Related issue(s)
[WOOSHIP-1535](https://linear.app/a8c/issue/WOOSHIP-1535/hide-print-feature-and-woo-shipping-settings-when-only-tax-flag-is-set)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
1. Install and configure the current **WooCommerce Tax** plugin release along with **WooCommerce Shipping**.
2. Go to **WooCommerce > Status > WooCommerce Tax** then you will find **Print functionality** still
4. Update the plugin with this branch and re-do the previous step.
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

