### PR TITLE
Refactor tax rate storing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Tax Changelog ***
 
 = 3.1.1 - 2025-xx-xx =
-* Tweak - Unify tax rate saving to always safe itemized tax rates.
+* Tweak - Unify tax rate saving to always save itemized tax rates.
 * Fix   - No tax calculated for multi-word state/counties.
 * Fix   - Incorrect tax rate saved in Woo Tax Table when Cart total is 0.
 * Fix   - Compatibility issue with plugins and themes that use woocommerce_find_rates filter.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
 = 3.1.1 - 2025-xx-xx =
+* Tweak - Unify tax rate saving to always safe itemized tax rates.
+* Fix   - No tax calculated for multi-word state/counties.
 * Fix   - Incorrect tax rate saved in Woo Tax Table when Cart total is 0.
 * Fix   - Compatibility issue with plugins and themes that use woocommerce_find_rates filter.
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1413,7 +1413,7 @@ class WC_Connect_TaxJar_Integration {
 			$this->_log( ':: Adding New Tax Rate ::' );
 			$this->_log( $tax_rate );
 			$rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
-			// VAT is alwyas country wide, no need to create spearate entires for each zip and city.
+			// VAT is always country wide, no need to create separate entires for each zip and city.
 			if ( 'VAT' !== $tax_rate_name ) {
 				WC_Tax::_update_tax_rate_postcodes( $rate_id, wc_normalize_postcode( wc_clean( $location['to_zip'] ) ) );
 				WC_Tax::_update_tax_rate_cities( $rate_id, wc_clean( $location['to_city'] ) );
@@ -1421,6 +1421,7 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		$this->_log( 'Tax Rate ID Set for ' . $rate_id );
+
 		return $rate_id;
 	}
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -130,60 +130,6 @@ class WC_Connect_TaxJar_Integration {
 		return $rate_name;
 	}
 
-	/**
-	 * Generates a combined tax rate name based on jurisdictions and location information.
-	 *
-	 * @param array  $jurisdictions Details for the tax jurisdictions (e.g., city, county, state, country).
-	 *                              This may include attributes for tax determination purposes.
-	 * @param string $to_country    The destination country for the tax calculation.
-	 * @param string $to_state      The destination state for the tax calculation.
-	 *
-	 * @return string The formatted and combined tax rate name including relevant jurisdictions and location data.
-	 */
-	private static function generate_combined_tax_rate_name( $jurisdictions, $to_country, $to_state ) {
-		if ( 'US' !== $to_country ) {
-			return sprintf(
-				'%s Tax',
-				$to_state
-			);
-		}
-
-		// for a list of possible attributes in the `jurisdictions` attribute, see:
-		// https://developers.taxjar.com/api/reference/#post-calculate-sales-tax-for-an-order
-		$jurisdiction_pieces = array_merge(
-			array(
-				'city'    => '',
-				'county'  => '',
-				'state'   => $to_state,
-				'country' => $to_country,
-			),
-			(array) $jurisdictions
-		);
-
-		// sometimes TaxJar returns a string with the value 'FALSE' for `state`.
-		if ( rest_is_boolean( $to_state ) ) {
-			$jurisdiction_pieces['state'] = '';
-		}
-
-		return sprintf(
-			'%s Tax',
-			join(
-				'-',
-				array_filter(
-					array(
-						// the `$jurisdiction_pieces` is not really sorted
-						// so let's sort it with COUNTRY-STATE-COUNTY-CITY
-						// `array_filter` will take care of filtering out the "falsy" entries
-						$jurisdiction_pieces['country'],
-						$jurisdiction_pieces['state'],
-						$jurisdiction_pieces['county'],
-						$jurisdiction_pieces['city'],
-					)
-				)
-			)
-		);
-	}
-
 	public function init() {
 		// Only enable WCS TaxJar integration if the official TaxJar plugin isn't active.
 		if ( class_exists( 'WC_Taxjar' ) ) {
@@ -1334,10 +1280,10 @@ class WC_Connect_TaxJar_Integration {
 	 *
 	 * @return int
 	 */
-	public function create_or_update_tax_rate( $jurisdictions, $location, $rate, $tax_class = '', $freight_taxable = 1, $rate_priority = 1, $rate_name = '' ) {
+	public function create_or_update_tax_rate( $jurisdictions, $location, $rate, $tax_class = '', $freight_taxable = 1, $rate_priority = 1, $tax_rate_name = 'Tax' ) {
 		// Prevent filling "State code" column for countries with VAT tax.
 		// VAT tax is country wide.
-		$to_state      = 'VAT' === $rate_name ? '' : $location['to_state'];
+		$to_state      = 'VAT' === $tax_rate_name ? '' : $location['to_state'];
 		$rate_priority = absint( $rate_priority );
 
 		/**
@@ -1361,14 +1307,14 @@ class WC_Connect_TaxJar_Integration {
 		if ( true === apply_filters( 'woocommerce_taxjar_enable_florida_shipping_tax', true ) && 'US' === $location['to_country'] && 'FL' === $location['from_state'] && 'FL' === $location['to_state'] ) {
 			$freight_taxable = 1;
 		}
-		$tax_rate_name = $rate_name ? $rate_name : self::generate_combined_tax_rate_name( $jurisdictions, $location['to_country'], $to_state );
-		$tax_rate      = array(
+
+		$tax_rate = array(
 			'tax_rate_country'  => $location['to_country'],
 			'tax_rate_state'    => $to_state,
 			// For the US, we're going to modify the name of the tax rate to simplify the reporting and distinguish between the tax rates at the counties level.
 			// I would love to do this for other locations, but it looks like that would create issues.
 			// For example, for the UK it would continuously rename the rate name with an updated `state` "piece", each time a request is made
-			'tax_rate_name'     => $rate_name,
+			'tax_rate_name'     => $tax_rate_name,
 			'tax_rate_priority' => $rate_priority,
 			'tax_rate_compound' => false,
 			'tax_rate_shipping' => $freight_taxable,

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1092,7 +1092,7 @@ class WC_Connect_TaxJar_Integration {
 			'tax_rate'        => 0,
 		);
 
-		// Strict conditions to be met before API call can be conducted
+		// Strict conditions to be met before API call can be conducted.
 		if (
 			empty( $to_country ) ||
 			empty( $to_zip ) ||
@@ -1140,17 +1140,17 @@ class WC_Connect_TaxJar_Integration {
 
 		$response = $this->smartcalcs_cache_request( wp_json_encode( $body ) );
 
-		// if no response, no need to keep going - bail early
+		// if no response, no need to keep going - bail early.
 		if ( ! isset( $response ) || ! $response ) {
 			$this->_log( 'Received: none.' );
 
 			return false;
 		}
 
-		// Log the response
+		// Log the response.
 		$this->_log( 'Received: ' . $response['body'] );
 
-		// Decode Response
+		// Decode Response.
 		$taxjar_response = json_decode( $response['body'] );
 		if ( empty( $taxjar_response->tax ) ) {
 			return false;
@@ -1184,7 +1184,7 @@ class WC_Connect_TaxJar_Integration {
 		$from_country   = $store_settings['country'];
 		$from_state     = $store_settings['state'];
 
-		// Update Properties based on Response
+		// Update Properties based on Response.
 		$taxes['freight_taxable'] = (int) $taxjar_taxes->freight_taxable;
 		$taxes['has_nexus']       = (int) $taxjar_taxes->has_nexus;
 		$taxes['tax_rate']        = $taxjar_taxes->rate;
@@ -1200,7 +1200,7 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		if ( $taxes['has_nexus'] ) {
-			// Use Woo core to find matching rates for taxable address
+			// Use Woo core to find matching rates for taxable address.
 			$location = array(
 				'from_country' => $from_country,
 				'from_state'   => $from_state,
@@ -1259,7 +1259,7 @@ class WC_Connect_TaxJar_Integration {
 
 				++$priority;
 			}
-		} // End if().
+		}
 
 		return $taxes;
 	}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -68,13 +68,6 @@ class WC_Connect_TaxJar_Integration {
 	private $response_line_items;
 
 	/**
-	 * Indicates whether taxes should be displayed in an itemized format.
-	 *
-	 * @var bool
-	 */
-	private $is_tax_display_itemized;
-
-	/**
 	 * Backend tax classes.
 	 *
 	 * @var array
@@ -392,16 +385,6 @@ class WC_Connect_TaxJar_Integration {
 		// the option is currently being enabled - backup the rates and flush the rates table
 		if ( ! $this->is_enabled() && self::OPTION_NAME === $option['id'] && 'yes' === $value ) {
 			$this->backup_existing_tax_rates();
-			return $value;
-		}
-
-		// If itemized taxes are enabled or disabled - backup the rates and flush the rates table.
-		if (
-			( 'single' === $value && $this->is_tax_display_itemized() )
-			|| ( 'itemized' === $value && ! $this->is_tax_display_itemized() )
-		) {
-			$this->backup_existing_tax_rates();
-			$this->is_tax_display_itemized = null;
 			return $value;
 		}
 
@@ -1187,7 +1170,6 @@ class WC_Connect_TaxJar_Integration {
 		$from_city       = $store_settings['city'];
 		$from_street     = $store_settings['street'];
 		$shipping_amount = is_null( $shipping_amount ) ? 0.0 : $shipping_amount;
-		$items_total     = array_sum( array_column( $line_items, 'unit_price' ) );
 
 		$this->_log( ':::: TaxJar API called ::::' );
 
@@ -1209,11 +1191,7 @@ class WC_Connect_TaxJar_Integration {
 		$body = $this->maybe_apply_taxjar_nexus_addresses_workaround( $body );
 
 		// Either `amount` or `line_items` parameters are required to perform tax calculations.
-		if (
-			empty( $line_items )
-			|| ( 0 == $items_total
-			&& ! $this->is_tax_display_itemized() )
-		) {
+		if ( empty( $line_items ) ) {
 			$body['amount'] = 0.01;
 		} else {
 			$body['line_items'] = $line_items;
@@ -1236,14 +1214,8 @@ class WC_Connect_TaxJar_Integration {
 		if ( empty( $taxjar_response->tax ) ) {
 			return false;
 		}
-
-		if ( $this->is_tax_display_itemized() ) {
-			$taxjar_taxes = $taxjar_response->tax;
-			$taxes        = $this->get_itemized_tax_rates( $taxes, $taxjar_taxes, $options );
-		} else {
-			$taxjar_taxes = $this->maybe_override_taxjar_tax( $taxjar_response->tax, $body );
-			$taxes        = $this->get_combined_tax_rates( $taxes, $taxjar_taxes, $options );
-		}
+		$taxjar_taxes = $this->maybe_override_taxjar_tax( $taxjar_response->tax, $body );
+		$taxes        = $this->get_itemized_tax_rates( $taxes, $taxjar_taxes, $options );
 
 		return $taxes;
 	} // End calculate_tax().
@@ -1354,96 +1326,6 @@ class WC_Connect_TaxJar_Integration {
 		return $taxes;
 	}
 
-	private function get_combined_tax_rates( $taxes, $taxjar_taxes, $options ) {
-
-		// Process $options array and turn them into variables
-		$options = is_array( $options ) ? $options : array();
-
-		extract(
-			array_replace_recursive(
-				array(
-					'to_country'      => null,
-					'to_state'        => null,
-					'to_zip'          => null,
-					'to_city'         => null,
-					'to_street'       => null,
-					'shipping_amount' => null,
-					'line_items'      => null,
-				),
-				$options
-			)
-		);
-
-		$store_settings = $this->get_store_settings();
-		$from_country   = $store_settings['country'];
-		$from_state     = $store_settings['state'];
-
-		// Update Properties based on Response
-		$taxes['freight_taxable'] = (int) $taxjar_taxes->freight_taxable;
-		$taxes['has_nexus']       = (int) $taxjar_taxes->has_nexus;
-		$taxes['tax_rate']        = $taxjar_taxes->rate;
-
-		if ( ! empty( $taxjar_taxes->breakdown ) ) {
-			if ( ! empty( $taxjar_taxes->breakdown->line_items ) ) {
-				$line_items = array();
-				foreach ( $taxjar_taxes->breakdown->line_items as $line_item ) {
-					$line_items[ $line_item->id ] = $line_item;
-				}
-				$taxes['line_items'] = $line_items;
-			}
-		}
-
-		if ( $taxes['has_nexus'] ) {
-			// Use Woo core to find matching rates for taxable address
-			$location = array(
-				'from_country' => $from_country,
-				'from_state'   => $from_state,
-				'to_country'   => $to_country,
-				'to_state'     => $to_state,
-				'to_zip'       => $to_zip,
-				'to_city'      => $to_city,
-			);
-
-			// Add line item tax rates
-			foreach ( $taxes['line_items'] as $line_item_key => $line_item ) {
-				$line_item_key_chunks = explode( '-', $line_item_key );
-				$product_id           = $line_item_key_chunks[0];
-				$product              = wc_get_product( $product_id );
-
-				if ( $product ) {
-					$tax_class = $product->get_tax_class();
-				} elseif ( isset( $this->backend_tax_classes[ $product_id ] ) ) {
-						$tax_class = $this->backend_tax_classes[ $product_id ];
-				}
-
-				if ( $line_item->combined_tax_rate ) {
-					$taxes['rate_ids'][ $line_item_key ] = $this->create_or_update_tax_rate(
-						$taxjar_taxes->jurisdictions,
-						$location,
-						round( $line_item->combined_tax_rate * 100, 4 ),
-						$tax_class,
-						$taxes['freight_taxable'],
-						1,
-						self::generate_combined_tax_rate_name( $taxjar_taxes->jurisdictions, $location['to_country'], $to_state )
-					);
-				}
-			}
-
-			// Add shipping tax rate
-			$taxes['rate_ids']['shipping'] = $this->create_or_update_tax_rate(
-				$taxjar_taxes->jurisdictions,
-				$location,
-				round( $taxes['tax_rate'] * 100, 4 ),
-				'',
-				$taxes['freight_taxable'],
-				1,
-				self::generate_combined_tax_rate_name( $taxjar_taxes->jurisdictions, $location['to_country'], $to_state )
-			);
-		} // End if().
-
-		return $taxes;
-	}
-
 	/**
 	 * Add or update a native WooCommerce tax rate
 	 *
@@ -1523,9 +1405,7 @@ class WC_Connect_TaxJar_Integration {
 			$this->_log( $tax_rate );
 			if ( $wc_rate[ $rate_id ]['label'] !== $tax_rate_name || (float) $wc_rate[ $rate_id ]['rate'] !== (float) $rate ) {
 				// Allow to manually change is Shipping taxable, won't be overwritten automatically.
-				if ( $this->is_tax_display_itemized() ) {
-					$tax_rate['tax_rate_shipping'] = wc_string_to_bool( $wc_rate[ $rate_id ]['shipping'] );
-				}
+				$tax_rate['tax_rate_shipping'] = wc_string_to_bool( $wc_rate[ $rate_id ]['shipping'] );
 				WC_Tax::_update_tax_rate( $rate_id, $tax_rate );
 			}
 		} else {
@@ -1765,18 +1645,5 @@ class WC_Connect_TaxJar_Integration {
 		}
 		// Load Javascript for WooCommerce new order page
 		wp_enqueue_script( 'wc-taxjar-order', $this->wc_connect_base_url . 'woocommerce-services-new-order-taxjar-' . WC_Connect_Loader::get_wcs_version() . '.js', array( 'jquery' ), null, true );
-	}
-
-	/**
-	 * Determines whether taxes are displayed itemized based on WooCommerce settings.
-	 *
-	 * @return bool True if taxes are displayed itemized, false otherwise.
-	 */
-	private function is_tax_display_itemized() {
-		if ( null === $this->is_tax_display_itemized ) {
-			$this->is_tax_display_itemized = 'itemized' === get_option( 'woocommerce_tax_total_display', 'single' );
-		}
-
-		return $this->is_tax_display_itemized;
 	}
 }

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1070,23 +1070,19 @@ class WC_Connect_TaxJar_Integration {
 	public function calculate_tax( $options = array() ) {
 		$this->_log( ':::: TaxJar Plugin requested ::::' );
 
-		// Process $options array and turn them into variables
+		// Normalize options to an array and safely map to local variables.
 		$options = is_array( $options ) ? $options : array();
 
-		extract(
-			array_replace_recursive(
-				array(
-					'to_country'      => null,
-					'to_state'        => null,
-					'to_zip'          => null,
-					'to_city'         => null,
-					'to_street'       => null,
-					'shipping_amount' => null,
-					'line_items'      => null,
-				),
-				$options
-			)
-		);
+		$to_country      = $options['to_country'] ?? null;
+		$to_state        = $options['to_state'] ?? null;
+		$to_zip          = $options['to_zip'] ?? null;
+		$to_city         = $options['to_city'] ?? null;
+		$to_street       = $options['to_street'] ?? null;
+		$shipping_amount = $options['shipping_amount'] ?? null;
+		$line_items      = $options['line_items'] ?? null;
+
+		// Treat null shipping amount as zero for validation purposes.
+		$shipping_amount = is_null( $shipping_amount ) ? 0.0 : $shipping_amount;
 
 		$taxes = array(
 			'freight_taxable' => 1,
@@ -1100,7 +1096,7 @@ class WC_Connect_TaxJar_Integration {
 		if (
 			empty( $to_country ) ||
 			empty( $to_zip ) ||
-			( empty( $line_items ) && ( 0 == $shipping_amount ) ) ||
+			( empty( $line_items ) && ( empty( $shipping_amount ) ) ) ||
 			WC()->customer->is_vat_exempt()
 		) {
 			return false;
@@ -1109,13 +1105,12 @@ class WC_Connect_TaxJar_Integration {
 		$to_zip = explode( ',', $to_zip );
 		$to_zip = array_shift( $to_zip );
 
-		$store_settings  = $this->get_store_settings();
-		$from_country    = $store_settings['country'];
-		$from_state      = $store_settings['state'];
-		$from_zip        = $store_settings['postcode'];
-		$from_city       = $store_settings['city'];
-		$from_street     = $store_settings['street'];
-		$shipping_amount = is_null( $shipping_amount ) ? 0.0 : $shipping_amount;
+		$store_settings = $this->get_store_settings();
+		$from_country   = $store_settings['country'];
+		$from_state     = $store_settings['state'];
+		$from_zip       = $store_settings['postcode'];
+		$from_city      = $store_settings['city'];
+		$from_street    = $store_settings['street'];
 
 		$this->_log( ':::: TaxJar API called ::::' );
 
@@ -1166,25 +1161,24 @@ class WC_Connect_TaxJar_Integration {
 		return $taxes;
 	} // End calculate_tax().
 
-	private function get_itemized_tax_rates( $taxes, $taxjar_taxes, $options ) {
+	/**
+	 * Get itemized tax rates from TaxJar response.
+	 *
+	 * @param array  $taxes        The tax data array that will be modified and returned.
+	 * @param object $taxjar_taxes TaxJar response object.
+	 * @param array  $options      Cart data used for tax calculation.
+	 *
+	 * @return array
+	 */
+	private function get_itemized_tax_rates( $taxes, $taxjar_taxes, $options ): array {
 
-		// Process $options array and turn them into variables
+		// Normalize options and safely map to local variables.
 		$options = is_array( $options ) ? $options : array();
 
-		extract(
-			array_replace_recursive(
-				array(
-					'to_country'      => null,
-					'to_state'        => null,
-					'to_zip'          => null,
-					'to_city'         => null,
-					'to_street'       => null,
-					'shipping_amount' => null,
-					'line_items'      => null,
-				),
-				$options
-			)
-		);
+		$to_country = $options['to_country'] ?? null;
+		$to_state   = $options['to_state'] ?? null;
+		$to_zip     = $options['to_zip'] ?? null;
+		$to_city    = $options['to_city'] ?? null;
 
 		$store_settings = $this->get_store_settings();
 		$from_country   = $store_settings['country'];

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1085,11 +1085,8 @@ class WC_Connect_TaxJar_Integration {
 		$to_zip          = $options['to_zip'] ?? null;
 		$to_city         = $options['to_city'] ?? null;
 		$to_street       = $options['to_street'] ?? null;
-		$shipping_amount = $options['shipping_amount'] ?? null;
+		$shipping_amount = $options['shipping_amount'] ?? 0;
 		$line_items      = $options['line_items'] ?? null;
-
-		// Treat null shipping amount as zero for validation purposes.
-		$shipping_amount = is_null( $shipping_amount ) ? 0.0 : $shipping_amount;
 
 		$taxes = array(
 			'freight_taxable' => 1,

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -861,32 +861,39 @@ class WC_Connect_TaxJar_Integration {
 	 * @return array
 	 */
 	public function override_woocommerce_tax_rates( $taxes, $price, $rates ) {
-		if ( isset( $this->response_line_items ) && array_values( $rates ) ) {
-			// Get tax rate ID for current item
-			$keys        = array_keys( $taxes );
-			$tax_rate_id = $keys[0];
-			$line_items  = array();
+		if (
+			! isset( $this->response_line_items )
+			|| empty( $rates )
+			|| ! is_array( $rates )
+			|| ! is_array( $taxes )
+		) {
+				return $taxes;
+		}
 
-			// Map line items using rate ID
-			foreach ( $this->response_rate_ids as $line_item_key => $rate_id ) {
-				if ( $rate_id == $tax_rate_id ) {
-					$line_items[] = $line_item_key;
-				}
+		// Get tax rate ID for current item
+		$keys        = array_keys( $taxes );
+		$tax_rate_id = $keys[0];
+		$line_items  = array();
+
+		// Map line items using rate ID
+		foreach ( $this->response_rate_ids as $line_item_key => $rate_id ) {
+			if ( $rate_id == $tax_rate_id ) {
+				$line_items[] = $line_item_key;
 			}
+		}
 
-			// Remove number precision if Woo 3.2+
-			if ( function_exists( 'wc_remove_number_precision' ) ) {
-				$price = wc_remove_number_precision( $price );
-			}
+		// Remove number precision if Woo 3.2+
+		if ( function_exists( 'wc_remove_number_precision' ) ) {
+			$price = wc_remove_number_precision( $price );
+		}
 
-			foreach ( $this->response_line_items as $line_item_key => $line_item ) {
-				// If line item belongs to rate and matches the price, manually set the tax
-				if ( in_array( $line_item_key, $line_items ) && $price == $line_item->line_total ) {
-					if ( function_exists( 'wc_add_number_precision' ) ) {
-						$taxes[ $tax_rate_id ] = wc_add_number_precision( $line_item->tax_collectable );
-					} else {
-						$taxes[ $tax_rate_id ] = $line_item->tax_collectable;
-					}
+		foreach ( $this->response_line_items as $line_item_key => $line_item ) {
+			// If line item belongs to rate and matches the price, manually set the tax
+			if ( in_array( $line_item_key, $line_items ) && $price == $line_item->line_total ) {
+				if ( function_exists( 'wc_add_number_precision' ) ) {
+					$taxes[ $tax_rate_id ] = wc_add_number_precision( $line_item->tax_collectable );
+				} else {
+					$taxes[ $tax_rate_id ] = $line_item->tax_collectable;
 				}
 			}
 		}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1335,9 +1335,9 @@ class WC_Connect_TaxJar_Integration {
 	 * @return int
 	 */
 	public function create_or_update_tax_rate( $jurisdictions, $location, $rate, $tax_class = '', $freight_taxable = 1, $rate_priority = 1, $rate_name = '' ) {
-		// all the states in GB have the same tax rate
-		// prevents from saving a "state" column value for GB
-		$to_state      = 'GB' === $location['to_country'] ? '' : $location['to_state'];
+		// Prevent filling "State code" column for countries with VAT tax.
+		// VAT tax is country wide.
+		$to_state      = 'VAT' === $rate_name ? '' : $location['to_state'];
 		$rate_priority = absint( $rate_priority );
 
 		/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1235,7 +1235,6 @@ class WC_Connect_TaxJar_Integration {
 						continue;
 					}
 					$taxes['rate_ids'][ $line_item_key ][] = $this->create_or_update_tax_rate(
-						$taxjar_taxes->jurisdictions,
 						$location,
 						round( $tax_rate * 100, 4 ),
 						$tax_class,
@@ -1256,7 +1255,6 @@ class WC_Connect_TaxJar_Integration {
 					continue;
 				}
 				$taxes['rate_ids']['shipping'][] = $this->create_or_update_tax_rate(
-					$taxjar_taxes->jurisdictions,
 					$location,
 					round( $tax_rate * 100, 4 ),
 					$tax_class,
@@ -1273,14 +1271,18 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	/**
-	 * Add or update a native WooCommerce tax rate
+	 * Add or update WooCommerce tax rate.
 	 *
-	 * Unchanged from the TaxJar plugin.
-	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/9d8e725/includes/class-wc-taxjar-integration.php#L396
+	 * @param  array     $location
+	 * @param  int|float $rate
+	 * @param  string    $tax_class
+	 * @param  int       $freight_taxable
+	 * @param  int       $rate_priority
+	 * @param  string    $tax_rate_name
 	 *
 	 * @return int
 	 */
-	public function create_or_update_tax_rate( $jurisdictions, $location, $rate, $tax_class = '', $freight_taxable = 1, $rate_priority = 1, $tax_rate_name = 'Tax' ) {
+	public function create_or_update_tax_rate( $location, $rate, $tax_class = '', $freight_taxable = 1, $rate_priority = 1, $tax_rate_name = 'Tax' ) {
 		// Prevent filling "State code" column for countries with VAT tax.
 		// VAT tax is country wide.
 		$to_state      = 'VAT' === $tax_rate_name ? '' : $location['to_state'];

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1379,7 +1379,7 @@ class WC_Connect_TaxJar_Integration {
 		$wc_rates = WC_Tax::find_rates(
 			array(
 				'country'   => $location['to_country'],
-				'state'     => $to_state,
+				'state'     => str_replace( ' ', '', $to_state ),
 				'postcode'  => $location['to_zip'],
 				'city'      => $location['to_city'],
 				'tax_class' => $tax_class,

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1216,10 +1216,11 @@ class WC_Connect_TaxJar_Integration {
 				$product_id           = $line_item_key_chunks[0];
 				$product              = wc_get_product( $product_id );
 
+				$tax_class = '';
 				if ( $product ) {
 					$tax_class = $product->get_tax_class();
 				} elseif ( isset( $this->backend_tax_classes[ $product_id ] ) ) {
-						$tax_class = $this->backend_tax_classes[ $product_id ];
+					$tax_class = $this->backend_tax_classes[ $product_id ];
 				}
 
 				$_tax_rates = (array) $line_item;
@@ -1251,7 +1252,7 @@ class WC_Connect_TaxJar_Integration {
 				$taxes['rate_ids']['shipping'][] = $this->create_or_update_tax_rate(
 					$location,
 					round( $tax_rate * 100, 4 ),
-					$tax_class,
+					'',
 					$taxes['freight_taxable'],
 					$priority,
 					self::generate_itemized_tax_rate_name( $tax_rate_name, $to_country )

--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,7 @@ This plugin relies on the following external services:
 == Changelog ==
 
 = 3.1.1 - 2025-xx-xx =
-* Tweak - Unify tax rate saving to always safe itemized tax rates.
+* Tweak - Unify tax rate saving to always save itemized tax rates.
 * Fix   - No tax calculated for multi-word state/counties.
 * Fix   - Incorrect tax rate saved in Woo Tax Table when Cart total is 0.
 * Fix   - Compatibility issue with plugins and themes that use woocommerce_find_rates filter.

--- a/readme.txt
+++ b/readme.txt
@@ -71,6 +71,8 @@ This plugin relies on the following external services:
 == Changelog ==
 
 = 3.1.1 - 2025-xx-xx =
+* Tweak - Unify tax rate saving to always safe itemized tax rates.
+* Fix   - No tax calculated for multi-word state/counties.
 * Fix   - Incorrect tax rate saved in Woo Tax Table when Cart total is 0.
 * Fix   - Compatibility issue with plugins and themes that use woocommerce_find_rates filter.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->
Unifies how rates are stored. It only use itemized rates. **Display tax totals** still allow to control how rates are displayed in Cart and Checkout and both options save same tax rates. This allow to remove clearing of tax rates after **Display tax totals** is changed.

Removes `get_combined_tax_rates` and `generate_combined_tax_rate_name` methods.

Prevent saving "State" for VAT tax. VAT is country wide tax.


### Related issue(s)
Closes https://linear.app/a8c/issue/WOOSHIP-1580/changing-display-tax-totals-clears-all-tax-rates-when-automated-taxes
And
Closes https://linear.app/a8c/issue/WOOSHIP-1569/no-vat-calculated-for-two-word-counties-in-lithuania
Closes https://linear.app/a8c/issue/WOOSHIP-1625/fatal-error-in-woocommerce-tax-taxjar-integration-conflict-with-square

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

