### PR TITLE
Fix regression causing slow loading times, loading shipping infrastructure when shipping is not enabled

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -529,6 +529,11 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		 * @return bool True if shipping label is enabled from the settings.
 		 */
 		public function is_shipping_label_enabled() {
+			// For tax-only installations, shipping labels are disabled
+			if ( WC_Connect_Loader::has_only_tax_functionality() ) {
+				return false;
+			}
+
 			$account_settings = $this->account_settings->get();
 
 			if ( isset( $account_settings['formData']['enabled'] ) && is_bool( $account_settings['formData']['enabled'] ) ) {


### PR DESCRIPTION
## Description
This pull request fixes a regression introduced in https://github.com/Automattic/woocommerce-services/pull/2877 that allowed the shipping infrastructure to load and cause slow page load times in the admin panel when the shipping features of this plugin are not used. 

The original fix was introduced in https://github.com/Automattic/woocommerce-services/pull/2856, and then modified slightly in https://github.com/Automattic/woocommerce-services/pull/2873.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

