### PR TITLE
Fix/issue WOOSHIP-1717 - Change priority for print notices method

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.2.2 - 2025-xx-xx =
+* Fix   - Error notices is displayed after value is corrected in legacy cart/checkout.
+
 = 3.2.1 - 2025-11-03 =
 * Fix   - Exclude shipping-related admin components when shipping functionality is disabled.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Tax Changelog ***
 
 = 3.2.2 - 2025-xx-xx =
-* Fix   - Error notices is displayed after value is corrected in legacy cart/checkout.
+* Fix   - Ensure the TaxJar error notices is displayed after tax is calculated.
 * Tweak - Add logging check for incorrect California tax nexus in the TaxJar API response or cached response.
 
 = 3.2.1 - 2025-11-03 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,10 +2,10 @@
 
 = 3.2.2 - 2025-xx-xx =
 * Fix   - Error notices is displayed after value is corrected in legacy cart/checkout.
+* Tweak - Add logging check for incorrect California tax nexus in the TaxJar API response or cached response.
 
 = 3.2.1 - 2025-11-03 =
 * Fix   - Exclude shipping-related admin components when shipping functionality is disabled.
-* Tweak - Add logging check for incorrect California tax nexus in the TaxJar API response or cached response.
 
 = 3.2.0 - 2025-10-14 =
 * Fix   - No tax calculated for multi-word state/counties.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
 = 3.2.2 - 2025-xx-xx =
-* Fix   - Ensure the TaxJar error notices is displayed after tax is calculated.
-* Tweak - Add logging check for incorrect California tax nexus in the TaxJar API response or cached response.
+* Fix   - Display TaxJar error notices only after taxes are calculated.
+* Tweak - Log detection of potential incorrect California tax nexus in successful TaxJar API and cached responses.
 
 = 3.2.1 - 2025-11-03 =
 * Fix   - Exclude shipping-related admin components when shipping functionality is disabled.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1628,9 +1628,9 @@ class WC_Connect_TaxJar_Integration {
 			$log_suffix    = 'in cached response.';
 		}
 
-		$to_state   = $response_body->tax->jurisdictions->state;
-		$to_country = $response_body->tax->jurisdictions->country;
-		$has_nexus  = $response_body->tax->has_nexus;
+		$to_state   = isset( $response_body->tax->jurisdictions->state ) ? $response_body->tax->jurisdictions->state : '';
+		$to_country = isset( $response_body->tax->jurisdictions->country ) ? $response_body->tax->jurisdictions->country : '';
+		$has_nexus  = isset( $response_body->tax->has_nexus ) ? $response_body->tax->has_nexus : false;
 
 		if ( 'CA' === $to_state && 'US' === $to_country && true === $has_nexus ) {
 			$this->_log(

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1646,7 +1646,7 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		if ( 'not set' === $to_state || 'not set' === $to_country || null === $has_nexus ) {
-			throw new Exception( sprintf( 'One or more value is not set : to_state=>%1$s, to_country=>%2$s, has_nexus=>%3$s', $to_state, $to_country, json_encode( $has_nexus ) ) );
+			throw new Exception( sprintf( 'One or more values are not set : to_state=>%1$s, to_country=>%2$s, has_nexus=>%3$s', $to_state, $to_country, json_encode( $has_nexus ) ) );
 		}
 	}
 }

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1628,9 +1628,9 @@ class WC_Connect_TaxJar_Integration {
 			$log_suffix    = 'in cached response.';
 		}
 
