### PR TITLE
Don't load shipping settings if WC shipping or tax-only is enabled

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -529,6 +529,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		 * @return bool True if shipping label is enabled from the settings.
 		 */
 		public function is_shipping_label_enabled() {
+
+			// For tax-only installations, shipping labels are disabled
+			if ( ! WC_Connect_Loader::is_wc_shipping_activated() && ! WC_Connect_Loader::has_only_tax_functionality() ) {
+				return false;
+			}
+
 			$account_settings = $this->account_settings->get();
 
 			if ( isset( $account_settings['formData']['enabled'] ) && is_bool( $account_settings['formData']['enabled'] ) ) {


### PR DESCRIPTION
Follow on from https://github.com/Automattic/woocommerce-services/pull/2898.

My original change in `class-wc-connect-shipping-label.php` [was deleted in that pull request](https://github.com/Automattic/woocommerce-services/pull/2897/commits/f2b2fe4f655f4f7fcaba56f11867f98c953389c2#diff-d81ca9b0ed185e03f6de2b90adcc4a8220bf6ac280715c5da04a719d958b7669L533), which removed the fix.

<img width="1375" height="676" alt="Screenshot 2025-11-29 at 8 25 53 PM" src="https://github.com/user-attachments/assets/4e610193-a49c-4471-af42-677321352ef2" />
