### PR TITLE
Add country validation for TaxJar requests and Optimize Woo Tax API Calls by Restricting Same-State Tax Checks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.4.0 - 2026-xx-xx =
+* Add   - Optimize Woo Tax API calls by restricting same-state tax checks.
+* Add   - Country validation for TaxJar requests.
+
 = 3.3.1 - 2026-01-12 =
 * Fix   - Normalize state and country codes to uppercase in TaxJar integration.
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1464,20 +1464,6 @@ class WC_Connect_TaxJar_Integration {
 
 		if ( $taxes['has_nexus'] ) {
 
-			$this->tracks->record_user_event(
-				'tax_calculation_nexus_detected',
-				array(
-					'from_country'      => $from_country,
-					'from_state'        => $from_state,
-					'to_country'        => $to_country,
-					'to_state'          => $to_state,
-					'to_zip'            => $to_zip,
-					'to_city'           => $to_city,
-					'freight_taxable'   => $taxes['freight_taxable'],
-					'combined_tax_rate' => $taxes['tax_rate'],
-				)
-			);
-
 			// Use Woo core to find matching rates for taxable address.
 			$jurisdictions = array(
 				'county' => $taxjar_taxes->jurisdictions->county ?? null,

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1278,16 +1278,6 @@ class WC_Connect_TaxJar_Integration {
 		$from_city      = $store_settings['city'];
 		$from_street    = $store_settings['street'];
 
-		// Require from_country.
-		if ( empty( $from_country ) ) {
-			return;
-		}
-
-		// Don't calculate taxes for US when from_state and to_state are different.
-		if ( 'US' === $from_country && $from_state !== $to_state ) {
-			return;
-		}
-
 		$this->_log( ':::: TaxJar API called ::::' );
 
 		$body = array(
@@ -1370,6 +1360,18 @@ class WC_Connect_TaxJar_Integration {
 			$body['nexus_addresses'] = array( $nexus_address );
 		}
 
+		$address_parts = $this->get_address_parts( $body );
+
+		// Require from_country.
+		if ( empty( $address_parts['from_country'] ) ) {
+			return false;
+		}
+
+		// Don't calculate taxes for US when from_state and to_state are different.
+		if ( 'US' === $address_parts['from_country'] && 'US' === $address_parts['to_country'] && $address_parts['from_state'] !== $address_parts['to_state'] ) {
+			return false;
+		}
+
 		// Either `amount` or `line_items` parameters are required to perform tax calculations.
 		if ( empty( $line_items ) ) {
 			$body['amount'] = 0.01;
@@ -1399,6 +1401,26 @@ class WC_Connect_TaxJar_Integration {
 
 		return $taxes;
 	} // End calculate_tax().
+
+
+	/**
+	 * Return address parts.
+	 * Primarily used in address validation to operate on normalized and predictable indexes.
+	 *
+	 * @param array $body Request body.
+	 *
+	 * @return array
+	 */
+	private function get_address_parts( $body ) {
+		return array(
+			'from_country' => strtoupper( $body['nexus_addresses'][0]['country'] ?? $body['from_country'] ?? '' ),
+			'from_state'   => strtoupper( $body['nexus_addresses'][0]['state'] ?? $body['from_state'] ?? '' ),
+			'from_zip'     => strtoupper( $body['nexus_addresses'][0]['zip'] ?? $body['from_zip'] ?? '' ),
+			'to_country'   => strtoupper( $body['to_country'] ?? '' ),
+			'to_state'     => strtoupper( $body['to_state'] ?? '' ),
+			'to_zip'       => strtoupper( $body['to_zip'] ?? '' ),
+		);
+	}
 
 	/**
 	 * Get itemized tax rates from TaxJar response.
@@ -1636,51 +1658,50 @@ class WC_Connect_TaxJar_Integration {
 	public function validate_taxjar_request( $json ) {
 		$this->_log( ':::: TaxJar API request validation ::::' );
 
-		$json = json_decode( $json, true );
+		$body    = json_decode( $json, true );
+		$address = $this->get_address_parts( $body );
 
-		if ( empty( $json['to_country'] ) ) {
-			$this->_error( 'API request is stopped. Empty country destination.' );
+		if ( empty( $address['from_country'] ) ) {
+			$this->_error( 'API request is stopped. Empty origin country.' );
 
 			return false;
 		}
 
-		if ( ( 'US' === $json['to_country'] || 'CA' === $json['to_country'] ) && empty( $json['to_state'] ) ) {
+		if ( empty( $address['to_country'] ) ) {
+			$this->_error( 'API request is stopped. Empty destination country.' );
+
+			return false;
+		}
+
+		if ( ( 'US' === $address['to_country'] || 'CA' === $address['to_country'] ) && empty( $address['to_state'] ) ) {
 			$this->_error( 'API request is stopped. Country destination is set to US or CA but the state is empty.' );
 
 			return false;
 		}
 
-		if ( 'US' === $json['to_country'] && empty( $json['to_zip'] ) ) {
+		if ( 'US' === $address['to_country'] && empty( $address['to_zip'] ) ) {
 			$this->_error( 'API request is stopped. Country destination is set to US but the zip code is empty.' );
 
 			return false;
 		}
 
 		if (
-			'US' === $json['to_country']
-			&& ! empty( $json['to_state'] )
-			&& (
-				( isset( $json['from_country'] ) && 'US' === $json['from_country'] )
-				|| ( isset( $json['nexus_addresses'][0]['country'] ) && 'US' === $json['nexus_addresses'][0]['country'] )
-			)
-			&& (
-				( ! empty( $json['from_state'] ) && $json['from_state'] !== $json['to_state'] )
-				|| ( ! empty( $json['nexus_addresses'][0]['state'] ) && $json['nexus_addresses'][0]['state'] !== $json['to_state'] )
-			)
+			'US' === $address['to_country'] && 'US' === $address['from_country']
+			&& $address['from_state'] !== $address['to_state']
 		) {
-			$this->_error( 'API request is stopped. from_state !== to_state.' );
+			$this->_error( 'API request is stopped. US from_state !== to_state, tax don\'t apply.' );
 
 			return false;
 		}
 
 		// Apply this validation only if the destination country is the US and the zip code is 5 or 10 digits long.
-		if ( 'US' === $json['to_country'] && ! empty( $json['to_zip'] ) && in_array( strlen( $json['to_zip'] ), array( 5, 10 ) ) && ! WC_Validation::is_postcode( $json['to_zip'], $json['to_country'] ) ) {
+		if ( 'US' === $address['to_country'] && in_array( strlen( $address['to_zip'] ), array( 5, 10 ) ) && ! WC_Validation::is_postcode( $address['to_zip'], $address['to_country'] ) ) {
 			$this->_error( 'API request is stopped. Country destination is set to US but the zip code has incorrect format.' );
 
 			return false;
 		}
 
-		if ( ! empty( $json['from_country'] ) && ! empty( $json['from_zip'] ) && 'US' === $json['from_country'] && ! WC_Validation::is_postcode( $json['from_zip'], $json['from_country'] ) ) {
+		if ( 'US' === $address['from_country'] && ! WC_Validation::is_postcode( $address['from_zip'], $address['from_country'] ) ) {
 			$this->_error( 'API request is stopped. Country store is set to US but the zip code has incorrect format.' );
 
 			return false;

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1364,11 +1364,13 @@ class WC_Connect_TaxJar_Integration {
 
 		// Require from_country.
 		if ( empty( $address_parts['from_country'] ) ) {
+			$this->_log( 'From country is missing. Aborting.' );
 			return false;
 		}
 
 		// Don't calculate taxes for US when from_state and to_state are different.
 		if ( 'US' === $address_parts['from_country'] && 'US' === $address_parts['to_country'] && $address_parts['from_state'] !== $address_parts['to_state'] ) {
+			$this->_log( 'US from_state and to_state are different. Aborting.' );
 			return false;
 		}
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1278,6 +1278,16 @@ class WC_Connect_TaxJar_Integration {
 		$from_city      = $store_settings['city'];
 		$from_street    = $store_settings['street'];
 
+		// Require from_country.
+		if ( empty( $from_country ) ) {
+			return;
+		}
+
+		// Don't calculate taxes for US when from_state and to_state are different.
+		if ( 'US' === $from_country && $from_state !== $to_state ) {
+			return;
+		}
+
 		$this->_log( ':::: TaxJar API called ::::' );
 
 		$body = array(
@@ -1642,6 +1652,23 @@ class WC_Connect_TaxJar_Integration {
 
 		if ( 'US' === $json['to_country'] && empty( $json['to_zip'] ) ) {
 			$this->_error( 'API request is stopped. Country destination is set to US but the zip code is empty.' );
+
+			return false;
+		}
+
+		if (
+			'US' === $json['to_country']
+			&& ! empty( $json['to_state'] )
+			&& (
+				( isset( $json['from_country'] ) && 'US' === $json['from_country'] )
+				|| ( isset( $json['nexus_addresses'][0]['country'] ) && 'US' === $json['nexus_addresses'][0]['country'] )
+			)
+			&& (
+				( ! empty( $json['from_state'] ) && $json['from_state'] !== $json['to_state'] )
+				|| ( ! empty( $json['nexus_addresses'][0]['state'] ) && $json['nexus_addresses'][0]['state'] !== $json['to_state'] )
+			)
+		) {
+			$this->_error( 'API request is stopped. from_state !== to_state.' );
 
 			return false;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,10 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.4.0 - 2026-xx-xx =
+* Add   - Optimize Woo Tax API calls by restricting same-state tax checks.
+* Add   - Country validation for TaxJar requests.
+
 = 3.3.1 - 2026-01-12 =
 * Fix   - Normalize state and country codes to uppercase in TaxJar integration.
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -965,8 +965,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			if ( is_admin() ) {
 				$this->load_admin_dependencies();
 			}
-
-			add_filter( 'wc_services_enable_us_co_retail_delivery_fee', '__return_true' );
 		}
 
 		/**

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -8,7 +8,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-services
  * Domain Path: /i18n/languages/
- * Version: 3.3.1
+ * Version: 3.4.0
  * Requires Plugins: woocommerce
  * Requires PHP: 7.4
  * Requires at least: 6.7
@@ -965,6 +965,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			if ( is_admin() ) {
 				$this->load_admin_dependencies();
 			}
+
+			add_filter( 'wc_services_enable_us_co_retail_delivery_fee', '__return_true' );
 		}
 
 		/**

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -8,7 +8,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-services
  * Domain Path: /i18n/languages/
- * Version: 3.4.0
+ * Version: 3.3.1
  * Requires Plugins: woocommerce
  * Requires PHP: 7.4
  * Requires at least: 6.7


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Add validation to prevent unnecessary or malformed API calls.
[Woo Tax Tracking Analysis: US State Matching Investigation](https://fulfillcodeable.wordpress.com/2025/12/19/woo-tax-tracking-analysis-us-state-matching-investigation/)

### Related issue(s)
Closes https://linear.app/a8c/issue/WOOTAX-236/add-country-validation-for-taxjar-requests
Closes https://linear.app/a8c/issue/WOOTAX-238/optimize-woo-tax-api-calls-by-restricting-same-state-tax-checks

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

Validate if TaxJar API calls are prevented when
- `from_country` is not set
- `from_country` and `to_country` is US; and `from_state` and `to_state` are not the same

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

