### PR TITLE
Send 0.01 amount to TaxJar when sum of unit_price of line_items is 0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.1.1 - 2025-xx-xx =
+* Fix   - Incorrect tax rate saved in Woo Tax Table when Cart total is 0.
+
 = 3.1.0 - 2025-09-16 =
 * Add   - Increase cache time for address validation errors.
 * Tweak - WooCommerce 10.2 Compatibility.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1225,7 +1225,7 @@ class WC_Connect_TaxJar_Integration {
 		if ( ! isset( $response ) || ! $response ) {
 			$this->_log( 'Received: none.' );
 
-			return $taxes;
+			return false;
 		}
 
 		// Log the response

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1187,6 +1187,7 @@ class WC_Connect_TaxJar_Integration {
 		$from_city       = $store_settings['city'];
 		$from_street     = $store_settings['street'];
 		$shipping_amount = is_null( $shipping_amount ) ? 0.0 : $shipping_amount;
+		$items_total     = array_sum( array_column( $line_items, 'unit_price' ) );
 
 		$this->_log( ':::: TaxJar API called ::::' );
 
@@ -1208,8 +1209,12 @@ class WC_Connect_TaxJar_Integration {
 		$body = $this->maybe_apply_taxjar_nexus_addresses_workaround( $body );
 
 		// Either `amount` or `line_items` parameters are required to perform tax calculations.
-		if ( empty( $line_items ) ) {
-			$body['amount'] = 0.0;
+		if (
+			empty( $line_items )
+			|| ( 0 == $items_total
+			&& ! $this->is_tax_display_itemized() )
+		) {
+			$body['amount'] = 0.01;
 		} else {
 			$body['line_items'] = $line_items;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.1.1 - 2025-xx-xx =
+* Fix   - Incorrect tax rate saved in Woo Tax Table when Cart total is 0.
+
 = 3.1.0 - 2025-09-16 =
 * Add   - Increase cache time for address validation errors.
 * Tweak - WooCommerce 10.2 Compatibility.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
Send 0.01 amount to TaxJar when sum of unit_price of line_items is 0.
TaxJar when all line items price is 0, TaxJar `rate` response prop is also 0 instead or default rate for given address.
Only affects "As a single total" setting, as "Itemized" use traversing through response line items tax rates where rate is not 0 even for 0 unit_price item.

### Related issue(s)
fixes https://linear.app/a8c/issue/WOOSHIP-1453/automatic-taxes-not-calculated-for-subscription-renewals-when-theres-a
fixes https://linear.app/a8c/issue/WOOSHIP-1482/ensure-compatibility-with-woocommerce-subscriptions

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
- Create Simple Product with price $0.00
- Set tax display in Woo-> Settings -> Tax to "As a single total"
   <img width="663" height="52" alt="image" src="https://github.com/user-attachments/assets/9265f622-2e04-49d2-b2d8-e87aeb5b1247" />

- Add product to cart and go to checkout
- Add shipping address that should have taxes calculated
- On `trunk` see the saved tax Rate for given address is 0
   <img width="1419" height="230" alt="image" src="https://github.com/user-attachments/assets/ec325373-f1ea-43e4-ad07-8d18e77d511c" />
- On this branch see correct rate is saved
   <img width="1387" height="175" alt="image" src="https://github.com/user-attachments/assets/5b691f36-b7c9-4251-ab9e-982b43fa04d5" />


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

