### PR TITLE
Fix code to pass QIT Security Tests

### DIFF
--- a/classes/class-wc-connect-logger.php
+++ b/classes/class-wc-connect-logger.php
@@ -110,6 +110,7 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 			$log_message = $this->format_message( $message, $context );
 
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore QITStandard.PHP.DebugCode.DebugFunctionFound -- Intended debug logging when WP_DEBUG is enabled.
 				error_log( $log_message );
 			}
 

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -121,7 +121,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 					return self::update_grouped_option( $group, $name, $value );
 				}
 			}
-			wp_trigger_error( 'WC_Connect_Options::get_option', esc_html( sprintf( 'Invalid WooCommerce Tax option name: %s', $name ) ), E_USER_WARNING );
+			wp_trigger_error( 'WC_Connect_Options::update_option', esc_html( sprintf( 'Invalid WooCommerce Tax option name: %s', $name ) ), E_USER_WARNING );
 			return false;
 		}
 

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -100,7 +100,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				}
 			}
 
-			wp_trigger_error( 'WC_Connect_Options::get_option', esc_html( sprintf( 'Invalid WooCommerce Tax option name: %s', $name ), E_USER_WARNING ) );
+			wp_trigger_error( 'WC_Connect_Options::get_option', esc_html( sprintf( 'Invalid WooCommerce Tax option name: %s', $name ) ), E_USER_WARNING );
 			return $default;
 		}
 
@@ -121,7 +121,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 					return self::update_grouped_option( $group, $name, $value );
 				}
 			}
-			wp_trigger_error( 'WC_Connect_Options::get_option', esc_html( sprintf( 'Invalid WooCommerce Tax option name: %s', $name ), E_USER_WARNING ) );
+			wp_trigger_error( 'WC_Connect_Options::get_option', esc_html( sprintf( 'Invalid WooCommerce Tax option name: %s', $name ) ), E_USER_WARNING );
 			return false;
 		}
 
@@ -137,7 +137,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			$result = true;
 			$names  = (array) $names;
 			if ( ! self::is_valid( $names ) ) {
-				wp_trigger_error( 'WC_Connect_Options::delete_option', esc_html( sprintf( 'Invalid WooCommerce Tax option names: %s', print_r( $names, 1 ) ), E_USER_WARNING ) );
+				wp_trigger_error( 'WC_Connect_Options::delete_option', esc_html( sprintf( 'Invalid WooCommerce Tax option names: %s', print_r( $names, 1 ) ) ), E_USER_WARNING );
 				return false;
 			}
 			foreach ( array_intersect( $names, self::get_option_names( 'non_compact' ) ) as $name ) {
@@ -167,7 +167,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			$option_name = self::get_shipping_method_option_name( $name, $service_id, $service_instance );
 
 			if ( ! $option_name ) {
-				wp_trigger_error( 'WC_Connect_Options::get_shipping_method_option', esc_html( sprintf( 'Invalid WooCommerce Tax shipping method option name: %s', $name ), E_USER_WARNING ) );
+				wp_trigger_error( 'WC_Connect_Options::get_shipping_method_option', esc_html( sprintf( 'Invalid WooCommerce Tax shipping method option name: %s', $name ) ), E_USER_WARNING );
 				return $default;
 			}
 
@@ -188,7 +188,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			$option_name = self::get_shipping_method_option_name( $name, $service_id, $service_instance );
 
 			if ( ! $option_name ) {
-				wp_trigger_error( 'WC_Connect_Options::update_shipping_method_option', esc_html( sprintf( 'Invalid WooCommerce Tax shipping method option name: %s', $name ), E_USER_WARNING ) );
+				wp_trigger_error( 'WC_Connect_Options::update_shipping_method_option', esc_html( sprintf( 'Invalid WooCommerce Tax shipping method option name: %s', $name ) ), E_USER_WARNING );
 				return false;
 			}
 
@@ -208,7 +208,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			$option_name = self::get_shipping_method_option_name( $name, $service_id, $service_instance );
 
 			if ( ! $option_name ) {
-				wp_trigger_error( 'WC_Connect_Options::delete_shipping_method_option', esc_html( sprintf( 'Invalid WooCommerce Tax shipping method option name: %s', $name ), E_USER_WARNING ) );
+				wp_trigger_error( 'WC_Connect_Options::delete_shipping_method_option', esc_html( sprintf( 'Invalid WooCommerce Tax shipping method option name: %s', $name ) ), E_USER_WARNING );
 				return false;
 			}
 

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -100,7 +100,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 				}
 			}
 
-			trigger_error( esc_html( sprintf( 'Invalid WooCommerce Tax option name: %s', $name ), E_USER_WARNING ) );
+			wp_trigger_error( 'WC_Connect_Options::get_option', esc_html( sprintf( 'Invalid WooCommerce Tax option name: %s', $name ), E_USER_WARNING ) );
 			return $default;
 		}
 
