### PR TITLE
Add extra logging for CA taxes added to non-CA merchants

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 3.2.1 - 2025-xx-xx =
 * Fix   - Exclude shipping-related admin components when shipping functionality is disabled.
+* Tweak - Add logging check for incorrect California tax nexus in the TaxJar API response or cached response.
 
 = 3.2.0 - 2025-10-14 =
 * Fix   - No tax calculated for multi-word state/counties.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1142,7 +1142,7 @@ class WC_Connect_TaxJar_Integration {
 			$body['line_items'] = $line_items;
 		}
 
-		$response = $this->smartcalcs_cache_request( wp_json_encode( $body ) );
+		$response = $this->smartcalcs_cache_request( wp_json_encode( $body ), $from_state );
 
 		// if no response, no need to keep going - bail early.
 		if ( ! isset( $response ) || ! $response ) {
@@ -1427,10 +1427,11 @@ class WC_Connect_TaxJar_Integration {
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L451
 	 *
 	 * @param $json
+	 * @param $from_state
 	 *
 	 * @return mixed|WP_Error
 	 */
-	public function smartcalcs_cache_request( $json ) {
+	public function smartcalcs_cache_request( $json, $from_state ) {
 		$cache_key           = 'tj_tax_' . hash( 'md5', $json );
 		$zip_state_cache_key = false;
 		$request             = json_decode( $json );
@@ -1440,7 +1441,10 @@ class WC_Connect_TaxJar_Integration {
 			$zip_state_cache_key = strtolower( 'tj_tax_' . $to_zip . '_' . $to_state );
 			$response            = get_transient( $zip_state_cache_key );
 		}
-		$response         = $response ? $response : get_transient( $cache_key );
+		$response = $response ? $response : get_transient( $cache_key );
+		if ( $response ) {
+			$this->check_for_incorrect_california_tax_nexus( $response['body'], true, $from_state );
+		}
 		$response_code    = wp_remote_retrieve_response_code( $response );
 		$save_error_codes = array( 404, 400 );
 
@@ -1448,9 +1452,10 @@ class WC_Connect_TaxJar_Integration {
 		$this->notifier->clear_notices( 'taxjar' );
 
 		if ( false === $response ) {
-			$response                 = $this->smartcalcs_request( $json );
-			$response_code            = wp_remote_retrieve_response_code( $response );
-			$body                     = json_decode( wp_remote_retrieve_body( $response ) );
+			$response      = $this->smartcalcs_request( $json );
+			$response_code = wp_remote_retrieve_response_code( $response );
+			$body          = json_decode( wp_remote_retrieve_body( $response ) );
+			$this->check_for_incorrect_california_tax_nexus( $body, false, $from_state );
 			$is_zip_to_state_mismatch = (
 				isset( $body->detail )
 				&& is_string( $body->detail )
@@ -1593,5 +1598,36 @@ class WC_Connect_TaxJar_Integration {
 		}
 		// Load Javascript for WooCommerce new order page
 		wp_enqueue_script( 'wc-taxjar-order', $this->wc_connect_base_url . 'woocommerce-services-new-order-taxjar-' . WC_Connect_Loader::get_wcs_version() . '.js', array( 'jquery' ), null, true );
+	}
+
+	/**
+	 * Check for incorrect California tax nexus in the TaxJar API response or cached response.
+	 *
+	 * @param $response_body
+	 * @param $cached
+	 * @param $from_state
+	 *
+	 * @return void
+	 */
+	private function check_for_incorrect_california_tax_nexus( $response_body, $cached, $from_state ): void {
+		if ( 'CA' === $from_state ) {
+			// If $from_state is California, we don't need to check for incorrect California tax nexus.
+			return;
+		}
+
+		$log_suffix = 'in TaxJar API response.';
+
+		if ( $cached ) {
+			$response_body = json_decode( $response_body );
+			$log_suffix    = 'in cached response.';
+		}
+
+		$to_state   = $response_body->tax->jurisdictions->state;
+		$to_country = $response_body->tax->jurisdictions->country;
+		$has_nexus  = $response_body->tax->has_nexus;
+
+		if ( 'CA' === $to_state && 'US' === $to_country && true === $has_nexus ) {
+			$this->_log( 'Incorrect California tax nexus detected ' . $log_suffix );
+		}
 	}
 }

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1444,7 +1444,11 @@ class WC_Connect_TaxJar_Integration {
 		$response = $response ? $response : get_transient( $cache_key );
 		if ( $response && 'CA' !== $from_state ) {
 			// If $from_state is not California, we need to check for incorrect California tax nexus.
-			$this->check_for_incorrect_california_tax_nexus( $response['body'], true );
+			try {
+				$this->check_for_incorrect_california_tax_nexus( $response['body'], true, $from_state );
+			} catch ( Exception $e ) {
+				$this->_log( 'Error checking for incorrect California tax nexus: ' . $e->getMessage() );
+			}
 		}
 		$response_code    = wp_remote_retrieve_response_code( $response );
 		$save_error_codes = array( 404, 400 );
@@ -1458,7 +1462,11 @@ class WC_Connect_TaxJar_Integration {
 			$body          = json_decode( wp_remote_retrieve_body( $response ) );
 			if ( 'CA' !== $from_state ) {
 				// If $from_state is not California, we need to check for incorrect California tax nexus.
-				$this->check_for_incorrect_california_tax_nexus( $body, false );
+				try {
+					$this->check_for_incorrect_california_tax_nexus( $body, false, $from_state );
+				} catch ( Exception $e ) {
+					$this->_log( 'Error checking for incorrect California tax nexus: ' . $e->getMessage() );
+				}
 			}
 			$is_zip_to_state_mismatch = (
 				isset( $body->detail )
@@ -1612,7 +1620,7 @@ class WC_Connect_TaxJar_Integration {
 	 *
 	 * @return void
 	 */
-	private function check_for_incorrect_california_tax_nexus( $response_body, $cached ): void {
+	private function check_for_incorrect_california_tax_nexus( $response_body, $cached, $from_state ): void {
 		$log_suffix = 'in TaxJar API response.';
 
 		if ( $cached ) {
@@ -1625,7 +1633,16 @@ class WC_Connect_TaxJar_Integration {
 		$has_nexus  = $response_body->tax->has_nexus;
 
 		if ( 'CA' === $to_state && 'US' === $to_country && true === $has_nexus ) {
-			$this->_log( 'Incorrect California tax nexus detected ' . $log_suffix );
+			$this->_log(
+				sprintf(
+					'Incorrect California tax nexus detected %s (from_state: %s, to_state: %s, to_country: %s, has_nexus: %s).',
+					$log_suffix,
+					$from_state ?: 'unknown',
+					$to_state,
+					$to_country,
+					$has_nexus ? 'true' : 'false'
+				)
+			);
 		}
 	}
 }

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1442,7 +1442,8 @@ class WC_Connect_TaxJar_Integration {
 			$response            = get_transient( $zip_state_cache_key );
 		}
 		$response = $response ? $response : get_transient( $cache_key );
-		if ( $response ) {
+		if ( $response && 'CA' !== $from_state ) {
+			// If $from_state is not California, we need to check for incorrect California tax nexus.
 			$this->check_for_incorrect_california_tax_nexus( $response['body'], true, $from_state );
 		}
 		$response_code    = wp_remote_retrieve_response_code( $response );
@@ -1455,7 +1456,10 @@ class WC_Connect_TaxJar_Integration {
 			$response      = $this->smartcalcs_request( $json );
 			$response_code = wp_remote_retrieve_response_code( $response );
 			$body          = json_decode( wp_remote_retrieve_body( $response ) );
-			$this->check_for_incorrect_california_tax_nexus( $body, false, $from_state );
+			if ( 'CA' !== $from_state ) {
+				// If $from_state is not California, we need to check for incorrect California tax nexus.
+				$this->check_for_incorrect_california_tax_nexus( $body, false, $from_state );
+			}
 			$is_zip_to_state_mismatch = (
 				isset( $body->detail )
 				&& is_string( $body->detail )
@@ -1605,16 +1609,10 @@ class WC_Connect_TaxJar_Integration {
 	 *
 	 * @param $response_body
 	 * @param $cached
-	 * @param $from_state
 	 *
 	 * @return void
 	 */
-	private function check_for_incorrect_california_tax_nexus( $response_body, $cached, $from_state ): void {
-		if ( 'CA' === $from_state ) {
-			// If $from_state is California, we don't need to check for incorrect California tax nexus.
-			return;
-		}
-
+	private function check_for_incorrect_california_tax_nexus( $response_body, $cached ): void {
 		$log_suffix = 'in TaxJar API response.';
 
 		if ( $cached ) {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1444,7 +1444,7 @@ class WC_Connect_TaxJar_Integration {
 		$response = $response ? $response : get_transient( $cache_key );
 		if ( $response && 'CA' !== $from_state ) {
 			// If $from_state is not California, we need to check for incorrect California tax nexus.
-			$this->check_for_incorrect_california_tax_nexus( $response['body'], true, $from_state );
+			$this->check_for_incorrect_california_tax_nexus( $response['body'], true );
 		}
 		$response_code    = wp_remote_retrieve_response_code( $response );
 		$save_error_codes = array( 404, 400 );
@@ -1458,7 +1458,7 @@ class WC_Connect_TaxJar_Integration {
 			$body          = json_decode( wp_remote_retrieve_body( $response ) );
 			if ( 'CA' !== $from_state ) {
 				// If $from_state is not California, we need to check for incorrect California tax nexus.
-				$this->check_for_incorrect_california_tax_nexus( $body, false, $from_state );
+				$this->check_for_incorrect_california_tax_nexus( $body, false );
 			}
 			$is_zip_to_state_mismatch = (
 				isset( $body->detail )

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,7 @@ This plugin relies on the following external services:
 
 = 3.2.1 - 2025-xx-xx =
 * Fix   - Exclude shipping-related admin components when shipping functionality is disabled.
+* Tweak - Add logging check for incorrect California tax nexus in the TaxJar API response or cached response.
 
 = 3.2.0 - 2025-10-14 =
 * Fix   - No tax calculated for multi-word state/counties.

--- a/tests/php/classes/test-class-wc-rest-connect-shipping-label-controller.php
+++ b/tests/php/classes/test-class-wc-rest-connect-shipping-label-controller.php
@@ -541,5 +541,7 @@ class WP_Test_WC_REST_Connect_Shipping_Label_Controller extends WC_Unit_Test_Cas
 	 */
 	private function set_destination_address( WC_Order $order, $address = array() ) {
 		$order->set_address( $address, 'shipping' );
+
+		$order->save(); // Required for WC 10.3+ HPOS compatibility
 	}
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

This change is being added to give us better visibility into the issue reported in WOOSHIP-1686. Many merchants located in US states other than California have reported intermittent issues where California customers are being charged sales tax for orders from their stores. 

This PR adds a method that logs when this happens and indicates if the response came directly from TaxJar or if it was a cached response. The method is only called if the store's address state is not California. 

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Fixes WOOSHIP-1713

### Testing

To test the logging method, we need to apply a patch file to remove the check for the store address in California so that the logging check method runs and the correct (taxable) responses are returned from TaxJar and the cache.

* Apply this patch: [woo-services-pr2893.patch](https://github.com/user-attachments/files/23265526/woo-services-pr2893.patch)
* Set your store address to the A8C corporate address: 
  * `60 29th Street #343`
  * `San Francisco, CA 94110`
* Go to the frontend of your site and add an item to your cart.
* Go to the checkout page and enter the customer info, using a California address.
* Check the logs for the following string: `Incorrect California tax nexus detected in TaxJar API response. (WCS Tax)`
* Now visit the shop or homepage of your local site, then go back to the checkout.
* Check the logs for the following string: `Incorrect California tax nexus detected in cached response. (WCS Tax)`

**Post testing clean up:**

* If desired, change the store address to whatever it was before.
* Go to WooCommerce > Settings > Tax > Standard rates and delete the CA related tax rates.
* Access your local env database via phpMyAdmin and delete all TaxJar related cache transients: 

```sql
SELECT * FROM `wp_options` WHERE `option_name` LIKE '%tj_tax_%';
```

### Example Data

<details><summary><strong>Non-taxable out of state response body from TaxJar API:</strong></summary>

```
[31-Oct-2025 13:25:12 UTC] stdClass Object
(
    [tax] => stdClass Object
        (
            [amount_to_collect] => 0
            [freight_taxable] => 
            [has_nexus] => 
            [order_total_amount] => 43.95
            [rate] => 0
            [shipping] => 9.95
            [tax_source] => 
            [taxable_amount] => 0
        )

)
 (WCS Tax)
```

</details>

<details><summary><strong>Cached response body for taxable order:</strong></summary>

```
[body] => {"tax":{"freight_taxable":true,"tax_source":"destination","rate":0.0675,"jurisdictions":{"state":"NC","city":"CLAYTON","country":"US","county":"JOHNSTON COUNTY"},"shipping":9.95,"taxable_amount":27.95,"amount_to_collect":1.89,"breakdown":{"shipping":{"tax_collectable":0.67,"taxable_amount":9.95,"combined_tax_rate":0.0675,"state_taxable_amount":9.95,"county_taxable_amount":9.95,"city_taxable_amount":0.0,"city_tax_rate":0.0,"county_tax_rate":0.02,"special_tax_rate":0.0,"special_district_amount":0.0,"special_taxable_amount":0.0,"city_amount":0.0,"county_amount":0.2,"state_amount":0.47,"state_sales_tax_rate":0.0475},"tax_collectable":1.89,"taxable_amount":27.95,"line_items":[{"id":"32-6364d3f0f495b6ab9dcf8d3b5c6e0b01","tax_collectable":1.22,"taxable_amount":18.0,"combined_tax_rate":0.0675,"state_taxable_amount":18.0,"county_taxable_amount":18.0,"city_taxable_amount":0.0,"special_district_taxable_amount":0.0,"city_tax_rate":0.0,"county_tax_rate":0.02,"special_tax_rate":0.0,"special_district_amount":0.0,"city_amount":0.0,"county_amount":0.36,"state_amount":0.86,"state_sales_tax_rate":0.0475}],"combined_tax_rate":0.0675,"state_taxable_amount":27.95,"state_tax_collectable":1.33,"county_taxable_amount":27.95,"county_tax_collectable":0.56,"city_taxable_amount":0.0,"city_tax_collectable":0.0,"special_district_taxable_amount":0.0,"special_district_tax_collectable":0.0,"city_tax_rate":0.0,"county_tax_rate":0.02,"special_tax_rate":0.0,"state_tax_rate":0.0475},"has_nexus":true,"order_total_amount":27.95}}
```

</details>

<details><summary><strong>TaxJar API response body for taxable order:</strong></summary>

```
[30-Oct-2025 18:08:55 UTC] TaxJar response body: stdClass Object
(
    [tax] => stdClass Object
        (
            [freight_taxable] => 1
            [tax_source] => destination
            [rate] => 0.0675
            [jurisdictions] => stdClass Object
                (
                    [state] => NC
                    [city] => CLAYTON
                    [country] => US
                    [county] => JOHNSTON COUNTY
                )

            [shipping] => 9.95
            [taxable_amount] => 27.95
            [amount_to_collect] => 1.89
            [breakdown] => stdClass Object
                (
                    [shipping] => stdClass Object
                        (
                            [tax_collectable] => 0.67
                            [taxable_amount] => 9.95
                            [combined_tax_rate] => 0.0675
                            [state_taxable_amount] => 9.95
                            [county_taxable_amount] => 9.95
                            [city_taxable_amount] => 0
                            [city_tax_rate] => 0
                            [county_tax_rate] => 0.02
                            [special_tax_rate] => 0
                            [special_district_amount] => 0
                            [special_taxable_amount] => 0
                            [city_amount] => 0
                            [county_amount] => 0.2
                            [state_amount] => 0.47
                            [state_sales_tax_rate] => 0.0475
                        )

                    [tax_collectable] => 1.89
                    [taxable_amount] => 27.95
                    [line_items] => Array
                        (
                            [0] => stdClass Object
                                (
                                    [id] => 32-6364d3f0f495b6ab9dcf8d3b5c6e0b01
                                    [tax_collectable] => 1.22
                                    [taxable_amount] => 18
                                    [combined_tax_rate] => 0.0675
                                    [state_taxable_amount] => 18
                                    [county_taxable_amount] => 18
                                    [city_taxable_amount] => 0
                                    [special_district_taxable_amount] => 0
                                    [city_tax_rate] => 0
                                    [county_tax_rate] => 0.02
                                    [special_tax_rate] => 0
                                    [special_district_amount] => 0
                                    [city_amount] => 0
                                    [county_amount] => 0.36
                                    [state_amount] => 0.86
                                    [state_sales_tax_rate] => 0.0475
                                )

                        )

                    [combined_tax_rate] => 0.0675
                    [state_taxable_amount] => 27.95
                    [state_tax_collectable] => 1.33
                    [county_taxable_amount] => 27.95
                    [county_tax_collectable] => 0.56
                    [city_taxable_amount] => 0
                    [city_tax_collectable] => 0
                    [special_district_taxable_amount] => 0
                    [special_district_tax_collectable] => 0
                    [city_tax_rate] => 0
                    [county_tax_rate] => 0.02
                    [special_tax_rate] => 0
                    [state_tax_rate] => 0.0475
                )

            [has_nexus] => 1
            [order_total_amount] => 27.95
        )

)
 (WCS Tax)
```

</details>

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

The bug that this PR seeks to log is difficult to reproduce as it is intermittent.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

