### PR TITLE
[WOOSHIP-1591] chore: bump jetpack autoloader dependency version

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.0.11- 2025-xx-xx =
+* Tweak - Bump jetpack autoloader version
+
 = 3.0.10 - 2025-09-02 =
 * Fix   - Corrected migration guide link in survey modal.
 

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,9 @@
       ],
       "qit:security": [
         "npm run build && composer install && ./vendor/bin/qit run:security woocommerce-services --zip=woocommerce-services.zip"
+      ],
+      "qit:woo-api": [
+        "npm run build && composer install && ./vendor/bin/qit run:woo-api woocommerce-services --zip=woocommerce-services.zip"
       ]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -175,16 +175,16 @@
         },
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v5.0.7",
+            "version": "v5.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "8ab8cc721937030a7a3d77d3d6698649f56de4d9"
+                "reference": "c9e9b82cc515d9ed093fa0ff21245f277aeceb4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/8ab8cc721937030a7a3d77d3d6698649f56de4d9",
-                "reference": "8ab8cc721937030a7a3d77d3d6698649f56de4d9",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/c9e9b82cc515d9ed093fa0ff21245f277aeceb4e",
+                "reference": "c9e9b82cc515d9ed093fa0ff21245f277aeceb4e",
                 "shasum": ""
             },
             "require": {
@@ -234,9 +234,9 @@
                 "wordpress"
             ],
             "support": {
-                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v5.0.7"
+                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v5.0.9"
             },
-            "time": "2025-04-28T15:12:56+00:00"
+            "time": "2025-07-28T19:49:50+00:00"
         },
         {
             "name": "automattic/jetpack-config",

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.0.11- 2025-xx-xx =
+* Tweak - Bump jetpack autoloader version
+
 = 3.0.10 - 2025-09-02 =
 * Fix   - Corrected migration guide link in survey modal.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
We are seeing QIT failures with the `woo-api` tests in our github actions. We tried upgrading the autoloader function but that doesn't seem to solve the issue. On further investigation, running the command locally seems to be passing. 

The issue was not related to the codebase however it is better to update the jetpack version. This PR makes the update and also adds a handy command to run the woo-api qit tests locally in future.

### Related issue(s)

Fixes WOOSHIP-1591
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
1. Checkout the branch.
2. Run command `composer run qit:woo-api` and check the results.

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