@@ -121,7 +121,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 					return self::update_grouped_option( $group, $name, $value );
 				}
 			}
-			trigger_error( esc_html( sprintf( 'Invalid WooCommerce Tax option name: %s', $name ), E_USER_WARNING ) );
+			wp_trigger_error( 'WC_Connect_Options::get_option', esc_html( sprintf( 'Invalid WooCommerce Tax option name: %s', $name ), E_USER_WARNING ) );
 			return false;
 		}
 
@@ -137,7 +137,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			$result = true;
 			$names  = (array) $names;
 			if ( ! self::is_valid( $names ) ) {
-				trigger_error( esc_html( sprintf( 'Invalid WooCommerce Tax option names: %s', print_r( $names, 1 ) ), E_USER_WARNING ) );
+				wp_trigger_error( 'WC_Connect_Options::delete_option', esc_html( sprintf( 'Invalid WooCommerce Tax option names: %s', print_r( $names, 1 ) ), E_USER_WARNING ) );
 				return false;
 			}
 			foreach ( array_intersect( $names, self::get_option_names( 'non_compact' ) ) as $name ) {
@@ -167,7 +167,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			$option_name = self::get_shipping_method_option_name( $name, $service_id, $service_instance );
 
 			if ( ! $option_name ) {
-				trigger_error( esc_html( sprintf( 'Invalid WooCommerce Tax shipping method option name: %s', $name ), E_USER_WARNING ) );
+				wp_trigger_error( 'WC_Connect_Options::get_shipping_method_option', esc_html( sprintf( 'Invalid WooCommerce Tax shipping method option name: %s', $name ), E_USER_WARNING ) );
 				return $default;
 			}
 
@@ -188,7 +188,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			$option_name = self::get_shipping_method_option_name( $name, $service_id, $service_instance );
 
 			if ( ! $option_name ) {
-				trigger_error( esc_html( sprintf( 'Invalid WooCommerce Tax shipping method option name: %s', $name ), E_USER_WARNING ) );
+				wp_trigger_error( 'WC_Connect_Options::update_shipping_method_option', esc_html( sprintf( 'Invalid WooCommerce Tax shipping method option name: %s', $name ), E_USER_WARNING ) );
 				return false;
 			}
 
@@ -208,7 +208,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			$option_name = self::get_shipping_method_option_name( $name, $service_id, $service_instance );
 
 			if ( ! $option_name ) {
-				trigger_error( esc_html( sprintf( 'Invalid WooCommerce Tax shipping method option name: %s', $name ), E_USER_WARNING ) );
+				wp_trigger_error( 'WC_Connect_Options::delete_shipping_method_option', esc_html( sprintf( 'Invalid WooCommerce Tax shipping method option name: %s', $name ), E_USER_WARNING ) );
 				return false;
 			}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Addresses:
```
phpcs	woocommerce-services/classes/class-wc-connect-options.php:103	Potential debug code detected: trigger_error(). trigger_error() may indicate debug code (legitimate for deprecation notices)	QITStandard.PHP.DebugCode.DebugFunctionFound
phpcs	woocommerce-services/classes/class-wc-connect-options.php:124	Potential debug code detected: trigger_error(). trigger_error() may indicate debug code (legitimate for deprecation notices)	QITStandard.PHP.DebugCode.DebugFunctionFound
phpcs	woocommerce-services/classes/class-wc-connect-options.php:140	Potential debug code detected: trigger_error(). trigger_error() may indicate debug code (legitimate for deprecation notices)	QITStandard.PHP.DebugCode.DebugFunctionFound
phpcs	woocommerce-services/classes/class-wc-connect-options.php:170	Potential debug code detected: trigger_error(). trigger_error() may indicate debug code (legitimate for deprecation notices)	QITStandard.PHP.DebugCode.DebugFunctionFound
phpcs	woocommerce-services/classes/class-wc-connect-options.php:191	Potential debug code detected: trigger_error(). trigger_error() may indicate debug code (legitimate for deprecation notices)	QITStandard.PHP.DebugCode.DebugFunctionFound
phpcs	woocommerce-services/classes/class-wc-connect-options.php:211	Potential debug code detected: trigger_error(). trigger_error() may indicate debug code (legitimate for deprecation notices)	QITStandard.PHP.DebugCode.DebugFunctionFound
phpcs	woocommerce-services/classes/class-wc-connect-logger.php:113	Potential debug code detected: error_log(). error_log() may indicate leftover debug code (legitimate for production logging)	QITStandard.PHP.DebugCode.DebugFunctionFound
```

### Related issue(s)
Closes https://linear.app/a8c/issue/WOOTAX-253/qit-security-test-are-failing

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

