### PR TITLE
Increase cache time when "ZIP Code does not match the selected state."

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.0.11 - 2025-xx-xx =
+* Add   - Increase cache time for address validation errors.
+
 = 3.0.10 - 2025-09-02 =
 * Fix   - Corrected migration guide link in survey modal.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Tax Changelog ***
 
-= 3.0.11 - 2025-xx-xx =
+= 3.1.0 - 2025-xx-xx =
 * Add   - Increase cache time for address validation errors.
 
 = 3.0.10 - 2025-09-02 =

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -44,6 +44,13 @@ class WC_Connect_TaxJar_Integration {
 	private $cache_time;
 
 	/**
+	 * Address Validation Cache time.
+	 *
+	 * @var int
+	 */
+	private $address_cache_time;
+
+	/**
 	 * Error cache time.
 	 *
 	 * @var int
@@ -99,6 +106,9 @@ class WC_Connect_TaxJar_Integration {
 
 		// Cache rates for 1 hour.
 		$this->cache_time = HOUR_IN_SECONDS;
+
+		// Cache address validation errors for 1 year.
+		$this->address_cache_time = YEAR_IN_SECONDS;
 
 		// Cache error response for 5 minutes.
 		$this->error_cache_time = MINUTE_IN_SECONDS * 5;
@@ -1587,8 +1597,16 @@ class WC_Connect_TaxJar_Integration {
 	 * @return mixed|WP_Error
 	 */
 	public function smartcalcs_cache_request( $json ) {
-		$cache_key        = 'tj_tax_' . hash( 'md5', $json );
-		$response         = get_transient( $cache_key );
+		$cache_key           = 'tj_tax_' . hash( 'md5', $json );
+		$zip_state_cache_key = false;
+		$request             = json_decode( $json );
+		$to_zip              = isset( $request->to_zip ) ? (string) $request->to_zip : false;
+		$to_state            = isset( $request->to_state ) ? (string) $request->to_state : false;
+		if ( $to_zip && $to_state ) {
+			$zip_state_cache_key = strtolower( 'tj_tax_' . $to_zip . '_' . $to_state );
+			$response            = get_transient( $zip_state_cache_key );
+		}
+		$response         = $response ? $response : get_transient( $cache_key );
 		$response_code    = wp_remote_retrieve_response_code( $response );
 		$save_error_codes = array( 404, 400 );
 
@@ -1596,18 +1614,37 @@ class WC_Connect_TaxJar_Integration {
 		$this->notifier->clear_notices( 'taxjar' );
 
 		if ( false === $response ) {
-			$response      = $this->smartcalcs_request( $json );
-			$response_code = wp_remote_retrieve_response_code( $response );
+			$response                 = $this->smartcalcs_request( $json );
+			$response_code            = wp_remote_retrieve_response_code( $response );
+			$body                     = json_decode( wp_remote_retrieve_body( $response ) );
+			$is_zip_to_state_mismatch = (
+				isset( $body->detail )
+				&& is_string( $body->detail )
+				&& $to_zip
+				&& $to_state
+				&& false !== strpos( $body->detail, 'to_zip ' . $to_zip )
+				&& false !== strpos( $body->detail, 'to_state ' . $to_state )
+			);
+			$transient_set            = false;
 
 			if ( 200 == $response_code ) {
 				set_transient( $cache_key, $response, $this->cache_time );
 			} elseif ( in_array( $response_code, $save_error_codes ) ) {
-				set_transient( $cache_key, $response, $this->error_cache_time );
+				if ( 400 == $response_code
+					&& $is_zip_to_state_mismatch
+					&& $zip_state_cache_key
+				) {
+					$transient_set = set_transient( $zip_state_cache_key, $response, $this->address_cache_time );
+				}
+
+				if ( ! $transient_set ) {
+					set_transient( $cache_key, $response, $this->error_cache_time );
+				}
 			}
 		}
 
 		if ( in_array( $response_code, $save_error_codes ) ) {
-			$this->_log( 'Retrieved the error from the cache.' );
+			$this->_log( 'Retrieved the error from the cache. Received (' . $response['response']['code'] . '): ' . $response['body'] );
 			$this->_error( 'Error retrieving the tax rates. Received (' . $response['response']['code'] . '): ' . $response['body'] );
 			return false;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -70,7 +70,7 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
-= 3.0.11 - 2025-xx-xx =
+= 3.1.0 - 2025-xx-xx =
 * Add   - Increase cache time for address validation errors.
 
 = 3.0.10 - 2025-09-02 =

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.0.11 - 2025-xx-xx =
+* Add   - Increase cache time for address validation errors.
+
 = 3.0.10 - 2025-09-02 =
 * Fix   - Corrected migration guide link in survey modal.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
For USA territory when ZIP and State don't match TaxJar API return `400` response indicating the issue.
```json
{"detail":"to_zip 33033 is not used within to_state CA","status":400,"error":"Bad Request"}
```
This PR modify the cache and allow to cache those responses for longer, currently 1 year.

There are no visible changes introduced by this PR.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
https://linear.app/a8c/issue/WOOSHIP-1566/taxjar-api-errors-caching-strategy

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

