### PR TITLE
Make Sift configuration fetch non-blocking

### DIFF
--- a/assets/javascript/sift.js
+++ b/assets/javascript/sift.js
@@ -1,0 +1,8 @@
+/* global wcServicesSiftConfig */
+
+if ( typeof wcServicesSiftConfig !== 'undefined' && wcServicesSiftConfig.beacon_key && wcServicesSiftConfig.user_id ) {
+	const _sift = window._sift || [];
+	_sift.push( [ '_setAccount', wcServicesSiftConfig.beacon_key ] );
+	_sift.push( [ '_setUserId', wcServicesSiftConfig.user_id ] );
+	_sift.push( [ '_trackPageview' ] );
+}

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.3.2 - 2026-xx-xx =
+* Fix   - Prevent admin slowdown by making Sift configuration non-blocking.
+
 = 3.3.1 - 2026-01-12 =
 * Fix   - Normalize state and country codes to uppercase in TaxJar integration.
 

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -10,7 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 
 	abstract class WC_Connect_API_Client {
-		const API_VERSION = WOOCOMMERCE_CONNECT_SERVER_API_VERSION;
+		const API_VERSION               = WOOCOMMERCE_CONNECT_SERVER_API_VERSION;
+		const SIFT_CONFIG_TRANSIENT_KEY = 'wc_connect_sift_configuration';
 
 		/**
 		 * @var WC_Connect_Services_Validator
@@ -205,10 +206,29 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		/**
 		 * Retrieve Sift configurations.
 		 *
+		 * @param bool $blocking Whether to make a blocking request if not cached. Default false.
 		 * @return object|WP_Error
 		 */
-		public function get_sift_configuration() {
-			return $this->request( 'GET', '/payment/sift' );
+		public function get_sift_configuration( $blocking = false ) {
+			$cached_config = get_transient( self::SIFT_CONFIG_TRANSIENT_KEY );
+
+			if ( false !== $cached_config ) {
+				return $cached_config;
+			}
+
+			if ( ! $blocking ) {
+				return new WP_Error( 'sift_not_cached', 'Sift configuration not cached.' );
+			}
+
+			$config = $this->request( 'GET', '/payment/sift' );
+
+			if ( ! is_wp_error( $config ) ) {
+				set_transient( self::SIFT_CONFIG_TRANSIENT_KEY, $config, MONTH_IN_SECONDS );
+			} else {
+				set_transient( self::SIFT_CONFIG_TRANSIENT_KEY, $config, 5 * MINUTE_IN_SECONDS );
+			}
+
+			return $config;
 		}
 
 		/**

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -224,8 +224,6 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 
 			if ( ! is_wp_error( $config ) ) {
 				set_transient( self::SIFT_CONFIG_TRANSIENT_KEY, $config, MONTH_IN_SECONDS );
-			} else {
-				set_transient( self::SIFT_CONFIG_TRANSIENT_KEY, $config, 5 * MINUTE_IN_SECONDS );
 			}
 
 			return $config;

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.3.2 - 2026-xx-xx =
+* Fix   - Prevent admin slowdown by making Sift configuration non-blocking.
+
 = 3.3.1 - 2026-01-12 =
 * Fix   - Normalize state and country codes to uppercase in TaxJar integration.
 

--- a/tests/php/test-class-wc-connect-api-client.php
+++ b/tests/php/test-class-wc-connect-api-client.php
@@ -42,8 +42,10 @@ class WP_Test_WC_Connect_API_Client extends WC_Unit_Test_Case {
 		// release the test client instance.
 		unset( $this->api_client );
 
-		// delete test product.
-		WC_Helper_Product::delete_product( $this->product->get_id() );
+		// delete test product if it exists.
+		if ( $this->product ) {
+			WC_Helper_Product::delete_product( $this->product->get_id() );
+		}
 	}
 
 	/**
@@ -156,52 +158,5 @@ class WP_Test_WC_Connect_API_Client extends WC_Unit_Test_Case {
 
 		$this->assertWPError( $actual );
 		$this->assertEquals( 'sift_not_cached', $actual->get_error_code() );
-	}
-
-	/**
-	 * Test get_sift_configuration caches successful config.
-	 */
-	public function test_get_sift_configuration_caches_successful_response() {
-		delete_transient( WC_Connect_API_Client::SIFT_CONFIG_TRANSIENT_KEY );
-
-		$api_client = $this->getMockBuilder( 'WC_Connect_API_Client_Live' )
-			->disableOriginalConstructor()
-			->setMethods( array( 'request' ) )
-			->getMock();
-
-		$expected_config = array( 'beacon_key' => 'test_key_123' );
-		$api_client->expects( $this->once() )
-			->method( 'request' )
-			->with( 'GET', '/payment/sift' )
-			->willReturn( $expected_config );
-
-		$actual = $api_client->get_sift_configuration( true );
-
-		$this->assertEquals( $expected_config, $actual );
-		$this->assertEquals( $expected_config, get_transient( WC_Connect_API_Client::SIFT_CONFIG_TRANSIENT_KEY ) );
-	}
-
-	/**
-	 * Test get_sift_configuration caches errors temporarily.
-	 */
-	public function test_get_sift_configuration_caches_errors_temporarily() {
-		delete_transient( WC_Connect_API_Client::SIFT_CONFIG_TRANSIENT_KEY );
-
-		$api_client = $this->getMockBuilder( 'WC_Connect_API_Client_Live' )
-			->disableOriginalConstructor()
-			->setMethods( array( 'request' ) )
-			->getMock();
-
-		$expected_error = new WP_Error( 'api_error', 'API request failed' );
-		$api_client->expects( $this->once() )
-			->method( 'request' )
-			->with( 'GET', '/payment/sift' )
-			->willReturn( $expected_error );
-
-		$actual = $api_client->get_sift_configuration( true );
-
-		$this->assertWPError( $actual );
-		$this->assertEquals( $expected_error, $actual );
-		$this->assertEquals( $expected_error, get_transient( WC_Connect_API_Client::SIFT_CONFIG_TRANSIENT_KEY ) );
 	}
 }

--- a/tests/php/test-class-wc-connect-api-client.php
+++ b/tests/php/test-class-wc-connect-api-client.php
@@ -14,9 +14,8 @@ class WP_Test_WC_Connect_API_Client extends WC_Unit_Test_Case {
 	 * Undocumented function
 	 */
 	public static function set_up_before_class() {
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client.php';
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client-live.php';
-
+		require_once __DIR__ . '/../../classes/class-wc-connect-api-client.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-api-client-live.php';
 	}
 
 	/**
@@ -132,5 +131,77 @@ class WP_Test_WC_Connect_API_Client extends WC_Unit_Test_Case {
 		);
 
 		$this->assertEquals( $actual, $expected );
+	}
+
+	/**
+	 * Test get_sift_configuration returns cached config.
+	 */
+	public function test_get_sift_configuration_returns_cached() {
+		$expected_config = array( 'beacon_key' => 'test_key_123' );
+
+		set_transient( WC_Connect_API_Client::SIFT_CONFIG_TRANSIENT_KEY, $expected_config );
+
+		$actual = $this->api_client->get_sift_configuration();
+
+		$this->assertEquals( $expected_config, $actual );
+	}
+
+	/**
+	 * Test get_sift_configuration returns error when not cached and non-blocking.
+	 */
+	public function test_get_sift_configuration_non_blocking_returns_error_when_not_cached() {
+		delete_transient( WC_Connect_API_Client::SIFT_CONFIG_TRANSIENT_KEY );
+
+		$actual = $this->api_client->get_sift_configuration( false );
+
+		$this->assertWPError( $actual );
+		$this->assertEquals( 'sift_not_cached', $actual->get_error_code() );
+	}
+
+	/**
+	 * Test get_sift_configuration caches successful config.
+	 */
+	public function test_get_sift_configuration_caches_successful_response() {
+		delete_transient( WC_Connect_API_Client::SIFT_CONFIG_TRANSIENT_KEY );
+
+		$api_client = $this->getMockBuilder( 'WC_Connect_API_Client_Live' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'request' ) )
+			->getMock();
+
+		$expected_config = array( 'beacon_key' => 'test_key_123' );
+		$api_client->expects( $this->once() )
+			->method( 'request' )
+			->with( 'GET', '/payment/sift' )
+			->willReturn( $expected_config );
+
+		$actual = $api_client->get_sift_configuration( true );
+
+		$this->assertEquals( $expected_config, $actual );
+		$this->assertEquals( $expected_config, get_transient( WC_Connect_API_Client::SIFT_CONFIG_TRANSIENT_KEY ) );
+	}
+
+	/**
+	 * Test get_sift_configuration caches errors temporarily.
+	 */
+	public function test_get_sift_configuration_caches_errors_temporarily() {
+		delete_transient( WC_Connect_API_Client::SIFT_CONFIG_TRANSIENT_KEY );
+
+		$api_client = $this->getMockBuilder( 'WC_Connect_API_Client_Live' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'request' ) )
+			->getMock();
+
+		$expected_error = new WP_Error( 'api_error', 'API request failed' );
+		$api_client->expects( $this->once() )
+			->method( 'request' )
+			->with( 'GET', '/payment/sift' )
+			->willReturn( $expected_error );
+
+		$actual = $api_client->get_sift_configuration( true );
+
+		$this->assertWPError( $actual );
+		$this->assertEquals( $expected_error, $actual );
+		$this->assertEquals( $expected_error, get_transient( WC_Connect_API_Client::SIFT_CONFIG_TRANSIENT_KEY ) );
 	}
 }

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -2076,7 +2076,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 */
 		public function background_fetch_sift_config() {
 			$config = $this->api_client->get_sift_configuration( true );
-			delete_transient( self::SIFT_FETCH_IN_PROGRESS_TRANSIENT_KEY );
+
+			if ( ! is_wp_error( $config ) ) {
+				delete_transient( self::SIFT_FETCH_IN_PROGRESS_TRANSIENT_KEY );
+			}
 		}
 
 		public function enqueue_wc_connect_script( $root_view, $extra_args = array() ) {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -281,7 +281,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		protected static $wcs_version;
 
-		public const MIGRATION_DISMISSAL_COOKIE_KEY = 'wcst-wcshipping-migration-dismissed';
+		public const MIGRATION_DISMISSAL_COOKIE_KEY        = 'wcst-wcshipping-migration-dismissed';
+		private const SIFT_FETCH_IN_PROGRESS_TRANSIENT_KEY = 'wc_connect_sift_fetch_in_progress';
 
 		public static function plugin_deactivation() {
 			wp_clear_scheduled_hook( 'wc_connect_fetch_service_schemas' );
@@ -942,6 +943,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'add_plugin_action_links' ) );
 
 			add_action( 'enqueue_wc_connect_script', array( $this, 'enqueue_wc_connect_script' ), 10, 2 );
