### PR TITLE
Move PR 2893 changelog entries to correct place

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,10 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.2.2 - 2025-xx-xx =
+* Tweak - Add logging check for incorrect California tax nexus in the TaxJar API response or cached response.
+
 = 3.2.1 - 2025-11-03 =
 * Fix   - Exclude shipping-related admin components when shipping functionality is disabled.
-* Tweak - Add logging check for incorrect California tax nexus in the TaxJar API response or cached response.
 
 = 3.2.0 - 2025-10-14 =
 * Fix   - No tax calculated for multi-word state/counties.

--- a/readme.txt
+++ b/readme.txt
@@ -70,9 +70,11 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.2.2 - 2025-xx-xx =
+* Tweak - Add logging check for incorrect California tax nexus in the TaxJar API response or cached response.
+
 = 3.2.1 - 2025-11-03 =
 * Fix   - Exclude shipping-related admin components when shipping functionality is disabled.
-* Tweak - Add logging check for incorrect California tax nexus in the TaxJar API response or cached response.
 
 = 3.2.0 - 2025-10-14 =
 * Fix   - No tax calculated for multi-word state/counties.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

This PR simply moves the changelog entries for PR #2893 to the correct place. I mistakenly placed them under an already released version in that PR.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

