### PR TITLE
Replace migration guide URL with the correct one

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.0.10 - 2025-xx-xx =
+* Fix   - Corrected migration guide link in survey modal.
+
 = 3.0.9 - 2025-08-26 =
 * Add   - Migration survey to understand WooCommerce Shipping adoption blockers.
 

--- a/client/components/migration-survey/modal.js
+++ b/client/components/migration-survey/modal.js
@@ -172,7 +172,7 @@ const MigrationSurveyModal = ( { isVisible, onClose, translate } ) => {
 					</div>
 					<div className="migration-survey__modal-content">
 						<p>{ translate( 'Your feedback is incredibly valuable. We want to make sure the new WooCommerce Shipping is an excellent replacement for you before we officially retire the shipping functionality in this plugin.' ) }</p>
-						<p>{ translate( 'P.S. While we work on improvements, did you know the new WooCommerce Shipping includes discounted UPS rates? You can print USPS, DHL, and now UPS labels right from your dashboard – no separate accounts needed. Want to see how easy it is?' ) } <a href={ MigrationGuideURL } target="_blank" rel="noopener noreferrer">{ translate( 'Read the step-by-step migration guide.' ) }</a></p>
+						<p>{ translate( 'P.S. While we work on improvements, did you know the new WooCommerce Shipping includes discounted UPS rates? You can print USPS, DHL, and now UPS labels right from your dashboard – no separate accounts needed. Want to see how easy it is?' ) } <a href={ MigrationGuideURL } target="_blank" rel="noopener noreferrer">{ translate( 'Read the migration guide.' ) }</a></p>
 					</div>
 					<div className="migration-survey__modal-footer">
 						<button 

--- a/client/components/migration-survey/modal.js
+++ b/client/components/migration-survey/modal.js
@@ -4,6 +4,7 @@
 import React, { useState } from 'react';
 import { localize } from 'i18n-calypso';
 
+const MigrationGuideURL = 'https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#how-do-i-migrate-from-wcst';
 /**
  * Migration Survey Modal Component
  * 
@@ -171,7 +172,7 @@ const MigrationSurveyModal = ( { isVisible, onClose, translate } ) => {
 					</div>
 					<div className="migration-survey__modal-content">
 						<p>{ translate( 'Your feedback is incredibly valuable. We want to make sure the new WooCommerce Shipping is an excellent replacement for you before we officially retire the shipping functionality in this plugin.' ) }</p>
-						<p>{ translate( 'P.S. While we work on improvements, did you know the new WooCommerce Shipping includes discounted UPS rates? You can print USPS, DHL, and now UPS labels right from your dashboard – no separate accounts needed. Want to see how easy it is?' ) } <a href="https://woocommerce.com/document/migrating-from-woocommerce-services-to-woocommerce-shipping/" target="_blank" rel="noopener noreferrer">{ translate( 'Read the step-by-step migration guide.' ) }</a></p>
+						<p>{ translate( 'P.S. While we work on improvements, did you know the new WooCommerce Shipping includes discounted UPS rates? You can print USPS, DHL, and now UPS labels right from your dashboard – no separate accounts needed. Want to see how easy it is?' ) } <a href={ MigrationGuideURL } target="_blank" rel="noopener noreferrer">{ translate( 'Read the step-by-step migration guide.' ) }</a></p>
 					</div>
 					<div className="migration-survey__modal-footer">
 						<button 

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.0.10 - 2025-xx-xx =
+* Fix   - Corrected migration guide link in survey modal.
+
 = 3.0.9 - 2025-08-26 =
 * Add   - Migration survey to understand WooCommerce Shipping adoption blockers.
 


### PR DESCRIPTION
### Description
This PR updates the link to the migration guide.
Fixes WOOSHIP-1511

### Steps to test:
- Make a build from this branch.
- Upload to your test site.
- Force the survey banner by using `&force_survey=1` in the order page URL where you want to make a label purchase.
- Make a label purchase, fillout the survey form, submit and on the success screen verify the the link to the guides page is this: https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#how-do-i-migrate-from-wcst and verify the link text doesn't contain `step-by-step`.