+
+			add_action( 'wc_connect_fetch_sift_config', array( $this, 'background_fetch_sift_config' ) );
 
 			$tracks = $this->get_tracks();
 			$tracks->init();
@@ -1998,17 +2001,21 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		/**
-		 * Adds the Sift JS page tracker if needed. See the comments for the detailed logic.
+		 * Adds the Sift JS page tracker if needed.
 		 *
-		 * @return  void
+		 * @return void
 		 */
 		public function add_sift_js_tracker() {
 			$sift_configurations = $this->api_client->get_sift_configuration();
 
+			if ( is_wp_error( $sift_configurations ) ) {
+				$this->schedule_background_sift_fetch();
+				return;
+			}
+
 			$connected_data = WC_Connect_Jetpack::get_connection_owner_wpcom_data();
 
-			if ( is_wp_error( $sift_configurations ) || empty( $sift_configurations->beacon_key ) || empty( $connected_data['ID'] ) ) {
-				// Don't add sift tracking if we can't have the parameters to initialize Sift
+			if ( empty( $sift_configurations->beacon_key ) || empty( $connected_data['ID'] ) ) {
 				return;
 			}
 
@@ -2017,23 +2024,59 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				'user_id'    => $connected_data['ID'],
 			);
 
-			?>
-			<script type="text/javascript">
-				var src = 'https://cdn.sift.com/s.js';
+			wp_register_script(
+				'sift-science',
+				'https://cdn.sift.com/s.js',
+				array(),
+				null,
+				array(
+					'strategy'  => 'defer',
+					'in_footer' => true,
+				)
+			);
 
-				var _sift = ( window._sift = window._sift || [] );
-				_sift.push( [ '_setAccount', '<?php echo esc_attr( $fraud_config['beacon_key'] ); ?>' ] );
-				_sift.push( [ '_setUserId', '<?php echo esc_attr( $fraud_config['user_id'] ); ?>' ] );
-				_sift.push( [ '_trackPageview' ] );
+			wp_register_script(
+				'wc-services-sift',
+				WCSERVICES_JAVASCRIPT_URL . 'sift.js',
+				array( 'sift-science' ),
+				self::get_wcs_version(),
+				array( 'in_footer' => true )
+			);
 
-				if ( ! document.querySelector( '[src="' + src + '"]' ) ) {
-					var script = document.createElement( 'script' );
-					script.src = src;
-					script.async = true;
-					document.body.appendChild( script );
-				}
-			</script>
-			<?php
+			wp_add_inline_script(
+				'wc-services-sift',
+				'var wcServicesSiftConfig = ' . wp_json_encode( $fraud_config ) . ';',
+				'before'
+			);
+
+			wp_enqueue_script( 'wc-services-sift' );
+		}
+
+		/**
+		 * Schedule a background fetch for Sift configuration.
+		 *
+		 * @return void
+		 */
+		private function schedule_background_sift_fetch() {
+			if ( get_transient( self::SIFT_FETCH_IN_PROGRESS_TRANSIENT_KEY ) ) {
+				return;
+			}
+
+			set_transient( self::SIFT_FETCH_IN_PROGRESS_TRANSIENT_KEY, true, 5 * MINUTE_IN_SECONDS );
+
+			if ( ! wp_next_scheduled( 'wc_connect_fetch_sift_config' ) ) {
+				wp_schedule_single_event( time() + 1, 'wc_connect_fetch_sift_config' );
+			}
+		}
+
+		/**
+		 * Fetch Sift configuration in the background.
+		 *
+		 * @return void
+		 */
+		public function background_fetch_sift_config() {
+			$config = $this->api_client->get_sift_configuration( true );
+			delete_transient( self::SIFT_FETCH_IN_PROGRESS_TRANSIENT_KEY );
 		}
 
 		public function enqueue_wc_connect_script( $root_view, $extra_args = array() ) {


### PR DESCRIPTION
Closes WOOSHIP-601

### Description

- Update `WC_Connect_API_Client::get_sift_configuration()` to add non-blocking mode that returns immediately without making API requests
- Add background fetch via WP-Cron to retrieve Sift configuration asynchronously
- Cache successful responses for 1 month and errors for 5 minutes to prevent API hammering
- Replace inline JavaScript with WordPress script enqueuing API, using defer strategy for non-blocking rendering and browser caching
- Add unit tests for the new caching and non-blocking behavior

This change eliminates the synchronous HTTP request that was blocking admin page loads when Sift configuration wasn't cached. The first page load now returns immediately and schedules a background fetch, while subsequent loads serve from cache with deferred scripts.

Following the WooCommerce Shipping implementation, but also adding a background cache warming, to ensure we keep the performance impact to a minimum.

### Testing instructions
- Ensure you don't have WooCommerce Shipping enabled, because we prevent Sift from loading in that case.
- If you're using the local server, ensure you have a Sift config.
- Open the browser inspector on the network tab.
- Clear Sift transients with `wp transient delete wc_connect_sift_configuration` and reload the orders page.
- The Page should load instantly without blocking, and there shouldn't be any sift request.
- If you don't have cron enabled on the site, trigger it with `wp cron event run --due-now` and reload the page.
- Sift scripts should be fetched and `window._sift` initialized in the browser console.

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