-		$to_state   = isset( $response_body->tax->jurisdictions->state ) ? $response_body->tax->jurisdictions->state : '';
-		$to_country = isset( $response_body->tax->jurisdictions->country ) ? $response_body->tax->jurisdictions->country : '';
-		$has_nexus  = isset( $response_body->tax->has_nexus ) ? $response_body->tax->has_nexus : false;
+		$to_state   = isset( $response_body->tax->jurisdictions->state ) ? $response_body->tax->jurisdictions->state : 'not set';
+		$to_country = isset( $response_body->tax->jurisdictions->country ) ? $response_body->tax->jurisdictions->country : 'not set';
+		$has_nexus  = isset( $response_body->tax->has_nexus ) ? $response_body->tax->has_nexus : null;
 
 		if ( 'CA' === $to_state && 'US' === $to_country && true === $has_nexus ) {
 			$this->_log(
@@ -1643,6 +1643,10 @@ class WC_Connect_TaxJar_Integration {
 					$has_nexus ? 'true' : 'false'
 				)
 			);
+		}
+
+		if ( 'not set' === $to_state || 'not set' === $to_country || null === $has_nexus || true ) {
+			throw new Exception( sprintf( __( 'One or more value is not set : to_state=>%1$s, to_country=>%2$s, has_nexus=>%3$d', 'woocommerce-services' ), $to_state, $to_country, $has_nexus ) );
 		}
 	}
 }

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1635,18 +1635,18 @@ class WC_Connect_TaxJar_Integration {
 		if ( 'CA' === $to_state && 'US' === $to_country && true === $has_nexus ) {
 			$this->_log(
 				sprintf(
-					'Incorrect California tax nexus detected %s (from_state: %s, to_state: %s, to_country: %s, has_nexus: %s).',
+					'Incorrect California tax nexus detected %1$s (from_state: %2$s, to_state: %3$s, to_country: %4$s, has_nexus: %5$s).',
 					$log_suffix,
 					$from_state ?: 'unknown',
 					$to_state,
 					$to_country,
-					$has_nexus ? 'true' : 'false'
+					json_encode( $has_nexus ),
 				)
 			);
 		}
 
-		if ( 'not set' === $to_state || 'not set' === $to_country || null === $has_nexus || true ) {
-			throw new Exception( sprintf( __( 'One or more value is not set : to_state=>%1$s, to_country=>%2$s, has_nexus=>%3$d', 'woocommerce-services' ), $to_state, $to_country, $has_nexus ) );
+		if ( 'not set' === $to_state || 'not set' === $to_country || null === $has_nexus ) {
+			throw new Exception( sprintf( 'One or more value is not set : to_state=>%1$s, to_country=>%2$s, has_nexus=>%3$d', $to_state, $to_country, $has_nexus ) );
 		}
 	}
 }

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1646,7 +1646,7 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		if ( 'not set' === $to_state || 'not set' === $to_country || null === $has_nexus ) {
-			throw new Exception( sprintf( 'One or more value is not set : to_state=>%1$s, to_country=>%2$s, has_nexus=>%3$d', $to_state, $to_country, $has_nexus ) );
+			throw new Exception( sprintf( 'One or more value is not set : to_state=>%1$s, to_country=>%2$s, has_nexus=>%3$s', $to_state, $to_country, json_encode( $has_nexus ) ) );
 		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -71,8 +71,8 @@ This plugin relies on the following external services:
 == Changelog ==
 
 = 3.2.2 - 2025-xx-xx =
-* Fix   - Ensure the TaxJar error notices is displayed after tax is calculated.
-* Tweak - Add logging check for incorrect California tax nexus in the TaxJar API response or cached response.
+* Fix   - Display TaxJar error notices only after taxes are calculated.
+* Tweak - Log detection of potential incorrect California tax nexus in successful TaxJar API and cached responses.
 
 = 3.2.1 - 2025-11-03 =
 * Fix   - Exclude shipping-related admin components when shipping functionality is disabled.

--- a/readme.txt
+++ b/readme.txt
@@ -72,10 +72,10 @@ This plugin relies on the following external services:
 
 = 3.2.2 - 2025-xx-xx =
 * Fix   - Error notices is displayed after value is corrected in legacy cart/checkout.
+* Tweak - Add logging check for incorrect California tax nexus in the TaxJar API response or cached response.
 
 = 3.2.1 - 2025-11-03 =
 * Fix   - Exclude shipping-related admin components when shipping functionality is disabled.
-* Tweak - Add logging check for incorrect California tax nexus in the TaxJar API response or cached response.
 
 = 3.2.0 - 2025-10-14 =
 * Fix   - No tax calculated for multi-word state/counties.

--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,7 @@ This plugin relies on the following external services:
 == Changelog ==
 
 = 3.2.2 - 2025-xx-xx =
-* Fix   - Error notices is displayed after value is corrected in legacy cart/checkout.
+* Fix   - Ensure the TaxJar error notices is displayed after tax is calculated.
 * Tweak - Add logging check for incorrect California tax nexus in the TaxJar API response or cached response.
 
 = 3.2.1 - 2025-11-03 =

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.2.2 - 2025-xx-xx =
+* Fix   - Error notices is displayed after value is corrected in legacy cart/checkout.
+
 = 3.2.1 - 2025-11-03 =
 * Fix   - Exclude shipping-related admin components when shipping functionality is disabled.
 

--- a/src/StoreNotices/StoreNoticesController.php
+++ b/src/StoreNotices/StoreNoticesController.php
@@ -34,7 +34,7 @@ class StoreNoticesController {
 	public function __construct( StoreNoticesNotifier $notifier ) {
 		$this->notifier = $notifier;
 
-		add_action( 'woocommerce_after_calculate_totals', array( $this, 'maybe_display_notices' ) );
+		add_action( 'woocommerce_after_calculate_totals', array( $this, 'maybe_display_notices' ), 30 );
 		add_filter( 'woocommerce_store_api_cart_errors', array( $this, 'add_store_api_cart_errors' ), 10, 2 );
 	}
 

--- a/tests/bin/install-wc-tests.sh
+++ b/tests/bin/install-wc-tests.sh
@@ -10,7 +10,7 @@ DB_USER=$2
 DB_PASS=$3
 DB_HOST=${4-localhost}
 WP_VERSION=${5-latest}
-WC_VERSION=${6-"7.4.1"}
+WC_VERSION=${6-"10.3.4"}
 
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm

--- a/tests/php/classes/test-class-wc-rest-connect-shipping-label-controller.php
+++ b/tests/php/classes/test-class-wc-rest-connect-shipping-label-controller.php
@@ -541,5 +541,6 @@ class WP_Test_WC_REST_Connect_Shipping_Label_Controller extends WC_Unit_Test_Cas
 	 */
 	private function set_destination_address( WC_Order $order, $address = array() ) {
 		$order->set_address( $address, 'shipping' );
+		$order->save();
 	}
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
Fix the error notices for being displayed too late (Currently the error will be displayed after the value is correct). It's fixed by changing the priority for `StoreNoticesController::maybe_display_notices()`.
<!-- Explain the motivation for making this change -->

### Related issue(s)

Closes [WOOSHIP-1717](https://linear.app/a8c/issue/WOOSHIP-1717/invalid-zip-code-error-appears-when-re-entering-valid-postcode-after#comment-15c8a563).
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

1. Go to checkout page with items in cart.
2. Enter a valid US ZIP code in the billing postcode field (e.g., 94539).
3. Wait for AJAX validation to complete - no error appears (correct behavior).
4. Delete the last digit from the postcode field to make it invalid (e.g., change 94539 to 9453).
5. The error will appear.
6. Add the deleted digit back to restore the valid postcode (e.g., 9453 → 94539)
7. The error will disappear

Observe the checkout page
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

