### PR TITLE
Fix release versioning issue

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,12 +1,16 @@
 *** WooCommerce Tax Changelog ***
 
-= 3.1.1 - 2025-10-14 =
+= 3.2.0 - xxxx-xx-xx =
 * Fix   - No tax calculated for multi-word state/counties.
 * Fix   - Incorrect tax rate saved in Woo Tax Table when Cart total is 0.
 * Fix   - Compatibility issue with plugins and themes that use woocommerce_find_rates filter.
 * Tweak - Update tax rate and tax nexus links.
 * Tweak - Unify tax rate saving to always save itemized tax rates.
 * Tweak - WooCommerce 10.3 Compatibility.
+
+= 3.1.1 - 2025-09-29 =
+* Fix   - Incorrect tax rate saved in Woo Tax Table when Cart total is 0.
+* Fix   - Compatibility issue with plugins and themes that use woocommerce_find_rates filter.
 
 = 3.1.0 - 2025-09-16 =
 * Add   - Increase cache time for address validation errors.

--- a/readme.txt
+++ b/readme.txt
@@ -70,13 +70,17 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
-= 3.1.1 - 2025-10-14 =
+= 3.2.0 - xxxx-xx-xx =
 * Fix   - No tax calculated for multi-word state/counties.
 * Fix   - Incorrect tax rate saved in Woo Tax Table when Cart total is 0.
 * Fix   - Compatibility issue with plugins and themes that use woocommerce_find_rates filter.
 * Tweak - Update tax rate and tax nexus links.
 * Tweak - Unify tax rate saving to always save itemized tax rates.
 * Tweak - WooCommerce 10.3 Compatibility.
+
+= 3.1.1 - 2025-09-29 =
+* Fix   - Incorrect tax rate saved in Woo Tax Table when Cart total is 0.
+* Fix   - Compatibility issue with plugins and themes that use woocommerce_find_rates filter.
 
 = 3.1.0 - 2025-09-16 =
 * Add   - Increase cache time for address validation errors.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

There was an issue with the previous release `3.1.1` on September 29, 2025. That release didn't make it to GitHub, but did make it to WordPress.org. That mismatch caused an issue where the release from today, October 14, 2025, was released as `3.1.1` on GH but was rejected on WordPress.org because there was already a `3.1.1` version available. This PR fixes the issue by adding the `3.1.1` changelog with the correct date from WordPress.org repo and then updating the latest release to `3.2.0`. 

No code is changed in this PR, only `readme.txt` and `changelog.txt` to fix the versioning issue. For additional context, please see this Slack thread:
p1760458653053139-slack-C04KWSNPSE5

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added