### PR TITLE
Change tax rate name

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.3.0 - 2025-xx-xx =
+* Add   - Jurisdiction information to generated US tax rate names to improve tax analytics accuracy.
+
 = 3.2.3 - 2025-11-17 =
 * Fix   - Resolved issue where shipping features loaded despite the site being set to tax-only mode.
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -110,7 +110,7 @@ class WC_Connect_TaxJar_Integration {
 	 *
 	 * @param string $taxjar_rate_name The tax rate name from TaxJar, typically including '_tax_rate'.
 	 * @param string $to_country       The destination country for the tax calculation.
-	 * @param object $jurisdictions    TaxJar tax jurisdictions.
+	 * @param array $jurisdictions     Tax jurisdictions.
 	 *
 	 * @return string The formatted and localized tax rate name.
 	 */
@@ -118,18 +118,18 @@ class WC_Connect_TaxJar_Integration {
 		$rate_name = str_replace( '_tax_rate', '', $taxjar_rate_name );
 		$rate_name = str_replace( '_', ' ', $rate_name );
 		$rate_name = ucwords( $rate_name ) . ' ' . __( 'Tax', 'woocommerce-services' );
-		if ( null !== $jurisdictions && 'country' === $rate_name && in_array( $to_country, WC()->countries->get_vat_countries(), true ) ) {
-			$full_rate_name = $jurisdictions->country . ' : VAT';
-		} elseif ( null !== $jurisdictions && 'US' === $to_country ) {
-			$full_rate_name = $jurisdictions->country . ' ' . $jurisdictions->state;
+		if ( 'country' === $rate_name && in_array( $to_country, WC()->countries->get_vat_countries(), true ) ) {
+			$full_rate_name = 'VAT';
+		} elseif ( 'US' === $to_country ) {
+			$full_rate_name = '';
 			if ( 'city_tax_rate' === $taxjar_rate_name || 'special_tax_rate' === $taxjar_rate_name ) {
-				$full_rate_name .= ' ' . $jurisdictions->county . ' ' . $jurisdictions->city . ' : ' . $rate_name;
+				$full_rate_name = $jurisdictions['county'] . ' ' . $jurisdictions['city'] . ' : ' . $rate_name;
 			}
 			if ( 'county_tax_rate' === $taxjar_rate_name ) {
-				$full_rate_name .= ' ' . $jurisdictions->county . ' : ' . $rate_name;
+				$full_rate_name = $jurisdictions['county'] . ' : ' . $rate_name;
 			}
 			if ( 'state_sales_tax_rate' === $taxjar_rate_name ) {
-				$full_rate_name .= ' : ' . $rate_name;
+				$full_rate_name = $rate_name;
 			}
 		} else {
 			$full_rate_name = strtoupper( $rate_name );
@@ -1219,7 +1219,10 @@ class WC_Connect_TaxJar_Integration {
 
 		if ( $taxes['has_nexus'] ) {
 			// Use Woo core to find matching rates for taxable address.
-			$jurisdictions = $taxjar_taxes->jurisdictions ?? null;
+			$jurisdictions = array(
+				'county' => $taxjar_taxes->jurisdictions->county ?? null,
+				'city'   => $taxjar_taxes->jurisdictions->city ?? null,
+			);
 			$location      = array(
 				'from_country' => $from_country,
 				'from_state'   => $from_state,

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -117,32 +117,63 @@ class WC_Connect_TaxJar_Integration {
 	 *
 	 * @param string $taxjar_rate_name The tax rate name from TaxJar, typically including '_tax_rate'.
 	 * @param string $to_country       The destination country for the tax calculation.
-	 * @param array $jurisdictions     Tax jurisdictions.
+	 * @param array  $jurisdictions    Tax jurisdictions.
 	 *
 	 * @return string The formatted and localized tax rate name.
 	 */
 	private static function generate_itemized_tax_rate_name( string $taxjar_rate_name, string $to_country, $jurisdictions ) {
-		$rate_name = str_replace( '_tax_rate', '', $taxjar_rate_name );
-		$rate_name = str_replace( '_', ' ', $rate_name );
-		$rate_name = ucwords( $rate_name ) . ' ' . __( 'Tax', 'woocommerce-services' );
-		if ( 'country' === $rate_name && in_array( $to_country, WC()->countries->get_vat_countries(), true ) ) {
-			$full_rate_name = 'VAT';
-		} elseif ( 'US' === $to_country ) {
-			$full_rate_name = '';
-			if ( 'city_tax_rate' === $taxjar_rate_name || 'special_tax_rate' === $taxjar_rate_name ) {
-				$full_rate_name = $jurisdictions['county'] . ' ' . $jurisdictions['city'] . ' : ' . $rate_name;
-			}
-			if ( 'county_tax_rate' === $taxjar_rate_name ) {
-				$full_rate_name = $jurisdictions['county'] . ' : ' . $rate_name;
-			}
-			if ( 'state_sales_tax_rate' === $taxjar_rate_name ) {
-				$full_rate_name = $rate_name;
-			}
-		} else {
-			$full_rate_name = strtoupper( $rate_name );
+		// Normalize the base key by stripping the trailing "_tax_rate" and converting underscores to spaces.
+		$base_key   = str_replace( '_tax_rate', '', $taxjar_rate_name );
+		$label_core = ucwords( str_replace( '_', ' ', $base_key ) );
+		$rate_name  = $label_core . ' ' . __( 'Tax', 'woocommerce-services' );
+
+		// Handle VAT countries where country-level tax should be labeled as VAT.
+		$is_vat_country = false;
+		if ( function_exists( 'WC' ) && WC() && isset( WC()->countries ) && method_exists( WC()->countries, 'get_vat_countries' ) ) {
+			$is_vat_country = in_array( $to_country, WC()->countries->get_vat_countries(), true );
 		}
 
-		return $full_rate_name;
+		if ( 'country' === $base_key && $is_vat_country ) {
+			return 'VAT';
+		}
+
+		// Default, country-agnostic formatting for non‑US destinations.
+		if ( 'US' !== $to_country ) {
+			// Preserve previous behavior of uppercasing for non‑US.
+			return strtoupper( $rate_name );
+		}
+
+		// United States specific naming enhancements with defensive jurisdiction access.
+		$county = '';
+		$city   = '';
+		if ( is_array( $jurisdictions ) ) {
+			$county = isset( $jurisdictions['county'] ) ? trim( (string) $jurisdictions['county'] ) : '';
+			$city   = isset( $jurisdictions['city'] ) ? trim( (string) $jurisdictions['city'] ) : '';
+		} elseif ( is_object( $jurisdictions ) ) {
+			// Objects may be returned by upstream callers; access safely.
+			$county = isset( $jurisdictions->county ) ? trim( (string) $jurisdictions->county ) : '';
+			$city   = isset( $jurisdictions->city ) ? trim( (string) $jurisdictions->city ) : '';
+		}
+
+		switch ( $taxjar_rate_name ) {
+			case 'city_tax_rate':
+			case 'special_tax_rate':
+				// Example: "Some County Some City : City Tax".
+				$prefix = trim( $county . ' ' . $city );
+				return ( '' !== $prefix ? $prefix . ' : ' : '' ) . $rate_name;
+
+			case 'county_tax_rate':
+				// Example: "Some County : County Tax".
+				return ( '' !== $county ? $county . ' : ' : '' ) . $rate_name;
+
+			case 'state_sales_tax_rate':
+				// Example: "State Sales Tax" (no jurisdiction prefix).
+				return $rate_name;
+
+			default:
+				// Fallback for any other US rate types.
+				return $rate_name;
+		}
 	}
 
 	public function init() {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -110,22 +110,32 @@ class WC_Connect_TaxJar_Integration {
 	 *
 	 * @param string $taxjar_rate_name The tax rate name from TaxJar, typically including '_tax_rate'.
 	 * @param string $to_country       The destination country for the tax calculation.
+	 * @param object $jurisdictions    TaxJar tax jurisdictions.
 	 *
 	 * @return string The formatted and localized tax rate name.
 	 */
-	private static function generate_itemized_tax_rate_name( string $taxjar_rate_name, string $to_country ) {
+	private static function generate_itemized_tax_rate_name( string $taxjar_rate_name, string $to_country, $jurisdictions ) {
 		$rate_name = str_replace( '_tax_rate', '', $taxjar_rate_name );
-		if ( 'country' === $rate_name && in_array( $to_country, WC()->countries->get_vat_countries(), true ) ) {
-			$rate_name = 'VAT';
-		} elseif ( 'US' === $to_country ) {
-			$rate_name = str_replace( '_', ' ', $rate_name );
-			$rate_name = ucwords( $rate_name ) . ' ' . __( 'Tax', 'woocommerce-services' );
-
+		$rate_name = str_replace( '_', ' ', $rate_name );
+		$rate_name = ucwords( $rate_name ) . ' ' . __( 'Tax', 'woocommerce-services' );
+		if ( null !== $jurisdictions && 'country' === $rate_name && in_array( $to_country, WC()->countries->get_vat_countries(), true ) ) {
+			$full_rate_name = $jurisdictions->country . ' : VAT';
+		} elseif ( null !== $jurisdictions && 'US' === $to_country ) {
+			$full_rate_name = $jurisdictions->country . ' ' . $jurisdictions->state;
+			if ( 'city_tax_rate' === $taxjar_rate_name || 'special_tax_rate' === $taxjar_rate_name ) {
+				$full_rate_name .= ' ' . $jurisdictions->county . ' ' . $jurisdictions->city . ' : ' . $rate_name;
+			}
+			if ( 'county_tax_rate' === $taxjar_rate_name ) {
+				$full_rate_name .= ' ' . $jurisdictions->county . ' : ' . $rate_name;
+			}
+			if ( 'state_sales_tax_rate' === $taxjar_rate_name ) {
+				$full_rate_name .= ' : ' . $rate_name;
+			}
 		} else {
-			$rate_name = strtoupper( $rate_name );
+			$full_rate_name = strtoupper( $rate_name );
 		}
 
-		return $rate_name;
+		return $full_rate_name;
 	}
 
 	public function init() {
@@ -1209,7 +1219,8 @@ class WC_Connect_TaxJar_Integration {
 
 		if ( $taxes['has_nexus'] ) {
 			// Use Woo core to find matching rates for taxable address.
-			$location = array(
+			$jurisdictions = $taxjar_taxes->jurisdictions ?? null;
+			$location      = array(
 				'from_country' => $from_country,
 				'from_state'   => $from_state,
 				'to_country'   => $to_country,
@@ -1243,7 +1254,7 @@ class WC_Connect_TaxJar_Integration {
 						$tax_class,
 						$taxes['freight_taxable'],
 						$priority,
-						self::generate_itemized_tax_rate_name( $tax_rate_name, $to_country )
+						self::generate_itemized_tax_rate_name( $tax_rate_name, $to_country, $jurisdictions )
 					);
 
 					++$priority;
@@ -1263,7 +1274,7 @@ class WC_Connect_TaxJar_Integration {
 					'',
 					$taxes['freight_taxable'],
 					$priority,
-					self::generate_itemized_tax_rate_name( $tax_rate_name, $to_country )
+					self::generate_itemized_tax_rate_name( $tax_rate_name, $to_country, $jurisdictions )
 				);
 
 				++$priority;

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -66,6 +66,11 @@ class WC_Connect_TaxJar_Integration {
 	private $response_line_items;
 
 	/**
+	 * @var bool
+	 */
+	private $is_itemized_tax_display;
+
+	/**
 	 * Backend tax classes.
 	 *
 	 * @var array
@@ -103,6 +108,8 @@ class WC_Connect_TaxJar_Integration {
 
 		// Cache error response for 5 minutes.
 		$this->error_cache_time = MINUTE_IN_SECONDS * 5;
+
+		$this->is_itemized_tax_display = ( 'itemized' === get_option( 'woocommerce_tax_total_display' ) );
 	}
 
 	/**
@@ -188,6 +195,8 @@ class WC_Connect_TaxJar_Integration {
 
 		add_filter( 'woocommerce_calc_tax', array( $this, 'override_woocommerce_tax_rates' ), 10, 3 );
 		add_filter( 'woocommerce_matched_rates', array( $this, 'allow_street_address_for_matched_rates' ), 10, 2 );
+
+		add_filter( 'woocommerce_rate_label', array( $this, 'cleanup_tax_label' ) );
 
 		WC_Connect_Custom_Surcharge::init();
 	}
@@ -670,6 +679,18 @@ class WC_Connect_TaxJar_Integration {
 			);
 		}
 		return $matched_tax_rates;
+	}
+
+	public function cleanup_tax_label( $rate_name ) {
+
+		if ( ! $this->is_itemized_tax_display ) {
+			return $rate_name;
+		}
+
+		$label_parts = explode( ' : ', $rate_name );
+		$clean_label = ! empty( $label_parts[1] ) ? $label_parts[1] : $label_parts[0];
+
+		return $clean_label;
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -121,7 +121,7 @@ class WC_Connect_TaxJar_Integration {
 	 *
 	 * @return string The formatted and localized tax rate name.
 	 */
-	private static function generate_itemized_tax_rate_name( string $taxjar_rate_name, string $to_country, $jurisdictions ) {
+	private static function generate_itemized_tax_rate_name( string $taxjar_rate_name, string $to_country, array $jurisdictions ) {
 		// Normalize the base key by stripping the trailing "_tax_rate" and converting underscores to spaces.
 		$base_key   = str_replace( '_tax_rate', '', $taxjar_rate_name );
 		$label_core = ucwords( str_replace( '_', ' ', $base_key ) );
@@ -143,17 +143,9 @@ class WC_Connect_TaxJar_Integration {
 			return strtoupper( $rate_name );
 		}
 
-		// United States specific naming enhancements with defensive jurisdiction access.
-		$county = '';
-		$city   = '';
-		if ( is_array( $jurisdictions ) ) {
-			$county = isset( $jurisdictions['county'] ) ? trim( (string) $jurisdictions['county'] ) : '';
-			$city   = isset( $jurisdictions['city'] ) ? trim( (string) $jurisdictions['city'] ) : '';
-		} elseif ( is_object( $jurisdictions ) ) {
-			// Objects may be returned by upstream callers; access safely.
-			$county = isset( $jurisdictions->county ) ? trim( (string) $jurisdictions->county ) : '';
-			$city   = isset( $jurisdictions->city ) ? trim( (string) $jurisdictions->city ) : '';
-		}
+		// United States specific naming enhancements.
+		$county = isset( $jurisdictions['county'] ) ? trim( (string) $jurisdictions['county'] ) : '';
+		$city   = isset( $jurisdictions['city'] ) ? trim( (string) $jurisdictions['city'] ) : '';
 
 		switch ( $taxjar_rate_name ) {
 			case 'city_tax_rate':

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.3.0 - 2025-xx-xx =
+* Add   - Jurisdiction information to generated US tax rate names to improve tax analytics accuracy.
+
 = 3.2.3 - 2025-11-17 =
 * Fix   - Resolved issue where shipping features loaded despite the site being set to tax-only mode.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

For better tax analytics we add Jurisdiction information to tax rates names.
It uses `woocommerce_rate_label` filter to strip jurisdiction information from tax names on checkout.

<img width="1705" height="592" alt="image" src="https://github.com/user-attachments/assets/1bff9ebe-f7a2-47db-bcba-5ea84673c634" />


Before the change all US tax rates were saved with those names:
- City Tax
- County Tax
- Special Tax
- State Sales Tax

This PR:
- COUNTY CITY : City Tax
- COUNTY : County Tax
- COUNTY CITY : Special Tax
- State Sales Tax

In analytics this result in tax names looking like this.
- US-FL-MIAMI-DADE HOMESTEAD : CITY TAX-1
- US-FL-MIAMI-DADE  : COUNTY TAX-2
- US-FL-MIAMI-DADE HOMESTEAD : SPECIAL TAX-3
- US-FL : STATE SALES TAX-4



### Related issue(s)
https://linear.app/a8c/issue/WOOSHIP-1774/the-tax-analytics-are-now-split-into-multiple-lines-with-generic

Alos closes https://linear.app/a8c/issue/WOOSHIP-865/tax-reporting-bug-when-calculated-by-us-county


<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

