### PR TITLE
Fix/issue wooship 1677 - Update links in "Automated Taxes" description

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,11 @@
 *** WooCommerce Tax Changelog ***
 
 = 3.1.1 - 2025-xx-xx =
-* Tweak - Unify tax rate saving to always save itemized tax rates.
 * Fix   - No tax calculated for multi-word state/counties.
 * Fix   - Incorrect tax rate saved in Woo Tax Table when Cart total is 0.
 * Fix   - Compatibility issue with plugins and themes that use woocommerce_find_rates filter.
+* Tweak - Update tax rate and tax nexus links.
+* Tweak - Unify tax rate saving to always save itemized tax rates.
 
 = 3.1.0 - 2025-09-16 =
 * Add   - Increase cache time for address validation errors.

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix   - Compatibility issue with plugins and themes that use woocommerce_find_rates filter.
 * Tweak - Update tax rate and tax nexus links.
 * Tweak - Unify tax rate saving to always save itemized tax rates.
+* Tweak - WooCommerce 10.3 Compatibility.
 
 = 3.1.0 - 2025-09-16 =
 * Add   - Increase cache time for address validation errors.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -272,12 +272,12 @@ class WC_Connect_TaxJar_Integration {
 		$country_state = ( $full_state ) ? $full_state . ', ' . $full_country : $full_country;
 
 		if ( ! $this->is_enabled() ) {
-			/* translators: 1: full state and country name */
-			return sprintf( __( 'Your tax rates and settings will be automatically configured for %1$s. Automated taxes uses your store address as your "tax nexus". If you want to charge tax for any other state, you can add a %2$stax rate%3$s for that state in addition to using automated taxes. %4$sLearn more about Tax Nexus here%5$s.', 'woocommerce-services' ), $country_state, '<a href="https://woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-12">', '</a>', '<a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#automated-taxes-do-not-appear-to-be-calculating">', '</a>' );
+			/* translators: 1: full state and country name, 2: anchor opening with tax rate link, 3: anchor closer, 4: anchor opening with tax nexus link, 5: anchor closer */
+			return sprintf( __( 'Your tax rates and settings will be automatically configured for %1$s. Automated taxes uses your store address as your "tax nexus". If you want to charge tax for any other state, you can add a %2$stax rate%3$s for that state in addition to using automated taxes. %4$sLearn more about Tax Nexus here%5$s.', 'woocommerce-services' ), $country_state, '<a href="https://woocommerce.com/document/setting-up-taxes-in-woocommerce/#setting-up-tax-rates">', '</a>', '<a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#section-14">', '</a>' );
 		}
 
-		/* translators: 1: full state and country name, 2: anchor opening with link, 3: anchor closing */
-		return sprintf( __( 'Your tax rates are now automatically calculated for %1$s. Automated taxes uses your store address as your "tax nexus". If you want to charge tax for any other state, you can add a %2$stax rate%3$s for that state in addition to using automated taxes. %4$sLearn more about Tax Nexus here%5$s.', 'woocommerce-services' ), $country_state, '<a href="https://woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-12">', '</a>', '<a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#automated-taxes-do-not-appear-to-be-calculating">', '</a>' );
+		/* translators: 1: full state and country name, 2: anchor opening with tax rate link, 3: anchor closer, 4: anchor opening with tax nexus link, 5: anchor closer */
+		return sprintf( __( 'Your tax rates are now automatically calculated for %1$s. Automated taxes uses your store address as your "tax nexus". If you want to charge tax for any other state, you can add a %2$stax rate%3$s for that state in addition to using automated taxes. %4$sLearn more about Tax Nexus here%5$s.', 'woocommerce-services' ), $country_state, '<a href="https://woocommerce.com/document/setting-up-taxes-in-woocommerce/#setting-up-tax-rates">', '</a>', '<a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#section-14">', '</a>' );
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -212,7 +212,7 @@ class WC_Connect_TaxJar_Integration {
 		$enabled                = $this->is_enabled();
 		$backedup_tax_rates_url = admin_url( '/admin.php?page=wc-status&tab=connect#tax-rate-backups' );
 
-		$powered_by_wct_notice = '<p>' . sprintf( __( 'Automated taxes take over from the WooCommerce core tax settings. This means that "Display prices" will be set to Excluding tax and tax will be Calculated using Customer shipping address. %1$sLearn more about Automated taxes here.%2$s', 'woocommerce-services' ), '<a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#automated-tax-calculation">', '</a>' ) . '</p>';
+		$powered_by_wct_notice = '<p>' . sprintf( __( 'Automated taxes take over from the WooCommerce core tax settings. This means that "Display prices" will be set to Excluding tax and tax will be Calculated using Customer shipping address. %1$sLearn more about Automated taxes here.%2$s', 'woocommerce-services' ), '<a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#setup-and-configuration">', '</a>' ) . '</p>';
 
 		$backup_notice = ( ! empty( WC_Connect_Functions::get_backed_up_tax_rate_files() ) ) ? '<p>' . sprintf( __( 'Your previous tax rates were backed up and can be downloaded %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . esc_url( $backedup_tax_rates_url ) . '">', '</a>' ) . '</p>' : '';
 

--- a/readme.txt
+++ b/readme.txt
@@ -76,6 +76,7 @@ This plugin relies on the following external services:
 * Fix   - Compatibility issue with plugins and themes that use woocommerce_find_rates filter.
 * Tweak - Update tax rate and tax nexus links.
 * Tweak - Unify tax rate saving to always save itemized tax rates.
+* Tweak - WooCommerce 10.3 Compatibility.
 
 = 3.1.0 - 2025-09-16 =
 * Add   - Increase cache time for address validation errors.

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Requires PHP: 7.4
 Requires at least: 6.7
 Requires Plugins: woocommerce
 Tested up to: 6.8
-WC requires at least: 10.0
-WC tested up to: 10.2
+WC requires at least: 10.1
+WC tested up to: 10.3
 Stable tag: 3.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -71,10 +71,11 @@ This plugin relies on the following external services:
 == Changelog ==
 
 = 3.1.1 - 2025-xx-xx =
-* Tweak - Unify tax rate saving to always save itemized tax rates.
 * Fix   - No tax calculated for multi-word state/counties.
 * Fix   - Incorrect tax rate saved in Woo Tax Table when Cart total is 0.
 * Fix   - Compatibility issue with plugins and themes that use woocommerce_find_rates filter.
+* Tweak - Update tax rate and tax nexus links.
+* Tweak - Unify tax rate saving to always save itemized tax rates.
 
 = 3.1.0 - 2025-09-16 =
 * Add   - Increase cache time for address validation errors.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -13,8 +13,8 @@
  * Requires PHP: 7.4
  * Requires at least: 6.7
  * Tested up to: 6.8
- * WC requires at least: 10.0
- * WC tested up to: 10.2
+ * WC requires at least: 10.1
+ * WC tested up to: 10.3
  *
  * Copyright (c) 2017-2023 Automattic
  *


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Bump WC compatibility to 10.3 and update the link in "Automated taxes" description:
<img width="2608" height="446" alt="image" src="https://github.com/user-attachments/assets/38626c05-eec9-4019-8e38-f368340776fc" />

<!-- Explain the motivation for making this change -->

### Related issue(s)
Fixes [WOOSHIP-1677](https://linear.app/a8c/issue/WOOSHIP-1677/incorrect-links-shown-on-the-tax-options-page)
Fixes [WOOSHIP-1683](https://linear.app/a8c/issue/WOOSHIP-1683/ensure-woocommerce-1030-compatibility)
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
1. Open `wp-admin/admin.php?page=wc-settings&tab=tax` page.
2. Click on the "Learn more about "Learn more about Automated taxes here.", "tax rate", and "Learn more about Tax Nexus here".
3. It will go to the correct article.
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

