### PR TITLE
Add default nexus address and allow to filter nexus address.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
 = 3.3.0 - 2025-xx-xx =
+* Add   - Add default nexus address.
+* Add   - Add woocommerce_taxjar_nexus_addresses filter.
 * Add   - Jurisdiction information to generated US tax rate names to improve tax analytics accuracy.
 * Tweak - Change default Retail Delivery Fee for Colorado to 28c.
 * Tweak - WordPress 6.9 and WooCommerce 10.4 Compatibility.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@
 
 = 3.3.0 - 2025-xx-xx =
 * Add   - Add default nexus address.
-* Add   - Add woocommerce_taxjar_nexus_addresses filter.
+* Add   - Add woocommerce_taxjar_nexus_address filter.
 * Add   - Jurisdiction information to generated US tax rate names to improve tax analytics accuracy.
 * Tweak - Change default Retail Delivery Fee for Colorado to 28c.
 * Tweak - WordPress 6.9 and WooCommerce 10.4 Compatibility.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1054,7 +1054,7 @@ class WC_Connect_TaxJar_Integration {
 	 * TaxJar request body and the "from" address needs to be removed from it in order to
 	 * get the correct rates. This is due to a limitation/miscalculation at the TaxJar API.
 	 *
-	 * This method adds the "nexus_addresses" element to the request body
+	 * This method returns a nexus address to be used as a workaround
 	 * if the workaround is enabled and an address case is matched.
 	 *
 	 * New edge cases can be added to the $cases array as needed.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1122,6 +1122,13 @@ class WC_Connect_TaxJar_Integration {
 		return $workaround_nexus_addresses;
 	}
 
+	/**
+	 * Validates TaxJar nexus address.
+	 *
+	 * @param  array $address
+	 *
+	 * @return bool
+	 */
 	private function is_nexus_address_valid( array $address ): bool {
 		$errors = array();
 		$schema = array(

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1178,7 +1178,25 @@ class WC_Connect_TaxJar_Integration {
 			'plugin'       => 'woo',
 		);
 
-		$body = $this->maybe_apply_taxjar_nexus_addresses_workaround( $body );
+		$workaround_nexus_addresses = $this->maybe_apply_taxjar_nexus_addresses_workaround( $body );
+
+		$default_nexus_addresses = array(
+			'country' => $body['from_country'],
+			'zip'     => $body['from_zip'],
+			'state'   => $body['from_state'],
+			'city'    => $body['from_city'],
+			'street'  => $body['from_street'],
+		);
+
+		$nexus_addresses = ! empty( $workaround_nexus_addresses )
+			? array_merge( array( $workaround_nexus_addresses ), array( $default_nexus_addresses ) )
+			: array( $default_nexus_addresses );
+
+		$nexus_addresses = apply_filters( 'woocommerce_taxjar_nexus_addresses', $nexus_addresses, $body );
+
+		if ( is_array( $nexus_addresses ) && ! empty( $nexus_addresses ) ) {
+			$body['nexus_addresses'] = $nexus_addresses;
+		}
 
 		// Either `amount` or `line_items` parameters are required to perform tax calculations.
 		if ( empty( $line_items ) ) {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -696,7 +696,7 @@ class WC_Connect_TaxJar_Integration {
 					'country'   => $country,
 					'state'     => $state,
 					'postcode'  => $postcode,
-					'city'      => $city,
+					'city'      => strtoupper( $city ),
 					'tax_class' => $tax_class,
 				)
 			);
@@ -1395,7 +1395,7 @@ class WC_Connect_TaxJar_Integration {
 				'country'   => $location['to_country'],
 				'state'     => str_replace( ' ', '', $to_state ),
 				'postcode'  => $location['to_zip'],
-				'city'      => $location['to_city'],
+				'city'      => strtoupper( $location['to_city'] ),
 				'tax_class' => $tax_class,
 			)
 		);

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1129,7 +1129,7 @@ class WC_Connect_TaxJar_Integration {
 	 *
 	 * @return bool
 	 */
-	private function is_nexus_address_valid( array $address ): bool {
+	private function is_nexus_address_valid( $address ): bool {
 		$errors = array();
 		$schema = array(
 			'id'      => array(

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1309,17 +1309,41 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		/**
-		 * Remove or modify nexus address.
+		 * Filter to modify or disable the nexus address sent to TaxJar API.
+		 *
+		 * This filter allows modification of the nexus address that will be sent
+		 * in the TaxJar API request. The nexus address replaces the standard from_*
+		 * address fields when provided.
+		 *
+		 * Return false or an empty array to disable sending nexus addresses entirely,
+		 * which will cause the request to use the standard from_* address fields instead.
+		 *
+		 * The nexus address array should contain the following keys:
+		 * - country: Two-letter country code (required).
+		 * - state: Two-letter state/province code (required for US/CA).
+		 * - zip: Postal/ZIP code (required).
+		 * - city: City name (required).
+		 * - street: Street address (optional).
 		 *
 		 * @since 3.3.0
 		 *
-		 * @param array $nexus_address TaxJar nexus address.
-		 * @param array $body TaxJar request body.
+		 * @param array $nexus_address The nexus address array to be sent to TaxJar.
+		 * @param array $body          The complete TaxJar API request body.
 		 *
-		 * if empty $nexus_addresses is passed, the nexus setting is skipped.
-		 * example: add_filter( 'woocommerce_taxjar_nexus_addresses', '__return_false' );
+		 * @return array|false Modified nexus address array, or false to disable nexus addresses.
+		 *
+		 * @example
+		 * // Disable nexus addresses entirely.
+		 * add_filter( 'woocommerce_taxjar_nexus_addresses', '__return_false' );
+		 *
+		 * @example
+		 * // Modify the nexus address.
+		 * add_filter( 'woocommerce_taxjar_nexus_addresses', function( $nexus_address, $body ) {
+		 *     $nexus_address['street'] = '123 Custom Street';
+		 *     return $nexus_address;
+		 * }, 10, 2 );
 		 */
-		$nexus_address = apply_filters( 'woocommerce_taxjar_nexus_addresses', $nexus_address, $body );
+		$nexus_address = apply_filters( 'woocommerce_taxjar_nexus_address', $nexus_address, $body );
 
 		if ( is_array( $nexus_address ) && ! empty( $nexus_address ) && $this->is_nexus_address_valid( $nexus_address ) ) {
 			$params_to_unset = array(

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1192,6 +1192,14 @@ class WC_Connect_TaxJar_Integration {
 			? array_merge( array( $workaround_nexus_addresses ), array( $default_nexus_addresses ) )
 			: array( $default_nexus_addresses );
 
+		/*
+		Add, remove or modify nexus addresses.
+		 *
+		 * @since 3.3.0
+		 *
+		 * @param array $nexus_addresses Array of nexus addresses.
+		 * @param array $body TaxJar request body.
+		 */
 		$nexus_addresses = apply_filters( 'woocommerce_taxjar_nexus_addresses', $nexus_addresses, $body );
 
 		if ( is_array( $nexus_addresses ) && ! empty( $nexus_addresses ) ) {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1122,6 +1122,98 @@ class WC_Connect_TaxJar_Integration {
 		return $workaround_nexus_addresses;
 	}
 
+	private function validate_nexus_addresses( array $addresses ): array {
+		$errors = array();
+		$schema = array(
+			'id'      => array(
+				'type'        => 'string',
+				'required'    => false,
+				'description' => 'Unique identifier for the nexus address (optional).',
+				'max_length'  => 255,
+			),
+			'country' => array(
+				'type'        => 'string',
+				'required'    => true,
+				'pattern'     => '/^[A-Z]{2}$/', // two-letter ISO alpha-2 (upper-case)
+				'description' => 'Two-letter ISO country code (e.g. "US").',
+				'max_length'  => 2,
+			),
+			'zip'     => array(
+				'type'        => 'string',
+				'required'    => false,
+				'description' => 'Postal code (format varies by country).',
+				'max_length'  => 20,
+			),
+			'state'   => array(
+				'type'        => 'string',
+				'required'    => true,
+				'pattern'     => '/^[A-Z0-9\-]{1,100}$/', // typical short code like "NY", "CA", "NSW"
+				'description' => 'Two-letter (or short) ISO state/province code where applicable.',
+				'max_length'  => 100,
+			),
+			'city'    => array(
+				'type'        => 'string',
+				'required'    => false,
+				'description' => 'City name.',
+				'max_length'  => 100,
+			),
+			'street'  => array(
+				'type'        => 'string',
+				'required'    => false,
+				'description' => 'Street address (line).',
+				'max_length'  => 255,
+			),
+		);
+
+		foreach ( $addresses as $i => $data ) {
+			$entryErrors = array();
+
+			if ( ! is_array( $data ) ) {
+				$errors[ $i ] = array( 'Nexus address has invalid format' );
+				continue;
+			}
+
+			foreach ( $schema as $field => $rules ) {
+				$exists = array_key_exists( $field, $data );
+				$value  = $exists ? $data[ $field ] : null;
+
+				if ( ! empty( $rules['required'] ) && ! $exists ) {
+					$entryErrors[] = "[$field] field is required";
+					continue;
+				}
+
+				if ( ! $exists || $value === '' || $value === null ) {
+					continue;
+				}
+
+				if ( isset( $rules['type'] ) ) {
+					if ( $rules['type'] === 'string' && ! is_string( $value ) ) {
+						$entryErrors[] = "[$field] field must be a string";
+						continue;
+					}
+				}
+
+				if ( isset( $rules['max_length'] ) && is_string( $value ) ) {
+					if ( strlen( $value ) > $rules['max_length'] ) {
+						$entryErrors[] = "[$field] field exceeds maximum length of {$rules['max_length']}";
+					}
+				}
+
+				if ( isset( $rules['pattern'] ) && is_string( $value ) ) {
+					if ( ! preg_match( $rules['pattern'], $value ) ) {
+						$entryErrors[] = "[$field] field format is invalid";
+					}
+				}
+			}
+
+			if ( ! empty( $entryErrors ) ) {
+				$errors[ $i ] = $entryErrors;
+			}
+		}
+
+		return $errors;
+	}
+
 	/**
 	 * Calculate sales tax using SmartCalcs
 	 *
@@ -1215,6 +1307,13 @@ class WC_Connect_TaxJar_Integration {
 		 * example: add_filter( 'woocommerce_taxjar_nexus_addresses', '__return_false' );
 		 */
 		$nexus_addresses = apply_filters( 'woocommerce_taxjar_nexus_addresses', $nexus_addresses, $body );
+
+		$errors = $this->validate_nexus_addresses( $nexus_addresses );
+
+		foreach ( $errors as $address_index => $address_errors ) {
+			$this->logger->error( 'Nexus Address ERRORS: ' . implode( ', ', $address_errors ) . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . print_r( $nexus_addresses[ $address_index ], true ), 'WCS Tax' );
+			unset( $nexus_addresses[ $address_index ] );
+		}
 
 		if ( is_array( $nexus_addresses ) && ! empty( $nexus_addresses ) ) {
 			$body['nexus_addresses'] = $nexus_addresses;

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1182,6 +1182,7 @@ class WC_Connect_TaxJar_Integration {
 
 		if ( ! is_array( $address ) ) {
 			$this->logger->error( 'Nexus Address ERRORS: Nexus addresses has invalid format' . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . print_r( $address, true ), 'WCS Tax' );
+
 			return false;
 		}
 
@@ -1220,6 +1221,8 @@ class WC_Connect_TaxJar_Integration {
 
 		if ( ! empty( $errors ) ) {
 			$this->logger->error( 'Nexus Address ERRORS: ' . implode( ', ', $errors ) . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . print_r( $address, true ), 'WCS Tax' );
+
+			return false;
 		}
 
 		return true;

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1305,21 +1305,6 @@ class WC_Connect_TaxJar_Integration {
 			);
 		}
 
-		add_filter(
-			'woocommerce_taxjar_nexus_addresses',
-			function ( $nexus_address ) {
-
-				$nexus_address = array(
-					'zip'    => '93307',
-					'state'  => 'CA',
-					'city'   => 'Bakersfield',
-					'street' => '1200 Bachelor St',
-				);
-
-				return $nexus_address;
-			}
-		);
-
 		/**
 		 * Remove or modify nexus address.
 		 *

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1203,15 +1203,15 @@ class WC_Connect_TaxJar_Integration {
 			? array_merge( array( $workaround_nexus_addresses ), array( $default_nexus_addresses ) )
 			: array( $default_nexus_addresses );
 
-		/*
-		Add, remove or modify nexus addresses.
+		/**
+		 * Add, remove or modify nexus addresses.
 		 *
 		 * @since 3.3.0
 		 *
 		 * @param array $nexus_addresses Array of nexus addresses.
 		 * @param array $body TaxJar request body.
 		 *
-		 * to remove nexus_addresses property return `false` in your filter.
+		 * if empty $nexus_addresses is passed, the nexus setting is skipped.
 		 * example: add_filter( 'woocommerce_taxjar_nexus_addresses', '__return_false' );
 		 */
 		$nexus_addresses = apply_filters( 'woocommerce_taxjar_nexus_addresses', $nexus_addresses, $body );

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1043,8 +1043,8 @@ class WC_Connect_TaxJar_Integration {
 	 * TaxJar request body and the "from" address needs to be removed from it in order to
 	 * get the correct rates. This is due to a limitation/miscalculation at the TaxJar API.
 	 *
-	 * This method adds the "nexus_addresses" element to the request body and unsets the "from"
-	 * address elements if the workaround is enabled and an address case is matched.
+	 * This method adds the "nexus_addresses" element to the request body
+	 * if the workaround is enabled and an address case is matched.
 	 *
 	 * New edge cases can be added to the $cases array as needed.
 	 *
@@ -1053,8 +1053,9 @@ class WC_Connect_TaxJar_Integration {
 	 * @return array
 	 */
 	public function maybe_apply_taxjar_nexus_addresses_workaround( $body ) {
+		$workaround_nexus_addresses = array();
 		if ( true !== apply_filters( 'woocommerce_apply_taxjar_nexus_addresses_workaround', true ) ) {
-			return $body;
+			return $workaround_nexus_addresses;
 		}
 
 		$cases = array(
@@ -1096,32 +1097,18 @@ class WC_Connect_TaxJar_Integration {
 				}
 			}
 
-			$body['nexus_addresses'] = array(
-				array(
-					'street'  => $body['to_street'],
-					'city'    => $body['to_city'],
-					'state'   => $body['to_state'],
-					'country' => $body['to_country'],
-					'zip'     => $body['to_zip'],
-				),
+			$workaround_nexus_addresses = array(
+				'country' => $body['to_country'],
+				'zip'     => $body['to_zip'],
+				'state'   => $body['to_state'],
+				'city'    => $body['to_city'],
+				'street'  => $body['to_street'],
 			);
-
-			$params_to_unset = array(
-				'from_country',
-				'from_state',
-				'from_zip',
-				'from_city',
-				'from_street',
-			);
-
-			foreach ( $params_to_unset as $param ) {
-				unset( $body[ $param ] );
-			}
 
 			break;
 		}
 
-		return $body;
+		return $workaround_nexus_addresses;
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1334,11 +1334,11 @@ class WC_Connect_TaxJar_Integration {
 		 *
 		 * @example
 		 * // Disable nexus addresses entirely.
-		 * add_filter( 'woocommerce_taxjar_nexus_addresses', '__return_false' );
+		 * add_filter( 'woocommerce_taxjar_nexus_address', '__return_false' );
 		 *
 		 * @example
 		 * // Modify the nexus address.
-		 * add_filter( 'woocommerce_taxjar_nexus_addresses', function( $nexus_address, $body ) {
+		 * add_filter( 'woocommerce_taxjar_nexus_address', function( $nexus_address, $body ) {
 		 *     $nexus_address['street'] = '123 Custom Street';
 		 *     return $nexus_address;
 		 * }, 10, 2 );

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1122,7 +1122,7 @@ class WC_Connect_TaxJar_Integration {
 		return $workaround_nexus_addresses;
 	}
 
-	private function validate_nexus_addresses( array $addresses ): array {
+	private function is_nexus_address_valid( array $address ): bool {
 		$errors = array();
 		$schema = array(
 			'id'      => array(
@@ -1165,56 +1165,49 @@ class WC_Connect_TaxJar_Integration {
 			),
 		);
 
-		if ( ! is_array( $addresses ) ) {
-			return array( 0 => array( 'Nexus addresses has invalid format' ) );
+		if ( ! is_array( $address ) ) {
+			$this->logger->error( 'Nexus Address ERRORS: Nexus addresses has invalid format' . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . print_r( $address, true ), 'WCS Tax' );
+			return false;
 		}
 
-		foreach ( $addresses as $i => $data ) {
-			$entryErrors = array();
+		foreach ( $schema as $field => $rules ) {
+			$exists = array_key_exists( $field, $address );
+			$value  = $exists ? $address[ $field ] : null;
 
-			if ( ! is_array( $data ) ) {
-				return array( 0 => array( 'Nexus addresses has invalid format' ) );
+			if ( ! empty( $rules['required'] ) && ! $exists ) {
+				$errors[] = "[$field] field is required";
+				continue;
 			}
 
-			foreach ( $schema as $field => $rules ) {
-				$exists = array_key_exists( $field, $data );
-				$value  = $exists ? $data[ $field ] : null;
+			if ( ! $exists || $value === '' || $value === null ) {
+				continue;
+			}
 
-				if ( ! empty( $rules['required'] ) && ! $exists ) {
-					$entryErrors[] = "[$field] field is required";
+			if ( isset( $rules['type'] ) ) {
+				if ( $rules['type'] === 'string' && ! is_string( $value ) ) {
+					$errors[] = "[$field] field must be a string";
 					continue;
-				}
-
-				if ( ! $exists || $value === '' || $value === null ) {
-					continue;
-				}
-
-				if ( isset( $rules['type'] ) ) {
-					if ( $rules['type'] === 'string' && ! is_string( $value ) ) {
-						$entryErrors[] = "[$field] field must be a string";
-						continue;
-					}
-				}
-
-				if ( isset( $rules['max_length'] ) && is_string( $value ) ) {
-					if ( strlen( $value ) > $rules['max_length'] ) {
-						$entryErrors[] = "[$field] field exceeds maximum length of {$rules['max_length']}";
-					}
-				}
-
-				if ( isset( $rules['pattern'] ) && is_string( $value ) ) {
-					if ( ! preg_match( $rules['pattern'], $value ) ) {
-						$entryErrors[] = "[$field] field format is invalid";
-					}
 				}
 			}
 
-			if ( ! empty( $entryErrors ) ) {
-				$errors[ $i ] = $entryErrors;
+			if ( isset( $rules['max_length'] ) && is_string( $value ) ) {
+				if ( strlen( $value ) > $rules['max_length'] ) {
+					$errors[] = "[$field] field exceeds maximum length of {$rules['max_length']}";
+				}
+			}
+
+			if ( isset( $rules['pattern'] ) && is_string( $value ) ) {
+				if ( ! preg_match( $rules['pattern'], $value ) ) {
+					$errors[] = "[$field] field format is invalid";
+				}
 			}
 		}
 
-		return $errors;
+		if ( ! empty( $errors ) ) {
+			$this->logger->error( 'Nexus Address ERRORS: ' . implode( ', ', $errors ) . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . print_r( $address, true ), 'WCS Tax' );
+		}
+
+		return true;
 	}
 
 	/**
@@ -1284,42 +1277,49 @@ class WC_Connect_TaxJar_Integration {
 			'plugin'       => 'woo',
 		);
 
-		$workaround_nexus_addresses = $this->maybe_apply_taxjar_nexus_addresses_workaround( $body );
+		$nexus_address = $this->maybe_apply_taxjar_nexus_addresses_workaround( $body );
 
-		$default_nexus_addresses = array(
-			'country' => $body['from_country'],
-			'zip'     => $body['from_zip'],
-			'state'   => $body['from_state'],
-			'city'    => $body['from_city'],
-			'street'  => $body['from_street'],
+		// If workaround empty use default store address as nexus address.
+		if ( empty( $nexus_address ) ) {
+			$nexus_address = array(
+				'country' => $body['from_country'],
+				'zip'     => $body['from_zip'],
+				'state'   => $body['from_state'],
+				'city'    => $body['from_city'],
+				'street'  => $body['from_street'],
+			);
+		}
+
+		add_filter(
+			'woocommerce_taxjar_nexus_addresses',
+			function ( $nexus_address ) {
+
+				$nexus_address = array(
+					'zip'    => '93307',
+					'state'  => 'CA',
+					'city'   => 'Bakersfield',
+					'street' => '1200 Bachelor St',
+				);
+
+				return $nexus_address;
+			}
 		);
 
-		$nexus_addresses = ! empty( $workaround_nexus_addresses )
-			? array_merge( array( $workaround_nexus_addresses ), array( $default_nexus_addresses ) )
-			: array( $default_nexus_addresses );
-
 		/**
-		 * Add, remove or modify nexus addresses.
+		 * Remove or modify nexus address.
 		 *
 		 * @since 3.3.0
 		 *
-		 * @param array $nexus_addresses Array of nexus addresses.
+		 * @param array $nexus_address TaxJar nexus address.
 		 * @param array $body TaxJar request body.
 		 *
 		 * if empty $nexus_addresses is passed, the nexus setting is skipped.
 		 * example: add_filter( 'woocommerce_taxjar_nexus_addresses', '__return_false' );
 		 */
-		$nexus_addresses = apply_filters( 'woocommerce_taxjar_nexus_addresses', $nexus_addresses, $body );
+		$nexus_address = apply_filters( 'woocommerce_taxjar_nexus_addresses', $nexus_address, $body );
 
-		$errors = $this->validate_nexus_addresses( $nexus_addresses );
-
-		foreach ( $errors as $address_index => $address_errors ) {
-			$this->logger->error( 'Nexus Address ERRORS: ' . implode( ', ', $address_errors ) . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . print_r( $nexus_addresses[ $address_index ], true ), 'WCS Tax' );
-			unset( $nexus_addresses[ $address_index ] );
-		}
-
-		if ( is_array( $nexus_addresses ) && ! empty( $nexus_addresses ) ) {
-			$body['nexus_addresses'] = $nexus_addresses;
+		if ( is_array( $nexus_address ) && ! empty( $nexus_address ) && $this->is_nexus_address_valid( $nexus_address ) ) {
+			$body['nexus_addresses'] = array( $nexus_address );
 		}
 
 		// Either `amount` or `line_items` parameters are required to perform tax calculations.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1172,6 +1172,14 @@ class WC_Connect_TaxJar_Integration {
 			),
 		);
 
+		/**
+		 * Return without logging as empty array() or false
+		 * might be return on purpose from filter to remove nexus address.
+		 */
+		if ( empty( $address ) ) {
+			return false;
+		}
+
 		if ( ! is_array( $address ) ) {
 			$this->logger->error( 'Nexus Address ERRORS: Nexus addresses has invalid format' . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . print_r( $address, true ), 'WCS Tax' );
 			return false;

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1199,6 +1199,9 @@ class WC_Connect_TaxJar_Integration {
 		 *
 		 * @param array $nexus_addresses Array of nexus addresses.
 		 * @param array $body TaxJar request body.
+		 *
+		 * to remove nexus_addresses property return `false` in your filter.
+		 * example: add_filter( 'woocommerce_taxjar_nexus_addresses', '__return_false' );
 		 */
 		$nexus_addresses = apply_filters( 'woocommerce_taxjar_nexus_addresses', $nexus_addresses, $body );
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1063,7 +1063,7 @@ class WC_Connect_TaxJar_Integration {
 	 *
 	 * @return array
 	 */
-	public function maybe_apply_taxjar_nexus_addresses_workaround( $body ) {
+	private function maybe_apply_taxjar_nexus_addresses_workaround( $body ) {
 		$workaround_nexus_addresses = array();
 		if ( true !== apply_filters( 'woocommerce_apply_taxjar_nexus_addresses_workaround', true ) ) {
 			return $workaround_nexus_addresses;

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1165,12 +1165,15 @@ class WC_Connect_TaxJar_Integration {
 			),
 		);
 
+		if ( ! is_array( $addresses ) ) {
+			return array( 0 => array( 'Nexus addresses has invalid format' ) );
+		}
+
 		foreach ( $addresses as $i => $data ) {
 			$entryErrors = array();
 
 			if ( ! is_array( $data ) ) {
-				$errors[ $i ] = array( 'Nexus address has invalid format' );
-				continue;
+				return array( 0 => array( 'Nexus addresses has invalid format' ) );
 			}
 
 			foreach ( $schema as $field => $rules ) {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1319,6 +1319,17 @@ class WC_Connect_TaxJar_Integration {
 		$nexus_address = apply_filters( 'woocommerce_taxjar_nexus_addresses', $nexus_address, $body );
 
 		if ( is_array( $nexus_address ) && ! empty( $nexus_address ) && $this->is_nexus_address_valid( $nexus_address ) ) {
+			$params_to_unset = array(
+				'from_country',
+				'from_state',
+				'from_zip',
+				'from_city',
+				'from_street',
+			);
+
+			foreach ( $params_to_unset as $param ) {
+				unset( $body[ $param ] );
+			}
 			$body['nexus_addresses'] = array( $nexus_address );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -71,6 +71,8 @@ This plugin relies on the following external services:
 == Changelog ==
 
 = 3.3.0 - 2025-xx-xx =
+* Add   - Add default nexus address.
+* Add   - Add woocommerce_taxjar_nexus_addresses filter.
 * Add   - Jurisdiction information to generated US tax rate names to improve tax analytics accuracy.
 * Tweak - Change default Retail Delivery Fee for Colorado to 28c.
 * Tweak - WordPress 6.9 and WooCommerce 10.4 Compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -72,7 +72,7 @@ This plugin relies on the following external services:
 
 = 3.3.0 - 2025-xx-xx =
 * Add   - Add default nexus address.
-* Add   - Add woocommerce_taxjar_nexus_addresses filter.
+* Add   - Add woocommerce_taxjar_nexus_address filter.
 * Add   - Jurisdiction information to generated US tax rate names to improve tax analytics accuracy.
 * Tweak - Change default Retail Delivery Fee for Colorado to 28c.
 * Tweak - WordPress 6.9 and WooCommerce 10.4 Compatibility.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

- Add `nexus_addresses` property to every request.
  - Before this change we only added `nexus_addresses` for edge cases.
- Allow to use `woocommerce_taxjar_nexus_addresses` to modify addresses or remove `nexus_addresses`.
- Applies edge cases nexus workaround first and then merges default tax nexus.
  - Doing other way gave different result, probably because "[TaxJar only supports 1 Nexus per state](https://linear.app/a8c/issue/WOOSHIP-835/feature-request-wctax-allow-the-merchant-to-add-multiple-economic)"

To disable `nexus_addresses`
```php
add_filter( 'woocommerce_taxjar_nexus_address', '__return_false' );
```

To add custom nexus or to modify existing.
```php
add_filter( 'woocommerce_taxjar_nexus_address', function( $nexus_address ) {

	$nexus_address = array(
		'country' => 'US',
		'zip'     => '93307',
		'state'   => 'CA',
		'city'    => 'Bakersfield',
		'street'  => '1200 Bachelor St',
	);

	return $nexus_address;
} );
```
Extra change:
- Set City to upper for `WC_Tax::find_rates();` as Woo uppers City names when saving to database. 

### Related issue(s)
Closes https://linear.app/a8c/issue/WOOTAX-15/set-nexus-address-in-request-payload

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
- Add custom nexus in state other than store address using `woocommerce_taxjar_nexus_addresses` filter.
- On checkout set shipping address located in same state your custom nexus.
- See taxes are calculated.


### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

