### PR TITLE
Don't load shipping settings if WC shipping or tax-only is enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,11 +1,13 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.2.3 - 2025-xx-xx =
+* Fix   - Resolved issue where shipping features were incorrectly loading when in tax-only mode for some installations.
+
 = 3.2.2 - 2025-11-10 =
 * Add   - Allow round tax at subtotal level, instead of rounding per line.
 * Add   - Allow calculating taxes for VAT countries without providing ZIP.
 * Fix   - Taxes were incorrectly calculated using the store’s base address for Ohio.
 * Fix   - Display TaxJar error notices only after taxes are calculated.
-* Fix   - Resolved issue where shipping features were incorrectly loading when in tax-only mode for some installations.
 * Tweak - Log detection of potential incorrect California tax nexus in successful TaxJar API and cached responses.
 
 = 3.2.1 - 2025-11-03 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.2.2 - 2025-xx-xx =
+* Fix - Resolved issue where shipping features were incorrectly loading when in tax-only mode for some installations.
+
 = 3.2.1 - 2025-11-03 =
 * Fix   - Exclude shipping-related admin components when shipping functionality is disabled.
 * Tweak - Add logging check for incorrect California tax nexus in the TaxJar API response or cached response.

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -298,7 +298,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			);
 
 			// Shipping related.
-			if ( ! WC_Connect_Loader::is_wc_shipping_activated() && '1' !== WC_Connect_Options::get_option( 'only_tax' ) ) {
+			if ( ! WC_Connect_Loader::is_wc_shipping_activated() && ! WC_Connect_Loader::has_only_tax_functionality() ) {
 				do_action(
 					'enqueue_wc_connect_script',
 					'wc-connect-admin-test-print',

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -298,7 +298,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			);
 
 			// Shipping related.
-			if ( ! WC_Connect_Loader::is_wc_shipping_activated() && ! WC_Connect_Loader::has_only_tax_functionality() ) {
+			if ( WC_Connect_Loader::should_load_shipping_features() ) {
 				do_action(
 					'enqueue_wc_connect_script',
 					'wc-connect-admin-test-print',

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -529,6 +529,11 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		 * @return bool True if shipping label is enabled from the settings.
 		 */
 		public function is_shipping_label_enabled() {
+			// For tax-only installations, shipping labels are disabled
+			if ( WC_Connect_Loader::has_only_tax_functionality() ) {
+				return false;
+			}
+
 			$account_settings = $this->account_settings->get();
 
 			if ( isset( $account_settings['formData']['enabled'] ) && is_bool( $account_settings['formData']['enabled'] ) ) {

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -529,11 +529,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		 * @return bool True if shipping label is enabled from the settings.
 		 */
 		public function is_shipping_label_enabled() {
-			// For tax-only installations, shipping labels are disabled
-			if ( WC_Connect_Loader::has_only_tax_functionality() ) {
-				return false;
-			}
-
 			$account_settings = $this->account_settings->get();
 
 			if ( isset( $account_settings['formData']['enabled'] ) && is_bool( $account_settings['formData']['enabled'] ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -70,12 +70,14 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.2.3 - 2025-xx-xx =
+* Fix   - Resolved issue where shipping features were incorrectly loading when in tax-only mode for some installations.
+
 = 3.2.2 - 2025-11-10 =
 * Add   - Allow round tax at subtotal level, instead of rounding per line.
 * Add   - Allow calculating taxes for VAT countries without providing ZIP.
 * Fix   - Taxes were incorrectly calculated using the store’s base address for Ohio.
 * Fix   - Display TaxJar error notices only after taxes are calculated.
-* Fix   - Resolved issue where shipping features were incorrectly loading when in tax-only mode for some installations.
 * Tweak - Log detection of potential incorrect California tax nexus in successful TaxJar API and cached responses.
 
 = 3.2.1 - 2025-11-03 =

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.2.2 - 2025-xx-xx =
+* Fix - Resolved issue where shipping features were incorrectly loading when in tax-only mode for some installations.
+
 = 3.2.1 - 2025-11-03 =
 * Fix   - Exclude shipping-related admin components when shipping functionality is disabled.
 * Tweak - Add logging check for incorrect California tax nexus in the TaxJar API response or cached response.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -915,7 +915,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'admin_notices', array( $this, 'render_schema_notices' ) );
 
 			// Don't register settings if only_tax mode.
-			if ( self::has_only_tax_functionality() ) {
+			if ( ! self::should_load_shipping_features() ) {
 				return;
 			}
 
@@ -950,7 +950,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->paypal_ec->init();
 
 			// Only register shipping label-related logic if WC Shipping is not active.
-			if ( ! self::is_wc_shipping_activated() && ! WC_Connect_Loader::has_only_tax_functionality() ) {
+			if ( self::should_load_shipping_features() ) {
 				add_action( 'rest_api_init', array( $this, 'wc_api_dev_init' ), 9999 );
 
 				$this->init_shipping_labels();
@@ -1950,8 +1950,20 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$result = ( WC_Connect_Jetpack::is_connected() && '1' === WC_Connect_Options::get_option( 'only_tax' ) ) ||
 						( ! WC_Connect_Jetpack::is_connected() && ! self::_has_any_labels_db_check() );
 
-			// Allow tests to override this functionality
+			// Allow tests to override this functionality.
 			return apply_filters( 'wc_connect_has_only_tax_functionality', $result );
+		}
+
+		/**
+		 * Checks whether shipping-related functionality and views should be loaded.
+		 *
+		 * Shipping features should only be loaded when the WooCommerce Shipping plugin
+		 * is not active and the site is not restricted to tax-only functionality.
+		 *
+		 * @return bool True if shipping features should be loaded, false otherwise.
+		 */
+		public static function should_load_shipping_features(): bool {
+			return ! self::is_wc_shipping_activated() && ! self::has_only_tax_functionality();
 		}
 
 		public function maybe_rename_plugin( $plugins ) {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -915,7 +915,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'admin_notices', array( $this, 'render_schema_notices' ) );
 
 			// Don't register settings if only_tax mode.
-			if ( '1' === WC_Connect_Options::get_option( 'only_tax' ) ) {
+			if ( self::has_only_tax_functionality() ) {
 				return;
 			}
 
@@ -950,7 +950,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->paypal_ec->init();
 
 			// Only register shipping label-related logic if WC Shipping is not active.
-			if ( ! self::is_wc_shipping_activated() && '1' !== WC_Connect_Options::get_option( 'only_tax' ) ) {
+			if ( ! self::is_wc_shipping_activated() && ! WC_Connect_Loader::has_only_tax_functionality() ) {
 				add_action( 'rest_api_init', array( $this, 'wc_api_dev_init' ), 9999 );
 
 				$this->init_shipping_labels();


### PR DESCRIPTION
Follow on from https://github.com/Automattic/woocommerce-services/pull/2883

https://github.com/Automattic/woocommerce-services/pull/2879 did not fix the issue.

<img width="1265" height="726" alt="Screenshot 2025-11-08 at 10 35 37 AM" src="https://github.com/user-attachments/assets/2fad52a5-50ae-4283-a74a-07a8573058df" />
