### PR TITLE
Add sanity check before using returned value from WC_Tax::find_rates() method.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 3.1.1 - 2025-xx-xx =
 * Fix   - Incorrect tax rate saved in Woo Tax Table when Cart total is 0.
+* Fix   - Compatibility issue with plugins and themes that use woocommerce_find_rates filter.
 
 = 3.1.0 - 2025-09-16 =
 * Add   - Increase cache time for address validation errors.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1455,7 +1455,8 @@ class WC_Connect_TaxJar_Integration {
 	public function create_or_update_tax_rate( $jurisdictions, $location, $rate, $tax_class = '', $freight_taxable = 1, $rate_priority = 1, $rate_name = '' ) {
 		// all the states in GB have the same tax rate
 		// prevents from saving a "state" column value for GB
-		$to_state = 'GB' === $location['to_country'] ? '' : $location['to_state'];
+		$to_state      = 'GB' === $location['to_country'] ? '' : $location['to_state'];
+		$rate_priority = absint( $rate_priority );
 
 		/**
 		 * @see https://github.com/Automattic/woocommerce-services/issues/2531

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1503,7 +1503,7 @@ class WC_Connect_TaxJar_Integration {
 			)
 		);
 
-		$wc_rates_ids = array_keys( $wc_rates );
+		$wc_rates_ids = is_array( $wc_rates ) ? array_keys( $wc_rates ) : array();
 		if ( isset( $wc_rates_ids[ $rate_priority - 1 ] ) ) {
 			$wc_rate[ $wc_rates_ids[ $rate_priority - 1 ] ] = $wc_rates[ $wc_rates_ids[ $rate_priority - 1 ] ];
 		} else {

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,7 @@ This plugin relies on the following external services:
 
 = 3.1.1 - 2025-xx-xx =
 * Fix   - Incorrect tax rate saved in Woo Tax Table when Cart total is 0.
+* Fix   - Compatibility issue with plugins and themes that use woocommerce_find_rates filter.
 
 = 3.1.0 - 2025-09-16 =
 * Add   - Increase cache time for address validation errors.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
Add sanity check before using returned value from WC_Tax::find_rates() method.
Although method definition in docblock says this method returns `array` there is a filter in this method `woocommerce_find_rates` right before it returns and some 3rd party code can break the type contract.


### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
https://linear.app/a8c/issue/WOOSHIP-1625/fatal-error-in-woocommerce-tax-taxjar-integration-conflict-with-square

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
You can follow instruction described in the issue.
https://linear.app/a8c/issue/WOOSHIP-1625/fatal-error-in-woocommerce-tax-taxjar-integration-conflict-with-square
or simulate the issue by adding snippet like.
```php
add_filter( 'woocommerce_find_rates', '__return_false' );
```


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

