### PR TITLE
[WOOSHIP-1511] chore: add active WC shipping plugin version to CS API calls

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -468,6 +468,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				'dimension_unit'       => strtolower( get_option( 'woocommerce_dimension_unit' ) ),
 				'weight_unit'          => strtolower( get_option( 'woocommerce_weight_unit' ) ),
 				'wcs_version'          => WC_Connect_Loader::get_wcs_version(),
+				'wcshipping_version'   => WC_Connect_Loader::get_wc_shipping_version(),
 				'jetpack_version'      => 'embed-' . WC_Connect_Jetpack::get_jetpack_connection_package_version(),
 				'is_atomic'            => WC_Connect_Jetpack::is_atomic_site(),
 				'wc_version'           => WC()->version,

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -2108,6 +2108,23 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		/**
+		 * Get the version of WooCommerce Shipping plugin
+		 *
+		 * @return string
+		 */
+		public static function get_wc_shipping_version() {
+			if ( ! self::is_wc_shipping_activated() ) {
+				return 'undefined';
+			}
+			// Ensure this code runs within the WordPress admin context or after wp-admin/includes/plugin.php is loaded.
+			if ( ! function_exists( 'get_plugins' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/plugin.php';
+			}
+			$all_plugins = get_plugins();
+			return $all_plugins['woocommerce-shipping/woocommerce-shipping.php']['Version'];
+		}
+
+		/**
 		 * Returns if both Woo Shipping and Woo Tax are active.
 		 *
 		 * @return bool


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
Add the plugin version of WC shipping to the API call made to connect server. This will inform the connect server if WC shipping is also active along with the current plugin.

### Related issue(s)
Fixes [#WOOSHIP-1511](https://linear.app/a8c/issue/WOOSHIP-1511/implement-survey-in-wcsandt-for-migration-blockers)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
1. Checkout locally and ensure both WC shipping and services are installed and activated. 
2. Ensure connect server is running locally and it's logs are accessible.
3. Add this console statement in any request handler. For eg: in `lib/services/index.js` in the function `validationHandler`, add `console.log("Request: ", JSON.stringify(request.payload, null, 2));`
4. Now navigate to `woocommerce>orders` page and notice the logs. It should show values for both `wcs_version` and `wcshipping_version` in the `settings` object.
5. Now go to `Installed plugins` and deactivate WC Shipping. Navigate back to `woocommerce>orders` page and notice that only value for both `wcs_version` is valid and `wcshipping_version` will be coming as `undefined`.

PS: ensure to test the similar PR in WC shipping for effective review.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

