### PR TITLE
Fix WOOSHIP-1453 - Automatic taxes calculation for subscription renewals with grace period

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.1.1 - 2025-xx-xx =
+* Fix   - Automatic taxes calculation for subscription renewals with grace period.
+
 = 3.1.0 - 2025-09-16 =
 * Add   - Increase cache time for address validation errors.
 * Tweak - WooCommerce 10.2 Compatibility.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -478,9 +478,6 @@ class WC_Connect_TaxJar_Integration {
 			return;
 		}
 
-		$cart_taxes     = array();
-		$cart_tax_total = 0;
-
 		/**
 		 * WC Coupon object.
 		 *
@@ -496,7 +493,7 @@ class WC_Connect_TaxJar_Integration {
 			}
 		}
 
-		$address    = $this->get_address( $wc_cart_object );
+		$address    = $this->get_address();
 		$line_items = $this->get_line_items( $wc_cart_object );
 
 		$taxes = $this->calculate_tax(

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -759,13 +759,7 @@ class WC_Connect_TaxJar_Integration {
 			// Get WC Subscription sign-up fees for calculations
 			if ( class_exists( 'WC_Subscriptions_Cart' ) ) {
 				if ( 'none' == WC_Subscriptions_Cart::get_calculation_type() ) {
-					if ( class_exists( 'WC_Subscriptions_Synchroniser' ) ) {
-						WC_Subscriptions_Synchroniser::maybe_set_free_trial();
-					}
 					$unit_price = WC_Subscriptions_Cart::set_subscription_prices_for_calculation( $unit_price, $product );
-					if ( class_exists( 'WC_Subscriptions_Synchroniser' ) ) {
-						WC_Subscriptions_Synchroniser::maybe_unset_free_trial();
-					}
 				}
 			}
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -829,13 +829,6 @@ class WC_Connect_TaxJar_Integration {
 				$tax_code = '99999';
 			}
 
-			// Get WC Subscription sign-up fees for calculations
-			if ( class_exists( 'WC_Subscriptions_Cart' ) ) {
-				if ( 'none' == WC_Subscriptions_Cart::get_calculation_type() ) {
-					$unit_price = WC_Subscriptions_Cart::set_subscription_prices_for_calculation( $unit_price, $product );
-				}
-			}
-
 			array_push(
 				$line_items,
 				array(

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1590,7 +1590,7 @@ class WC_Connect_TaxJar_Integration {
 			$zip_state_cache_key = strtolower( 'tj_tax_' . $to_zip . '_' . $to_state );
 			$response            = get_transient( $zip_state_cache_key );
 		}
-		$response         = $response ? $response : get_transient( $cache_key );
+		$response         = isset( $response ) ? $response : get_transient( $cache_key );
 		$response_code    = wp_remote_retrieve_response_code( $response );
 		$save_error_codes = array( 404, 400 );
 

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.1.1 - 2025-xx-xx =
+* Fix   - Automatic taxes calculation for subscription renewals with grace period.
+
 = 3.1.0 - 2025-09-16 =
 * Add   - Increase cache time for address validation errors.
 * Tweak - WooCommerce 10.2 Compatibility.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Fix automatic taxes not calculated for subscription renewals when there's a grace period

<!-- Explain the motivation for making this change -->

### Steps to reproduce & screenshots/GIFs
- Install WC Subscriptions, WC Tax, WC core.
- Enable automated tax calculations with WC Tax.
- In WooCommerce - > Settings → Subscriptions, enable Synchronise renewals, set Prorate First renewal to Never .(charge the full recurring amount at sign-up), then set up a grace period of 29 days.
- Create a simple subscription product with synchronise renewals set to 1st day of the month.
- Try to checkout the simple product, being sure you use an address automatic taxes can be calculated for.
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

As single total // Itemized
<img width="946" height="1718" alt="image" src="https://github.com/user-attachments/assets/645f91e2-d361-44fa-b7fc-beae45617e56" /> <img width="938" height="1600" alt="image" src="https://github.com/user-attachments/assets/46ea088a-e696-47fd-847c-720d4a87101f" />

Free trial Order :
<img width="1228" height="788" alt="image" src="https://github.com/user-attachments/assets/35973769-3431-40d9-b2c6-19898373d9f1" />

Renewal Order :
<img width="1231" height="648" alt="image" src="https://github.com/user-attachments/assets/98945f8a-8177-4408-82f9-92ac483f81af" />


### Related issue(s)
[#WOOSHIP-1453](https://linear.app/a8c/issue/WOOSHIP-1453/automatic-taxes-not-calculated-for-subscription-renewals-when-theres-a)
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

