### PR TITLE
Add tracks event for TaxJar

### DIFF
--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -77,6 +77,13 @@ class WC_Connect_TaxJar_Integration {
 	 */
 	private $backend_tax_classes;
 
+	/**
+	 * Tracks instance.
+	 *
+	 * @var WC_Connect_Tracks
+	 */
+	protected $tracks;
+
 	const PROXY_PATH               = 'taxjar/v2';
 	const OPTION_NAME              = 'wc_connect_taxes_enabled';
 	const SETUP_WIZARD_OPTION_NAME = 'woocommerce_setup_automated_taxes';
@@ -87,18 +94,21 @@ class WC_Connect_TaxJar_Integration {
 	 * @param WC_Connect_API_Client     $api_client          TaxJar API client.
 	 * @param WC_Connect_Logger         $logger              Logger.
 	 * @param string                    $wc_connect_base_url WC Connect base URL.
+	 * @param WC_Connect_Tracks         $tracks              Tracks.
 	 * @param StoreNoticesNotifier|null $notifier            Notifier.
 	 */
 	public function __construct(
 		WC_Connect_API_Client $api_client,
 		WC_Connect_Logger $logger,
 		$wc_connect_base_url,
+		WC_Connect_Tracks $tracks,
 		?StoreNoticesNotifier $notifier = null
 	) {
 		$this->api_client          = $api_client;
 		$this->logger              = $logger;
 		$this->wc_connect_base_url = $wc_connect_base_url;
 		$this->notifier            = $notifier;
+		$this->tracks              = $tracks;
 
 		// Cache rates for 1 hour.
 		$this->cache_time = HOUR_IN_SECONDS;
@@ -631,6 +641,9 @@ class WC_Connect_TaxJar_Integration {
 			)
 		);
 		if ( class_exists( 'WC_Order_Item_Tax' ) ) { // Add tax rates manually for Woo 3.0+
+			/**
+			 * @var WC_Order_Item_Product $item Product Order Item.
+			 */
 			foreach ( $order->get_items() as $item_key => $item ) {
 				$product_id    = $item->get_product_id();
 				$line_item_key = $product_id . '-' . $item_key;
@@ -985,8 +998,6 @@ class WC_Connect_TaxJar_Integration {
 
 		if ( '' != $street ) {
 			return array( $country, $state, $postcode, $city, $street );
-		} else {
-			return array( $country, $state, $postcode, $city );
 		}
 
 		return array( $country, $state, $postcode, $city );
@@ -1262,6 +1273,21 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		if ( $taxes['has_nexus'] ) {
+
+			$this->tracks->record_user_event(
+				'tax_calculation_nexus_detected',
+				array(
+					'from_country'      => $from_country,
+					'from_state'        => $from_state,
+					'to_country'        => $to_country,
+					'to_state'          => $to_state,
+					'to_zip'            => $to_zip,
+					'to_city'           => $to_city,
+					'freight_taxable'   => $taxes['freight_taxable'],
+					'combined_tax_rate' => $taxes['tax_rate'],
+				)
+			);
+
 			// Use Woo core to find matching rates for taxable address.
 			$jurisdictions = array(
 				'county' => $taxjar_taxes->jurisdictions->county ?? null,

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -874,7 +874,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$shipping_label         = new WC_Connect_Shipping_Label( $api_client, $settings_store, $schemas_store, $payment_methods_store );
 			$nux                    = new WC_Connect_Nux( $tracks, $shipping_label );
 			$store_notices_notifier = new StoreNoticesNotifier( $taxes_logger->is_debug_enabled() );
-			$taxjar                 = new WC_Connect_TaxJar_Integration( $api_client, $taxes_logger, $this->wc_connect_base_url, $store_notices_notifier );
+			$taxjar                 = new WC_Connect_TaxJar_Integration( $api_client, $taxes_logger, $this->wc_connect_base_url, $tracks, $store_notices_notifier );
 			$this->set_store_notices_notifier( $store_notices_notifier );
 			$paypal_ec     = new WC_Connect_PayPal_EC( $api_client, $nux );
 			$label_reports = new WC_Connect_Label_Reports( $settings_store );


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

We want to run experiment to see if we can skip all request to TaxJar to US when `from_state != to_state` to reduce amount of request that we assume should always give 0 tax rate. For this we are adding tracking event to see if `combined_tax_rate` is equal to 0 for all the cases.

Add a Tracks event immediately after the has_nexus[ check ](https://github.com/Automattic/woocommerce-services/blob/34d118847aa0af325e435bb1d895b5e3b1c0f2d8/classes/class-wc-connect-taxjar-integration.php#L1210)that captures the from/to states (and ideally the full addresses). Let it run for a week so we can see the actual distribution. That should give us enough signal to confirm whether narrowing API calls would silently break things for a meaningful number of merchants.

### Related issue(s)
Closes https://linear.app/a8c/issue/WOOSHIP-1821/add-tracks-even-tax-calculation-nexus-detected


<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

