### PR TITLE
Fix tax calculation for Ohio, Tax rounding and allow calculating VAT without providing ZIP

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.2.2 - 2025-xx-xx =
+* Add   - Allow round tax at subtotal level, instead of rounding per line.
+* Add   - Allow calculating taxes for VAT countries without providing ZIP.
+* Fix   - Taxes were incorrectly calculated using the store’s base address for Ohio.
+
 = 3.2.1 - 2025-11-03 =
 * Fix   - Exclude shipping-related admin components when shipping functionality is disabled.
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1097,7 +1097,7 @@ class WC_Connect_TaxJar_Integration {
 		// Strict conditions to be met before API call can be conducted.
 		if (
 			empty( $to_country ) ||
-			empty( $to_zip ) ||
+			( empty( $to_zip ) && ! in_array( $to_country, WC()->countries->get_vat_countries() ) ) ||
 			( empty( $line_items ) && ( empty( $shipping_amount ) ) ) ||
 			WC()->customer->is_vat_exempt()
 		) {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1021,6 +1021,12 @@ class WC_Connect_TaxJar_Integration {
 				'from_country' => 'US',
 				'from_state'   => 'AZ',
 			),
+			'US-OH' => array(
+				'to_country'   => 'US',
+				'to_state'     => 'OH',
+				'from_country' => 'US',
+				'from_state'   => 'OH',
+			),
 		);
 
 		foreach ( $cases as $case ) {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1444,7 +1444,7 @@ class WC_Connect_TaxJar_Integration {
 			$zip_state_cache_key = strtolower( 'tj_tax_' . $to_zip . '_' . $to_state );
 			$response            = get_transient( $zip_state_cache_key );
 		}
-		$response         = $response ? $response : get_transient( $cache_key );
+		$response         = ! empty( $response ) ? $response : get_transient( $cache_key );
 		$response_code    = wp_remote_retrieve_response_code( $response );
 		$save_error_codes = array( 404, 400 );
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -23,17 +23,15 @@ class WC_Connect_TaxJar_Integration {
 
 	private $expected_options = array(
 		// Users can set either billing or shipping address for tax rates but not shop
-		'woocommerce_tax_based_on'          => 'shipping',
+		'woocommerce_tax_based_on'       => 'shipping',
 		// Rate calculations assume tax not included
-		'woocommerce_prices_include_tax'    => 'no',
+		'woocommerce_prices_include_tax' => 'no',
 		// Use no special handling on shipping taxes, our API handles that
-		'woocommerce_shipping_tax_class'    => '',
-		// API handles rounding precision
-		'woocommerce_tax_round_at_subtotal' => 'no',
+		'woocommerce_shipping_tax_class' => '',
 		// Rates are calculated in the cart assuming tax not included
-		'woocommerce_tax_display_shop'      => 'excl',
+		'woocommerce_tax_display_shop'   => 'excl',
 		// TaxJar returns one total amount, not line item amounts
-		'woocommerce_tax_display_cart'      => 'excl',
+		'woocommerce_tax_display_cart'   => 'excl',
 	);
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,11 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.2.2 - 2025-xx-xx =
+* Add   - Allow round tax at subtotal level, instead of rounding per line.
+* Add   - Allow calculating taxes for VAT countries without providing ZIP.
+* Fix   - Taxes were incorrectly calculated using the store’s base address for Ohio.
+
 = 3.2.1 - 2025-11-03 =
 * Fix   - Exclude shipping-related admin components when shipping functionality is disabled.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

### Related issue(s)
Closes https://linear.app/a8c/issue/WOOSHIP-932/automatic-tax-rate-is-returning-the-wrong-rate-for-california-zip
Closes https://linear.app/a8c/issue/WOOSHIP-1646/automated-taxes-calculating-with-stores-base-address-for-ohio
Closes https://linear.app/a8c/issue/WOOSHIP-603/automated-taxes-fetching-rate-for-wrong-county-in-ohio
Closes https://linear.app/a8c/issue/WOOSHIP-1709/some-zipcodes-adds-the-incorrect-tax-total
Closes https://linear.app/a8c/issue/WOOSHIP-963/tax-rounding-product-level-order-level-values-in-api-response-do-not
Closes https://linear.app/a8c/issue/WOOSHIP-1712/tax-rounding-behaviour-after-32
Closes https://linear.app/a8c/issue/WOOSHIP-809/tax-calculation-doesnt-work-as-expected-on-the-cart-page-for-european

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs
Follow instructions in corresponding issue.

Used addresses
```
OH
Store:
4376 Edgarton Dr, Grove City, OH 43123

Checkout:
4376 Edgarton Dr, Grove City, OH 43123 should be 8% and falls in Franklin County.
223 W Water Street, Sandusky, OH 44870 should be 6.75% and falls in Erie County
953 Eden Park Dr, Cincinnati, OH 45202 should be 7.8% and falls in Hamilton County
7827 Redsky Dr, Cincinnati, OH 45249

CA
Store:
66 Highway 1, Carmel, CA 93923-9725
Checkout:
120 Highlands Drive, Carmel, CA 93923

NY
Store:
300 Pulteney St, Geneva, NY 14456
Checkout:
7921 Hickory Bottom Rd, Naples, NY 14512

AL
Store and Checkout
6415 Atlanta Hwy, Montgomery, AL 36117
```

#### California
<img width="886" height="501" alt="ca-addr1" src="https://github.com/user-attachments/assets/d0427b53-bb80-49ac-ab24-685072d10d00" />
<img width="886" height="499" alt="ca-addr2" src="https://github.com/user-attachments/assets/491af791-f98b-4e02-b804-061a564301f8" />
<img width="1660" height="445" alt="CA-woo" src="https://github.com/user-attachments/assets/4498b059-bedd-4a8e-a601-7da308d7b587" />

#### Ohio
<img width="879" height="495" alt="oh-addr1" src="https://github.com/user-attachments/assets/3a1a02ab-0369-49cc-9b13-20019fbc71b5" />
<img width="1658" height="246" alt="oh-addr1-woo" src="https://github.com/user-attachments/assets/48579061-06c8-4af2-b51b-1cde05310544" />
<img width="877" height="492" alt="oh-addr2" src="https://github.com/user-attachments/assets/9acb44b8-d7cf-4301-9d9d-b5f040d4c6ee" />
<img width="1664" height="247" alt="oh-addr2-woo" src="https://github.com/user-attachments/assets/b771781f-56b9-428d-86c4-dee29e0bb777" />
<img width="879" height="495" alt="oh-addr3" src="https://github.com/user-attachments/assets/83fe037c-b2a3-4dc8-ad40-983020a0a772" />
<img width="1661" height="249" alt="oh-addr3-woo" src="https://github.com/user-attachments/assets/7b2da6e9-945c-49f3-9742-07f638feab76" />
<img width="879" height="499" alt="oh-addr4" src="https://github.com/user-attachments/assets/14a84dad-04cf-4529-a2e8-98171024486e" />
<img width="1661" height="246" alt="oh-addr4-woo" src="https://github.com/user-attachments/assets/73d58373-d06b-4c4c-8059-0fe7817005e7" />
<img width="879" height="499" alt="oh-addr5" src="https://github.com/user-attachments/assets/b7ca2e36-ae1b-42ad-8345-b7dcb921062f" />
<img width="1667" height="248" alt="oh-addr5-woo" src="https://github.com/user-attachments/assets/b3d70a27-c84e-49c5-a94f-9b821e19efb2" />

#### Tax Rounding
Item-level
<img width="468" height="723" alt="tax-rounding-item-level" src="https://github.com/user-attachments/assets/c0b8457f-b363-408e-8bbb-db358ee635a1" />
Order-level
<img width="462" height="724" alt="tax-rounding-order-level" src="https://github.com/user-attachments/assets/e39509a3-5fe8-46c4-8267-ab87e6c40d38" />

Case 2 Item-level
<img width="453" height="566" alt="tax-rounding-case2-item-level" src="https://github.com/user-attachments/assets/abb2f1c6-b306-442a-a4ad-4722e54936d0" />
Case 2 Order-level (when adding each tax item you still get 1 cent discrepancy but order total is good)
<img width="462" height="576" alt="tax-rounding-case2-order-level" src="https://github.com/user-attachments/assets/8529adb3-151e-4e59-8197-ca8293e537f2" />
Case 2 Order-level summary
<img width="458" height="515" alt="tax-rounding-case2-order-level-summary" src="https://github.com/user-attachments/assets/2288e44e-1efd-4912-aafa-58437c30386e" />

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

