### PR TITLE
Fixes/WOOTAX-29 - Prevent opted_out tracks event from being sent when user never opted in

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,10 +3,10 @@
 = 3.4.0 - 2026-xx-xx =
 * Add   - Optimize Woo Tax API calls by restricting same-state tax checks.
 * Add   - Country validation for TaxJar requests.
+* Add   - Add woocommerce_tax_line_item_location filter for per-item tax location override.
 * Fix   - Prevent admin slowdown by making Sift configuration non-blocking.
 * Fix   - Prevent opted_out tracks event from being sent when user never opted in.
 * Tweak - WooCommerce 10.5 Compatibility.
-* Add   - Add woocommerce_tax_line_item_location filter for per-item tax location override.
 
 = 3.3.1 - 2026-01-12 =
 * Fix   - Normalize state and country codes to uppercase in TaxJar integration.

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Add   - Optimize Woo Tax API calls by restricting same-state tax checks.
 * Add   - Country validation for TaxJar requests.
 * Fix   - Prevent admin slowdown by making Sift configuration non-blocking.
+* Fix   - Prevent opted_out tracks event from being sent when user never opted in.
 * Tweak - WooCommerce 10.5 Compatibility.
 
 = 3.3.1 - 2026-01-12 =

--- a/classes/class-wc-connect-tracks.php
+++ b/classes/class-wc-connect-tracks.php
@@ -44,7 +44,10 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 		}
 
 		public function opted_out() {
-			$this->record_user_event( 'opted_out' );
+			// Only send opted_out if user has previously opted in
+			if ( WC_Connect_Options::get_option( 'tos_accepted' ) ) {
+				$this->record_user_event( 'opted_out' );
+			}
 		}
 
 		public function shipping_zone_method_added( $instance_id, $service_id ) {

--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,7 @@ This plugin relies on the following external services:
 * Add   - Optimize Woo Tax API calls by restricting same-state tax checks.
 * Add   - Country validation for TaxJar requests.
 * Fix   - Prevent admin slowdown by making Sift configuration non-blocking.
+* Fix   - Prevent opted_out tracks event from being sent when user never opted in.
 * Tweak - WooCommerce 10.5 Compatibility.
 
 = 3.3.1 - 2026-01-12 =

--- a/readme.txt
+++ b/readme.txt
@@ -73,10 +73,10 @@ This plugin relies on the following external services:
 = 3.4.0 - 2026-xx-xx =
 * Add   - Optimize Woo Tax API calls by restricting same-state tax checks.
 * Add   - Country validation for TaxJar requests.
+* Add   - Add woocommerce_tax_line_item_location filter for per-item tax location override.
 * Fix   - Prevent admin slowdown by making Sift configuration non-blocking.
 * Fix   - Prevent opted_out tracks event from being sent when user never opted in.
 * Tweak - WooCommerce 10.5 Compatibility.
-* Add   - Add woocommerce_tax_line_item_location filter for per-item tax location override.
 
 = 3.3.1 - 2026-01-12 =
 * Fix   - Normalize state and country codes to uppercase in TaxJar integration.

--- a/tests/php/test-woocommerce-connect-tracks.php
+++ b/tests/php/test-woocommerce-connect-tracks.php
@@ -7,6 +7,7 @@ class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 	protected $jetpack_tracker;
 
 	public static function set_up_before_class() {
+		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-options.php';
 		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-tracks.php';
 	}
 
@@ -94,6 +95,9 @@ class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 	}
 
 	public function test_opted_out() {
+		// Set tos_accepted to true to simulate user has opted in
+		WC_Connect_Options::update_option( 'tos_accepted', true );
+
 		$this->logger->expects( $this->once() )
 					 ->method( 'log' )
 					->with(
@@ -127,6 +131,25 @@ class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 		);
 
 		// $record will contain the args received by jetpack_tracks_record_event
+		$this->tracks->opted_out();
+
+		// Clean up
+		WC_Connect_Options::delete_option( 'tos_accepted' );
+	}
+
+	public function test_opted_out_without_opt_in() {
+		// Ensure tos_accepted is not set (user never opted in)
+		WC_Connect_Options::delete_option( 'tos_accepted' );
+
+		// Logger should NOT be called since user never opted in
+		$this->logger->expects( $this->never() )
+					 ->method( 'log' );
+
+		// Jetpack tracker should NOT be called
+		$this->jetpack_tracker->expects( $this->never() )
+							   ->method( 'tracks_record_event' );
+
+		// Call opted_out - should not send any event
 		$this->tracks->opted_out();
 	}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

This PR fixes an issue where the `opted_out` tracks event was being sent when the plugin was deactivated, even if the user never opted in (never clicked "Connect" or accepted the Terms of Service).

**The Problem:**
- The `opted_out` method in `WC_Connect_Tracks` was unconditionally registered as a deactivation hook
- When the plugin was deactivated, it always sent the `opted_out` tracks event regardless of whether the user had actually opted in
- This resulted in semantically incorrect tracking data

**The Solution:**
- Added a check in the `opted_out` method to verify if the user has previously accepted the ToS (`tos_accepted` option is set to true)
- The `opted_out` event is now only sent if the user had previously opted in, making the tracking data accurate

### Related issue(s)

Closes [WOOTAX-29](https://linear.app/a8c/issue/WOOTAX-29/opted-out-event-tracked-before-tos-accepted)
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

<!-- Add issue number here if available -->

### Steps to reproduce & screenshots/GIFs
<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

1. Set up a fresh WP install with Jetpack connected
2. Delete all WCS options (to simulate fresh state)
3. Activate WCS plugin
4. Deactivate WCS without clicking "Connect" button
5. The `opted_out` tracks event is NOT sent (correct behavior)

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added
