### PR TITLE
Change Retail Delivery Fee for Colorado to 28c.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.2.4 - 2025-xx-xx =
+* Tweak  - Change default Retail Delivery Fee for Colorado to 28c.
+
 = 3.2.3 - 2025-11-17 =
 * Fix   - Resolved issue where shipping features loaded despite the site being set to tax-only mode.
 

--- a/classes/class-wc-connect-custom-surcharge.php
+++ b/classes/class-wc-connect-custom-surcharge.php
@@ -110,7 +110,7 @@ if ( ! class_exists( 'WC_Connect_Custom_Surcharge' ) ) {
 			$fee_info = apply_filters(
 				'wc_services_apply_us_co_retail_delivery_fee',
 				array(
-					'value' => 0.29,
+					'value' => 0.28,
 					'text'  => __( 'Retail Delivery Fee', 'woocommerce_services' ),
 				),
 				$cart

--- a/classes/class-wc-connect-custom-surcharge.php
+++ b/classes/class-wc-connect-custom-surcharge.php
@@ -28,9 +28,9 @@ if ( ! class_exists( 'WC_Connect_Custom_Surcharge' ) ) {
 		 * https://www.avalara.com/blog/en/north-america/2022/10/what-you-need-to-know-about-the-colorado-retail-delivery-fee-now.html
 		 *
 		 * RDF fee is DISABLED by default - not all business are required to charge the fee.
-		 * To apply the fee use `wc_services_apply_us_co_retail_delivery_fee` filter.
-		 * Change boolian flag to `true`
-		 * Example: `add_filter( 'wc_services_apply_us_co_retail_delivery_fee', '__return_true' );`
+		 * To apply the fee use `wc_services_enable_us_co_retail_delivery_fee` filter.
+		 * Change boolean flag to `true`
+		 * Example: `add_filter( 'wc_services_enable_us_co_retail_delivery_fee', '__return_true' );`
 		 *
 		 * @param WC_Cart $cart WooCommerce Cart object.
 		 */
@@ -97,7 +97,7 @@ if ( ! class_exists( 'WC_Connect_Custom_Surcharge' ) ) {
 
 			/**
 			 * Filter for manipulate the custom surcharge.
-			 * 
+			 *
 			 * As of July 1, 2024 till June 30, 2025 RDF is 29 cents per order
 			 * RDF is subject to sales tax.
 			 * https://www.avalara.com/blog/en/north-america/2022/10/what-you-need-to-know-about-the-colorado-retail-delivery-fee-now.html.

--- a/classes/class-wc-connect-custom-surcharge.php
+++ b/classes/class-wc-connect-custom-surcharge.php
@@ -98,9 +98,9 @@ if ( ! class_exists( 'WC_Connect_Custom_Surcharge' ) ) {
 			/**
 			 * Filter for manipulate the custom surcharge.
 			 *
-			 * As of July 1, 2024 till June 30, 2025 RDF is 29 cents per order
+			 * As of July 2025 to June 2026 RDF is 28 cents per order.
 			 * RDF is subject to sales tax.
-			 * https://www.avalara.com/blog/en/north-america/2022/10/what-you-need-to-know-about-the-colorado-retail-delivery-fee-now.html.
+			 * https://tax.colorado.gov/retail-delivery-fee-rates.
 			 *
 			 * @since 2.9.0
 			 *

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.2.4 - 2025-xx-xx =
+* Tweak  - Change default Retail Delivery Fee for Colorado to 28c.
+
 = 3.2.3 - 2025-11-17 =
 * Fix   - Resolved issue where shipping features loaded despite the site being set to tax-only mode.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Changes Retail Delivery Fee for Colorado from 29c to 28c.
Based on https://tax.colorado.gov/retail-delivery-fee-rates
<img width="1030" height="505" alt="image" src="https://github.com/user-attachments/assets/570566ac-aa32-4020-8b0e-31a077654186" />

Adjust methods and filter documentation.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Closes https://linear.app/a8c/issue/WOOSHIP-1781/colorado-dollar028-tax-not-applied-after-rate-change

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

