### PR TITLE
[WOOTAX-250] fix: implement itemized tax calculation for mixed carts services

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.4.1 - 2026-xx-xx =
+* Add   - Itemized tax calculation for mixed carts with per-item tax locations.
+
 = 3.4.0 - 2026-02-03 =
 * Add   - Optimize Woo Tax API calls by restricting same-state tax checks.
 * Add   - Country validation for TaxJar requests.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -902,13 +902,13 @@ class WC_Connect_TaxJar_Integration {
 	 * @return array
 	 */
 	protected function get_backend_address() {
-	// phpcs:disable WordPress.Security.NonceVerification.Missing --- Security handled by WooCommerce
+    // phpcs:disable WordPress.Security.NonceVerification.Missing --- Security handled by WooCommerce
 		$to_country = isset( $_POST['country'] ) ? strtoupper( wc_clean( $_POST['country'] ) ) : false;
 		$to_state   = isset( $_POST['state'] ) ? strtoupper( wc_clean( $_POST['state'] ) ) : false;
 		$to_zip     = isset( $_POST['postcode'] ) ? strtoupper( wc_clean( $_POST['postcode'] ) ) : false;
 		$to_city    = isset( $_POST['city'] ) ? strtoupper( wc_clean( $_POST['city'] ) ) : false;
 		$to_street  = isset( $_POST['street'] ) ? strtoupper( wc_clean( $_POST['street'] ) ) : false;
-	// phpcs:enable WordPress.Security.NonceVerification.Missing
+    // phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		return array(
 			'to_country' => $to_country,
@@ -919,14 +919,14 @@ class WC_Connect_TaxJar_Integration {
 		);
 	}
 
-		/**
-		 * Get line items at checkout
-		 *
-		 * Unchanged from the TaxJar plugin.
-		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L645
-		 *
-		 * @return array
-		 */
+	/**
+	 * Get line items at checkout
+	 *
+	 * Unchanged from the TaxJar plugin.
+	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L645
+	 *
+	 * @return array
+	 */
 	protected function get_line_items( $wc_cart_object ) {
 		$line_items       = array();
 		$default_location = get_option( 'woocommerce_tax_based_on', 'shipping' );
@@ -992,14 +992,14 @@ class WC_Connect_TaxJar_Integration {
 		return $line_items;
 	}
 
-		/**
-		 * Get line items for backend orders
-		 *
-		 * Unchanged from the TaxJar plugin.
-		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L695
-		 *
-		 * @return array
-		 */
+	/**
+	 * Get line items for backend orders
+	 *
+	 * Unchanged from the TaxJar plugin.
+	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L695
+	 *
+	 * @return array
+	 */
 	protected function get_backend_line_items( $order ) {
 		$line_items                = array();
 		$this->backend_tax_classes = array();
@@ -1177,14 +1177,14 @@ class WC_Connect_TaxJar_Integration {
 		return $taxes;
 	}
 
-		/**
-		 * Set customer zip code and state to store if local shipping option set
-		 *
-		 * Unchanged from the TaxJar plugin.
-		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/82bf7c587/includes/class-wc-taxjar-integration.php#L653
-		 *
-		 * @return array
-		 */
+	/**
+	 * Set customer zip code and state to store if local shipping option set
+	 *
+	 * Unchanged from the TaxJar plugin.
+	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/82bf7c587/includes/class-wc-taxjar-integration.php#L653
+	 *
+	 * @return array
+	 */
 	public function append_base_address_to_customer_taxable_address( $address ) {
 		$tax_based_on = '';
 
@@ -1197,7 +1197,7 @@ class WC_Connect_TaxJar_Integration {
 				$tax_based_on = 'base';
 			}
 		} elseif ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( WC()->session->get( 'chosen_shipping_methods', array() ), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
-			$tax_based_on = 'base';
+				$tax_based_on = 'base';
 		}
 
 		if ( 'base' == $tax_based_on ) {
@@ -1214,14 +1214,14 @@ class WC_Connect_TaxJar_Integration {
 		return array( $country, $state, $postcode, $city );
 	}
 
-		/**
-		 * This method is used to override the TaxJar result.
-		 *
-		 * @param object $taxjar_resp_tax TaxJar response object.
-		 * @param array  $body            Body of TaxJar request.
-		 *
-		 * @return object
-		 */
+	/**
+	 * This method is used to override the TaxJar result.
+	 *
+	 * @param object $taxjar_resp_tax TaxJar response object.
+	 * @param array  $body            Body of TaxJar request.
+	 *
+	 * @return object
+	 */
 	public function maybe_override_taxjar_tax( $taxjar_resp_tax, $body ) {
 		if ( ! isset( $taxjar_resp_tax ) ) {
 			return;
@@ -1257,23 +1257,23 @@ class WC_Connect_TaxJar_Integration {
 		return $taxjar_resp_tax;
 	}
 
-		/**
-		 * Maybe apply a temporary workaround for the TaxJar API to get the correct rates for
-		 * specific edge cases.
-		 *
-		 * For these specific edge cases a "nexus_addresses" element needs to be added to the
-		 * TaxJar request body and the "from" address needs to be removed from it in order to
-		 * get the correct rates. This is due to a limitation/miscalculation at the TaxJar API.
-		 *
-		 * This method returns a nexus address to be used as a workaround
-		 * if the workaround is enabled and an address case is matched.
-		 *
-		 * New edge cases can be added to the $cases array as needed.
-		 *
-		 * @param array $body Request body.
-		 *
-		 * @return array
-		 */
+	/**
+	 * Maybe apply a temporary workaround for the TaxJar API to get the correct rates for
+	 * specific edge cases.
+	 *
+	 * For these specific edge cases a "nexus_addresses" element needs to be added to the
+	 * TaxJar request body and the "from" address needs to be removed from it in order to
+	 * get the correct rates. This is due to a limitation/miscalculation at the TaxJar API.
+	 *
+	 * This method returns a nexus address to be used as a workaround
+	 * if the workaround is enabled and an address case is matched.
+	 *
+	 * New edge cases can be added to the $cases array as needed.
+	 *
+	 * @param array $body Request body.
+	 *
+	 * @return array
+	 */
 	private function maybe_apply_taxjar_nexus_addresses_workaround( $body ) {
 		$workaround_nexus_addresses = array();
 		if ( true !== apply_filters( 'woocommerce_apply_taxjar_nexus_addresses_workaround', true ) ) {
@@ -1333,13 +1333,13 @@ class WC_Connect_TaxJar_Integration {
 		return $workaround_nexus_addresses;
 	}
 
-		/**
-		 * Validates TaxJar nexus address.
-		 *
-		 * @param  array $address
-		 *
-		 * @return bool
-		 */
+	/**
+	 * Validates TaxJar nexus address.
+	 *
+	 * @param  array $address
+	 *
+	 * @return bool
+	 */
 	private function is_nexus_address_valid( $address ): bool {
 		$errors = array();
 		$schema = array(
@@ -1439,14 +1439,14 @@ class WC_Connect_TaxJar_Integration {
 		return true;
 	}
 
-		/**
-		 * Calculate sales tax using SmartCalcs
-		 *
-		 * Direct from the TaxJar plugin, without Nexus check.
-		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L247
-		 *
-		 * @return array|boolean
-		 */
+	/**
+	 * Calculate sales tax using SmartCalcs
+	 *
+	 * Direct from the TaxJar plugin, without Nexus check.
+	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L247
+	 *
+	 * @return array|boolean
+	 */
 	public function calculate_tax( $options = array() ) {
 		$this->_log( ':::: TaxJar Plugin requested ::::' );
 
@@ -1615,14 +1615,14 @@ class WC_Connect_TaxJar_Integration {
 		return $taxes;
 	} // End calculate_tax().
 
-		/**
-		 * Return address parts.
-		 * Primarily used in address validation to operate on normalized and predictable indexes.
-		 *
-		 * @param array $body Request body.
-		 *
-		 * @return array
-		 */
+	/**
+	 * Return address parts.
+	 * Primarily used in address validation to operate on normalized and predictable indexes.
+	 *
+	 * @param array $body Request body.
+	 *
+	 * @return array
+	 */
 	private function get_address_parts( $body ) {
 		return array(
 			'from_country' => strtoupper( $body['nexus_addresses'][0]['country'] ?? $body['from_country'] ?? '' ),
@@ -1634,15 +1634,15 @@ class WC_Connect_TaxJar_Integration {
 		);
 	}
 
-		/**
-		 * Get itemized tax rates from TaxJar response.
-		 *
-		 * @param array  $taxes        The tax data array that will be modified and returned.
-		 * @param object $taxjar_taxes TaxJar response object.
-		 * @param array  $options      Cart data used for tax calculation.
-		 *
-		 * @return array
-		 */
+	/**
+	 * Get itemized tax rates from TaxJar response.
+	 *
+	 * @param array  $taxes        The tax data array that will be modified and returned.
+	 * @param object $taxjar_taxes TaxJar response object.
+	 * @param array  $options      Cart data used for tax calculation.
+	 *
+	 * @return array
+	 */
 	private function get_itemized_tax_rates( $taxes, $taxjar_taxes, $options ): array {
 
 		// Normalize options and safely map to local variables.
@@ -1743,18 +1743,18 @@ class WC_Connect_TaxJar_Integration {
 		return $taxes;
 	}
 
-		/**
-		 * Add or update WooCommerce tax rate.
-		 *
-		 * @param  array     $location
-		 * @param  int|float $rate
-		 * @param  string    $tax_class
-		 * @param  int       $freight_taxable
-		 * @param  int       $rate_priority
-		 * @param  string    $tax_rate_name
-		 *
-		 * @return int
-		 */
+	/**
+	 * Add or update WooCommerce tax rate.
+	 *
+	 * @param  array     $location
+	 * @param  int|float $rate
+	 * @param  string    $tax_class
+	 * @param  int       $freight_taxable
+	 * @param  int       $rate_priority
+	 * @param  string    $tax_rate_name
+	 *
+	 * @return int
+	 */
 	public function create_or_update_tax_rate( $location, $rate, $tax_class = '', $freight_taxable = 1, $rate_priority = 1, $tax_rate_name = 'Tax' ) {
 		// Prevent filling "State code" column for countries with VAT tax.
 		// VAT tax is country wide.
@@ -1846,13 +1846,13 @@ class WC_Connect_TaxJar_Integration {
 		return $rate_id;
 	}
 
-		/**
-		 * Validate TaxJar API request json value and add the error to log.
-		 *
-		 * @param $json
-		 *
-		 * @return bool
-		 */
+	/**
+	 * Validate TaxJar API request json value and add the error to log.
+	 *
+	 * @param $json
+	 *
+	 * @return bool
+	 */
 	public function validate_taxjar_request( $json ) {
 		$this->_log( ':::: TaxJar API request validation ::::' );
 
@@ -1910,17 +1910,17 @@ class WC_Connect_TaxJar_Integration {
 		return true;
 	}
 
-		/**
-		 * Wrap SmartCalcs API requests in a transient-based caching layer.
-		 *
-		 * Unchanged from the TaxJar plugin.
-		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L451
-		 *
-		 * @param $json
-		 * @param $from_state
-		 *
-		 * @return mixed|WP_Error
-		 */
+	/**
+	 * Wrap SmartCalcs API requests in a transient-based caching layer.
+	 *
+	 * Unchanged from the TaxJar plugin.
+	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L451
+	 *
+	 * @param $json
+	 * @param $from_state
+	 *
+	 * @return mixed|WP_Error
+	 */
 	public function smartcalcs_cache_request( $json, $from_state ) {
 		$cache_key           = 'tj_tax_' . hash( 'md5', $json );
 		$zip_state_cache_key = false;
@@ -1993,16 +1993,16 @@ class WC_Connect_TaxJar_Integration {
 		return $response;
 	}
 
-		/**
-		 * Make a TaxJar SmartCalcs API request through the WCS proxy.
-		 *
-		 * Modified from TaxJar's plugin.
-		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/82bf7c58/includes/class-wc-taxjar-integration.php#L440
-		 *
-		 * @param $json
-		 *
-		 * @return array|WP_Error
-		 */
+	/**
+	 * Make a TaxJar SmartCalcs API request through the WCS proxy.
+	 *
+	 * Modified from TaxJar's plugin.
+	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/82bf7c58/includes/class-wc-taxjar-integration.php#L440
+	 *
+	 * @param $json
+	 *
+	 * @return array|WP_Error
+	 */
 	public function smartcalcs_request( $json ) {
 		$path = trailingslashit( self::PROXY_PATH ) . 'taxes';
 
@@ -2037,12 +2037,12 @@ class WC_Connect_TaxJar_Integration {
 		}
 	}
 
-		/**
-		 * Exports existing tax rates to a CSV and clears the table.
-		 *
-		 * Ported from TaxJar's plugin.
-		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/42cd4cd0/taxjar-woocommerce.php#L75
-		 */
+	/**
+	 * Exports existing tax rates to a CSV and clears the table.
+	 *
+	 * Ported from TaxJar's plugin.
+	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/42cd4cd0/taxjar-woocommerce.php#L75
+	 */
 	public function backup_existing_tax_rates() {
 
 		// Back up all tax rates to a csv file
@@ -2059,11 +2059,11 @@ class WC_Connect_TaxJar_Integration {
 		$wpdb->query( 'TRUNCATE ' . $wpdb->prefix . 'woocommerce_tax_rate_locations' );
 	}
 
-		/**
-		 * Checks if currently on the WooCommerce order page.
-		 *
-		 * @return boolean
-		 */
+	/**
+	 * Checks if currently on the WooCommerce order page.
+	 *
+	 * @return boolean
+	 */
 	public function on_order_page() {
 		if ( ! function_exists( 'get_current_screen' ) ) {
 			return false;
@@ -2091,9 +2091,9 @@ class WC_Connect_TaxJar_Integration {
 		return $screen->id === $wc_order_screen_id;
 	}
 
-		/**
-		 * Admin New Order Assets
-		 */
+	/**
+	 * Admin New Order Assets
+	 */
 	public function load_taxjar_admin_new_order_assets() {
 		if ( ! $this->on_order_page() ) {
 			return;
@@ -2102,14 +2102,14 @@ class WC_Connect_TaxJar_Integration {
 		wp_enqueue_script( 'wc-taxjar-order', $this->wc_connect_base_url . 'woocommerce-services-new-order-taxjar-' . WC_Connect_Loader::get_wcs_version() . '.js', array( 'jquery' ), null, true );
 	}
 
-		/**
-		 * Check for incorrect California tax nexus in the TaxJar API response or cached response.
-		 *
-		 * @param $response_body
-		 * @param $cached
-		 *
-		 * @return void
-		 */
+	/**
+	 * Check for incorrect California tax nexus in the TaxJar API response or cached response.
+	 *
+	 * @param $response_body
+	 * @param $cached
+	 *
+	 * @return void
+	 */
 	private function check_for_incorrect_california_tax_nexus( $response_body, $cached, $from_state ): void {
 		$log_suffix = 'in TaxJar API response.';
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -260,6 +260,7 @@ class WC_Connect_TaxJar_Integration {
 
 		add_filter( 'woocommerce_calc_tax', array( $this, 'override_woocommerce_tax_rates' ), 10, 3 );
 		add_filter( 'woocommerce_matched_rates', array( $this, 'allow_street_address_for_matched_rates' ), 10, 2 );
+		add_filter( 'woocommerce_cart_totals_get_item_tax_rates', array( $this, 'override_item_tax_rates' ), 10, 3 );
 
 		add_filter( 'woocommerce_rate_label', array( $this, 'cleanup_tax_label' ) );
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -809,22 +809,25 @@ class WC_Connect_TaxJar_Integration {
 		}
 	}
 
-		/**
-		 * Get taxable address.
-		 *
-		 * @return array
-		 */
-	public function get_taxable_address() {
-		$tax_based_on = get_option( 'woocommerce_tax_based_on' );
-		// Check shipping method at this point to see if we need special handling
-		// See WC_Customer get_taxable_address()
-		// wc_get_chosen_shipping_method_ids() available since Woo 2.6.2+
-		if ( function_exists( 'wc_get_chosen_shipping_method_ids' ) ) {
-			if ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
+	/**
+	 * Get taxable address.
+	 *
+	 * @param string|null $location_type Location type: 'base', 'shipping', or 'billing'.
+	 *                                   If null, uses woocommerce_tax_based_on option with
+	 *                                   local pickup override. Null is kept for backward
+	 *                                   compatibility - internal code always passes explicit type.
+	 * @return array
+	 */
+	public function get_taxable_address( $location_type = null ) {
+		if ( null === $location_type ) {
+			// Backward compatibility: external plugins may call without parameter.
+			// Internal code always passes explicit location type.
+			$tax_based_on = get_option( 'woocommerce_tax_based_on' );
+			if ( $this->is_local_pickup() ) {
 				$tax_based_on = 'base';
 			}
-		} elseif ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( WC()->session->get( 'chosen_shipping_methods', array() ), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
-			$tax_based_on = 'base';
+		} else {
+			$tax_based_on = $location_type;
 		}
 
 		if ( 'base' === $tax_based_on ) {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1390,6 +1390,7 @@ class WC_Connect_TaxJar_Integration {
 		$to_street       = $options['to_street'] ?? null;
 		$shipping_amount = $options['shipping_amount'] ?? 0;
 		$line_items      = $options['line_items'] ?? null;
+		$location_type   = $options['location_type'] ?? null;
 
 		$taxes = array(
 			'freight_taxable' => 1,
@@ -1578,10 +1579,11 @@ class WC_Connect_TaxJar_Integration {
 		// Normalize options and safely map to local variables.
 		$options = is_array( $options ) ? $options : array();
 
-		$to_country = isset( $options['to_country'] ) ? strtoupper( $options['to_country'] ) : null;
-		$to_state   = isset( $options['to_state'] ) ? strtoupper( $options['to_state'] ) : null;
-		$to_zip     = $options['to_zip'] ?? null;
-		$to_city    = $options['to_city'] ?? null;
+		$to_country    = isset( $options['to_country'] ) ? strtoupper( $options['to_country'] ) : null;
+		$to_state      = isset( $options['to_state'] ) ? strtoupper( $options['to_state'] ) : null;
+		$to_zip        = $options['to_zip'] ?? null;
+		$to_city       = $options['to_city'] ?? null;
+		$location_type = $options['location_type'] ?? null;
 
 		$store_settings = $this->get_store_settings();
 		$from_country   = strtoupper( $store_settings['country'] );
@@ -1643,7 +1645,7 @@ class WC_Connect_TaxJar_Integration {
 						$tax_class,
 						$taxes['freight_taxable'],
 						$priority,
-						self::generate_itemized_tax_rate_name( $tax_rate_name, $to_country, $jurisdictions )
+						self::generate_itemized_tax_rate_name( $tax_rate_name, $to_country, $jurisdictions, $location_type )
 					);
 
 					++$priority;
@@ -1663,7 +1665,7 @@ class WC_Connect_TaxJar_Integration {
 					'',
 					$taxes['freight_taxable'],
 					$priority,
-					self::generate_itemized_tax_rate_name( $tax_rate_name, $to_country, $jurisdictions )
+					self::generate_itemized_tax_rate_name( $tax_rate_name, $to_country, $jurisdictions, $location_type )
 				);
 
 				++$priority;

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -233,6 +233,7 @@ class WC_Connect_TaxJar_Integration {
 
 		add_filter( 'woocommerce_rate_label', array( $this, 'cleanup_tax_label' ) );
 		add_filter( 'woocommerce_cart_tax_totals', array( $this, 'aggregate_tax_totals' ), 10, 2 );
+		add_filter( 'woocommerce_order_get_tax_totals', array( $this, 'aggregate_tax_totals' ), 10, 2 );
 
 		WC_Connect_Custom_Surcharge::init();
 	}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1885,8 +1885,8 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		if (
-		'US' === $address['to_country'] && 'US' === $address['from_country']
-		&& $address['from_state'] !== $address['to_state']
+			'US' === $address['to_country'] && 'US' === $address['from_country']
+			&& $address['from_state'] !== $address['to_state']
 		) {
 			$this->_error( 'API request is stopped. US from_state !== to_state, tax don\'t apply.' );
 
@@ -1960,12 +1960,12 @@ class WC_Connect_TaxJar_Integration {
 				}
 			}
 			$is_zip_to_state_mismatch = (
-			isset( $body->detail )
-			&& is_string( $body->detail )
-			&& $to_zip
-			&& $to_state
-			&& false !== strpos( $body->detail, 'to_zip ' . $to_zip )
-			&& false !== strpos( $body->detail, 'to_state ' . $to_state )
+				isset( $body->detail )
+				&& is_string( $body->detail )
+				&& $to_zip
+				&& $to_state
+				&& false !== strpos( $body->detail, 'to_zip ' . $to_zip )
+				&& false !== strpos( $body->detail, 'to_state ' . $to_state )
 			);
 			$transient_set            = false;
 
@@ -1973,8 +1973,8 @@ class WC_Connect_TaxJar_Integration {
 				set_transient( $cache_key, $response, $this->cache_time );
 			} elseif ( in_array( $response_code, $save_error_codes ) ) {
 				if ( 400 == $response_code
-				&& $is_zip_to_state_mismatch
-				&& $zip_state_cache_key
+					&& $is_zip_to_state_mismatch
+					&& $zip_state_cache_key
 				) {
 					$transient_set = set_transient( $zip_state_cache_key, $response, $this->address_cache_time );
 				}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1135,6 +1135,82 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	/**
+	 * Re-apply TaxJar-calculated taxes to order items after WooCommerce recalculates them.
+	 *
+	 * When the Store API creates an order from a cart, it calls $order->calculate_taxes()
+	 * which looks up tax rates using the customer's address. For mixed-location carts
+	 * (some items taxed at base, others at customer address), the customer-address lookup
+	 * can zero out taxes for base-taxed items. This hook restores the correct TaxJar rates.
+	 *
+	 * @param WC_Order_Item $item             The order item.
+	 * @param array         $calculate_tax_for Tax calculation arguments.
+	 */
+	public function override_order_item_taxes( $item, $calculate_tax_for ) {
+		// Only act if we have TaxJar-calculated rate IDs from this request.
+		if ( empty( $this->response_rate_ids ) || ! is_array( $this->response_rate_ids ) ) {
+			return;
+		}
+
+		// Only override product line items.
+		if ( ! ( $item instanceof \WC_Order_Item_Product ) ) {
+			return;
+		}
+
+		$product_id = $item->get_product_id();
+		if ( ! $product_id ) {
+			return;
+		}
+
+		// Find matching rate_ids by product_id prefix (format: "product_id-cart_item_key").
+		$matching_rate_ids = null;
+		foreach ( $this->response_rate_ids as $line_item_key => $rate_ids ) {
+			if ( strpos( $line_item_key, $product_id . '-' ) === 0 ) {
+				$matching_rate_ids = $rate_ids;
+				break;
+			}
+		}
+
+		// No match means this item wasn't TaxJar-calculated (e.g. cross-state) — leave as-is.
+		if ( empty( $matching_rate_ids ) || ! is_array( $matching_rate_ids ) ) {
+			return;
+		}
+
+		// Build tax rates array from the stored rate IDs.
+		$tax_rates = array();
+		foreach ( $matching_rate_ids as $rate_id ) {
+			$rate_id = absint( $rate_id );
+			if ( ! $rate_id ) {
+				continue;
+			}
+
+			$rate_data = \WC_Tax::_get_tax_rate( $rate_id );
+			if ( $rate_data ) {
+				$tax_rates[ $rate_id ] = array(
+					'rate'     => (float) $rate_data['tax_rate'],
+					'label'    => $rate_data['tax_rate_name'],
+					'shipping' => 'yes' === $rate_data['tax_rate_shipping'] ? 'yes' : 'no',
+					'compound' => 'yes' === $rate_data['tax_rate_compound'] ? 'yes' : 'no',
+				);
+			}
+		}
+
+		if ( empty( $tax_rates ) ) {
+			return;
+		}
+
+		// Recalculate taxes using TaxJar rates and apply to the item.
+		$taxes          = \WC_Tax::calc_tax( $item->get_total(), $tax_rates, false );
+		$subtotal_taxes = \WC_Tax::calc_tax( $item->get_subtotal(), $tax_rates, false );
+
+		$item->set_taxes(
+			array(
+				'total'    => $taxes,
+				'subtotal' => $subtotal_taxes,
+			)
+		);
+	}
+
+	/**
 	 * Override Woo's native tax rates to handle multiple line items with the same tax rate
 	 * within the same tax class with different rates due to exemption thresholds
 	 *

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1057,6 +1057,71 @@ class WC_Connect_TaxJar_Integration {
 		return null;
 	}
 
+	/**
+	 * Override tax rates for individual cart items.
+	 *
+	 * This filter intercepts WooCommerce's tax rate lookup and returns
+	 * the correct rates for each item based on its tax location (base vs shipping).
+	 * This enables mixed carts where some items are taxed at the store address
+	 * and others at the customer's shipping address.
+	 *
+	 * @param array  $item_tax_rates Tax rates found by WooCommerce's native lookup.
+	 * @param object $item           Cart item object with product, quantity, etc.
+	 * @param object $cart           The WC_Cart object.
+	 * @return array Tax rates to use for this item.
+	 */
+	public function override_item_tax_rates( $item_tax_rates, $item, $cart ) {
+		// Only override if we have calculated rate IDs from TaxJar.
+		if ( empty( $this->response_rate_ids ) || ! is_array( $this->response_rate_ids ) ) {
+			return $item_tax_rates;
+		}
+
+		// Get the product ID and cart item key to build the line_item_key.
+		$product = $item->product ?? null;
+		if ( ! $product ) {
+			return $item_tax_rates;
+		}
+
+		$product_id = $product->get_id();
+
+		// Find the matching line_item_key in response_rate_ids.
+		// Format is "product_id-cart_item_key".
+		$matching_rate_ids = null;
+		foreach ( $this->response_rate_ids as $line_item_key => $rate_ids ) {
+			if ( strpos( $line_item_key, $product_id . '-' ) === 0 ) {
+				$matching_rate_ids = $rate_ids;
+				break;
+			}
+		}
+
+		if ( empty( $matching_rate_ids ) || ! is_array( $matching_rate_ids ) ) {
+			return $item_tax_rates;
+		}
+
+		// Fetch the tax rates from the database using the rate IDs.
+		$tax_rates = array();
+		foreach ( $matching_rate_ids as $rate_id ) {
+			$rate_id = absint( $rate_id );
+			if ( ! $rate_id ) {
+				continue;
+			}
+
+			// Get rate data from WooCommerce.
+			$rate_data = WC_Tax::_get_tax_rate( $rate_id );
+			if ( $rate_data ) {
+				$tax_rates[ $rate_id ] = array(
+					'rate'     => (float) $rate_data['tax_rate'],
+					'label'    => $rate_data['tax_rate_name'],
+					'shipping' => 'yes' === $rate_data['tax_rate_shipping'] ? 'yes' : 'no',
+					'compound' => 'yes' === $rate_data['tax_rate_compound'] ? 'yes' : 'no',
+				);
+			}
+		}
+
+		// Return our rates if we found any, otherwise fall back to WooCommerce's.
+		return ! empty( $tax_rates ) ? $tax_rates : $item_tax_rates;
+	}
+
 		/**
 		 * Override Woo's native tax rates to handle multiple line items with the same tax rate
 		 * within the same tax class with different rates due to exemption thresholds

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -125,15 +125,13 @@ class WC_Connect_TaxJar_Integration {
 	/**
 	 * Generates an itemized tax rate name based on the provided tax rate and country.
 	 *
-	 * @param string      $taxjar_rate_name The tax rate name from TaxJar, typically including '_tax_rate'.
-	 * @param string      $to_country       The destination country for the tax calculation.
-	 * @param array       $jurisdictions    Tax jurisdictions.
-	 * @param string|null $location_type    Location type: 'base', 'shipping', or 'billing'. Used to distinguish
-	 *                                      tax rates for different locations in multi-location tax scenarios.
+	 * @param string $taxjar_rate_name The tax rate name from TaxJar, typically including '_tax_rate'.
+	 * @param string $to_country       The destination country for the tax calculation.
+	 * @param array  $jurisdictions    Tax jurisdictions.
 	 *
 	 * @return string The formatted and localized tax rate name.
 	 */
-	private static function generate_itemized_tax_rate_name( string $taxjar_rate_name, string $to_country, array $jurisdictions, ?string $location_type = null ) {
+	private static function generate_itemized_tax_rate_name( string $taxjar_rate_name, string $to_country, array $jurisdictions ) {
 		// Normalize the base key by stripping the trailing "_tax_rate" and converting underscores to spaces.
 		$base_key   = str_replace( '_tax_rate', '', $taxjar_rate_name );
 		$label_core = ucwords( str_replace( '_', ' ', $base_key ) );
@@ -146,13 +144,13 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		if ( 'country' === $base_key && $is_vat_country ) {
-			return self::append_location_suffix( 'VAT', $location_type );
+			return 'VAT';
 		}
 
 		// Default, country-agnostic formatting for non‑US destinations.
 		if ( 'US' !== $to_country ) {
 			// Preserve previous behavior of uppercasing for non‑US.
-			return self::append_location_suffix( strtoupper( $rate_name ), $location_type );
+			return strtoupper( $rate_name );
 		}
 
 		// United States specific naming enhancements.
@@ -163,51 +161,21 @@ class WC_Connect_TaxJar_Integration {
 			case 'city_tax_rate':
 			case 'special_tax_rate':
 				// Example: "Some County Some City : City Tax".
-				$prefix     = trim( $county . ' ' . $city );
-				$final_name = ( '' !== $prefix ? $prefix . ' : ' : '' ) . $rate_name;
-				return self::append_location_suffix( $final_name, $location_type );
+				$prefix = trim( $county . ' ' . $city );
+				return ( '' !== $prefix ? $prefix . ' : ' : '' ) . $rate_name;
 
 			case 'county_tax_rate':
 				// Example: "Some County : County Tax".
-				$final_name = ( '' !== $county ? $county . ' : ' : '' ) . $rate_name;
-				return self::append_location_suffix( $final_name, $location_type );
+				return ( '' !== $county ? $county . ' : ' : '' ) . $rate_name;
 
 			case 'state_sales_tax_rate':
 				// Example: "State Sales Tax" (no jurisdiction prefix).
-				return self::append_location_suffix( $rate_name, $location_type );
+				return $rate_name;
 
 			default:
 				// Fallback for any other US rate types.
-				return self::append_location_suffix( $rate_name, $location_type );
+				return $rate_name;
 		}
-	}
-
-	/**
-	 * Appends a location suffix to the tax rate name for multi-location tax scenarios.
-	 *
-	 * @param string      $rate_name     The tax rate name.
-	 * @param string|null $location_type Location type: 'base', 'shipping', or 'billing'.
-	 *
-	 * @return string The rate name with location suffix if applicable.
-	 */
-	private static function append_location_suffix( string $rate_name, ?string $location_type ): string {
-		if ( null === $location_type ) {
-			return $rate_name;
-		}
-
-		$location_labels = array(
-			'base'     => __( 'Store Address', 'woocommerce-services' ),
-			'shipping' => __( 'Customer Address', 'woocommerce-services' ),
-			'billing'  => __( 'Billing Address', 'woocommerce-services' ),
-		);
-
-		$suffix = $location_labels[ $location_type ] ?? null;
-
-		if ( null === $suffix ) {
-			return $rate_name;
-		}
-
-		return $rate_name . ' (' . $suffix . ')';
 	}
 
 	public function init() {
@@ -828,7 +796,6 @@ class WC_Connect_TaxJar_Integration {
 					'to_street'       => $address['to_street'],
 					'shipping_amount' => $group_shipping,
 					'line_items'      => $items,
-					'location_type'   => $location_type,
 				)
 			);
 
@@ -1456,7 +1423,6 @@ class WC_Connect_TaxJar_Integration {
 		$to_street       = $options['to_street'] ?? null;
 		$shipping_amount = $options['shipping_amount'] ?? 0;
 		$line_items      = $options['line_items'] ?? null;
-		$location_type   = $options['location_type'] ?? null;
 
 		$taxes = array(
 			'freight_taxable' => 1,
@@ -1645,11 +1611,10 @@ class WC_Connect_TaxJar_Integration {
 		// Normalize options and safely map to local variables.
 		$options = is_array( $options ) ? $options : array();
 
-		$to_country    = isset( $options['to_country'] ) ? strtoupper( $options['to_country'] ) : null;
-		$to_state      = isset( $options['to_state'] ) ? strtoupper( $options['to_state'] ) : null;
-		$to_zip        = $options['to_zip'] ?? null;
-		$to_city       = $options['to_city'] ?? null;
-		$location_type = $options['location_type'] ?? null;
+		$to_country = isset( $options['to_country'] ) ? strtoupper( $options['to_country'] ) : null;
+		$to_state   = isset( $options['to_state'] ) ? strtoupper( $options['to_state'] ) : null;
+		$to_zip     = $options['to_zip'] ?? null;
+		$to_city    = $options['to_city'] ?? null;
 
 		$store_settings = $this->get_store_settings();
 		$from_country   = strtoupper( $store_settings['country'] );
@@ -1711,7 +1676,7 @@ class WC_Connect_TaxJar_Integration {
 						$tax_class,
 						$taxes['freight_taxable'],
 						$priority,
-						self::generate_itemized_tax_rate_name( $tax_rate_name, $to_country, $jurisdictions, $location_type )
+						self::generate_itemized_tax_rate_name( $tax_rate_name, $to_country, $jurisdictions )
 					);
 
 					++$priority;
@@ -1731,7 +1696,7 @@ class WC_Connect_TaxJar_Integration {
 					'',
 					$taxes['freight_taxable'],
 					$priority,
-					self::generate_itemized_tax_rate_name( $tax_rate_name, $to_country, $jurisdictions, $location_type )
+					self::generate_itemized_tax_rate_name( $tax_rate_name, $to_country, $jurisdictions )
 				);
 
 				++$priority;

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -722,6 +722,42 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	/**
+	 * Aggregate tax totals by label.
+	 *
+	 * When items are taxed at different locations (e.g., services at store address,
+	 * products at customer address), this combines taxes with the same label into
+	 * a single line for cleaner display.
+	 *
+	 * Example: Two "County Tax" entries ($0.25 + $0.12) become one "County Tax" ($0.37).
+	 *
+	 * @param array   $tax_totals Array of tax total objects from WooCommerce.
+	 * @param WC_Cart $cart       The cart object.
+	 * @return array Aggregated tax totals.
+	 */
+	public function aggregate_tax_totals( $tax_totals, $cart ) {
+		if ( ! is_array( $tax_totals ) || count( $tax_totals ) <= 1 ) {
+			return $tax_totals;
+		}
+
+		$aggregated = array();
+
+		foreach ( $tax_totals as $code => $tax ) {
+			$label = $tax->label;
+
+			if ( isset( $aggregated[ $label ] ) ) {
+				// Add to existing entry with same label.
+				$aggregated[ $label ]->amount          += $tax->amount;
+				$aggregated[ $label ]->formatted_amount = wc_price( $aggregated[ $label ]->amount );
+			} else {
+				// First entry for this label - clone to avoid modifying original.
+				$aggregated[ $label ] = clone $tax;
+			}
+		}
+
+		return $aggregated;
+	}
+
+	/**
 	 * Check if local pickup shipping method is selected.
 	 *
 	 * @return bool

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -548,8 +548,14 @@ class WC_Connect_TaxJar_Integration {
 			}
 		}
 
-		$line_items = $this->get_line_items( $wc_cart_object );
+		$line_items      = $this->get_line_items( $wc_cart_object );
+		$shipping_amount = method_exists( $wc_cart_object, 'get_shipping_total' )
+			? $wc_cart_object->get_shipping_total()
+			: WC()->shipping->shipping_total;
 
+		// Group items by tax location and calculate taxes.
+		$items_by_location = $this->group_items_by_location( $line_items, $this->is_local_pickup() );
+		$taxes             = $this->calculate_taxes_by_location( $items_by_location, $shipping_amount );
 		// Return if taxes could not be calculated.
 		if ( false === $taxes ) {
 			return;

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -777,68 +777,70 @@ class WC_Connect_TaxJar_Integration {
 				$local_pickup_methods
 			)
 		) > 0;
-		/**
-		 * Group line items by their tax location.
-		 *
-		 * @param array $line_items      Line items with 'tax_location' key.
-		 * @param bool  $is_local_pickup If true, all items grouped under 'base'.
-		 * @return array Items grouped by location type.
-		 */
-		protected function group_items_by_location( $line_items, $is_local_pickup = false ) {
-			$groups           = array();
-			$default_location = get_option( 'woocommerce_tax_based_on', 'shipping' );
+	}
 
-			foreach ( $line_items as $item ) {
-				$location              = $is_local_pickup ? 'base' : ( $item['tax_location'] ?? $default_location );
-				$groups[ $location ][] = $item;
-			}
+	/**
+	 * Group line items by their tax location.
+	 *
+	 * @param array $line_items      Line items with 'tax_location' key.
+	 * @param bool  $is_local_pickup If true, all items grouped under 'base'.
+	 * @return array Items grouped by location type.
+	 */
+	protected function group_items_by_location( $line_items, $is_local_pickup = false ) {
+		$groups           = array();
+		$default_location = get_option( 'woocommerce_tax_based_on', 'shipping' );
 
-			return $groups;
+		foreach ( $line_items as $item ) {
+			$location              = $is_local_pickup ? 'base' : ( $item['tax_location'] ?? $default_location );
+			$groups[ $location ][] = $item;
 		}
 
-		/**
-		 * Calculate taxes for items grouped by location.
-		 *
-		 * @param array $items_by_location Items grouped by location type.
-		 * @param float $shipping_amount   Shipping amount.
-		 * @return array|false Merged taxes or false if any calculation fails.
-		 */
-		protected function calculate_taxes_by_location( $items_by_location, $shipping_amount ) {
-			$merged_taxes = array(
-				'rate_ids'   => array(),
-				'line_items' => array(),
+		return $groups;
+	}
+
+	/**
+	 * Calculate taxes for items grouped by location.
+	 *
+	 * @param array $items_by_location Items grouped by location type.
+	 * @param float $shipping_amount   Shipping amount.
+	 * @return array|false Merged taxes or false if any calculation fails.
+	 */
+	protected function calculate_taxes_by_location( $items_by_location, $shipping_amount ) {
+		$merged_taxes = array(
+			'rate_ids'   => array(),
+			'line_items' => array(),
+		);
+
+		foreach ( $items_by_location as $location_type => $items ) {
+			$address = $this->get_address( $location_type );
+
+			// Shipping only applies to 'shipping' location group.
+			// Note: Service fees could be added to 'base' group here in the future.
+			$group_shipping = ( 'shipping' === $location_type ) ? $shipping_amount : 0;
+
+			$taxes = $this->calculate_tax(
+				array(
+					'to_country'      => $address['to_country'],
+					'to_state'        => $address['to_state'],
+					'to_zip'          => $address['to_zip'],
+					'to_city'         => $address['to_city'],
+					'to_street'       => $address['to_street'],
+					'shipping_amount' => $group_shipping,
+					'line_items'      => $items,
+					'location_type'   => $location_type,
+				)
 			);
 
-			foreach ( $items_by_location as $location_type => $items ) {
-				$address = $this->get_address( $location_type );
-
-				// Shipping only applies to 'shipping' location group.
-				// Note: Service fees could be added to 'base' group here in the future.
-				$group_shipping = ( 'shipping' === $location_type ) ? $shipping_amount : 0;
-
-				$taxes = $this->calculate_tax(
-					array(
-						'to_country'      => $address['to_country'],
-						'to_state'        => $address['to_state'],
-						'to_zip'          => $address['to_zip'],
-						'to_city'         => $address['to_city'],
-						'to_street'       => $address['to_street'],
-						'shipping_amount' => $group_shipping,
-						'line_items'      => $items,
-					)
-				);
-
-				// If any group fails, fail entire calculation.
-				if ( false === $taxes ) {
-					return false;
-				}
-
-				$merged_taxes['rate_ids']   += $taxes['rate_ids'];
-				$merged_taxes['line_items'] += $taxes['line_items'];
+			// If any group fails, fail entire calculation.
+			if ( false === $taxes ) {
+				return false;
 			}
 
-			return $merged_taxes;
+			$merged_taxes['rate_ids']   += $taxes['rate_ids'];
+			$merged_taxes['line_items'] += $taxes['line_items'];
 		}
+
+		return $merged_taxes;
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -548,21 +548,7 @@ class WC_Connect_TaxJar_Integration {
 			}
 		}
 
-		$address    = $this->get_address( $wc_cart_object );
 		$line_items = $this->get_line_items( $wc_cart_object );
-
-		$taxes = $this->calculate_tax(
-			array(
-				'to_country'      => $address['to_country'],
-				'to_zip'          => $address['to_zip'],
-				'to_state'        => $address['to_state'],
-				'to_city'         => $address['to_city'],
-				'to_street'       => $address['to_street'],
-				'shipping_amount' => method_exists( $wc_cart_object, 'get_shipping_total' ) ?
-					$wc_cart_object->get_shipping_total() : WC()->shipping->shipping_total,
-				'line_items'      => $line_items,
-			)
-		);
 
 		// Return if taxes could not be calculated.
 		if ( false === $taxes ) {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1127,21 +1127,21 @@ class WC_Connect_TaxJar_Integration {
 		return ! empty( $tax_rates ) ? $tax_rates : $item_tax_rates;
 	}
 
-		/**
-		 * Override Woo's native tax rates to handle multiple line items with the same tax rate
-		 * within the same tax class with different rates due to exemption thresholds
-		 *
-		 * Unchanged from the TaxJar plugin.
-		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L729
-		 *
-		 * @return array
-		 */
+	/**
+	 * Override Woo's native tax rates to handle multiple line items with the same tax rate
+	 * within the same tax class with different rates due to exemption thresholds
+	 *
+	 * Unchanged from the TaxJar plugin.
+	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L729
+	 *
+	 * @return array
+	 */
 	public function override_woocommerce_tax_rates( $taxes, $price, $rates ) {
 		if (
-		! isset( $this->response_line_items )
-		|| empty( $rates )
-		|| ! is_array( $rates )
-		|| ! is_array( $taxes )
+			! isset( $this->response_line_items )
+			|| empty( $rates )
+			|| ! is_array( $rates )
+			|| ! is_array( $taxes )
 		) {
 			return $taxes;
 		}
@@ -1471,10 +1471,10 @@ class WC_Connect_TaxJar_Integration {
 
 		// Strict conditions to be met before API call can be conducted.
 		if (
-		empty( $to_country ) ||
-		( empty( $to_zip ) && ! in_array( $to_country, WC()->countries->get_vat_countries() ) ) ||
-		( empty( $line_items ) && ( empty( $shipping_amount ) ) ) ||
-		WC()->customer->is_vat_exempt()
+			empty( $to_country ) ||
+			( empty( $to_zip ) && ! in_array( $to_country, WC()->countries->get_vat_countries() ) ) ||
+			( empty( $line_items ) && ( empty( $shipping_amount ) ) ) ||
+			WC()->customer->is_vat_exempt()
 		) {
 			return false;
 		}
@@ -1614,6 +1614,7 @@ class WC_Connect_TaxJar_Integration {
 
 		return $taxes;
 	} // End calculate_tax().
+
 
 	/**
 	 * Return address parts.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -730,6 +730,33 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	/**
+	 * Check if local pickup shipping method is selected.
+	 *
+	 * @return bool
+	 */
+	protected function is_local_pickup() {
+		if ( ! apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) ) {
+			return false;
+		}
+
+		$local_pickup_methods = apply_filters(
+			'woocommerce_local_pickup_methods',
+			array( 'legacy_local_pickup', 'local_pickup' )
+		);
+
+		if ( function_exists( 'wc_get_chosen_shipping_method_ids' ) ) {
+			return count( array_intersect( wc_get_chosen_shipping_method_ids(), $local_pickup_methods ) ) > 0;
+		}
+
+		return count(
+			array_intersect(
+				WC()->session->get( 'chosen_shipping_methods', array() ),
+				$local_pickup_methods
+			)
+		) > 0;
+	}
+
+	/**
 	 * Get taxable address.
 	 *
 	 * @return array

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -657,15 +657,14 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	/**
-	 * Get address details of customer at checkout
+	 * Get formatted address for tax calculation.
 	 *
-	 * Unchanged from the TaxJar plugin.
-	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L585
-	 *
-	 * @return array
+	 * @param string|null $location_type Location type: 'base', 'shipping', or 'billing'.
+	 *                                   If null, uses default behavior from get_taxable_address().
+	 * @return array Address array with to_country, to_state, etc.
 	 */
-	protected function get_address() {
-		$taxable_address = $this->get_taxable_address();
+	protected function get_address( $location_type = null ) {
+		$taxable_address = $this->get_taxable_address( $location_type );
 		$taxable_address = is_array( $taxable_address ) ? $taxable_address : array();
 
 		$to_country = isset( $taxable_address[0] ) && ! empty( $taxable_address[0] ) ? strtoupper( $taxable_address[0] ) : false;

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -988,6 +988,10 @@ class WC_Connect_TaxJar_Integration {
 			 */
 			$tax_location = apply_filters( 'woocommerce_tax_line_item_location', $default_location, $product );
 
+			if ( $tax_location !== $default_location ) {
+				$this->_log( 'Tax location override for product ' . $id . ': ' . $default_location . ' -> ' . $tax_location );
+			}
+
 			array_push(
 				$line_items,
 				array(
@@ -1047,6 +1051,10 @@ class WC_Connect_TaxJar_Integration {
 
 			/** This filter is documented in get_line_items() */
 			$tax_location = apply_filters( 'woocommerce_tax_line_item_location', $default_location, $product );
+
+			if ( $tax_location !== $default_location ) {
+				$this->_log( 'Tax location override for product ' . $id . ': ' . $default_location . ' -> ' . $tax_location );
+			}
 
 			if ( $unit_price ) {
 				array_push(

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -754,198 +754,154 @@ class WC_Connect_TaxJar_Integration {
 				$local_pickup_methods
 			)
 		) > 0;
-	}
+		/**
+		 * Group line items by their tax location.
+		 *
+		 * @param array $line_items      Line items with 'tax_location' key.
+		 * @param bool  $is_local_pickup If true, all items grouped under 'base'.
+		 * @return array Items grouped by location type.
+		 */
+		protected function group_items_by_location( $line_items, $is_local_pickup = false ) {
+			$groups           = array();
+			$default_location = get_option( 'woocommerce_tax_based_on', 'shipping' );
 
-	/**
-	 * Get taxable address.
-	 *
-	 * @return array
-	 */
-	public function get_taxable_address() {
-		$tax_based_on = get_option( 'woocommerce_tax_based_on' );
-		// Check shipping method at this point to see if we need special handling
-		// See WC_Customer get_taxable_address()
-		// wc_get_chosen_shipping_method_ids() available since Woo 2.6.2+
-		if ( function_exists( 'wc_get_chosen_shipping_method_ids' ) ) {
-			if ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
-				$tax_based_on = 'base';
+			foreach ( $line_items as $item ) {
+				$location              = $is_local_pickup ? 'base' : ( $item['tax_location'] ?? $default_location );
+				$groups[ $location ][] = $item;
 			}
-		} elseif ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( WC()->session->get( 'chosen_shipping_methods', array() ), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
-				$tax_based_on = 'base';
+
+			return $groups;
 		}
 
-		if ( 'base' === $tax_based_on ) {
-			$store_settings = $this->get_store_settings();
-			$country        = $store_settings['country'];
-			$state          = $store_settings['state'];
-			$postcode       = $store_settings['postcode'];
-			$city           = $store_settings['city'];
-			$street         = $store_settings['street'];
-		} elseif ( 'billing' === $tax_based_on ) {
-			$country  = WC()->customer->get_billing_country();
-			$state    = WC()->customer->get_billing_state();
-			$postcode = WC()->customer->get_billing_postcode();
-			$city     = WC()->customer->get_billing_city();
-			$street   = WC()->customer->get_billing_address();
-		} else {
-			$country  = WC()->customer->get_shipping_country();
-			$state    = WC()->customer->get_shipping_state();
-			$postcode = WC()->customer->get_shipping_postcode();
-			$city     = WC()->customer->get_shipping_city();
-			$street   = WC()->customer->get_shipping_address();
-		}
-
-		return apply_filters( 'woocommerce_customer_taxable_address', array( $country, $state, $postcode, $city, $street ) );
-	}
-
-	/**
-	 * Get address details of customer for backend orders
-	 *
-	 * Unchanged from the TaxJar plugin.
-	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L607
-	 *
-	 * @return array
-	 */
-	protected function get_backend_address() {
-    // phpcs:disable WordPress.Security.NonceVerification.Missing --- Security handled by WooCommerce
-		$to_country = isset( $_POST['country'] ) ? strtoupper( wc_clean( $_POST['country'] ) ) : false;
-		$to_state   = isset( $_POST['state'] ) ? strtoupper( wc_clean( $_POST['state'] ) ) : false;
-		$to_zip     = isset( $_POST['postcode'] ) ? strtoupper( wc_clean( $_POST['postcode'] ) ) : false;
-		$to_city    = isset( $_POST['city'] ) ? strtoupper( wc_clean( $_POST['city'] ) ) : false;
-		$to_street  = isset( $_POST['street'] ) ? strtoupper( wc_clean( $_POST['street'] ) ) : false;
-    // phpcs:enable WordPress.Security.NonceVerification.Missing
-
-		return array(
-			'to_country' => $to_country,
-			'to_state'   => $to_state,
-			'to_zip'     => $to_zip,
-			'to_city'    => $to_city,
-			'to_street'  => $to_street,
-		);
-	}
-
-	/**
-	 * Get line items at checkout
-	 *
-	 * Unchanged from the TaxJar plugin.
-	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L645
-	 *
-	 * @return array
-	 */
-	protected function get_line_items( $wc_cart_object ) {
-		$line_items       = array();
-		$default_location = get_option( 'woocommerce_tax_based_on', 'shipping' );
-
-		foreach ( $wc_cart_object->get_cart() as $cart_item_key => $cart_item ) {
-			$product       = $cart_item['data'];
-			$id            = $product->get_id();
-			$quantity      = $cart_item['quantity'];
-			$unit_price    = wc_format_decimal( $product->get_price() );
-			$line_subtotal = wc_format_decimal( $cart_item['line_subtotal'] );
-			$discount      = wc_format_decimal( $cart_item['line_subtotal'] - $cart_item['line_total'] );
-			$tax_class     = explode( '-', $product->get_tax_class() );
-			$tax_code      = '';
-
-			if ( isset( $tax_class ) && is_numeric( end( $tax_class ) ) ) {
-				$tax_code = end( $tax_class );
-			}
-
-			if ( 'shipping' !== $product->get_tax_status() && ( ! $product->is_taxable() || 'zero-rate' == sanitize_title( $product->get_tax_class() ) ) ) {
-				$tax_code = '99999';
-			}
-
-			// Get WC Subscription sign-up fees for calculations
-			if ( class_exists( 'WC_Subscriptions_Cart' ) ) {
-				if ( 'none' == WC_Subscriptions_Cart::get_calculation_type() ) {
-					if ( class_exists( 'WC_Subscriptions_Synchroniser' ) ) {
-						WC_Subscriptions_Synchroniser::maybe_set_free_trial();
-					}
-					$unit_price = WC_Subscriptions_Cart::set_subscription_prices_for_calculation( $unit_price, $product );
-					if ( class_exists( 'WC_Subscriptions_Synchroniser' ) ) {
-						WC_Subscriptions_Synchroniser::maybe_unset_free_trial();
-					}
+		/**
+		 * Get taxable address.
+		 *
+		 * @return array
+		 */
+		public function get_taxable_address() {
+			$tax_based_on = get_option( 'woocommerce_tax_based_on' );
+			// Check shipping method at this point to see if we need special handling
+			// See WC_Customer get_taxable_address()
+			// wc_get_chosen_shipping_method_ids() available since Woo 2.6.2+
+			if ( function_exists( 'wc_get_chosen_shipping_method_ids' ) ) {
+				if ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
+					$tax_based_on = 'base';
 				}
+			} elseif ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( WC()->session->get( 'chosen_shipping_methods', array() ), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
+				$tax_based_on = 'base';
 			}
 
-			/**
-			 * Filter the tax location type for a line item.
-			 *
-			 * Allows plugins to specify where a product should be taxed.
-			 * For example, service products (bookings) can be taxed at the shop
-			 * base address instead of the customer's shipping address.
-			 *
-			 * @since 2.8.0
-			 *
-			 * @param string     $location Tax location type: 'base', 'shipping', or 'billing'.
-			 * @param WC_Product $product  The product being taxed.
-			 */
-			$tax_location = apply_filters( 'woocommerce_tax_line_item_location', $default_location, $product );
+			if ( 'base' === $tax_based_on ) {
+				$store_settings = $this->get_store_settings();
+				$country        = $store_settings['country'];
+				$state          = $store_settings['state'];
+				$postcode       = $store_settings['postcode'];
+				$city           = $store_settings['city'];
+				$street         = $store_settings['street'];
+			} elseif ( 'billing' === $tax_based_on ) {
+				$country  = WC()->customer->get_billing_country();
+				$state    = WC()->customer->get_billing_state();
+				$postcode = WC()->customer->get_billing_postcode();
+				$city     = WC()->customer->get_billing_city();
+				$street   = WC()->customer->get_billing_address();
+			} else {
+				$country  = WC()->customer->get_shipping_country();
+				$state    = WC()->customer->get_shipping_state();
+				$postcode = WC()->customer->get_shipping_postcode();
+				$city     = WC()->customer->get_shipping_city();
+				$street   = WC()->customer->get_shipping_address();
+			}
 
-			array_push(
-				$line_items,
-				array(
-					'id'               => $id . '-' . $cart_item_key,
-					'quantity'         => $quantity,
-					'product_tax_code' => $tax_code,
-					'unit_price'       => $unit_price,
-					'discount'         => $discount,
-					'tax_location'     => $tax_location,
-				)
+			return apply_filters( 'woocommerce_customer_taxable_address', array( $country, $state, $postcode, $city, $street ) );
+		}
+
+		/**
+		 * Get address details of customer for backend orders
+		 *
+		 * Unchanged from the TaxJar plugin.
+		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L607
+		 *
+		 * @return array
+		 */
+		protected function get_backend_address() {
+		// phpcs:disable WordPress.Security.NonceVerification.Missing --- Security handled by WooCommerce
+			$to_country = isset( $_POST['country'] ) ? strtoupper( wc_clean( $_POST['country'] ) ) : false;
+			$to_state   = isset( $_POST['state'] ) ? strtoupper( wc_clean( $_POST['state'] ) ) : false;
+			$to_zip     = isset( $_POST['postcode'] ) ? strtoupper( wc_clean( $_POST['postcode'] ) ) : false;
+			$to_city    = isset( $_POST['city'] ) ? strtoupper( wc_clean( $_POST['city'] ) ) : false;
+			$to_street  = isset( $_POST['street'] ) ? strtoupper( wc_clean( $_POST['street'] ) ) : false;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+			return array(
+				'to_country' => $to_country,
+				'to_state'   => $to_state,
+				'to_zip'     => $to_zip,
+				'to_city'    => $to_city,
+				'to_street'  => $to_street,
 			);
 		}
 
-		return $line_items;
-	}
+		/**
+		 * Get line items at checkout
+		 *
+		 * Unchanged from the TaxJar plugin.
+		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L645
+		 *
+		 * @return array
+		 */
+		protected function get_line_items( $wc_cart_object ) {
+			$line_items       = array();
+			$default_location = get_option( 'woocommerce_tax_based_on', 'shipping' );
 
-	/**
-	 * Get line items for backend orders
-	 *
-	 * Unchanged from the TaxJar plugin.
-	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L695
-	 *
-	 * @return array
-	 */
-	protected function get_backend_line_items( $order ) {
-		$line_items                = array();
-		$this->backend_tax_classes = array();
-		$default_location          = get_option( 'woocommerce_tax_based_on', 'shipping' );
+			foreach ( $wc_cart_object->get_cart() as $cart_item_key => $cart_item ) {
+				$product       = $cart_item['data'];
+				$id            = $product->get_id();
+				$quantity      = $cart_item['quantity'];
+				$unit_price    = wc_format_decimal( $product->get_price() );
+				$line_subtotal = wc_format_decimal( $cart_item['line_subtotal'] );
+				$discount      = wc_format_decimal( $cart_item['line_subtotal'] - $cart_item['line_total'] );
+				$tax_class     = explode( '-', $product->get_tax_class() );
+				$tax_code      = '';
 
-		foreach ( $order->get_items() as $item_key => $item ) {
-			if ( is_object( $item ) ) { // Woo 3.0+
-				$id             = $item->get_product_id();
-				$quantity       = $item->get_quantity();
-				$unit_price     = empty( $quantity ) ? $item->get_subtotal() : wc_format_decimal( $item->get_subtotal() / $quantity );
-				$discount       = wc_format_decimal( $item->get_subtotal() - $item->get_total() );
-				$tax_class_name = $item->get_tax_class();
-				$tax_status     = $item->get_tax_status();
-				$product        = $item->get_product();
-			} else { // Woo 2.6
-				$id             = $item['product_id'];
-				$quantity       = $item['qty'];
-				$unit_price     = empty( $quantity ) ? $item['line_subtotal'] : wc_format_decimal( $item['line_subtotal'] / $quantity );
-				$discount       = wc_format_decimal( $item['line_subtotal'] - $item['line_total'] );
-				$tax_class_name = $item['tax_class'];
-				$product        = $order->get_product_from_item( $item );
-				$tax_status     = $product ? $product->get_tax_status() : 'taxable';
-			}
-			$this->backend_tax_classes[ $id ] = $tax_class_name;
-			$tax_class                        = explode( '-', $tax_class_name );
-			$tax_code                         = '';
-			if ( isset( $tax_class[1] ) && is_numeric( $tax_class[1] ) ) {
-				$tax_code = $tax_class[1];
-			}
-			if ( 'taxable' !== $tax_status ) {
-				$tax_code = '99999';
-			}
+				if ( isset( $tax_class ) && is_numeric( end( $tax_class ) ) ) {
+					$tax_code = end( $tax_class );
+				}
 
-			/** This filter is documented in get_line_items() */
-			$tax_location = apply_filters( 'woocommerce_tax_line_item_location', $default_location, $product );
+				if ( 'shipping' !== $product->get_tax_status() && ( ! $product->is_taxable() || 'zero-rate' == sanitize_title( $product->get_tax_class() ) ) ) {
+					$tax_code = '99999';
+				}
 
-			if ( $unit_price ) {
+				// Get WC Subscription sign-up fees for calculations
+				if ( class_exists( 'WC_Subscriptions_Cart' ) ) {
+					if ( 'none' == WC_Subscriptions_Cart::get_calculation_type() ) {
+						if ( class_exists( 'WC_Subscriptions_Synchroniser' ) ) {
+							WC_Subscriptions_Synchroniser::maybe_set_free_trial();
+						}
+						$unit_price = WC_Subscriptions_Cart::set_subscription_prices_for_calculation( $unit_price, $product );
+						if ( class_exists( 'WC_Subscriptions_Synchroniser' ) ) {
+							WC_Subscriptions_Synchroniser::maybe_unset_free_trial();
+						}
+					}
+				}
+
+				/**
+				 * Filter the tax location type for a line item.
+				 *
+				 * Allows plugins to specify where a product should be taxed.
+				 * For example, service products (bookings) can be taxed at the shop
+				 * base address instead of the customer's shipping address.
+				 *
+				 * @since 2.8.0
+				 *
+				 * @param string     $location Tax location type: 'base', 'shipping', or 'billing'.
+				 * @param WC_Product $product  The product being taxed.
+				 */
+				$tax_location = apply_filters( 'woocommerce_tax_line_item_location', $default_location, $product );
+
 				array_push(
 					$line_items,
 					array(
-						'id'               => $id . '-' . $item_key,
+						'id'               => $id . '-' . $cart_item_key,
 						'quantity'         => $quantity,
 						'product_tax_code' => $tax_code,
 						'unit_price'       => $unit_price,
@@ -954,604 +910,684 @@ class WC_Connect_TaxJar_Integration {
 					)
 				);
 			}
-		}
-		return $line_items;
-	}
 
-	protected function get_line_item( $id, $line_items ) {
-		foreach ( $line_items as $line_item ) {
-			if ( $line_item['id'] === $id ) {
-				return $line_item;
+			return $line_items;
+		}
+
+		/**
+		 * Get line items for backend orders
+		 *
+		 * Unchanged from the TaxJar plugin.
+		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L695
+		 *
+		 * @return array
+		 */
+		protected function get_backend_line_items( $order ) {
+			$line_items                = array();
+			$this->backend_tax_classes = array();
+			$default_location          = get_option( 'woocommerce_tax_based_on', 'shipping' );
+
+			foreach ( $order->get_items() as $item_key => $item ) {
+				if ( is_object( $item ) ) { // Woo 3.0+
+					$id             = $item->get_product_id();
+					$quantity       = $item->get_quantity();
+					$unit_price     = empty( $quantity ) ? $item->get_subtotal() : wc_format_decimal( $item->get_subtotal() / $quantity );
+					$discount       = wc_format_decimal( $item->get_subtotal() - $item->get_total() );
+					$tax_class_name = $item->get_tax_class();
+					$tax_status     = $item->get_tax_status();
+					$product        = $item->get_product();
+				} else { // Woo 2.6
+					$id             = $item['product_id'];
+					$quantity       = $item['qty'];
+					$unit_price     = empty( $quantity ) ? $item['line_subtotal'] : wc_format_decimal( $item['line_subtotal'] / $quantity );
+					$discount       = wc_format_decimal( $item['line_subtotal'] - $item['line_total'] );
+					$tax_class_name = $item['tax_class'];
+					$product        = $order->get_product_from_item( $item );
+					$tax_status     = $product ? $product->get_tax_status() : 'taxable';
+				}
+				$this->backend_tax_classes[ $id ] = $tax_class_name;
+				$tax_class                        = explode( '-', $tax_class_name );
+				$tax_code                         = '';
+				if ( isset( $tax_class[1] ) && is_numeric( $tax_class[1] ) ) {
+					$tax_code = $tax_class[1];
+				}
+				if ( 'taxable' !== $tax_status ) {
+					$tax_code = '99999';
+				}
+
+				/** This filter is documented in get_line_items() */
+				$tax_location = apply_filters( 'woocommerce_tax_line_item_location', $default_location, $product );
+
+				if ( $unit_price ) {
+					array_push(
+						$line_items,
+						array(
+							'id'               => $id . '-' . $item_key,
+							'quantity'         => $quantity,
+							'product_tax_code' => $tax_code,
+							'unit_price'       => $unit_price,
+							'discount'         => $discount,
+							'tax_location'     => $tax_location,
+						)
+					);
+				}
 			}
+			return $line_items;
 		}
-		return null;
-	}
 
-	/**
-	 * Override Woo's native tax rates to handle multiple line items with the same tax rate
-	 * within the same tax class with different rates due to exemption thresholds
-	 *
-	 * Unchanged from the TaxJar plugin.
-	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L729
-	 *
-	 * @return array
-	 */
-	public function override_woocommerce_tax_rates( $taxes, $price, $rates ) {
-		if (
+		protected function get_line_item( $id, $line_items ) {
+			foreach ( $line_items as $line_item ) {
+				if ( $line_item['id'] === $id ) {
+					return $line_item;
+				}
+			}
+			return null;
+		}
+
+		/**
+		 * Override Woo's native tax rates to handle multiple line items with the same tax rate
+		 * within the same tax class with different rates due to exemption thresholds
+		 *
+		 * Unchanged from the TaxJar plugin.
+		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L729
+		 *
+		 * @return array
+		 */
+		public function override_woocommerce_tax_rates( $taxes, $price, $rates ) {
+			if (
 			! isset( $this->response_line_items )
 			|| empty( $rates )
 			|| ! is_array( $rates )
 			|| ! is_array( $taxes )
-		) {
+			) {
 				return $taxes;
-		}
-
-		// Get tax rate ID for current item
-		$keys        = array_keys( $taxes );
-		$tax_rate_id = $keys[0];
-		$line_items  = array();
-
-		// Map line items using rate ID
-		foreach ( $this->response_rate_ids as $line_item_key => $rate_id ) {
-			if ( $rate_id == $tax_rate_id ) {
-				$line_items[] = $line_item_key;
 			}
-		}
 
-		// Remove number precision if Woo 3.2+
-		if ( function_exists( 'wc_remove_number_precision' ) ) {
-			$price = wc_remove_number_precision( $price );
-		}
+			// Get tax rate ID for current item
+			$keys        = array_keys( $taxes );
+			$tax_rate_id = $keys[0];
+			$line_items  = array();
 
-		foreach ( $this->response_line_items as $line_item_key => $line_item ) {
-			// If line item belongs to rate and matches the price, manually set the tax
-			if ( in_array( $line_item_key, $line_items ) && $price == $line_item->line_total ) {
-				if ( function_exists( 'wc_add_number_precision' ) ) {
-					$taxes[ $tax_rate_id ] = wc_add_number_precision( $line_item->tax_collectable );
-				} else {
-					$taxes[ $tax_rate_id ] = $line_item->tax_collectable;
+			// Map line items using rate ID
+			foreach ( $this->response_rate_ids as $line_item_key => $rate_id ) {
+				if ( $rate_id == $tax_rate_id ) {
+					$line_items[] = $line_item_key;
 				}
 			}
+
+			// Remove number precision if Woo 3.2+
+			if ( function_exists( 'wc_remove_number_precision' ) ) {
+				$price = wc_remove_number_precision( $price );
+			}
+
+			foreach ( $this->response_line_items as $line_item_key => $line_item ) {
+				// If line item belongs to rate and matches the price, manually set the tax
+				if ( in_array( $line_item_key, $line_items ) && $price == $line_item->line_total ) {
+					if ( function_exists( 'wc_add_number_precision' ) ) {
+						$taxes[ $tax_rate_id ] = wc_add_number_precision( $line_item->tax_collectable );
+					} else {
+						$taxes[ $tax_rate_id ] = $line_item->tax_collectable;
+					}
+				}
+			}
+
+			return $taxes;
 		}
 
-		return $taxes;
-	}
+		/**
+		 * Set customer zip code and state to store if local shipping option set
+		 *
+		 * Unchanged from the TaxJar plugin.
+		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/82bf7c587/includes/class-wc-taxjar-integration.php#L653
+		 *
+		 * @return array
+		 */
+		public function append_base_address_to_customer_taxable_address( $address ) {
+			$tax_based_on = '';
 
-	/**
-	 * Set customer zip code and state to store if local shipping option set
-	 *
-	 * Unchanged from the TaxJar plugin.
-	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/82bf7c587/includes/class-wc-taxjar-integration.php#L653
-	 *
-	 * @return array
-	 */
-	public function append_base_address_to_customer_taxable_address( $address ) {
-		$tax_based_on = '';
+			list( $country, $state, $postcode, $city, $street ) = array_pad( $address, 5, '' );
 
-		list( $country, $state, $postcode, $city, $street ) = array_pad( $address, 5, '' );
-
-		// See WC_Customer get_taxable_address()
-		// wc_get_chosen_shipping_method_ids() available since Woo 2.6.2+
-		if ( function_exists( 'wc_get_chosen_shipping_method_ids' ) ) {
-			if ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
+			// See WC_Customer get_taxable_address()
+			// wc_get_chosen_shipping_method_ids() available since Woo 2.6.2+
+			if ( function_exists( 'wc_get_chosen_shipping_method_ids' ) ) {
+				if ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
+					$tax_based_on = 'base';
+				}
+			} elseif ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( WC()->session->get( 'chosen_shipping_methods', array() ), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
 				$tax_based_on = 'base';
 			}
-		} elseif ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( WC()->session->get( 'chosen_shipping_methods', array() ), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
-				$tax_based_on = 'base';
+
+			if ( 'base' == $tax_based_on ) {
+				$store_settings = $this->get_store_settings();
+				$postcode       = $store_settings['postcode'];
+				$city           = strtoupper( $store_settings['city'] );
+				$street         = $store_settings['street'];
+			}
+
+			if ( '' != $street ) {
+				return array( $country, $state, $postcode, $city, $street );
+			}
+
+			return array( $country, $state, $postcode, $city );
 		}
 
-		if ( 'base' == $tax_based_on ) {
-			$store_settings = $this->get_store_settings();
-			$postcode       = $store_settings['postcode'];
-			$city           = strtoupper( $store_settings['city'] );
-			$street         = $store_settings['street'];
-		}
+		/**
+		 * This method is used to override the TaxJar result.
+		 *
+		 * @param object $taxjar_resp_tax TaxJar response object.
+		 * @param array  $body            Body of TaxJar request.
+		 *
+		 * @return object
+		 */
+		public function maybe_override_taxjar_tax( $taxjar_resp_tax, $body ) {
+			if ( ! isset( $taxjar_resp_tax ) ) {
+				return;
+			}
 
-		if ( '' != $street ) {
-			return array( $country, $state, $postcode, $city, $street );
-		}
+			$new_tax_rate = floatval( apply_filters( 'woocommerce_services_override_tax_rate', $taxjar_resp_tax->rate, $taxjar_resp_tax, $body ) );
 
-		return array( $country, $state, $postcode, $city );
-	}
+			if ( $new_tax_rate === floatval( $taxjar_resp_tax->rate ) ) {
+				return $taxjar_resp_tax;
+			}
 
-	/**
-	 * This method is used to override the TaxJar result.
-	 *
-	 * @param object $taxjar_resp_tax TaxJar response object.
-	 * @param array  $body            Body of TaxJar request.
-	 *
-	 * @return object
-	 */
-	public function maybe_override_taxjar_tax( $taxjar_resp_tax, $body ) {
-		if ( ! isset( $taxjar_resp_tax ) ) {
-			return;
-		}
+			if ( ! empty( $taxjar_resp_tax->breakdown->line_items ) ) {
+				$taxjar_resp_tax->breakdown->line_items = array_map(
+					function ( $line_item ) use ( $new_tax_rate ) {
+						$line_item->combined_tax_rate       = $new_tax_rate;
+						$line_item->country_tax_rate        = $new_tax_rate;
+						$line_item->country_tax_collectable = $line_item->country_taxable_amount * $new_tax_rate;
+						$line_item->tax_collectable         = $line_item->taxable_amount * $new_tax_rate;
 
-		$new_tax_rate = floatval( apply_filters( 'woocommerce_services_override_tax_rate', $taxjar_resp_tax->rate, $taxjar_resp_tax, $body ) );
+						return $line_item;
+					},
+					$taxjar_resp_tax->breakdown->line_items
+				);
+			}
 
-		if ( $new_tax_rate === floatval( $taxjar_resp_tax->rate ) ) {
+			$taxjar_resp_tax->breakdown->combined_tax_rate           = $new_tax_rate;
+			$taxjar_resp_tax->breakdown->country_tax_rate            = $new_tax_rate;
+			$taxjar_resp_tax->breakdown->shipping->combined_tax_rate = $new_tax_rate;
+			$taxjar_resp_tax->breakdown->shipping->country_tax_rate  = $new_tax_rate;
+
+			$taxjar_resp_tax->rate = $new_tax_rate;
+
 			return $taxjar_resp_tax;
 		}
 
-		if ( ! empty( $taxjar_resp_tax->breakdown->line_items ) ) {
-			$taxjar_resp_tax->breakdown->line_items = array_map(
-				function ( $line_item ) use ( $new_tax_rate ) {
-					$line_item->combined_tax_rate       = $new_tax_rate;
-					$line_item->country_tax_rate        = $new_tax_rate;
-					$line_item->country_tax_collectable = $line_item->country_taxable_amount * $new_tax_rate;
-					$line_item->tax_collectable         = $line_item->taxable_amount * $new_tax_rate;
+		/**
+		 * Maybe apply a temporary workaround for the TaxJar API to get the correct rates for
+		 * specific edge cases.
+		 *
+		 * For these specific edge cases a "nexus_addresses" element needs to be added to the
+		 * TaxJar request body and the "from" address needs to be removed from it in order to
+		 * get the correct rates. This is due to a limitation/miscalculation at the TaxJar API.
+		 *
+		 * This method returns a nexus address to be used as a workaround
+		 * if the workaround is enabled and an address case is matched.
+		 *
+		 * New edge cases can be added to the $cases array as needed.
+		 *
+		 * @param array $body Request body.
+		 *
+		 * @return array
+		 */
+		private function maybe_apply_taxjar_nexus_addresses_workaround( $body ) {
+			$workaround_nexus_addresses = array();
+			if ( true !== apply_filters( 'woocommerce_apply_taxjar_nexus_addresses_workaround', true ) ) {
+				return $workaround_nexus_addresses;
+			}
 
-					return $line_item;
-				},
-				$taxjar_resp_tax->breakdown->line_items
+			$cases = array(
+				'CA-QC' => array(
+					'to_country'   => 'CA',
+					'to_state'     => 'QC',
+					'from_country' => 'CA',
+				),
+				'US-CO' => array(
+					'to_country'   => 'US',
+					'to_state'     => 'CO',
+					'from_country' => 'US',
+					'from_state'   => 'CO',
+				),
+				'US-AZ' => array(
+					'to_country'   => 'US',
+					'to_state'     => 'AZ',
+					'from_country' => 'US',
+					'from_state'   => 'AZ',
+				),
+				'US-OH' => array(
+					'to_country'   => 'US',
+					'to_state'     => 'OH',
+					'from_country' => 'US',
+					'from_state'   => 'OH',
+				),
 			);
-		}
 
-		$taxjar_resp_tax->breakdown->combined_tax_rate           = $new_tax_rate;
-		$taxjar_resp_tax->breakdown->country_tax_rate            = $new_tax_rate;
-		$taxjar_resp_tax->breakdown->shipping->combined_tax_rate = $new_tax_rate;
-		$taxjar_resp_tax->breakdown->shipping->country_tax_rate  = $new_tax_rate;
+			foreach ( $cases as $case ) {
 
-		$taxjar_resp_tax->rate = $new_tax_rate;
+				/**
+				 * Ensure the body has all the required address keys, and that the body address
+				 * values match the case address values before applying the workaround.
+				 */
+				$address_keys = array_keys( $case );
+				foreach ( $address_keys as $address_key ) {
+					if ( ! isset( $body[ $address_key ] ) || $body[ $address_key ] !== $case[ $address_key ] ) {
+						continue 2;
+					}
+				}
 
-		return $taxjar_resp_tax;
-	}
+				$workaround_nexus_addresses = array(
+					'country' => $body['to_country'],
+					'zip'     => $body['to_zip'],
+					'state'   => $body['to_state'],
+					'city'    => $body['to_city'],
+					'street'  => $body['to_street'],
+				);
 
-	/**
-	 * Maybe apply a temporary workaround for the TaxJar API to get the correct rates for
-	 * specific edge cases.
-	 *
-	 * For these specific edge cases a "nexus_addresses" element needs to be added to the
-	 * TaxJar request body and the "from" address needs to be removed from it in order to
-	 * get the correct rates. This is due to a limitation/miscalculation at the TaxJar API.
-	 *
-	 * This method returns a nexus address to be used as a workaround
-	 * if the workaround is enabled and an address case is matched.
-	 *
-	 * New edge cases can be added to the $cases array as needed.
-	 *
-	 * @param array $body Request body.
-	 *
-	 * @return array
-	 */
-	private function maybe_apply_taxjar_nexus_addresses_workaround( $body ) {
-		$workaround_nexus_addresses = array();
-		if ( true !== apply_filters( 'woocommerce_apply_taxjar_nexus_addresses_workaround', true ) ) {
+				break;
+			}
+
 			return $workaround_nexus_addresses;
 		}
 
-		$cases = array(
-			'CA-QC' => array(
-				'to_country'   => 'CA',
-				'to_state'     => 'QC',
-				'from_country' => 'CA',
-			),
-			'US-CO' => array(
-				'to_country'   => 'US',
-				'to_state'     => 'CO',
-				'from_country' => 'US',
-				'from_state'   => 'CO',
-			),
-			'US-AZ' => array(
-				'to_country'   => 'US',
-				'to_state'     => 'AZ',
-				'from_country' => 'US',
-				'from_state'   => 'AZ',
-			),
-			'US-OH' => array(
-				'to_country'   => 'US',
-				'to_state'     => 'OH',
-				'from_country' => 'US',
-				'from_state'   => 'OH',
-			),
-		);
-
-		foreach ( $cases as $case ) {
-
-			/**
-			 * Ensure the body has all the required address keys, and that the body address
-			 * values match the case address values before applying the workaround.
-			 */
-			$address_keys = array_keys( $case );
-			foreach ( $address_keys as $address_key ) {
-				if ( ! isset( $body[ $address_key ] ) || $body[ $address_key ] !== $case[ $address_key ] ) {
-					continue 2;
-				}
-			}
-
-			$workaround_nexus_addresses = array(
-				'country' => $body['to_country'],
-				'zip'     => $body['to_zip'],
-				'state'   => $body['to_state'],
-				'city'    => $body['to_city'],
-				'street'  => $body['to_street'],
+		/**
+		 * Validates TaxJar nexus address.
+		 *
+		 * @param  array $address
+		 *
+		 * @return bool
+		 */
+		private function is_nexus_address_valid( $address ): bool {
+			$errors = array();
+			$schema = array(
+				'id'      => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Unique identifier for the nexus address (optional).',
+					'max_length'  => 255,
+				),
+				'country' => array(
+					'type'        => 'string',
+					'required'    => true,
+					'pattern'     => '/^[A-Z]{2}$/', // two-letter ISO alpha-2 (upper-case)
+					'description' => 'Two-letter ISO country code (e.g. "US").',
+					'max_length'  => 2,
+				),
+				'zip'     => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Postal code (format varies by country).',
+					'max_length'  => 20,
+				),
+				'state'   => array(
+					'type'        => 'string',
+					'required'    => true,
+					'pattern'     => '/^[A-Z0-9\-]{1,100}$/', // typical short code like "NY", "CA", "NSW"
+					'description' => 'Two-letter (or short) ISO state/province code where applicable.',
+					'max_length'  => 100,
+				),
+				'city'    => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'City name.',
+					'max_length'  => 100,
+				),
+				'street'  => array(
+					'type'        => 'string',
+					'required'    => false,
+					'description' => 'Street address (line).',
+					'max_length'  => 255,
+				),
 			);
 
-			break;
-		}
-
-		return $workaround_nexus_addresses;
-	}
-
-	/**
-	 * Validates TaxJar nexus address.
-	 *
-	 * @param  array $address
-	 *
-	 * @return bool
-	 */
-	private function is_nexus_address_valid( $address ): bool {
-		$errors = array();
-		$schema = array(
-			'id'      => array(
-				'type'        => 'string',
-				'required'    => false,
-				'description' => 'Unique identifier for the nexus address (optional).',
-				'max_length'  => 255,
-			),
-			'country' => array(
-				'type'        => 'string',
-				'required'    => true,
-				'pattern'     => '/^[A-Z]{2}$/', // two-letter ISO alpha-2 (upper-case)
-				'description' => 'Two-letter ISO country code (e.g. "US").',
-				'max_length'  => 2,
-			),
-			'zip'     => array(
-				'type'        => 'string',
-				'required'    => false,
-				'description' => 'Postal code (format varies by country).',
-				'max_length'  => 20,
-			),
-			'state'   => array(
-				'type'        => 'string',
-				'required'    => true,
-				'pattern'     => '/^[A-Z0-9\-]{1,100}$/', // typical short code like "NY", "CA", "NSW"
-				'description' => 'Two-letter (or short) ISO state/province code where applicable.',
-				'max_length'  => 100,
-			),
-			'city'    => array(
-				'type'        => 'string',
-				'required'    => false,
-				'description' => 'City name.',
-				'max_length'  => 100,
-			),
-			'street'  => array(
-				'type'        => 'string',
-				'required'    => false,
-				'description' => 'Street address (line).',
-				'max_length'  => 255,
-			),
-		);
-
-		/**
-		 * Return without logging as empty array() or false
-		 * might be return on purpose from filter to remove nexus address.
-		 */
-		if ( empty( $address ) ) {
-			return false;
-		}
-
-		if ( ! is_array( $address ) ) {
-			$this->logger->error( 'Nexus Address ERRORS: Nexus addresses has invalid format' . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . print_r( $address, true ), 'WCS Tax' );
-
-			return false;
-		}
-
-		foreach ( $schema as $field => $rules ) {
-			$exists = array_key_exists( $field, $address );
-			$value  = $exists ? $address[ $field ] : null;
-
-			if ( ! empty( $rules['required'] ) && ! $exists ) {
-				$errors[] = "[$field] field is required";
-				continue;
+			/**
+			 * Return without logging as empty array() or false
+			 * might be return on purpose from filter to remove nexus address.
+			 */
+			if ( empty( $address ) ) {
+				return false;
 			}
 
-			if ( ! $exists || $value === '' || $value === null ) {
-				continue;
+			if ( ! is_array( $address ) ) {
+				$this->logger->error( 'Nexus Address ERRORS: Nexus addresses has invalid format' . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . print_r( $address, true ), 'WCS Tax' );
+
+				return false;
 			}
 
-			if ( isset( $rules['type'] ) ) {
-				if ( $rules['type'] === 'string' && ! is_string( $value ) ) {
-					$errors[] = "[$field] field must be a string";
+			foreach ( $schema as $field => $rules ) {
+				$exists = array_key_exists( $field, $address );
+				$value  = $exists ? $address[ $field ] : null;
+
+				if ( ! empty( $rules['required'] ) && ! $exists ) {
+					$errors[] = "[$field] field is required";
 					continue;
 				}
-			}
 
-			if ( isset( $rules['max_length'] ) && is_string( $value ) ) {
-				if ( strlen( $value ) > $rules['max_length'] ) {
-					$errors[] = "[$field] field exceeds maximum length of {$rules['max_length']}";
+				if ( ! $exists || $value === '' || $value === null ) {
+					continue;
+				}
+
+				if ( isset( $rules['type'] ) ) {
+					if ( $rules['type'] === 'string' && ! is_string( $value ) ) {
+						$errors[] = "[$field] field must be a string";
+						continue;
+					}
+				}
+
+				if ( isset( $rules['max_length'] ) && is_string( $value ) ) {
+					if ( strlen( $value ) > $rules['max_length'] ) {
+						$errors[] = "[$field] field exceeds maximum length of {$rules['max_length']}";
+					}
+				}
+
+				if ( isset( $rules['pattern'] ) && is_string( $value ) ) {
+					if ( ! preg_match( $rules['pattern'], $value ) ) {
+						$errors[] = "[$field] field format is invalid";
+					}
 				}
 			}
 
-			if ( isset( $rules['pattern'] ) && is_string( $value ) ) {
-				if ( ! preg_match( $rules['pattern'], $value ) ) {
-					$errors[] = "[$field] field format is invalid";
-				}
+			if ( ! empty( $errors ) ) {
+				$this->logger->error( 'Nexus Address ERRORS: ' . implode( ', ', $errors ) . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . print_r( $address, true ), 'WCS Tax' );
+
+				return false;
 			}
+
+			return true;
 		}
 
-		if ( ! empty( $errors ) ) {
-			$this->logger->error( 'Nexus Address ERRORS: ' . implode( ', ', $errors ) . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . print_r( $address, true ), 'WCS Tax' );
+		/**
+		 * Calculate sales tax using SmartCalcs
+		 *
+		 * Direct from the TaxJar plugin, without Nexus check.
+		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L247
+		 *
+		 * @return array|boolean
+		 */
+		public function calculate_tax( $options = array() ) {
+			$this->_log( ':::: TaxJar Plugin requested ::::' );
 
-			return false;
-		}
+			// Normalize options to an array and safely map to local variables.
+			$options = is_array( $options ) ? $options : array();
 
-		return true;
-	}
+			$to_country      = isset( $options['to_country'] ) ? strtoupper( $options['to_country'] ) : null;
+			$to_state        = isset( $options['to_state'] ) ? strtoupper( $options['to_state'] ) : null;
+			$to_zip          = $options['to_zip'] ?? null;
+			$to_city         = $options['to_city'] ?? null;
+			$to_street       = $options['to_street'] ?? null;
+			$shipping_amount = $options['shipping_amount'] ?? 0;
+			$line_items      = $options['line_items'] ?? null;
 
-	/**
-	 * Calculate sales tax using SmartCalcs
-	 *
-	 * Direct from the TaxJar plugin, without Nexus check.
-	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L247
-	 *
-	 * @return array|boolean
-	 */
-	public function calculate_tax( $options = array() ) {
-		$this->_log( ':::: TaxJar Plugin requested ::::' );
+			$taxes = array(
+				'freight_taxable' => 1,
+				'has_nexus'       => 0,
+				'line_items'      => array(),
+				'rate_ids'        => array(),
+				'tax_rate'        => 0,
+			);
 
-		// Normalize options to an array and safely map to local variables.
-		$options = is_array( $options ) ? $options : array();
-
-		$to_country      = isset( $options['to_country'] ) ? strtoupper( $options['to_country'] ) : null;
-		$to_state        = isset( $options['to_state'] ) ? strtoupper( $options['to_state'] ) : null;
-		$to_zip          = $options['to_zip'] ?? null;
-		$to_city         = $options['to_city'] ?? null;
-		$to_street       = $options['to_street'] ?? null;
-		$shipping_amount = $options['shipping_amount'] ?? 0;
-		$line_items      = $options['line_items'] ?? null;
-
-		$taxes = array(
-			'freight_taxable' => 1,
-			'has_nexus'       => 0,
-			'line_items'      => array(),
-			'rate_ids'        => array(),
-			'tax_rate'        => 0,
-		);
-
-		// Strict conditions to be met before API call can be conducted.
-		if (
+			// Strict conditions to be met before API call can be conducted.
+			if (
 			empty( $to_country ) ||
 			( empty( $to_zip ) && ! in_array( $to_country, WC()->countries->get_vat_countries() ) ) ||
 			( empty( $line_items ) && ( empty( $shipping_amount ) ) ) ||
 			WC()->customer->is_vat_exempt()
-		) {
-			return false;
-		}
-
-		$to_zip = explode( ',', $to_zip );
-		$to_zip = array_shift( $to_zip );
-
-		$store_settings = $this->get_store_settings();
-		$from_country   = strtoupper( $store_settings['country'] );
-		$from_state     = strtoupper( $store_settings['state'] );
-		$from_zip       = $store_settings['postcode'];
-		$from_city      = $store_settings['city'];
-		$from_street    = $store_settings['street'];
-
-		$this->_log( ':::: TaxJar API called ::::' );
-
-		$body = array(
-			'from_country' => $from_country,
-			'from_state'   => $from_state,
-			'from_zip'     => $from_zip,
-			'from_city'    => $from_city,
-			'from_street'  => $from_street,
-			'to_country'   => $to_country,
-			'to_state'     => $to_state,
-			'to_zip'       => $to_zip,
-			'to_city'      => $to_city,
-			'to_street'    => $to_street,
-			'shipping'     => $shipping_amount,
-			'plugin'       => 'woo',
-		);
-
-		$nexus_address = $this->maybe_apply_taxjar_nexus_addresses_workaround( $body );
-
-		// If workaround empty use default store address as nexus address.
-		if ( empty( $nexus_address ) ) {
-			$nexus_address = array(
-				'country' => $body['from_country'],
-				'zip'     => $body['from_zip'],
-				'state'   => $body['from_state'],
-				'city'    => $body['from_city'],
-				'street'  => $body['from_street'],
-			);
-		}
-
-		/**
-		 * Filter to modify or disable the nexus address sent to TaxJar API.
-		 *
-		 * This filter allows modification of the nexus address that will be sent
-		 * in the TaxJar API request. The nexus address replaces the standard from_*
-		 * address fields when provided.
-		 *
-		 * Return false or an empty array to disable sending nexus addresses entirely,
-		 * which will cause the request to use the standard from_* address fields instead.
-		 *
-		 * The nexus address array should contain the following keys:
-		 * - country: Two-letter country code (required).
-		 * - state: Two-letter state/province code (required for US/CA).
-		 * - zip: Postal/ZIP code (required).
-		 * - city: City name (required).
-		 * - street: Street address (optional).
-		 *
-		 * @since 3.3.0
-		 *
-		 * @param array $nexus_address The nexus address array to be sent to TaxJar.
-		 * @param array $body          The complete TaxJar API request body.
-		 *
-		 * @return array|false Modified nexus address array, or false to disable nexus addresses.
-		 *
-		 * @example
-		 * // Disable nexus addresses entirely.
-		 * add_filter( 'woocommerce_taxjar_nexus_address', '__return_false' );
-		 *
-		 * @example
-		 * // Modify the nexus address.
-		 * add_filter( 'woocommerce_taxjar_nexus_address', function( $nexus_address, $body ) {
-		 *     $nexus_address['street'] = '123 Custom Street';
-		 *     return $nexus_address;
-		 * }, 10, 2 );
-		 */
-		$nexus_address = apply_filters( 'woocommerce_taxjar_nexus_address', $nexus_address, $body );
-
-		if ( is_array( $nexus_address ) && ! empty( $nexus_address ) && $this->is_nexus_address_valid( $nexus_address ) ) {
-			$params_to_unset = array(
-				'from_country',
-				'from_state',
-				'from_zip',
-				'from_city',
-				'from_street',
-			);
-
-			foreach ( $params_to_unset as $param ) {
-				unset( $body[ $param ] );
+			) {
+				return false;
 			}
-			$body['nexus_addresses'] = array( $nexus_address );
-		}
 
-		$address_parts = $this->get_address_parts( $body );
+			$to_zip = explode( ',', $to_zip );
+			$to_zip = array_shift( $to_zip );
 
-		// Require from_country.
-		if ( empty( $address_parts['from_country'] ) ) {
-			$this->_log( 'From country is missing. Aborting.' );
-			return false;
-		}
+			$store_settings = $this->get_store_settings();
+			$from_country   = strtoupper( $store_settings['country'] );
+			$from_state     = strtoupper( $store_settings['state'] );
+			$from_zip       = $store_settings['postcode'];
+			$from_city      = $store_settings['city'];
+			$from_street    = $store_settings['street'];
 
-		// Don't calculate taxes for US when from_state and to_state are different.
-		if ( 'US' === $address_parts['from_country'] && 'US' === $address_parts['to_country'] && $address_parts['from_state'] !== $address_parts['to_state'] ) {
-			$this->_log( 'US from_state and to_state are different. Aborting.' );
-			return false;
-		}
+			$this->_log( ':::: TaxJar API called ::::' );
 
-		// Either `amount` or `line_items` parameters are required to perform tax calculations.
-		if ( empty( $line_items ) ) {
-			$body['amount'] = 0.01;
-		} else {
-			$body['line_items'] = $line_items;
-		}
-
-		$response = $this->smartcalcs_cache_request( wp_json_encode( $body ), $from_state );
-
-		// if no response, no need to keep going - bail early.
-		if ( ! isset( $response ) || ! $response ) {
-			$this->_log( 'Received: none.' );
-
-			return false;
-		}
-
-		// Log the response.
-		$this->_log( 'Received: ' . $response['body'] );
-
-		// Decode Response.
-		$taxjar_response = json_decode( $response['body'] );
-		if ( empty( $taxjar_response->tax ) ) {
-			return false;
-		}
-		$taxjar_taxes = $this->maybe_override_taxjar_tax( $taxjar_response->tax, $body );
-		$taxes        = $this->get_itemized_tax_rates( $taxes, $taxjar_taxes, $options );
-
-		return $taxes;
-	} // End calculate_tax().
-
-
-	/**
-	 * Return address parts.
-	 * Primarily used in address validation to operate on normalized and predictable indexes.
-	 *
-	 * @param array $body Request body.
-	 *
-	 * @return array
-	 */
-	private function get_address_parts( $body ) {
-		return array(
-			'from_country' => strtoupper( $body['nexus_addresses'][0]['country'] ?? $body['from_country'] ?? '' ),
-			'from_state'   => strtoupper( $body['nexus_addresses'][0]['state'] ?? $body['from_state'] ?? '' ),
-			'from_zip'     => strtoupper( $body['nexus_addresses'][0]['zip'] ?? $body['from_zip'] ?? '' ),
-			'to_country'   => strtoupper( $body['to_country'] ?? '' ),
-			'to_state'     => strtoupper( $body['to_state'] ?? '' ),
-			'to_zip'       => strtoupper( $body['to_zip'] ?? '' ),
-		);
-	}
-
-	/**
-	 * Get itemized tax rates from TaxJar response.
-	 *
-	 * @param array  $taxes        The tax data array that will be modified and returned.
-	 * @param object $taxjar_taxes TaxJar response object.
-	 * @param array  $options      Cart data used for tax calculation.
-	 *
-	 * @return array
-	 */
-	private function get_itemized_tax_rates( $taxes, $taxjar_taxes, $options ): array {
-
-		// Normalize options and safely map to local variables.
-		$options = is_array( $options ) ? $options : array();
-
-		$to_country = isset( $options['to_country'] ) ? strtoupper( $options['to_country'] ) : null;
-		$to_state   = isset( $options['to_state'] ) ? strtoupper( $options['to_state'] ) : null;
-		$to_zip     = $options['to_zip'] ?? null;
-		$to_city    = $options['to_city'] ?? null;
-
-		$store_settings = $this->get_store_settings();
-		$from_country   = strtoupper( $store_settings['country'] );
-		$from_state     = strtoupper( $store_settings['state'] );
-
-		// Update Properties based on Response.
-		$taxes['freight_taxable'] = (int) $taxjar_taxes->freight_taxable;
-		$taxes['has_nexus']       = (int) $taxjar_taxes->has_nexus;
-		$taxes['tax_rate']        = $taxjar_taxes->rate;
-
-		if ( ! empty( $taxjar_taxes->breakdown ) ) {
-			if ( ! empty( $taxjar_taxes->breakdown->line_items ) ) {
-				$line_items = array();
-				foreach ( $taxjar_taxes->breakdown->line_items as $line_item ) {
-					$line_items[ $line_item->id ] = $line_item;
-				}
-				$taxes['line_items'] = $line_items;
-			}
-		}
-
-		if ( $taxes['has_nexus'] ) {
-
-			// Use Woo core to find matching rates for taxable address.
-			$jurisdictions = array(
-				'county' => $taxjar_taxes->jurisdictions->county ?? null,
-				'city'   => $taxjar_taxes->jurisdictions->city ?? null,
-			);
-			$location      = array(
+			$body = array(
 				'from_country' => $from_country,
 				'from_state'   => $from_state,
+				'from_zip'     => $from_zip,
+				'from_city'    => $from_city,
+				'from_street'  => $from_street,
 				'to_country'   => $to_country,
 				'to_state'     => $to_state,
 				'to_zip'       => $to_zip,
 				'to_city'      => $to_city,
+				'to_street'    => $to_street,
+				'shipping'     => $shipping_amount,
+				'plugin'       => 'woo',
 			);
 
-			// Add line item tax rates.
-			foreach ( $taxes['line_items'] as $line_item_key => $line_item ) {
-				$line_item_key_chunks = explode( '-', $line_item_key );
-				$product_id           = $line_item_key_chunks[0];
-				$product              = wc_get_product( $product_id );
+			$nexus_address = $this->maybe_apply_taxjar_nexus_addresses_workaround( $body );
 
-				$tax_class = '';
-				if ( $product ) {
-					$tax_class = $product->get_tax_class();
-				} elseif ( isset( $this->backend_tax_classes[ $product_id ] ) ) {
-					$tax_class = $this->backend_tax_classes[ $product_id ];
+			// If workaround empty use default store address as nexus address.
+			if ( empty( $nexus_address ) ) {
+				$nexus_address = array(
+					'country' => $body['from_country'],
+					'zip'     => $body['from_zip'],
+					'state'   => $body['from_state'],
+					'city'    => $body['from_city'],
+					'street'  => $body['from_street'],
+				);
+			}
+
+			/**
+			 * Filter to modify or disable the nexus address sent to TaxJar API.
+			 *
+			 * This filter allows modification of the nexus address that will be sent
+			 * in the TaxJar API request. The nexus address replaces the standard from_*
+			 * address fields when provided.
+			 *
+			 * Return false or an empty array to disable sending nexus addresses entirely,
+			 * which will cause the request to use the standard from_* address fields instead.
+			 *
+			 * The nexus address array should contain the following keys:
+			 * - country: Two-letter country code (required).
+			 * - state: Two-letter state/province code (required for US/CA).
+			 * - zip: Postal/ZIP code (required).
+			 * - city: City name (required).
+			 * - street: Street address (optional).
+			 *
+			 * @since 3.3.0
+			 *
+			 * @param array $nexus_address The nexus address array to be sent to TaxJar.
+			 * @param array $body          The complete TaxJar API request body.
+			 *
+			 * @return array|false Modified nexus address array, or false to disable nexus addresses.
+			 *
+			 * @example
+			 * // Disable nexus addresses entirely.
+			 * add_filter( 'woocommerce_taxjar_nexus_address', '__return_false' );
+			 *
+			 * @example
+			 * // Modify the nexus address.
+			 * add_filter( 'woocommerce_taxjar_nexus_address', function( $nexus_address, $body ) {
+			 *     $nexus_address['street'] = '123 Custom Street';
+			 *     return $nexus_address;
+			 * }, 10, 2 );
+			 */
+			$nexus_address = apply_filters( 'woocommerce_taxjar_nexus_address', $nexus_address, $body );
+
+			if ( is_array( $nexus_address ) && ! empty( $nexus_address ) && $this->is_nexus_address_valid( $nexus_address ) ) {
+				$params_to_unset = array(
+					'from_country',
+					'from_state',
+					'from_zip',
+					'from_city',
+					'from_street',
+				);
+
+				foreach ( $params_to_unset as $param ) {
+					unset( $body[ $param ] );
+				}
+				$body['nexus_addresses'] = array( $nexus_address );
+			}
+
+			$address_parts = $this->get_address_parts( $body );
+
+			// Require from_country.
+			if ( empty( $address_parts['from_country'] ) ) {
+				$this->_log( 'From country is missing. Aborting.' );
+				return false;
+			}
+
+			// Don't calculate taxes for US when from_state and to_state are different.
+			if ( 'US' === $address_parts['from_country'] && 'US' === $address_parts['to_country'] && $address_parts['from_state'] !== $address_parts['to_state'] ) {
+				$this->_log( 'US from_state and to_state are different. Aborting.' );
+				return false;
+			}
+
+			// Either `amount` or `line_items` parameters are required to perform tax calculations.
+			if ( empty( $line_items ) ) {
+				$body['amount'] = 0.01;
+			} else {
+				$body['line_items'] = $line_items;
+			}
+
+			$response = $this->smartcalcs_cache_request( wp_json_encode( $body ), $from_state );
+
+			// if no response, no need to keep going - bail early.
+			if ( ! isset( $response ) || ! $response ) {
+				$this->_log( 'Received: none.' );
+
+				return false;
+			}
+
+			// Log the response.
+			$this->_log( 'Received: ' . $response['body'] );
+
+			// Decode Response.
+			$taxjar_response = json_decode( $response['body'] );
+			if ( empty( $taxjar_response->tax ) ) {
+				return false;
+			}
+			$taxjar_taxes = $this->maybe_override_taxjar_tax( $taxjar_response->tax, $body );
+			$taxes        = $this->get_itemized_tax_rates( $taxes, $taxjar_taxes, $options );
+
+			return $taxes;
+		} // End calculate_tax().
+
+		/**
+		 * Return address parts.
+		 * Primarily used in address validation to operate on normalized and predictable indexes.
+		 *
+		 * @param array $body Request body.
+		 *
+		 * @return array
+		 */
+		private function get_address_parts( $body ) {
+			return array(
+				'from_country' => strtoupper( $body['nexus_addresses'][0]['country'] ?? $body['from_country'] ?? '' ),
+				'from_state'   => strtoupper( $body['nexus_addresses'][0]['state'] ?? $body['from_state'] ?? '' ),
+				'from_zip'     => strtoupper( $body['nexus_addresses'][0]['zip'] ?? $body['from_zip'] ?? '' ),
+				'to_country'   => strtoupper( $body['to_country'] ?? '' ),
+				'to_state'     => strtoupper( $body['to_state'] ?? '' ),
+				'to_zip'       => strtoupper( $body['to_zip'] ?? '' ),
+			);
+		}
+
+		/**
+		 * Get itemized tax rates from TaxJar response.
+		 *
+		 * @param array  $taxes        The tax data array that will be modified and returned.
+		 * @param object $taxjar_taxes TaxJar response object.
+		 * @param array  $options      Cart data used for tax calculation.
+		 *
+		 * @return array
+		 */
+		private function get_itemized_tax_rates( $taxes, $taxjar_taxes, $options ): array {
+
+			// Normalize options and safely map to local variables.
+			$options = is_array( $options ) ? $options : array();
+
+			$to_country = isset( $options['to_country'] ) ? strtoupper( $options['to_country'] ) : null;
+			$to_state   = isset( $options['to_state'] ) ? strtoupper( $options['to_state'] ) : null;
+			$to_zip     = $options['to_zip'] ?? null;
+			$to_city    = $options['to_city'] ?? null;
+
+			$store_settings = $this->get_store_settings();
+			$from_country   = strtoupper( $store_settings['country'] );
+			$from_state     = strtoupper( $store_settings['state'] );
+
+			// Update Properties based on Response.
+			$taxes['freight_taxable'] = (int) $taxjar_taxes->freight_taxable;
+			$taxes['has_nexus']       = (int) $taxjar_taxes->has_nexus;
+			$taxes['tax_rate']        = $taxjar_taxes->rate;
+
+			if ( ! empty( $taxjar_taxes->breakdown ) ) {
+				if ( ! empty( $taxjar_taxes->breakdown->line_items ) ) {
+					$line_items = array();
+					foreach ( $taxjar_taxes->breakdown->line_items as $line_item ) {
+						$line_items[ $line_item->id ] = $line_item;
+					}
+					$taxes['line_items'] = $line_items;
+				}
+			}
+
+			if ( $taxes['has_nexus'] ) {
+
+				// Use Woo core to find matching rates for taxable address.
+				$jurisdictions = array(
+					'county' => $taxjar_taxes->jurisdictions->county ?? null,
+					'city'   => $taxjar_taxes->jurisdictions->city ?? null,
+				);
+				$location      = array(
+					'from_country' => $from_country,
+					'from_state'   => $from_state,
+					'to_country'   => $to_country,
+					'to_state'     => $to_state,
+					'to_zip'       => $to_zip,
+					'to_city'      => $to_city,
+				);
+
+				// Add line item tax rates.
+				foreach ( $taxes['line_items'] as $line_item_key => $line_item ) {
+					$line_item_key_chunks = explode( '-', $line_item_key );
+					$product_id           = $line_item_key_chunks[0];
+					$product              = wc_get_product( $product_id );
+
+					$tax_class = '';
+					if ( $product ) {
+						$tax_class = $product->get_tax_class();
+					} elseif ( isset( $this->backend_tax_classes[ $product_id ] ) ) {
+						$tax_class = $this->backend_tax_classes[ $product_id ];
+					}
+
+					$_tax_rates = (array) $line_item;
+					$priority   = 1;
+					foreach ( $_tax_rates as $tax_rate_name => $tax_rate ) {
+						if ( 'combined_tax_rate' === $tax_rate_name || false === strpos( $tax_rate_name, '_tax_rate' ) ) {
+							continue;
+						}
+						$taxes['rate_ids'][ $line_item_key ][] = $this->create_or_update_tax_rate(
+							$location,
+							round( $tax_rate * 100, 4 ),
+							$tax_class,
+							$taxes['freight_taxable'],
+							$priority,
+							self::generate_itemized_tax_rate_name( $tax_rate_name, $to_country, $jurisdictions )
+						);
+
+						++$priority;
+					}
 				}
 
-				$_tax_rates = (array) $line_item;
+				// Add shipping tax rate.
+				$_tax_rates = isset( $taxjar_taxes->breakdown->shipping ) ? (array) $taxjar_taxes->breakdown->shipping : array();
 				$priority   = 1;
 				foreach ( $_tax_rates as $tax_rate_name => $tax_rate ) {
 					if ( 'combined_tax_rate' === $tax_rate_name || false === strpos( $tax_rate_name, '_tax_rate' ) ) {
 						continue;
 					}
-					$taxes['rate_ids'][ $line_item_key ][] = $this->create_or_update_tax_rate(
+					$taxes['rate_ids']['shipping'][] = $this->create_or_update_tax_rate(
 						$location,
 						round( $tax_rate * 100, 4 ),
-						$tax_class,
+						'',
 						$taxes['freight_taxable'],
 						$priority,
 						self::generate_itemized_tax_rate_name( $tax_rate_name, $to_country, $jurisdictions )
@@ -1561,423 +1597,403 @@ class WC_Connect_TaxJar_Integration {
 				}
 			}
 
-			// Add shipping tax rate.
-			$_tax_rates = isset( $taxjar_taxes->breakdown->shipping ) ? (array) $taxjar_taxes->breakdown->shipping : array();
-			$priority   = 1;
-			foreach ( $_tax_rates as $tax_rate_name => $tax_rate ) {
-				if ( 'combined_tax_rate' === $tax_rate_name || false === strpos( $tax_rate_name, '_tax_rate' ) ) {
-					continue;
-				}
-				$taxes['rate_ids']['shipping'][] = $this->create_or_update_tax_rate(
-					$location,
-					round( $tax_rate * 100, 4 ),
-					'',
-					$taxes['freight_taxable'],
-					$priority,
-					self::generate_itemized_tax_rate_name( $tax_rate_name, $to_country, $jurisdictions )
-				);
-
-				++$priority;
-			}
+			return $taxes;
 		}
-
-		return $taxes;
-	}
-
-	/**
-	 * Add or update WooCommerce tax rate.
-	 *
-	 * @param  array     $location
-	 * @param  int|float $rate
-	 * @param  string    $tax_class
-	 * @param  int       $freight_taxable
-	 * @param  int       $rate_priority
-	 * @param  string    $tax_rate_name
-	 *
-	 * @return int
-	 */
-	public function create_or_update_tax_rate( $location, $rate, $tax_class = '', $freight_taxable = 1, $rate_priority = 1, $tax_rate_name = 'Tax' ) {
-		// Prevent filling "State code" column for countries with VAT tax.
-		// VAT tax is country wide.
-		$to_state      = 'VAT' === $tax_rate_name ? '' : strtoupper( $location['to_state'] );
-		$rate_priority = absint( $rate_priority );
 
 		/**
-		 * @see https://github.com/Automattic/woocommerce-services/issues/2531
-		 * @see https://floridarevenue.com/faq/Pages/FAQDetails.aspx?FAQID=1277&IsDlg=1
+		 * Add or update WooCommerce tax rate.
 		 *
-		 * According to the Florida Department of Revenue, sales tax must be charged on
-		 * shipping costs if the customer does not have an option to avoid paying the
-		 * merchant for shipping costs by either picking up the merchandise themselves
-		 * or arranging for a third party to pick up the merchandise and deliver it to
-		 * them.
+		 * @param  array     $location
+		 * @param  int|float $rate
+		 * @param  string    $tax_class
+		 * @param  int       $freight_taxable
+		 * @param  int       $rate_priority
+		 * @param  string    $tax_rate_name
 		 *
-		 * Normally TaxJar enables taxes on shipping by default for Florida to
-		 * Florida shipping, but because WooCommerce uses a single account, a nexus
-		 * cannot be added for Florida (or any state) which means the shipping tax
-		 * is not enabled. So, we will enable it here by default and give merchants
-		 * the option to disable it if needed via filter.
-		 *
-		 * @since 1.26.0
+		 * @return int
 		 */
-		if ( true === apply_filters( 'woocommerce_taxjar_enable_florida_shipping_tax', true ) && 'US' === $location['to_country'] && 'FL' === $location['from_state'] && 'FL' === $location['to_state'] ) {
-			$freight_taxable = 1;
-		}
+		public function create_or_update_tax_rate( $location, $rate, $tax_class = '', $freight_taxable = 1, $rate_priority = 1, $tax_rate_name = 'Tax' ) {
+			// Prevent filling "State code" column for countries with VAT tax.
+			// VAT tax is country wide.
+			$to_state      = 'VAT' === $tax_rate_name ? '' : strtoupper( $location['to_state'] );
+			$rate_priority = absint( $rate_priority );
 
-		$tax_rate = array(
-			'tax_rate_country'  => $location['to_country'],
-			'tax_rate_state'    => $to_state,
-			// For the US, we're going to modify the name of the tax rate to simplify the reporting and distinguish between the tax rates at the counties level.
-			// I would love to do this for other locations, but it looks like that would create issues.
-			// For example, for the UK it would continuously rename the rate name with an updated `state` "piece", each time a request is made
-			'tax_rate_name'     => $tax_rate_name,
-			'tax_rate_priority' => $rate_priority,
-			'tax_rate_compound' => false,
-			'tax_rate_shipping' => $freight_taxable,
-			'tax_rate'          => $rate,
-			'tax_rate_class'    => $tax_class,
-		);
-
-		$wc_rates = WC_Tax::find_rates(
-			array(
-				'country'   => $location['to_country'],
-				'state'     => str_replace( ' ', '', $to_state ),
-				'postcode'  => $location['to_zip'],
-				'city'      => strtoupper( $location['to_city'] ),
-				'tax_class' => $tax_class,
-			)
-		);
-
-		$wc_rates_ids = is_array( $wc_rates ) ? array_keys( $wc_rates ) : array();
-		if ( isset( $wc_rates_ids[ $rate_priority - 1 ] ) ) {
-			$wc_rate[ $wc_rates_ids[ $rate_priority - 1 ] ] = $wc_rates[ $wc_rates_ids[ $rate_priority - 1 ] ];
-		} else {
-			$wc_rate = array();
-		}
-
-		if ( ! empty( $wc_rate ) ) {
-			$this->_log( ':: Tax Rate Found ::' );
-			$this->_log( $wc_rate );
-
-			// Get the existing ID
-			$rate_id = key( $wc_rate );
-
-			// Update Tax Rates with TaxJar rates ( rates might be coming from a cached taxjar rate )
-			$this->_log( ':: Updating Tax Rate To ::' );
-			$this->_log( $tax_rate );
-			if ( $wc_rate[ $rate_id ]['label'] !== $tax_rate_name || (float) $wc_rate[ $rate_id ]['rate'] !== (float) $rate ) {
-				// Allow to manually change is Shipping taxable, won't be overwritten automatically.
-				$tax_rate['tax_rate_shipping'] = wc_string_to_bool( $wc_rate[ $rate_id ]['shipping'] );
-				WC_Tax::_update_tax_rate( $rate_id, $tax_rate );
+			/**
+			 * @see https://github.com/Automattic/woocommerce-services/issues/2531
+			 * @see https://floridarevenue.com/faq/Pages/FAQDetails.aspx?FAQID=1277&IsDlg=1
+			 *
+			 * According to the Florida Department of Revenue, sales tax must be charged on
+			 * shipping costs if the customer does not have an option to avoid paying the
+			 * merchant for shipping costs by either picking up the merchandise themselves
+			 * or arranging for a third party to pick up the merchandise and deliver it to
+			 * them.
+			 *
+			 * Normally TaxJar enables taxes on shipping by default for Florida to
+			 * Florida shipping, but because WooCommerce uses a single account, a nexus
+			 * cannot be added for Florida (or any state) which means the shipping tax
+			 * is not enabled. So, we will enable it here by default and give merchants
+			 * the option to disable it if needed via filter.
+			 *
+			 * @since 1.26.0
+			 */
+			if ( true === apply_filters( 'woocommerce_taxjar_enable_florida_shipping_tax', true ) && 'US' === $location['to_country'] && 'FL' === $location['from_state'] && 'FL' === $location['to_state'] ) {
+				$freight_taxable = 1;
 			}
-		} else {
-			// Insert a rate if we did not find one
-			$this->_log( ':: Adding New Tax Rate ::' );
-			$this->_log( $tax_rate );
-			$rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
-			// VAT is always country wide, no need to create separate entires for each zip and city.
-			if ( 'VAT' !== $tax_rate_name ) {
-				WC_Tax::_update_tax_rate_postcodes( $rate_id, wc_normalize_postcode( wc_clean( $location['to_zip'] ) ) );
-				WC_Tax::_update_tax_rate_cities( $rate_id, wc_clean( $location['to_city'] ) );
+
+			$tax_rate = array(
+				'tax_rate_country'  => $location['to_country'],
+				'tax_rate_state'    => $to_state,
+				// For the US, we're going to modify the name of the tax rate to simplify the reporting and distinguish between the tax rates at the counties level.
+				// I would love to do this for other locations, but it looks like that would create issues.
+				// For example, for the UK it would continuously rename the rate name with an updated `state` "piece", each time a request is made
+				'tax_rate_name'     => $tax_rate_name,
+				'tax_rate_priority' => $rate_priority,
+				'tax_rate_compound' => false,
+				'tax_rate_shipping' => $freight_taxable,
+				'tax_rate'          => $rate,
+				'tax_rate_class'    => $tax_class,
+			);
+
+			$wc_rates = WC_Tax::find_rates(
+				array(
+					'country'   => $location['to_country'],
+					'state'     => str_replace( ' ', '', $to_state ),
+					'postcode'  => $location['to_zip'],
+					'city'      => strtoupper( $location['to_city'] ),
+					'tax_class' => $tax_class,
+				)
+			);
+
+			$wc_rates_ids = is_array( $wc_rates ) ? array_keys( $wc_rates ) : array();
+			if ( isset( $wc_rates_ids[ $rate_priority - 1 ] ) ) {
+				$wc_rate[ $wc_rates_ids[ $rate_priority - 1 ] ] = $wc_rates[ $wc_rates_ids[ $rate_priority - 1 ] ];
+			} else {
+				$wc_rate = array();
 			}
+
+			if ( ! empty( $wc_rate ) ) {
+				$this->_log( ':: Tax Rate Found ::' );
+				$this->_log( $wc_rate );
+
+				// Get the existing ID
+				$rate_id = key( $wc_rate );
+
+				// Update Tax Rates with TaxJar rates ( rates might be coming from a cached taxjar rate )
+				$this->_log( ':: Updating Tax Rate To ::' );
+				$this->_log( $tax_rate );
+				if ( $wc_rate[ $rate_id ]['label'] !== $tax_rate_name || (float) $wc_rate[ $rate_id ]['rate'] !== (float) $rate ) {
+					// Allow to manually change is Shipping taxable, won't be overwritten automatically.
+					$tax_rate['tax_rate_shipping'] = wc_string_to_bool( $wc_rate[ $rate_id ]['shipping'] );
+					WC_Tax::_update_tax_rate( $rate_id, $tax_rate );
+				}
+			} else {
+				// Insert a rate if we did not find one
+				$this->_log( ':: Adding New Tax Rate ::' );
+				$this->_log( $tax_rate );
+				$rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
+				// VAT is always country wide, no need to create separate entires for each zip and city.
+				if ( 'VAT' !== $tax_rate_name ) {
+					WC_Tax::_update_tax_rate_postcodes( $rate_id, wc_normalize_postcode( wc_clean( $location['to_zip'] ) ) );
+					WC_Tax::_update_tax_rate_cities( $rate_id, wc_clean( $location['to_city'] ) );
+				}
+			}
+
+			$this->_log( 'Tax Rate ID Set for ' . $rate_id );
+
+			return $rate_id;
 		}
 
-		$this->_log( 'Tax Rate ID Set for ' . $rate_id );
+		/**
+		 * Validate TaxJar API request json value and add the error to log.
+		 *
+		 * @param $json
+		 *
+		 * @return bool
+		 */
+		public function validate_taxjar_request( $json ) {
+			$this->_log( ':::: TaxJar API request validation ::::' );
 
-		return $rate_id;
-	}
+			$body    = json_decode( $json, true );
+			$address = $this->get_address_parts( $body );
 
-	/**
-	 * Validate TaxJar API request json value and add the error to log.
-	 *
-	 * @param $json
-	 *
-	 * @return bool
-	 */
-	public function validate_taxjar_request( $json ) {
-		$this->_log( ':::: TaxJar API request validation ::::' );
+			if ( empty( $address['from_country'] ) ) {
+				$this->_error( 'API request is stopped. Empty origin country.' );
 
-		$body    = json_decode( $json, true );
-		$address = $this->get_address_parts( $body );
+				return false;
+			}
 
-		if ( empty( $address['from_country'] ) ) {
-			$this->_error( 'API request is stopped. Empty origin country.' );
+			if ( empty( $address['to_country'] ) ) {
+				$this->_error( 'API request is stopped. Empty destination country.' );
 
-			return false;
-		}
+				return false;
+			}
 
-		if ( empty( $address['to_country'] ) ) {
-			$this->_error( 'API request is stopped. Empty destination country.' );
+			if ( ( 'US' === $address['to_country'] || 'CA' === $address['to_country'] ) && empty( $address['to_state'] ) ) {
+				$this->_error( 'API request is stopped. Country destination is set to US or CA but the state is empty.' );
 
-			return false;
-		}
+				return false;
+			}
 
-		if ( ( 'US' === $address['to_country'] || 'CA' === $address['to_country'] ) && empty( $address['to_state'] ) ) {
-			$this->_error( 'API request is stopped. Country destination is set to US or CA but the state is empty.' );
+			if ( 'US' === $address['to_country'] && empty( $address['to_zip'] ) ) {
+				$this->_error( 'API request is stopped. Country destination is set to US but the zip code is empty.' );
 
-			return false;
-		}
+				return false;
+			}
 
-		if ( 'US' === $address['to_country'] && empty( $address['to_zip'] ) ) {
-			$this->_error( 'API request is stopped. Country destination is set to US but the zip code is empty.' );
-
-			return false;
-		}
-
-		if (
+			if (
 			'US' === $address['to_country'] && 'US' === $address['from_country']
 			&& $address['from_state'] !== $address['to_state']
-		) {
-			$this->_error( 'API request is stopped. US from_state !== to_state, tax don\'t apply.' );
+			) {
+				$this->_error( 'API request is stopped. US from_state !== to_state, tax don\'t apply.' );
 
-			return false;
-		}
-
-		// Apply this validation only if the destination country is the US and the zip code is 5 or 10 digits long.
-		if ( 'US' === $address['to_country'] && in_array( strlen( $address['to_zip'] ), array( 5, 10 ) ) && ! WC_Validation::is_postcode( $address['to_zip'], $address['to_country'] ) ) {
-			$this->_error( 'API request is stopped. Country destination is set to US but the zip code has incorrect format.' );
-
-			return false;
-		}
-
-		if ( 'US' === $address['from_country'] && ! WC_Validation::is_postcode( $address['from_zip'], $address['from_country'] ) ) {
-			$this->_error( 'API request is stopped. Country store is set to US but the zip code has incorrect format.' );
-
-			return false;
-		}
-
-		$this->_log( 'API request is in good format.' );
-
-		return true;
-	}
-
-	/**
-	 * Wrap SmartCalcs API requests in a transient-based caching layer.
-	 *
-	 * Unchanged from the TaxJar plugin.
-	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L451
-	 *
-	 * @param $json
-	 * @param $from_state
-	 *
-	 * @return mixed|WP_Error
-	 */
-	public function smartcalcs_cache_request( $json, $from_state ) {
-		$cache_key           = 'tj_tax_' . hash( 'md5', $json );
-		$zip_state_cache_key = false;
-		$request             = json_decode( $json );
-		$to_zip              = isset( $request->to_zip ) ? (string) $request->to_zip : false;
-		$to_state            = isset( $request->to_state ) ? strtoupper( (string) $request->to_state ) : false;
-		if ( $to_zip && $to_state ) {
-			$zip_state_cache_key = strtolower( 'tj_tax_' . $to_zip . '_' . $to_state );
-			$response            = get_transient( $zip_state_cache_key );
-		}
-		$response = ! empty( $response ) ? $response : get_transient( $cache_key );
-		if ( $response && 'CA' !== $from_state ) {
-			// If $from_state is not California, we need to check for incorrect California tax nexus.
-			try {
-				$this->check_for_incorrect_california_tax_nexus( $response['body'], true, $from_state );
-			} catch ( Exception $e ) {
-				$this->_log( 'Error checking for incorrect California tax nexus: ' . $e->getMessage() );
+				return false;
 			}
+
+			// Apply this validation only if the destination country is the US and the zip code is 5 or 10 digits long.
+			if ( 'US' === $address['to_country'] && in_array( strlen( $address['to_zip'] ), array( 5, 10 ) ) && ! WC_Validation::is_postcode( $address['to_zip'], $address['to_country'] ) ) {
+				$this->_error( 'API request is stopped. Country destination is set to US but the zip code has incorrect format.' );
+
+				return false;
+			}
+
+			if ( 'US' === $address['from_country'] && ! WC_Validation::is_postcode( $address['from_zip'], $address['from_country'] ) ) {
+				$this->_error( 'API request is stopped. Country store is set to US but the zip code has incorrect format.' );
+
+				return false;
+			}
+
+			$this->_log( 'API request is in good format.' );
+
+			return true;
 		}
-		$response_code    = wp_remote_retrieve_response_code( $response );
-		$save_error_codes = array( 404, 400 );
 
-		// Clear the taxjar notices before calculating taxes or using cached response.
-		$this->notifier->clear_notices( 'taxjar' );
-
-		if ( false === $response ) {
-			$response      = $this->smartcalcs_request( $json );
-			$response_code = wp_remote_retrieve_response_code( $response );
-			$body          = json_decode( wp_remote_retrieve_body( $response ) );
-			if ( 'CA' !== $from_state ) {
+		/**
+		 * Wrap SmartCalcs API requests in a transient-based caching layer.
+		 *
+		 * Unchanged from the TaxJar plugin.
+		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L451
+		 *
+		 * @param $json
+		 * @param $from_state
+		 *
+		 * @return mixed|WP_Error
+		 */
+		public function smartcalcs_cache_request( $json, $from_state ) {
+			$cache_key           = 'tj_tax_' . hash( 'md5', $json );
+			$zip_state_cache_key = false;
+			$request             = json_decode( $json );
+			$to_zip              = isset( $request->to_zip ) ? (string) $request->to_zip : false;
+			$to_state            = isset( $request->to_state ) ? strtoupper( (string) $request->to_state ) : false;
+			if ( $to_zip && $to_state ) {
+				$zip_state_cache_key = strtolower( 'tj_tax_' . $to_zip . '_' . $to_state );
+				$response            = get_transient( $zip_state_cache_key );
+			}
+			$response = ! empty( $response ) ? $response : get_transient( $cache_key );
+			if ( $response && 'CA' !== $from_state ) {
 				// If $from_state is not California, we need to check for incorrect California tax nexus.
 				try {
-					$this->check_for_incorrect_california_tax_nexus( $body, false, $from_state );
+					$this->check_for_incorrect_california_tax_nexus( $response['body'], true, $from_state );
 				} catch ( Exception $e ) {
 					$this->_log( 'Error checking for incorrect California tax nexus: ' . $e->getMessage() );
 				}
 			}
-			$is_zip_to_state_mismatch = (
+			$response_code    = wp_remote_retrieve_response_code( $response );
+			$save_error_codes = array( 404, 400 );
+
+			// Clear the taxjar notices before calculating taxes or using cached response.
+			$this->notifier->clear_notices( 'taxjar' );
+
+			if ( false === $response ) {
+				$response      = $this->smartcalcs_request( $json );
+				$response_code = wp_remote_retrieve_response_code( $response );
+				$body          = json_decode( wp_remote_retrieve_body( $response ) );
+				if ( 'CA' !== $from_state ) {
+					// If $from_state is not California, we need to check for incorrect California tax nexus.
+					try {
+						$this->check_for_incorrect_california_tax_nexus( $body, false, $from_state );
+					} catch ( Exception $e ) {
+						$this->_log( 'Error checking for incorrect California tax nexus: ' . $e->getMessage() );
+					}
+				}
+				$is_zip_to_state_mismatch = (
 				isset( $body->detail )
 				&& is_string( $body->detail )
 				&& $to_zip
 				&& $to_state
 				&& false !== strpos( $body->detail, 'to_zip ' . $to_zip )
 				&& false !== strpos( $body->detail, 'to_state ' . $to_state )
-			);
-			$transient_set            = false;
+				);
+				$transient_set            = false;
 
-			if ( 200 == $response_code ) {
-				set_transient( $cache_key, $response, $this->cache_time );
-			} elseif ( in_array( $response_code, $save_error_codes ) ) {
-				if ( 400 == $response_code
+				if ( 200 == $response_code ) {
+					set_transient( $cache_key, $response, $this->cache_time );
+				} elseif ( in_array( $response_code, $save_error_codes ) ) {
+					if ( 400 == $response_code
 					&& $is_zip_to_state_mismatch
 					&& $zip_state_cache_key
-				) {
-					$transient_set = set_transient( $zip_state_cache_key, $response, $this->address_cache_time );
-				}
+					) {
+						$transient_set = set_transient( $zip_state_cache_key, $response, $this->address_cache_time );
+					}
 
-				if ( ! $transient_set ) {
-					set_transient( $cache_key, $response, $this->error_cache_time );
+					if ( ! $transient_set ) {
+						set_transient( $cache_key, $response, $this->error_cache_time );
+					}
 				}
+			}
+
+			if ( in_array( $response_code, $save_error_codes ) ) {
+				$this->_log( 'Retrieved the error from the cache. Received (' . $response['response']['code'] . '): ' . $response['body'] );
+				$this->_error( 'Error retrieving the tax rates. Received (' . $response['response']['code'] . '): ' . $response['body'] );
+				return false;
+			}
+
+			return $response;
+		}
+
+		/**
+		 * Make a TaxJar SmartCalcs API request through the WCS proxy.
+		 *
+		 * Modified from TaxJar's plugin.
+		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/82bf7c58/includes/class-wc-taxjar-integration.php#L440
+		 *
+		 * @param $json
+		 *
+		 * @return array|WP_Error
+		 */
+		public function smartcalcs_request( $json ) {
+			$path = trailingslashit( self::PROXY_PATH ) . 'taxes';
+
+			// Validate the request before sending a request.
+			if ( ! $this->validate_taxjar_request( $json ) ) {
+				return false;
+			}
+
+			$this->_log( 'Requesting: ' . $path . ' - ' . $json );
+
+			$response = $this->api_client->proxy_request(
+				$path,
+				array(
+					'method'  => 'POST',
+					'headers' => array(
+						'Content-Type' => 'application/json',
+					),
+					'body'    => $json,
+				)
+			);
+
+			if ( is_wp_error( $response ) ) {
+				$this->_error( 'Error retrieving the tax rates. Received (' . $response->get_error_code() . '): ' . $response->get_error_message() );
+			} elseif ( 200 == $response['response']['code'] ) {
+				return $response;
+			} elseif ( 404 == $response['response']['code'] || 400 == $response['response']['code'] ) {
+				$this->_error( 'Error retrieving the tax rates. Received (' . $response['response']['code'] . '): ' . $response['body'] );
+
+				return $response;
+			} else {
+				$this->_error( 'Error retrieving the tax rates. Received (' . $response['response']['code'] . '): ' . $response['body'] );
 			}
 		}
 
-		if ( in_array( $response_code, $save_error_codes ) ) {
-			$this->_log( 'Retrieved the error from the cache. Received (' . $response['response']['code'] . '): ' . $response['body'] );
-			$this->_error( 'Error retrieving the tax rates. Received (' . $response['response']['code'] . '): ' . $response['body'] );
-			return false;
+		/**
+		 * Exports existing tax rates to a CSV and clears the table.
+		 *
+		 * Ported from TaxJar's plugin.
+		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/42cd4cd0/taxjar-woocommerce.php#L75
+		 */
+		public function backup_existing_tax_rates() {
+
+			// Back up all tax rates to a csv file
+			$backed_up = WC_Connect_Functions::backup_existing_tax_rates();
+
+			if ( ! $backed_up ) {
+				return;
+			}
+
+			global $wpdb;
+
+			// Delete all tax rates
+			$wpdb->query( 'TRUNCATE ' . $wpdb->prefix . 'woocommerce_tax_rates' );
+			$wpdb->query( 'TRUNCATE ' . $wpdb->prefix . 'woocommerce_tax_rate_locations' );
 		}
 
-		return $response;
-	}
+		/**
+		 * Checks if currently on the WooCommerce order page.
+		 *
+		 * @return boolean
+		 */
+		public function on_order_page() {
+			if ( ! function_exists( 'get_current_screen' ) ) {
+				return false;
+			}
 
-	/**
-	 * Make a TaxJar SmartCalcs API request through the WCS proxy.
-	 *
-	 * Modified from TaxJar's plugin.
-	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/82bf7c58/includes/class-wc-taxjar-integration.php#L440
-	 *
-	 * @param $json
-	 *
-	 * @return array|WP_Error
-	 */
-	public function smartcalcs_request( $json ) {
-		$path = trailingslashit( self::PROXY_PATH ) . 'taxes';
+			$screen = get_current_screen();
+			if ( ! $screen || ! isset( $screen->id ) ) {
+				return false;
+			}
 
-		// Validate the request before sending a request.
-		if ( ! $this->validate_taxjar_request( $json ) ) {
-			return false;
+			if ( ! function_exists( 'wc_get_page_screen_id' ) ) {
+				return false;
+			}
+
+			$wc_order_screen_id = wc_get_page_screen_id( 'shop_order' );
+			if ( ! $wc_order_screen_id ) {
+				return false;
+			}
+
+			// If HPOS is enabled, and we're on the Orders list page, return false.
+			if ( 'woocommerce_page_wc-orders' === $wc_order_screen_id && ! isset( $_GET['action'] ) ) {
+				return false;
+			}
+
+			return $screen->id === $wc_order_screen_id;
 		}
 
-		$this->_log( 'Requesting: ' . $path . ' - ' . $json );
-
-		$response = $this->api_client->proxy_request(
-			$path,
-			array(
-				'method'  => 'POST',
-				'headers' => array(
-					'Content-Type' => 'application/json',
-				),
-				'body'    => $json,
-			)
-		);
-
-		if ( is_wp_error( $response ) ) {
-			$this->_error( 'Error retrieving the tax rates. Received (' . $response->get_error_code() . '): ' . $response->get_error_message() );
-		} elseif ( 200 == $response['response']['code'] ) {
-			return $response;
-		} elseif ( 404 == $response['response']['code'] || 400 == $response['response']['code'] ) {
-			$this->_error( 'Error retrieving the tax rates. Received (' . $response['response']['code'] . '): ' . $response['body'] );
-
-			return $response;
-		} else {
-			$this->_error( 'Error retrieving the tax rates. Received (' . $response['response']['code'] . '): ' . $response['body'] );
-		}
-	}
-
-	/**
-	 * Exports existing tax rates to a CSV and clears the table.
-	 *
-	 * Ported from TaxJar's plugin.
-	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/42cd4cd0/taxjar-woocommerce.php#L75
-	 */
-	public function backup_existing_tax_rates() {
-
-		// Back up all tax rates to a csv file
-		$backed_up = WC_Connect_Functions::backup_existing_tax_rates();
-
-		if ( ! $backed_up ) {
-			return;
+		/**
+		 * Admin New Order Assets
+		 */
+		public function load_taxjar_admin_new_order_assets() {
+			if ( ! $this->on_order_page() ) {
+				return;
+			}
+			// Load Javascript for WooCommerce new order page
+			wp_enqueue_script( 'wc-taxjar-order', $this->wc_connect_base_url . 'woocommerce-services-new-order-taxjar-' . WC_Connect_Loader::get_wcs_version() . '.js', array( 'jquery' ), null, true );
 		}
 
-		global $wpdb;
+		/**
+		 * Check for incorrect California tax nexus in the TaxJar API response or cached response.
+		 *
+		 * @param $response_body
+		 * @param $cached
+		 *
+		 * @return void
+		 */
+		private function check_for_incorrect_california_tax_nexus( $response_body, $cached, $from_state ): void {
+			$log_suffix = 'in TaxJar API response.';
 
-		// Delete all tax rates
-		$wpdb->query( 'TRUNCATE ' . $wpdb->prefix . 'woocommerce_tax_rates' );
-		$wpdb->query( 'TRUNCATE ' . $wpdb->prefix . 'woocommerce_tax_rate_locations' );
-	}
+			if ( $cached ) {
+				$response_body = json_decode( $response_body );
+				$log_suffix    = 'in cached response.';
+			}
 
-	/**
-	 * Checks if currently on the WooCommerce order page.
-	 *
-	 * @return boolean
-	 */
-	public function on_order_page() {
-		if ( ! function_exists( 'get_current_screen' ) ) {
-			return false;
-		}
+			$to_state   = isset( $response_body->tax->jurisdictions->state ) ? strtoupper( $response_body->tax->jurisdictions->state ) : 'not set';
+			$to_country = isset( $response_body->tax->jurisdictions->country ) ? strtoupper( $response_body->tax->jurisdictions->country ) : 'not set';
+			$has_nexus  = isset( $response_body->tax->has_nexus ) ? $response_body->tax->has_nexus : null;
 
-		$screen = get_current_screen();
-		if ( ! $screen || ! isset( $screen->id ) ) {
-			return false;
-		}
+			if ( 'CA' === $to_state && 'US' === $to_country && true === $has_nexus ) {
+				$this->_log(
+					sprintf(
+						'Incorrect California tax nexus detected %1$s (from_state: %2$s, to_state: %3$s, to_country: %4$s, has_nexus: %5$s).',
+						$log_suffix,
+						$from_state ?: 'unknown',
+						$to_state,
+						$to_country,
+						json_encode( $has_nexus ),
+					)
+				);
+			}
 
-		if ( ! function_exists( 'wc_get_page_screen_id' ) ) {
-			return false;
-		}
-
-		$wc_order_screen_id = wc_get_page_screen_id( 'shop_order' );
-		if ( ! $wc_order_screen_id ) {
-			return false;
-		}
-
-		// If HPOS is enabled, and we're on the Orders list page, return false.
-		if ( 'woocommerce_page_wc-orders' === $wc_order_screen_id && ! isset( $_GET['action'] ) ) {
-			return false;
-		}
-
-		return $screen->id === $wc_order_screen_id;
-	}
-
-	/**
-	 * Admin New Order Assets
-	 */
-	public function load_taxjar_admin_new_order_assets() {
-		if ( ! $this->on_order_page() ) {
-			return;
-		}
-		// Load Javascript for WooCommerce new order page
-		wp_enqueue_script( 'wc-taxjar-order', $this->wc_connect_base_url . 'woocommerce-services-new-order-taxjar-' . WC_Connect_Loader::get_wcs_version() . '.js', array( 'jquery' ), null, true );
-	}
-
-	/**
-	 * Check for incorrect California tax nexus in the TaxJar API response or cached response.
-	 *
-	 * @param $response_body
-	 * @param $cached
-	 *
-	 * @return void
-	 */
-	private function check_for_incorrect_california_tax_nexus( $response_body, $cached, $from_state ): void {
-		$log_suffix = 'in TaxJar API response.';
-
-		if ( $cached ) {
-			$response_body = json_decode( $response_body );
-			$log_suffix    = 'in cached response.';
-		}
-
-		$to_state   = isset( $response_body->tax->jurisdictions->state ) ? strtoupper( $response_body->tax->jurisdictions->state ) : 'not set';
-		$to_country = isset( $response_body->tax->jurisdictions->country ) ? strtoupper( $response_body->tax->jurisdictions->country ) : 'not set';
-		$has_nexus  = isset( $response_body->tax->has_nexus ) ? $response_body->tax->has_nexus : null;
-
-		if ( 'CA' === $to_state && 'US' === $to_country && true === $has_nexus ) {
-			$this->_log(
-				sprintf(
-					'Incorrect California tax nexus detected %1$s (from_state: %2$s, to_state: %3$s, to_country: %4$s, has_nexus: %5$s).',
-					$log_suffix,
-					$from_state ?: 'unknown',
-					$to_state,
-					$to_country,
-					json_encode( $has_nexus ),
-				)
-			);
-		}
-
-		if ( 'not set' === $to_state || 'not set' === $to_country || null === $has_nexus ) {
-			throw new Exception( sprintf( 'One or more values are not set : to_state=>%1$s, to_country=>%2$s, has_nexus=>%3$s', $to_state, $to_country, json_encode( $has_nexus ) ) );
+			if ( 'not set' === $to_state || 'not set' === $to_country || null === $has_nexus ) {
+				throw new Exception( sprintf( 'One or more values are not set : to_state=>%1$s, to_country=>%2$s, has_nexus=>%3$s', $to_state, $to_country, json_encode( $has_nexus ) ) );
+			}
 		}
 	}
-}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -231,6 +231,7 @@ class WC_Connect_TaxJar_Integration {
 		add_filter( 'woocommerce_cart_totals_get_item_tax_rates', array( $this, 'override_item_tax_rates' ), 10, 3 );
 
 		add_filter( 'woocommerce_rate_label', array( $this, 'cleanup_tax_label' ) );
+		add_filter( 'woocommerce_cart_tax_totals', array( $this, 'aggregate_tax_totals' ), 10, 2 );
 
 		WC_Connect_Custom_Surcharge::init();
 	}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -845,6 +845,13 @@ class WC_Connect_TaxJar_Integration {
 			$merged_taxes['line_items'] += $taxes['line_items'];
 		}
 
+		// If no group produced any taxes (e.g. all groups were cross-state), return false
+		// to preserve backward compatibility with callers that check for false.
+		if ( empty( $merged_taxes['rate_ids'] ) && empty( $merged_taxes['line_items'] ) ) {
+			return false;
+		}
+
+		$this->_log( $merged_taxes );
 		return $merged_taxes;
 	}
 
@@ -1579,10 +1586,11 @@ class WC_Connect_TaxJar_Integration {
 			return false;
 		}
 
-		// Don't calculate taxes for US when from_state and to_state are different.
+		// US cross-state: no nexus means no tax applies. Return empty taxes (not false)
+		// so that calculate_taxes_by_location() can continue with other groups.
 		if ( 'US' === $address_parts['from_country'] && 'US' === $address_parts['to_country'] && $address_parts['from_state'] !== $address_parts['to_state'] ) {
-			$this->_log( 'US from_state and to_state are different. Aborting.' );
-			return false;
+			$this->_log( 'US from_state and to_state are different. No tax applies.' );
+			return $taxes;
 		}
 
 		// Either `amount` or `line_items` parameters are required to perform tax calculations.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -228,7 +228,7 @@ class WC_Connect_TaxJar_Integration {
 
 		add_filter( 'woocommerce_calc_tax', array( $this, 'override_woocommerce_tax_rates' ), 10, 3 );
 		add_filter( 'woocommerce_matched_rates', array( $this, 'allow_street_address_for_matched_rates' ), 10, 2 );
-		add_filter( 'woocommerce_cart_totals_get_item_tax_rates', array( $this, 'override_item_tax_rates' ), 10, 3 );
+		add_filter( 'woocommerce_cart_totals_get_item_tax_rates', array( $this, 'override_cart_item_tax_rates' ), 10, 3 );
 		add_action( 'woocommerce_order_item_after_calculate_taxes', array( $this, 'override_order_item_taxes' ), 10, 2 );
 
 		add_filter( 'woocommerce_rate_label', array( $this, 'cleanup_tax_label' ) );
@@ -1083,7 +1083,7 @@ class WC_Connect_TaxJar_Integration {
 	 * @param object $cart           The WC_Cart object.
 	 * @return array Tax rates to use for this item.
 	 */
-	public function override_item_tax_rates( $item_tax_rates, $item, $cart ) {
+	public function override_cart_item_tax_rates( $item_tax_rates, $item, $cart ) {
 		// Only override if we have calculated rate IDs from TaxJar.
 		if ( empty( $this->response_rate_ids ) || ! is_array( $this->response_rate_ids ) ) {
 			return $item_tax_rates;

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -843,6 +843,9 @@ class WC_Connect_TaxJar_Integration {
 				return false;
 			}
 
+			// Using += (array union) is safe here because keys are line item IDs (e.g. "42-abc123")
+			// and each item exists in exactly one location group, so keys can't collide across groups.
+			// array_merge() would be incorrect as it re-indexes numeric keys.
 			$merged_taxes['rate_ids']   += $taxes['rate_ids'];
 			$merged_taxes['line_items'] += $taxes['line_items'];
 		}
@@ -1099,7 +1102,10 @@ class WC_Connect_TaxJar_Integration {
 		$product_id = $product->get_id();
 
 		// Find the matching line_item_key in response_rate_ids.
-		// Format is "product_id-cart_item_key".
+		// Format is "product_id-cart_item_key". The trailing "-" delimiter prevents
+		// false prefix matches (e.g. product ID 1 won't match "10-xyz" because "1-" != "10").
+		// First-match-wins is safe: if the same product ID appears multiple times (e.g.
+		// two bookings), they share the same tax_location and thus the same tax rates.
 		$matching_rate_ids = null;
 		foreach ( $this->response_rate_ids as $line_item_key => $rate_ids ) {
 			if ( strpos( $line_item_key, $product_id . '-' ) === 0 ) {
@@ -1164,6 +1170,8 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		// Find matching rate_ids by product_id prefix (format: "product_id-cart_item_key").
+		// The trailing "-" delimiter prevents false prefix matches between IDs (e.g. 1 vs 10).
+		// First-match-wins is safe: same product always shares the same tax_location and rates.
 		$matching_rate_ids = null;
 		foreach ( $this->response_rate_ids as $line_item_key => $rate_ids ) {
 			if ( strpos( $line_item_key, $product_id . '-' ) === 0 ) {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -977,7 +977,7 @@ class WC_Connect_TaxJar_Integration {
 			 * For example, service products (bookings) can be taxed at the shop
 			 * base address instead of the customer's shipping address.
 			 *
-			 * @since 2.8.0
+			 * @since 3.4.0
 			 *
 			 * @param string     $location Tax location type: 'base', 'shipping', or 'billing'.
 			 * @param WC_Product $product  The product being taxed.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -125,13 +125,15 @@ class WC_Connect_TaxJar_Integration {
 	/**
 	 * Generates an itemized tax rate name based on the provided tax rate and country.
 	 *
-	 * @param string $taxjar_rate_name The tax rate name from TaxJar, typically including '_tax_rate'.
-	 * @param string $to_country       The destination country for the tax calculation.
-	 * @param array  $jurisdictions    Tax jurisdictions.
+	 * @param string      $taxjar_rate_name The tax rate name from TaxJar, typically including '_tax_rate'.
+	 * @param string      $to_country       The destination country for the tax calculation.
+	 * @param array       $jurisdictions    Tax jurisdictions.
+	 * @param string|null $location_type    Location type: 'base', 'shipping', or 'billing'. Used to distinguish
+	 *                                      tax rates for different locations in multi-location tax scenarios.
 	 *
 	 * @return string The formatted and localized tax rate name.
 	 */
-	private static function generate_itemized_tax_rate_name( string $taxjar_rate_name, string $to_country, array $jurisdictions ) {
+	private static function generate_itemized_tax_rate_name( string $taxjar_rate_name, string $to_country, array $jurisdictions, ?string $location_type = null ) {
 		// Normalize the base key by stripping the trailing "_tax_rate" and converting underscores to spaces.
 		$base_key   = str_replace( '_tax_rate', '', $taxjar_rate_name );
 		$label_core = ucwords( str_replace( '_', ' ', $base_key ) );
@@ -144,13 +146,13 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		if ( 'country' === $base_key && $is_vat_country ) {
-			return 'VAT';
+			return self::append_location_suffix( 'VAT', $location_type );
 		}
 
 		// Default, country-agnostic formatting for non‑US destinations.
 		if ( 'US' !== $to_country ) {
 			// Preserve previous behavior of uppercasing for non‑US.
-			return strtoupper( $rate_name );
+			return self::append_location_suffix( strtoupper( $rate_name ), $location_type );
 		}
 
 		// United States specific naming enhancements.
@@ -161,21 +163,51 @@ class WC_Connect_TaxJar_Integration {
 			case 'city_tax_rate':
 			case 'special_tax_rate':
 				// Example: "Some County Some City : City Tax".
-				$prefix = trim( $county . ' ' . $city );
-				return ( '' !== $prefix ? $prefix . ' : ' : '' ) . $rate_name;
+				$prefix     = trim( $county . ' ' . $city );
+				$final_name = ( '' !== $prefix ? $prefix . ' : ' : '' ) . $rate_name;
+				return self::append_location_suffix( $final_name, $location_type );
 
 			case 'county_tax_rate':
 				// Example: "Some County : County Tax".
-				return ( '' !== $county ? $county . ' : ' : '' ) . $rate_name;
+				$final_name = ( '' !== $county ? $county . ' : ' : '' ) . $rate_name;
+				return self::append_location_suffix( $final_name, $location_type );
 
 			case 'state_sales_tax_rate':
 				// Example: "State Sales Tax" (no jurisdiction prefix).
-				return $rate_name;
+				return self::append_location_suffix( $rate_name, $location_type );
 
 			default:
 				// Fallback for any other US rate types.
-				return $rate_name;
+				return self::append_location_suffix( $rate_name, $location_type );
 		}
+	}
+
+	/**
+	 * Appends a location suffix to the tax rate name for multi-location tax scenarios.
+	 *
+	 * @param string      $rate_name     The tax rate name.
+	 * @param string|null $location_type Location type: 'base', 'shipping', or 'billing'.
+	 *
+	 * @return string The rate name with location suffix if applicable.
+	 */
+	private static function append_location_suffix( string $rate_name, ?string $location_type ): string {
+		if ( null === $location_type ) {
+			return $rate_name;
+		}
+
+		$location_labels = array(
+			'base'     => __( 'Store Address', 'woocommerce-services' ),
+			'shipping' => __( 'Customer Address', 'woocommerce-services' ),
+			'billing'  => __( 'Billing Address', 'woocommerce-services' ),
+		);
+
+		$suffix = $location_labels[ $location_type ] ?? null;
+
+		if ( null === $suffix ) {
+			return $rate_name;
+		}
+
+		return $rate_name . ' (' . $suffix . ')';
 	}
 
 	public function init() {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -888,6 +888,9 @@ class WC_Connect_TaxJar_Integration {
 			$postcode       = $store_settings['postcode'];
 			$city           = $store_settings['city'];
 			$street         = $store_settings['street'];
+		} elseif ( null === WC()->customer ) {
+			$this->_log( 'Warning: WC()->customer is null when resolving ' . $tax_based_on . ' address.' );
+			return array( '', '', '', '', '' );
 		} elseif ( 'billing' === $tax_based_on ) {
 			$country  = WC()->customer->get_billing_country();
 			$state    = WC()->customer->get_billing_state();

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -893,22 +893,22 @@ class WC_Connect_TaxJar_Integration {
 		return apply_filters( 'woocommerce_customer_taxable_address', array( $country, $state, $postcode, $city, $street ) );
 	}
 
-		/**
-		 * Get address details of customer for backend orders
-		 *
-		 * Unchanged from the TaxJar plugin.
-		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L607
-		 *
-		 * @return array
-		 */
+	/**
+	 * Get address details of customer for backend orders
+	 *
+	 * Unchanged from the TaxJar plugin.
+	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L607
+	 *
+	 * @return array
+	 */
 	protected function get_backend_address() {
-		// phpcs:disable WordPress.Security.NonceVerification.Missing --- Security handled by WooCommerce
+	// phpcs:disable WordPress.Security.NonceVerification.Missing --- Security handled by WooCommerce
 		$to_country = isset( $_POST['country'] ) ? strtoupper( wc_clean( $_POST['country'] ) ) : false;
 		$to_state   = isset( $_POST['state'] ) ? strtoupper( wc_clean( $_POST['state'] ) ) : false;
 		$to_zip     = isset( $_POST['postcode'] ) ? strtoupper( wc_clean( $_POST['postcode'] ) ) : false;
 		$to_city    = isset( $_POST['city'] ) ? strtoupper( wc_clean( $_POST['city'] ) ) : false;
 		$to_street  = isset( $_POST['street'] ) ? strtoupper( wc_clean( $_POST['street'] ) ) : false;
-		// phpcs:enable WordPress.Security.NonceVerification.Missing
+	// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		return array(
 			'to_country' => $to_country,

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -774,46 +774,91 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		/**
+		 * Calculate taxes for items grouped by location.
+		 *
+		 * @param array $items_by_location Items grouped by location type.
+		 * @param float $shipping_amount   Shipping amount.
+		 * @return array|false Merged taxes or false if any calculation fails.
+		 */
+		protected function calculate_taxes_by_location( $items_by_location, $shipping_amount ) {
+			$merged_taxes = array(
+				'rate_ids'   => array(),
+				'line_items' => array(),
+			);
+
+			foreach ( $items_by_location as $location_type => $items ) {
+				$address = $this->get_address( $location_type );
+
+				// Shipping only applies to 'shipping' location group.
+				// Note: Service fees could be added to 'base' group here in the future.
+				$group_shipping = ( 'shipping' === $location_type ) ? $shipping_amount : 0;
+
+				$taxes = $this->calculate_tax(
+					array(
+						'to_country'      => $address['to_country'],
+						'to_state'        => $address['to_state'],
+						'to_zip'          => $address['to_zip'],
+						'to_city'         => $address['to_city'],
+						'to_street'       => $address['to_street'],
+						'shipping_amount' => $group_shipping,
+						'line_items'      => $items,
+					)
+				);
+
+				// If any group fails, fail entire calculation.
+				if ( false === $taxes ) {
+					return false;
+				}
+
+				$merged_taxes['rate_ids']   += $taxes['rate_ids'];
+				$merged_taxes['line_items'] += $taxes['line_items'];
+			}
+
+			return $merged_taxes;
+		}
+	}
+
+		/**
 		 * Get taxable address.
 		 *
 		 * @return array
 		 */
-		public function get_taxable_address() {
-			$tax_based_on = get_option( 'woocommerce_tax_based_on' );
-			// Check shipping method at this point to see if we need special handling
-			// See WC_Customer get_taxable_address()
-			// wc_get_chosen_shipping_method_ids() available since Woo 2.6.2+
-			if ( function_exists( 'wc_get_chosen_shipping_method_ids' ) ) {
-				if ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
-					$tax_based_on = 'base';
-				}
-			} elseif ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( WC()->session->get( 'chosen_shipping_methods', array() ), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
+	public function get_taxable_address() {
+		$tax_based_on = get_option( 'woocommerce_tax_based_on' );
+		// Check shipping method at this point to see if we need special handling
+		// See WC_Customer get_taxable_address()
+		// wc_get_chosen_shipping_method_ids() available since Woo 2.6.2+
+		if ( function_exists( 'wc_get_chosen_shipping_method_ids' ) ) {
+			if ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
 				$tax_based_on = 'base';
 			}
-
-			if ( 'base' === $tax_based_on ) {
-				$store_settings = $this->get_store_settings();
-				$country        = $store_settings['country'];
-				$state          = $store_settings['state'];
-				$postcode       = $store_settings['postcode'];
-				$city           = $store_settings['city'];
-				$street         = $store_settings['street'];
-			} elseif ( 'billing' === $tax_based_on ) {
-				$country  = WC()->customer->get_billing_country();
-				$state    = WC()->customer->get_billing_state();
-				$postcode = WC()->customer->get_billing_postcode();
-				$city     = WC()->customer->get_billing_city();
-				$street   = WC()->customer->get_billing_address();
-			} else {
-				$country  = WC()->customer->get_shipping_country();
-				$state    = WC()->customer->get_shipping_state();
-				$postcode = WC()->customer->get_shipping_postcode();
-				$city     = WC()->customer->get_shipping_city();
-				$street   = WC()->customer->get_shipping_address();
-			}
-
-			return apply_filters( 'woocommerce_customer_taxable_address', array( $country, $state, $postcode, $city, $street ) );
+		} elseif ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( WC()->session->get( 'chosen_shipping_methods', array() ), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
+			$tax_based_on = 'base';
 		}
+
+		if ( 'base' === $tax_based_on ) {
+			$store_settings = $this->get_store_settings();
+			$country        = $store_settings['country'];
+			$state          = $store_settings['state'];
+			$postcode       = $store_settings['postcode'];
+			$city           = $store_settings['city'];
+			$street         = $store_settings['street'];
+		} elseif ( 'billing' === $tax_based_on ) {
+			$country  = WC()->customer->get_billing_country();
+			$state    = WC()->customer->get_billing_state();
+			$postcode = WC()->customer->get_billing_postcode();
+			$city     = WC()->customer->get_billing_city();
+			$street   = WC()->customer->get_billing_address();
+		} else {
+			$country  = WC()->customer->get_shipping_country();
+			$state    = WC()->customer->get_shipping_state();
+			$postcode = WC()->customer->get_shipping_postcode();
+			$city     = WC()->customer->get_shipping_city();
+			$street   = WC()->customer->get_shipping_address();
+		}
+
+		return apply_filters( 'woocommerce_customer_taxable_address', array( $country, $state, $postcode, $city, $street ) );
+	}
 
 		/**
 		 * Get address details of customer for backend orders
@@ -823,23 +868,23 @@ class WC_Connect_TaxJar_Integration {
 		 *
 		 * @return array
 		 */
-		protected function get_backend_address() {
+	protected function get_backend_address() {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing --- Security handled by WooCommerce
-			$to_country = isset( $_POST['country'] ) ? strtoupper( wc_clean( $_POST['country'] ) ) : false;
-			$to_state   = isset( $_POST['state'] ) ? strtoupper( wc_clean( $_POST['state'] ) ) : false;
-			$to_zip     = isset( $_POST['postcode'] ) ? strtoupper( wc_clean( $_POST['postcode'] ) ) : false;
-			$to_city    = isset( $_POST['city'] ) ? strtoupper( wc_clean( $_POST['city'] ) ) : false;
-			$to_street  = isset( $_POST['street'] ) ? strtoupper( wc_clean( $_POST['street'] ) ) : false;
+		$to_country = isset( $_POST['country'] ) ? strtoupper( wc_clean( $_POST['country'] ) ) : false;
+		$to_state   = isset( $_POST['state'] ) ? strtoupper( wc_clean( $_POST['state'] ) ) : false;
+		$to_zip     = isset( $_POST['postcode'] ) ? strtoupper( wc_clean( $_POST['postcode'] ) ) : false;
+		$to_city    = isset( $_POST['city'] ) ? strtoupper( wc_clean( $_POST['city'] ) ) : false;
+		$to_street  = isset( $_POST['street'] ) ? strtoupper( wc_clean( $_POST['street'] ) ) : false;
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
-			return array(
-				'to_country' => $to_country,
-				'to_state'   => $to_state,
-				'to_zip'     => $to_zip,
-				'to_city'    => $to_city,
-				'to_street'  => $to_street,
-			);
-		}
+		return array(
+			'to_country' => $to_country,
+			'to_state'   => $to_state,
+			'to_zip'     => $to_zip,
+			'to_city'    => $to_city,
+			'to_street'  => $to_street,
+		);
+	}
 
 		/**
 		 * Get line items at checkout
@@ -849,70 +894,70 @@ class WC_Connect_TaxJar_Integration {
 		 *
 		 * @return array
 		 */
-		protected function get_line_items( $wc_cart_object ) {
-			$line_items       = array();
-			$default_location = get_option( 'woocommerce_tax_based_on', 'shipping' );
+	protected function get_line_items( $wc_cart_object ) {
+		$line_items       = array();
+		$default_location = get_option( 'woocommerce_tax_based_on', 'shipping' );
 
-			foreach ( $wc_cart_object->get_cart() as $cart_item_key => $cart_item ) {
-				$product       = $cart_item['data'];
-				$id            = $product->get_id();
-				$quantity      = $cart_item['quantity'];
-				$unit_price    = wc_format_decimal( $product->get_price() );
-				$line_subtotal = wc_format_decimal( $cart_item['line_subtotal'] );
-				$discount      = wc_format_decimal( $cart_item['line_subtotal'] - $cart_item['line_total'] );
-				$tax_class     = explode( '-', $product->get_tax_class() );
-				$tax_code      = '';
+		foreach ( $wc_cart_object->get_cart() as $cart_item_key => $cart_item ) {
+			$product       = $cart_item['data'];
+			$id            = $product->get_id();
+			$quantity      = $cart_item['quantity'];
+			$unit_price    = wc_format_decimal( $product->get_price() );
+			$line_subtotal = wc_format_decimal( $cart_item['line_subtotal'] );
+			$discount      = wc_format_decimal( $cart_item['line_subtotal'] - $cart_item['line_total'] );
+			$tax_class     = explode( '-', $product->get_tax_class() );
+			$tax_code      = '';
 
-				if ( isset( $tax_class ) && is_numeric( end( $tax_class ) ) ) {
-					$tax_code = end( $tax_class );
-				}
-
-				if ( 'shipping' !== $product->get_tax_status() && ( ! $product->is_taxable() || 'zero-rate' == sanitize_title( $product->get_tax_class() ) ) ) {
-					$tax_code = '99999';
-				}
-
-				// Get WC Subscription sign-up fees for calculations
-				if ( class_exists( 'WC_Subscriptions_Cart' ) ) {
-					if ( 'none' == WC_Subscriptions_Cart::get_calculation_type() ) {
-						if ( class_exists( 'WC_Subscriptions_Synchroniser' ) ) {
-							WC_Subscriptions_Synchroniser::maybe_set_free_trial();
-						}
-						$unit_price = WC_Subscriptions_Cart::set_subscription_prices_for_calculation( $unit_price, $product );
-						if ( class_exists( 'WC_Subscriptions_Synchroniser' ) ) {
-							WC_Subscriptions_Synchroniser::maybe_unset_free_trial();
-						}
-					}
-				}
-
-				/**
-				 * Filter the tax location type for a line item.
-				 *
-				 * Allows plugins to specify where a product should be taxed.
-				 * For example, service products (bookings) can be taxed at the shop
-				 * base address instead of the customer's shipping address.
-				 *
-				 * @since 2.8.0
-				 *
-				 * @param string     $location Tax location type: 'base', 'shipping', or 'billing'.
-				 * @param WC_Product $product  The product being taxed.
-				 */
-				$tax_location = apply_filters( 'woocommerce_tax_line_item_location', $default_location, $product );
-
-				array_push(
-					$line_items,
-					array(
-						'id'               => $id . '-' . $cart_item_key,
-						'quantity'         => $quantity,
-						'product_tax_code' => $tax_code,
-						'unit_price'       => $unit_price,
-						'discount'         => $discount,
-						'tax_location'     => $tax_location,
-					)
-				);
+			if ( isset( $tax_class ) && is_numeric( end( $tax_class ) ) ) {
+				$tax_code = end( $tax_class );
 			}
 
-			return $line_items;
+			if ( 'shipping' !== $product->get_tax_status() && ( ! $product->is_taxable() || 'zero-rate' == sanitize_title( $product->get_tax_class() ) ) ) {
+				$tax_code = '99999';
+			}
+
+			// Get WC Subscription sign-up fees for calculations
+			if ( class_exists( 'WC_Subscriptions_Cart' ) ) {
+				if ( 'none' == WC_Subscriptions_Cart::get_calculation_type() ) {
+					if ( class_exists( 'WC_Subscriptions_Synchroniser' ) ) {
+						WC_Subscriptions_Synchroniser::maybe_set_free_trial();
+					}
+					$unit_price = WC_Subscriptions_Cart::set_subscription_prices_for_calculation( $unit_price, $product );
+					if ( class_exists( 'WC_Subscriptions_Synchroniser' ) ) {
+						WC_Subscriptions_Synchroniser::maybe_unset_free_trial();
+					}
+				}
+			}
+
+			/**
+			 * Filter the tax location type for a line item.
+			 *
+			 * Allows plugins to specify where a product should be taxed.
+			 * For example, service products (bookings) can be taxed at the shop
+			 * base address instead of the customer's shipping address.
+			 *
+			 * @since 2.8.0
+			 *
+			 * @param string     $location Tax location type: 'base', 'shipping', or 'billing'.
+			 * @param WC_Product $product  The product being taxed.
+			 */
+			$tax_location = apply_filters( 'woocommerce_tax_line_item_location', $default_location, $product );
+
+			array_push(
+				$line_items,
+				array(
+					'id'               => $id . '-' . $cart_item_key,
+					'quantity'         => $quantity,
+					'product_tax_code' => $tax_code,
+					'unit_price'       => $unit_price,
+					'discount'         => $discount,
+					'tax_location'     => $tax_location,
+				)
+			);
 		}
+
+		return $line_items;
+	}
 
 		/**
 		 * Get line items for backend orders
@@ -922,67 +967,67 @@ class WC_Connect_TaxJar_Integration {
 		 *
 		 * @return array
 		 */
-		protected function get_backend_line_items( $order ) {
-			$line_items                = array();
-			$this->backend_tax_classes = array();
-			$default_location          = get_option( 'woocommerce_tax_based_on', 'shipping' );
+	protected function get_backend_line_items( $order ) {
+		$line_items                = array();
+		$this->backend_tax_classes = array();
+		$default_location          = get_option( 'woocommerce_tax_based_on', 'shipping' );
 
-			foreach ( $order->get_items() as $item_key => $item ) {
-				if ( is_object( $item ) ) { // Woo 3.0+
-					$id             = $item->get_product_id();
-					$quantity       = $item->get_quantity();
-					$unit_price     = empty( $quantity ) ? $item->get_subtotal() : wc_format_decimal( $item->get_subtotal() / $quantity );
-					$discount       = wc_format_decimal( $item->get_subtotal() - $item->get_total() );
-					$tax_class_name = $item->get_tax_class();
-					$tax_status     = $item->get_tax_status();
-					$product        = $item->get_product();
-				} else { // Woo 2.6
-					$id             = $item['product_id'];
-					$quantity       = $item['qty'];
-					$unit_price     = empty( $quantity ) ? $item['line_subtotal'] : wc_format_decimal( $item['line_subtotal'] / $quantity );
-					$discount       = wc_format_decimal( $item['line_subtotal'] - $item['line_total'] );
-					$tax_class_name = $item['tax_class'];
-					$product        = $order->get_product_from_item( $item );
-					$tax_status     = $product ? $product->get_tax_status() : 'taxable';
-				}
-				$this->backend_tax_classes[ $id ] = $tax_class_name;
-				$tax_class                        = explode( '-', $tax_class_name );
-				$tax_code                         = '';
-				if ( isset( $tax_class[1] ) && is_numeric( $tax_class[1] ) ) {
-					$tax_code = $tax_class[1];
-				}
-				if ( 'taxable' !== $tax_status ) {
-					$tax_code = '99999';
-				}
-
-				/** This filter is documented in get_line_items() */
-				$tax_location = apply_filters( 'woocommerce_tax_line_item_location', $default_location, $product );
-
-				if ( $unit_price ) {
-					array_push(
-						$line_items,
-						array(
-							'id'               => $id . '-' . $item_key,
-							'quantity'         => $quantity,
-							'product_tax_code' => $tax_code,
-							'unit_price'       => $unit_price,
-							'discount'         => $discount,
-							'tax_location'     => $tax_location,
-						)
-					);
-				}
+		foreach ( $order->get_items() as $item_key => $item ) {
+			if ( is_object( $item ) ) { // Woo 3.0+
+				$id             = $item->get_product_id();
+				$quantity       = $item->get_quantity();
+				$unit_price     = empty( $quantity ) ? $item->get_subtotal() : wc_format_decimal( $item->get_subtotal() / $quantity );
+				$discount       = wc_format_decimal( $item->get_subtotal() - $item->get_total() );
+				$tax_class_name = $item->get_tax_class();
+				$tax_status     = $item->get_tax_status();
+				$product        = $item->get_product();
+			} else { // Woo 2.6
+				$id             = $item['product_id'];
+				$quantity       = $item['qty'];
+				$unit_price     = empty( $quantity ) ? $item['line_subtotal'] : wc_format_decimal( $item['line_subtotal'] / $quantity );
+				$discount       = wc_format_decimal( $item['line_subtotal'] - $item['line_total'] );
+				$tax_class_name = $item['tax_class'];
+				$product        = $order->get_product_from_item( $item );
+				$tax_status     = $product ? $product->get_tax_status() : 'taxable';
 			}
-			return $line_items;
-		}
-
-		protected function get_line_item( $id, $line_items ) {
-			foreach ( $line_items as $line_item ) {
-				if ( $line_item['id'] === $id ) {
-					return $line_item;
-				}
+			$this->backend_tax_classes[ $id ] = $tax_class_name;
+			$tax_class                        = explode( '-', $tax_class_name );
+			$tax_code                         = '';
+			if ( isset( $tax_class[1] ) && is_numeric( $tax_class[1] ) ) {
+				$tax_code = $tax_class[1];
 			}
-			return null;
+			if ( 'taxable' !== $tax_status ) {
+				$tax_code = '99999';
+			}
+
+			/** This filter is documented in get_line_items() */
+			$tax_location = apply_filters( 'woocommerce_tax_line_item_location', $default_location, $product );
+
+			if ( $unit_price ) {
+				array_push(
+					$line_items,
+					array(
+						'id'               => $id . '-' . $item_key,
+						'quantity'         => $quantity,
+						'product_tax_code' => $tax_code,
+						'unit_price'       => $unit_price,
+						'discount'         => $discount,
+						'tax_location'     => $tax_location,
+					)
+				);
+			}
 		}
+		return $line_items;
+	}
+
+	protected function get_line_item( $id, $line_items ) {
+		foreach ( $line_items as $line_item ) {
+			if ( $line_item['id'] === $id ) {
+				return $line_item;
+			}
+		}
+		return null;
+	}
 
 		/**
 		 * Override Woo's native tax rates to handle multiple line items with the same tax rate
@@ -993,46 +1038,46 @@ class WC_Connect_TaxJar_Integration {
 		 *
 		 * @return array
 		 */
-		public function override_woocommerce_tax_rates( $taxes, $price, $rates ) {
-			if (
-			! isset( $this->response_line_items )
-			|| empty( $rates )
-			|| ! is_array( $rates )
-			|| ! is_array( $taxes )
-			) {
-				return $taxes;
-			}
-
-			// Get tax rate ID for current item
-			$keys        = array_keys( $taxes );
-			$tax_rate_id = $keys[0];
-			$line_items  = array();
-
-			// Map line items using rate ID
-			foreach ( $this->response_rate_ids as $line_item_key => $rate_id ) {
-				if ( $rate_id == $tax_rate_id ) {
-					$line_items[] = $line_item_key;
-				}
-			}
-
-			// Remove number precision if Woo 3.2+
-			if ( function_exists( 'wc_remove_number_precision' ) ) {
-				$price = wc_remove_number_precision( $price );
-			}
-
-			foreach ( $this->response_line_items as $line_item_key => $line_item ) {
-				// If line item belongs to rate and matches the price, manually set the tax
-				if ( in_array( $line_item_key, $line_items ) && $price == $line_item->line_total ) {
-					if ( function_exists( 'wc_add_number_precision' ) ) {
-						$taxes[ $tax_rate_id ] = wc_add_number_precision( $line_item->tax_collectable );
-					} else {
-						$taxes[ $tax_rate_id ] = $line_item->tax_collectable;
-					}
-				}
-			}
-
+	public function override_woocommerce_tax_rates( $taxes, $price, $rates ) {
+		if (
+		! isset( $this->response_line_items )
+		|| empty( $rates )
+		|| ! is_array( $rates )
+		|| ! is_array( $taxes )
+		) {
 			return $taxes;
 		}
+
+		// Get tax rate ID for current item
+		$keys        = array_keys( $taxes );
+		$tax_rate_id = $keys[0];
+		$line_items  = array();
+
+		// Map line items using rate ID
+		foreach ( $this->response_rate_ids as $line_item_key => $rate_id ) {
+			if ( $rate_id == $tax_rate_id ) {
+				$line_items[] = $line_item_key;
+			}
+		}
+
+		// Remove number precision if Woo 3.2+
+		if ( function_exists( 'wc_remove_number_precision' ) ) {
+			$price = wc_remove_number_precision( $price );
+		}
+
+		foreach ( $this->response_line_items as $line_item_key => $line_item ) {
+			// If line item belongs to rate and matches the price, manually set the tax
+			if ( in_array( $line_item_key, $line_items ) && $price == $line_item->line_total ) {
+				if ( function_exists( 'wc_add_number_precision' ) ) {
+					$taxes[ $tax_rate_id ] = wc_add_number_precision( $line_item->tax_collectable );
+				} else {
+					$taxes[ $tax_rate_id ] = $line_item->tax_collectable;
+				}
+			}
+		}
+
+		return $taxes;
+	}
 
 		/**
 		 * Set customer zip code and state to store if local shipping option set
@@ -1042,34 +1087,34 @@ class WC_Connect_TaxJar_Integration {
 		 *
 		 * @return array
 		 */
-		public function append_base_address_to_customer_taxable_address( $address ) {
-			$tax_based_on = '';
+	public function append_base_address_to_customer_taxable_address( $address ) {
+		$tax_based_on = '';
 
-			list( $country, $state, $postcode, $city, $street ) = array_pad( $address, 5, '' );
+		list( $country, $state, $postcode, $city, $street ) = array_pad( $address, 5, '' );
 
-			// See WC_Customer get_taxable_address()
-			// wc_get_chosen_shipping_method_ids() available since Woo 2.6.2+
-			if ( function_exists( 'wc_get_chosen_shipping_method_ids' ) ) {
-				if ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
-					$tax_based_on = 'base';
-				}
-			} elseif ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( WC()->session->get( 'chosen_shipping_methods', array() ), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
+		// See WC_Customer get_taxable_address()
+		// wc_get_chosen_shipping_method_ids() available since Woo 2.6.2+
+		if ( function_exists( 'wc_get_chosen_shipping_method_ids' ) ) {
+			if ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
 				$tax_based_on = 'base';
 			}
-
-			if ( 'base' == $tax_based_on ) {
-				$store_settings = $this->get_store_settings();
-				$postcode       = $store_settings['postcode'];
-				$city           = strtoupper( $store_settings['city'] );
-				$street         = $store_settings['street'];
-			}
-
-			if ( '' != $street ) {
-				return array( $country, $state, $postcode, $city, $street );
-			}
-
-			return array( $country, $state, $postcode, $city );
+		} elseif ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( WC()->session->get( 'chosen_shipping_methods', array() ), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
+			$tax_based_on = 'base';
 		}
+
+		if ( 'base' == $tax_based_on ) {
+			$store_settings = $this->get_store_settings();
+			$postcode       = $store_settings['postcode'];
+			$city           = strtoupper( $store_settings['city'] );
+			$street         = $store_settings['street'];
+		}
+
+		if ( '' != $street ) {
+			return array( $country, $state, $postcode, $city, $street );
+		}
+
+		return array( $country, $state, $postcode, $city );
+	}
 
 		/**
 		 * This method is used to override the TaxJar result.
@@ -1079,40 +1124,40 @@ class WC_Connect_TaxJar_Integration {
 		 *
 		 * @return object
 		 */
-		public function maybe_override_taxjar_tax( $taxjar_resp_tax, $body ) {
-			if ( ! isset( $taxjar_resp_tax ) ) {
-				return;
-			}
+	public function maybe_override_taxjar_tax( $taxjar_resp_tax, $body ) {
+		if ( ! isset( $taxjar_resp_tax ) ) {
+			return;
+		}
 
-			$new_tax_rate = floatval( apply_filters( 'woocommerce_services_override_tax_rate', $taxjar_resp_tax->rate, $taxjar_resp_tax, $body ) );
+		$new_tax_rate = floatval( apply_filters( 'woocommerce_services_override_tax_rate', $taxjar_resp_tax->rate, $taxjar_resp_tax, $body ) );
 
-			if ( $new_tax_rate === floatval( $taxjar_resp_tax->rate ) ) {
-				return $taxjar_resp_tax;
-			}
-
-			if ( ! empty( $taxjar_resp_tax->breakdown->line_items ) ) {
-				$taxjar_resp_tax->breakdown->line_items = array_map(
-					function ( $line_item ) use ( $new_tax_rate ) {
-						$line_item->combined_tax_rate       = $new_tax_rate;
-						$line_item->country_tax_rate        = $new_tax_rate;
-						$line_item->country_tax_collectable = $line_item->country_taxable_amount * $new_tax_rate;
-						$line_item->tax_collectable         = $line_item->taxable_amount * $new_tax_rate;
-
-						return $line_item;
-					},
-					$taxjar_resp_tax->breakdown->line_items
-				);
-			}
-
-			$taxjar_resp_tax->breakdown->combined_tax_rate           = $new_tax_rate;
-			$taxjar_resp_tax->breakdown->country_tax_rate            = $new_tax_rate;
-			$taxjar_resp_tax->breakdown->shipping->combined_tax_rate = $new_tax_rate;
-			$taxjar_resp_tax->breakdown->shipping->country_tax_rate  = $new_tax_rate;
-
-			$taxjar_resp_tax->rate = $new_tax_rate;
-
+		if ( $new_tax_rate === floatval( $taxjar_resp_tax->rate ) ) {
 			return $taxjar_resp_tax;
 		}
+
+		if ( ! empty( $taxjar_resp_tax->breakdown->line_items ) ) {
+			$taxjar_resp_tax->breakdown->line_items = array_map(
+				function ( $line_item ) use ( $new_tax_rate ) {
+					$line_item->combined_tax_rate       = $new_tax_rate;
+					$line_item->country_tax_rate        = $new_tax_rate;
+					$line_item->country_tax_collectable = $line_item->country_taxable_amount * $new_tax_rate;
+					$line_item->tax_collectable         = $line_item->taxable_amount * $new_tax_rate;
+
+					return $line_item;
+				},
+				$taxjar_resp_tax->breakdown->line_items
+			);
+		}
+
+		$taxjar_resp_tax->breakdown->combined_tax_rate           = $new_tax_rate;
+		$taxjar_resp_tax->breakdown->country_tax_rate            = $new_tax_rate;
+		$taxjar_resp_tax->breakdown->shipping->combined_tax_rate = $new_tax_rate;
+		$taxjar_resp_tax->breakdown->shipping->country_tax_rate  = $new_tax_rate;
+
+		$taxjar_resp_tax->rate = $new_tax_rate;
+
+		return $taxjar_resp_tax;
+	}
 
 		/**
 		 * Maybe apply a temporary workaround for the TaxJar API to get the correct rates for
@@ -1131,64 +1176,64 @@ class WC_Connect_TaxJar_Integration {
 		 *
 		 * @return array
 		 */
-		private function maybe_apply_taxjar_nexus_addresses_workaround( $body ) {
-			$workaround_nexus_addresses = array();
-			if ( true !== apply_filters( 'woocommerce_apply_taxjar_nexus_addresses_workaround', true ) ) {
-				return $workaround_nexus_addresses;
-			}
-
-			$cases = array(
-				'CA-QC' => array(
-					'to_country'   => 'CA',
-					'to_state'     => 'QC',
-					'from_country' => 'CA',
-				),
-				'US-CO' => array(
-					'to_country'   => 'US',
-					'to_state'     => 'CO',
-					'from_country' => 'US',
-					'from_state'   => 'CO',
-				),
-				'US-AZ' => array(
-					'to_country'   => 'US',
-					'to_state'     => 'AZ',
-					'from_country' => 'US',
-					'from_state'   => 'AZ',
-				),
-				'US-OH' => array(
-					'to_country'   => 'US',
-					'to_state'     => 'OH',
-					'from_country' => 'US',
-					'from_state'   => 'OH',
-				),
-			);
-
-			foreach ( $cases as $case ) {
-
-				/**
-				 * Ensure the body has all the required address keys, and that the body address
-				 * values match the case address values before applying the workaround.
-				 */
-				$address_keys = array_keys( $case );
-				foreach ( $address_keys as $address_key ) {
-					if ( ! isset( $body[ $address_key ] ) || $body[ $address_key ] !== $case[ $address_key ] ) {
-						continue 2;
-					}
-				}
-
-				$workaround_nexus_addresses = array(
-					'country' => $body['to_country'],
-					'zip'     => $body['to_zip'],
-					'state'   => $body['to_state'],
-					'city'    => $body['to_city'],
-					'street'  => $body['to_street'],
-				);
-
-				break;
-			}
-
+	private function maybe_apply_taxjar_nexus_addresses_workaround( $body ) {
+		$workaround_nexus_addresses = array();
+		if ( true !== apply_filters( 'woocommerce_apply_taxjar_nexus_addresses_workaround', true ) ) {
 			return $workaround_nexus_addresses;
 		}
+
+		$cases = array(
+			'CA-QC' => array(
+				'to_country'   => 'CA',
+				'to_state'     => 'QC',
+				'from_country' => 'CA',
+			),
+			'US-CO' => array(
+				'to_country'   => 'US',
+				'to_state'     => 'CO',
+				'from_country' => 'US',
+				'from_state'   => 'CO',
+			),
+			'US-AZ' => array(
+				'to_country'   => 'US',
+				'to_state'     => 'AZ',
+				'from_country' => 'US',
+				'from_state'   => 'AZ',
+			),
+			'US-OH' => array(
+				'to_country'   => 'US',
+				'to_state'     => 'OH',
+				'from_country' => 'US',
+				'from_state'   => 'OH',
+			),
+		);
+
+		foreach ( $cases as $case ) {
+
+			/**
+			 * Ensure the body has all the required address keys, and that the body address
+			 * values match the case address values before applying the workaround.
+			 */
+			$address_keys = array_keys( $case );
+			foreach ( $address_keys as $address_key ) {
+				if ( ! isset( $body[ $address_key ] ) || $body[ $address_key ] !== $case[ $address_key ] ) {
+					continue 2;
+				}
+			}
+
+			$workaround_nexus_addresses = array(
+				'country' => $body['to_country'],
+				'zip'     => $body['to_zip'],
+				'state'   => $body['to_state'],
+				'city'    => $body['to_city'],
+				'street'  => $body['to_street'],
+			);
+
+			break;
+		}
+
+		return $workaround_nexus_addresses;
+	}
 
 		/**
 		 * Validates TaxJar nexus address.
@@ -1197,104 +1242,104 @@ class WC_Connect_TaxJar_Integration {
 		 *
 		 * @return bool
 		 */
-		private function is_nexus_address_valid( $address ): bool {
-			$errors = array();
-			$schema = array(
-				'id'      => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Unique identifier for the nexus address (optional).',
-					'max_length'  => 255,
-				),
-				'country' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'pattern'     => '/^[A-Z]{2}$/', // two-letter ISO alpha-2 (upper-case)
-					'description' => 'Two-letter ISO country code (e.g. "US").',
-					'max_length'  => 2,
-				),
-				'zip'     => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Postal code (format varies by country).',
-					'max_length'  => 20,
-				),
-				'state'   => array(
-					'type'        => 'string',
-					'required'    => true,
-					'pattern'     => '/^[A-Z0-9\-]{1,100}$/', // typical short code like "NY", "CA", "NSW"
-					'description' => 'Two-letter (or short) ISO state/province code where applicable.',
-					'max_length'  => 100,
-				),
-				'city'    => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'City name.',
-					'max_length'  => 100,
-				),
-				'street'  => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Street address (line).',
-					'max_length'  => 255,
-				),
-			);
+	private function is_nexus_address_valid( $address ): bool {
+		$errors = array();
+		$schema = array(
+			'id'      => array(
+				'type'        => 'string',
+				'required'    => false,
+				'description' => 'Unique identifier for the nexus address (optional).',
+				'max_length'  => 255,
+			),
+			'country' => array(
+				'type'        => 'string',
+				'required'    => true,
+				'pattern'     => '/^[A-Z]{2}$/', // two-letter ISO alpha-2 (upper-case)
+				'description' => 'Two-letter ISO country code (e.g. "US").',
+				'max_length'  => 2,
+			),
+			'zip'     => array(
+				'type'        => 'string',
+				'required'    => false,
+				'description' => 'Postal code (format varies by country).',
+				'max_length'  => 20,
+			),
+			'state'   => array(
+				'type'        => 'string',
+				'required'    => true,
+				'pattern'     => '/^[A-Z0-9\-]{1,100}$/', // typical short code like "NY", "CA", "NSW"
+				'description' => 'Two-letter (or short) ISO state/province code where applicable.',
+				'max_length'  => 100,
+			),
+			'city'    => array(
+				'type'        => 'string',
+				'required'    => false,
+				'description' => 'City name.',
+				'max_length'  => 100,
+			),
+			'street'  => array(
+				'type'        => 'string',
+				'required'    => false,
+				'description' => 'Street address (line).',
+				'max_length'  => 255,
+			),
+		);
 
-			/**
-			 * Return without logging as empty array() or false
-			 * might be return on purpose from filter to remove nexus address.
-			 */
-			if ( empty( $address ) ) {
-				return false;
-			}
-
-			if ( ! is_array( $address ) ) {
-				$this->logger->error( 'Nexus Address ERRORS: Nexus addresses has invalid format' . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . print_r( $address, true ), 'WCS Tax' );
-
-				return false;
-			}
-
-			foreach ( $schema as $field => $rules ) {
-				$exists = array_key_exists( $field, $address );
-				$value  = $exists ? $address[ $field ] : null;
-
-				if ( ! empty( $rules['required'] ) && ! $exists ) {
-					$errors[] = "[$field] field is required";
-					continue;
-				}
-
-				if ( ! $exists || $value === '' || $value === null ) {
-					continue;
-				}
-
-				if ( isset( $rules['type'] ) ) {
-					if ( $rules['type'] === 'string' && ! is_string( $value ) ) {
-						$errors[] = "[$field] field must be a string";
-						continue;
-					}
-				}
-
-				if ( isset( $rules['max_length'] ) && is_string( $value ) ) {
-					if ( strlen( $value ) > $rules['max_length'] ) {
-						$errors[] = "[$field] field exceeds maximum length of {$rules['max_length']}";
-					}
-				}
-
-				if ( isset( $rules['pattern'] ) && is_string( $value ) ) {
-					if ( ! preg_match( $rules['pattern'], $value ) ) {
-						$errors[] = "[$field] field format is invalid";
-					}
-				}
-			}
-
-			if ( ! empty( $errors ) ) {
-				$this->logger->error( 'Nexus Address ERRORS: ' . implode( ', ', $errors ) . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . print_r( $address, true ), 'WCS Tax' );
-
-				return false;
-			}
-
-			return true;
+		/**
+		 * Return without logging as empty array() or false
+		 * might be return on purpose from filter to remove nexus address.
+		 */
+		if ( empty( $address ) ) {
+			return false;
 		}
+
+		if ( ! is_array( $address ) ) {
+			$this->logger->error( 'Nexus Address ERRORS: Nexus addresses has invalid format' . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . print_r( $address, true ), 'WCS Tax' );
+
+			return false;
+		}
+
+		foreach ( $schema as $field => $rules ) {
+			$exists = array_key_exists( $field, $address );
+			$value  = $exists ? $address[ $field ] : null;
+
+			if ( ! empty( $rules['required'] ) && ! $exists ) {
+				$errors[] = "[$field] field is required";
+				continue;
+			}
+
+			if ( ! $exists || $value === '' || $value === null ) {
+				continue;
+			}
+
+			if ( isset( $rules['type'] ) ) {
+				if ( $rules['type'] === 'string' && ! is_string( $value ) ) {
+					$errors[] = "[$field] field must be a string";
+					continue;
+				}
+			}
+
+			if ( isset( $rules['max_length'] ) && is_string( $value ) ) {
+				if ( strlen( $value ) > $rules['max_length'] ) {
+					$errors[] = "[$field] field exceeds maximum length of {$rules['max_length']}";
+				}
+			}
+
+			if ( isset( $rules['pattern'] ) && is_string( $value ) ) {
+				if ( ! preg_match( $rules['pattern'], $value ) ) {
+					$errors[] = "[$field] field format is invalid";
+				}
+			}
+		}
+
+		if ( ! empty( $errors ) ) {
+			$this->logger->error( 'Nexus Address ERRORS: ' . implode( ', ', $errors ) . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . print_r( $address, true ), 'WCS Tax' );
+
+			return false;
+		}
+
+		return true;
+	}
 
 		/**
 		 * Calculate sales tax using SmartCalcs
@@ -1304,173 +1349,173 @@ class WC_Connect_TaxJar_Integration {
 		 *
 		 * @return array|boolean
 		 */
-		public function calculate_tax( $options = array() ) {
-			$this->_log( ':::: TaxJar Plugin requested ::::' );
+	public function calculate_tax( $options = array() ) {
+		$this->_log( ':::: TaxJar Plugin requested ::::' );
 
-			// Normalize options to an array and safely map to local variables.
-			$options = is_array( $options ) ? $options : array();
+		// Normalize options to an array and safely map to local variables.
+		$options = is_array( $options ) ? $options : array();
 
-			$to_country      = isset( $options['to_country'] ) ? strtoupper( $options['to_country'] ) : null;
-			$to_state        = isset( $options['to_state'] ) ? strtoupper( $options['to_state'] ) : null;
-			$to_zip          = $options['to_zip'] ?? null;
-			$to_city         = $options['to_city'] ?? null;
-			$to_street       = $options['to_street'] ?? null;
-			$shipping_amount = $options['shipping_amount'] ?? 0;
-			$line_items      = $options['line_items'] ?? null;
+		$to_country      = isset( $options['to_country'] ) ? strtoupper( $options['to_country'] ) : null;
+		$to_state        = isset( $options['to_state'] ) ? strtoupper( $options['to_state'] ) : null;
+		$to_zip          = $options['to_zip'] ?? null;
+		$to_city         = $options['to_city'] ?? null;
+		$to_street       = $options['to_street'] ?? null;
+		$shipping_amount = $options['shipping_amount'] ?? 0;
+		$line_items      = $options['line_items'] ?? null;
 
-			$taxes = array(
-				'freight_taxable' => 1,
-				'has_nexus'       => 0,
-				'line_items'      => array(),
-				'rate_ids'        => array(),
-				'tax_rate'        => 0,
+		$taxes = array(
+			'freight_taxable' => 1,
+			'has_nexus'       => 0,
+			'line_items'      => array(),
+			'rate_ids'        => array(),
+			'tax_rate'        => 0,
+		);
+
+		// Strict conditions to be met before API call can be conducted.
+		if (
+		empty( $to_country ) ||
+		( empty( $to_zip ) && ! in_array( $to_country, WC()->countries->get_vat_countries() ) ) ||
+		( empty( $line_items ) && ( empty( $shipping_amount ) ) ) ||
+		WC()->customer->is_vat_exempt()
+		) {
+			return false;
+		}
+
+		$to_zip = explode( ',', $to_zip );
+		$to_zip = array_shift( $to_zip );
+
+		$store_settings = $this->get_store_settings();
+		$from_country   = strtoupper( $store_settings['country'] );
+		$from_state     = strtoupper( $store_settings['state'] );
+		$from_zip       = $store_settings['postcode'];
+		$from_city      = $store_settings['city'];
+		$from_street    = $store_settings['street'];
+
+		$this->_log( ':::: TaxJar API called ::::' );
+
+		$body = array(
+			'from_country' => $from_country,
+			'from_state'   => $from_state,
+			'from_zip'     => $from_zip,
+			'from_city'    => $from_city,
+			'from_street'  => $from_street,
+			'to_country'   => $to_country,
+			'to_state'     => $to_state,
+			'to_zip'       => $to_zip,
+			'to_city'      => $to_city,
+			'to_street'    => $to_street,
+			'shipping'     => $shipping_amount,
+			'plugin'       => 'woo',
+		);
+
+		$nexus_address = $this->maybe_apply_taxjar_nexus_addresses_workaround( $body );
+
+		// If workaround empty use default store address as nexus address.
+		if ( empty( $nexus_address ) ) {
+			$nexus_address = array(
+				'country' => $body['from_country'],
+				'zip'     => $body['from_zip'],
+				'state'   => $body['from_state'],
+				'city'    => $body['from_city'],
+				'street'  => $body['from_street'],
+			);
+		}
+
+		/**
+		 * Filter to modify or disable the nexus address sent to TaxJar API.
+		 *
+		 * This filter allows modification of the nexus address that will be sent
+		 * in the TaxJar API request. The nexus address replaces the standard from_*
+		 * address fields when provided.
+		 *
+		 * Return false or an empty array to disable sending nexus addresses entirely,
+		 * which will cause the request to use the standard from_* address fields instead.
+		 *
+		 * The nexus address array should contain the following keys:
+		 * - country: Two-letter country code (required).
+		 * - state: Two-letter state/province code (required for US/CA).
+		 * - zip: Postal/ZIP code (required).
+		 * - city: City name (required).
+		 * - street: Street address (optional).
+		 *
+		 * @since 3.3.0
+		 *
+		 * @param array $nexus_address The nexus address array to be sent to TaxJar.
+		 * @param array $body          The complete TaxJar API request body.
+		 *
+		 * @return array|false Modified nexus address array, or false to disable nexus addresses.
+		 *
+		 * @example
+		 * // Disable nexus addresses entirely.
+		 * add_filter( 'woocommerce_taxjar_nexus_address', '__return_false' );
+		 *
+		 * @example
+		 * // Modify the nexus address.
+		 * add_filter( 'woocommerce_taxjar_nexus_address', function( $nexus_address, $body ) {
+		 *     $nexus_address['street'] = '123 Custom Street';
+		 *     return $nexus_address;
+		 * }, 10, 2 );
+		 */
+		$nexus_address = apply_filters( 'woocommerce_taxjar_nexus_address', $nexus_address, $body );
+
+		if ( is_array( $nexus_address ) && ! empty( $nexus_address ) && $this->is_nexus_address_valid( $nexus_address ) ) {
+			$params_to_unset = array(
+				'from_country',
+				'from_state',
+				'from_zip',
+				'from_city',
+				'from_street',
 			);
 
-			// Strict conditions to be met before API call can be conducted.
-			if (
-			empty( $to_country ) ||
-			( empty( $to_zip ) && ! in_array( $to_country, WC()->countries->get_vat_countries() ) ) ||
-			( empty( $line_items ) && ( empty( $shipping_amount ) ) ) ||
-			WC()->customer->is_vat_exempt()
-			) {
-				return false;
+			foreach ( $params_to_unset as $param ) {
+				unset( $body[ $param ] );
 			}
+			$body['nexus_addresses'] = array( $nexus_address );
+		}
 
-			$to_zip = explode( ',', $to_zip );
-			$to_zip = array_shift( $to_zip );
+		$address_parts = $this->get_address_parts( $body );
 
-			$store_settings = $this->get_store_settings();
-			$from_country   = strtoupper( $store_settings['country'] );
-			$from_state     = strtoupper( $store_settings['state'] );
-			$from_zip       = $store_settings['postcode'];
-			$from_city      = $store_settings['city'];
-			$from_street    = $store_settings['street'];
+		// Require from_country.
+		if ( empty( $address_parts['from_country'] ) ) {
+			$this->_log( 'From country is missing. Aborting.' );
+			return false;
+		}
 
-			$this->_log( ':::: TaxJar API called ::::' );
+		// Don't calculate taxes for US when from_state and to_state are different.
+		if ( 'US' === $address_parts['from_country'] && 'US' === $address_parts['to_country'] && $address_parts['from_state'] !== $address_parts['to_state'] ) {
+			$this->_log( 'US from_state and to_state are different. Aborting.' );
+			return false;
+		}
 
-			$body = array(
-				'from_country' => $from_country,
-				'from_state'   => $from_state,
-				'from_zip'     => $from_zip,
-				'from_city'    => $from_city,
-				'from_street'  => $from_street,
-				'to_country'   => $to_country,
-				'to_state'     => $to_state,
-				'to_zip'       => $to_zip,
-				'to_city'      => $to_city,
-				'to_street'    => $to_street,
-				'shipping'     => $shipping_amount,
-				'plugin'       => 'woo',
-			);
+		// Either `amount` or `line_items` parameters are required to perform tax calculations.
+		if ( empty( $line_items ) ) {
+			$body['amount'] = 0.01;
+		} else {
+			$body['line_items'] = $line_items;
+		}
 
-			$nexus_address = $this->maybe_apply_taxjar_nexus_addresses_workaround( $body );
+		$response = $this->smartcalcs_cache_request( wp_json_encode( $body ), $from_state );
 
-			// If workaround empty use default store address as nexus address.
-			if ( empty( $nexus_address ) ) {
-				$nexus_address = array(
-					'country' => $body['from_country'],
-					'zip'     => $body['from_zip'],
-					'state'   => $body['from_state'],
-					'city'    => $body['from_city'],
-					'street'  => $body['from_street'],
-				);
-			}
+		// if no response, no need to keep going - bail early.
+		if ( ! isset( $response ) || ! $response ) {
+			$this->_log( 'Received: none.' );
 
-			/**
-			 * Filter to modify or disable the nexus address sent to TaxJar API.
-			 *
-			 * This filter allows modification of the nexus address that will be sent
-			 * in the TaxJar API request. The nexus address replaces the standard from_*
-			 * address fields when provided.
-			 *
-			 * Return false or an empty array to disable sending nexus addresses entirely,
-			 * which will cause the request to use the standard from_* address fields instead.
-			 *
-			 * The nexus address array should contain the following keys:
-			 * - country: Two-letter country code (required).
-			 * - state: Two-letter state/province code (required for US/CA).
-			 * - zip: Postal/ZIP code (required).
-			 * - city: City name (required).
-			 * - street: Street address (optional).
-			 *
-			 * @since 3.3.0
-			 *
-			 * @param array $nexus_address The nexus address array to be sent to TaxJar.
-			 * @param array $body          The complete TaxJar API request body.
-			 *
-			 * @return array|false Modified nexus address array, or false to disable nexus addresses.
-			 *
-			 * @example
-			 * // Disable nexus addresses entirely.
-			 * add_filter( 'woocommerce_taxjar_nexus_address', '__return_false' );
-			 *
-			 * @example
-			 * // Modify the nexus address.
-			 * add_filter( 'woocommerce_taxjar_nexus_address', function( $nexus_address, $body ) {
-			 *     $nexus_address['street'] = '123 Custom Street';
-			 *     return $nexus_address;
-			 * }, 10, 2 );
-			 */
-			$nexus_address = apply_filters( 'woocommerce_taxjar_nexus_address', $nexus_address, $body );
+			return false;
+		}
 
-			if ( is_array( $nexus_address ) && ! empty( $nexus_address ) && $this->is_nexus_address_valid( $nexus_address ) ) {
-				$params_to_unset = array(
-					'from_country',
-					'from_state',
-					'from_zip',
-					'from_city',
-					'from_street',
-				);
+		// Log the response.
+		$this->_log( 'Received: ' . $response['body'] );
 
-				foreach ( $params_to_unset as $param ) {
-					unset( $body[ $param ] );
-				}
-				$body['nexus_addresses'] = array( $nexus_address );
-			}
+		// Decode Response.
+		$taxjar_response = json_decode( $response['body'] );
+		if ( empty( $taxjar_response->tax ) ) {
+			return false;
+		}
+		$taxjar_taxes = $this->maybe_override_taxjar_tax( $taxjar_response->tax, $body );
+		$taxes        = $this->get_itemized_tax_rates( $taxes, $taxjar_taxes, $options );
 
-			$address_parts = $this->get_address_parts( $body );
-
-			// Require from_country.
-			if ( empty( $address_parts['from_country'] ) ) {
-				$this->_log( 'From country is missing. Aborting.' );
-				return false;
-			}
-
-			// Don't calculate taxes for US when from_state and to_state are different.
-			if ( 'US' === $address_parts['from_country'] && 'US' === $address_parts['to_country'] && $address_parts['from_state'] !== $address_parts['to_state'] ) {
-				$this->_log( 'US from_state and to_state are different. Aborting.' );
-				return false;
-			}
-
-			// Either `amount` or `line_items` parameters are required to perform tax calculations.
-			if ( empty( $line_items ) ) {
-				$body['amount'] = 0.01;
-			} else {
-				$body['line_items'] = $line_items;
-			}
-
-			$response = $this->smartcalcs_cache_request( wp_json_encode( $body ), $from_state );
-
-			// if no response, no need to keep going - bail early.
-			if ( ! isset( $response ) || ! $response ) {
-				$this->_log( 'Received: none.' );
-
-				return false;
-			}
-
-			// Log the response.
-			$this->_log( 'Received: ' . $response['body'] );
-
-			// Decode Response.
-			$taxjar_response = json_decode( $response['body'] );
-			if ( empty( $taxjar_response->tax ) ) {
-				return false;
-			}
-			$taxjar_taxes = $this->maybe_override_taxjar_tax( $taxjar_response->tax, $body );
-			$taxes        = $this->get_itemized_tax_rates( $taxes, $taxjar_taxes, $options );
-
-			return $taxes;
-		} // End calculate_tax().
+		return $taxes;
+	} // End calculate_tax().
 
 		/**
 		 * Return address parts.
@@ -1480,16 +1525,16 @@ class WC_Connect_TaxJar_Integration {
 		 *
 		 * @return array
 		 */
-		private function get_address_parts( $body ) {
-			return array(
-				'from_country' => strtoupper( $body['nexus_addresses'][0]['country'] ?? $body['from_country'] ?? '' ),
-				'from_state'   => strtoupper( $body['nexus_addresses'][0]['state'] ?? $body['from_state'] ?? '' ),
-				'from_zip'     => strtoupper( $body['nexus_addresses'][0]['zip'] ?? $body['from_zip'] ?? '' ),
-				'to_country'   => strtoupper( $body['to_country'] ?? '' ),
-				'to_state'     => strtoupper( $body['to_state'] ?? '' ),
-				'to_zip'       => strtoupper( $body['to_zip'] ?? '' ),
-			);
-		}
+	private function get_address_parts( $body ) {
+		return array(
+			'from_country' => strtoupper( $body['nexus_addresses'][0]['country'] ?? $body['from_country'] ?? '' ),
+			'from_state'   => strtoupper( $body['nexus_addresses'][0]['state'] ?? $body['from_state'] ?? '' ),
+			'from_zip'     => strtoupper( $body['nexus_addresses'][0]['zip'] ?? $body['from_zip'] ?? '' ),
+			'to_country'   => strtoupper( $body['to_country'] ?? '' ),
+			'to_state'     => strtoupper( $body['to_state'] ?? '' ),
+			'to_zip'       => strtoupper( $body['to_zip'] ?? '' ),
+		);
+	}
 
 		/**
 		 * Get itemized tax rates from TaxJar response.
@@ -1500,94 +1545,74 @@ class WC_Connect_TaxJar_Integration {
 		 *
 		 * @return array
 		 */
-		private function get_itemized_tax_rates( $taxes, $taxjar_taxes, $options ): array {
+	private function get_itemized_tax_rates( $taxes, $taxjar_taxes, $options ): array {
 
-			// Normalize options and safely map to local variables.
-			$options = is_array( $options ) ? $options : array();
+		// Normalize options and safely map to local variables.
+		$options = is_array( $options ) ? $options : array();
 
-			$to_country = isset( $options['to_country'] ) ? strtoupper( $options['to_country'] ) : null;
-			$to_state   = isset( $options['to_state'] ) ? strtoupper( $options['to_state'] ) : null;
-			$to_zip     = $options['to_zip'] ?? null;
-			$to_city    = $options['to_city'] ?? null;
+		$to_country = isset( $options['to_country'] ) ? strtoupper( $options['to_country'] ) : null;
+		$to_state   = isset( $options['to_state'] ) ? strtoupper( $options['to_state'] ) : null;
+		$to_zip     = $options['to_zip'] ?? null;
+		$to_city    = $options['to_city'] ?? null;
 
-			$store_settings = $this->get_store_settings();
-			$from_country   = strtoupper( $store_settings['country'] );
-			$from_state     = strtoupper( $store_settings['state'] );
+		$store_settings = $this->get_store_settings();
+		$from_country   = strtoupper( $store_settings['country'] );
+		$from_state     = strtoupper( $store_settings['state'] );
 
-			// Update Properties based on Response.
-			$taxes['freight_taxable'] = (int) $taxjar_taxes->freight_taxable;
-			$taxes['has_nexus']       = (int) $taxjar_taxes->has_nexus;
-			$taxes['tax_rate']        = $taxjar_taxes->rate;
+		// Update Properties based on Response.
+		$taxes['freight_taxable'] = (int) $taxjar_taxes->freight_taxable;
+		$taxes['has_nexus']       = (int) $taxjar_taxes->has_nexus;
+		$taxes['tax_rate']        = $taxjar_taxes->rate;
 
-			if ( ! empty( $taxjar_taxes->breakdown ) ) {
-				if ( ! empty( $taxjar_taxes->breakdown->line_items ) ) {
-					$line_items = array();
-					foreach ( $taxjar_taxes->breakdown->line_items as $line_item ) {
-						$line_items[ $line_item->id ] = $line_item;
-					}
-					$taxes['line_items'] = $line_items;
+		if ( ! empty( $taxjar_taxes->breakdown ) ) {
+			if ( ! empty( $taxjar_taxes->breakdown->line_items ) ) {
+				$line_items = array();
+				foreach ( $taxjar_taxes->breakdown->line_items as $line_item ) {
+					$line_items[ $line_item->id ] = $line_item;
 				}
+				$taxes['line_items'] = $line_items;
 			}
+		}
 
-			if ( $taxes['has_nexus'] ) {
+		if ( $taxes['has_nexus'] ) {
 
-				// Use Woo core to find matching rates for taxable address.
-				$jurisdictions = array(
-					'county' => $taxjar_taxes->jurisdictions->county ?? null,
-					'city'   => $taxjar_taxes->jurisdictions->city ?? null,
-				);
-				$location      = array(
-					'from_country' => $from_country,
-					'from_state'   => $from_state,
-					'to_country'   => $to_country,
-					'to_state'     => $to_state,
-					'to_zip'       => $to_zip,
-					'to_city'      => $to_city,
-				);
+			// Use Woo core to find matching rates for taxable address.
+			$jurisdictions = array(
+				'county' => $taxjar_taxes->jurisdictions->county ?? null,
+				'city'   => $taxjar_taxes->jurisdictions->city ?? null,
+			);
+			$location      = array(
+				'from_country' => $from_country,
+				'from_state'   => $from_state,
+				'to_country'   => $to_country,
+				'to_state'     => $to_state,
+				'to_zip'       => $to_zip,
+				'to_city'      => $to_city,
+			);
 
-				// Add line item tax rates.
-				foreach ( $taxes['line_items'] as $line_item_key => $line_item ) {
-					$line_item_key_chunks = explode( '-', $line_item_key );
-					$product_id           = $line_item_key_chunks[0];
-					$product              = wc_get_product( $product_id );
+			// Add line item tax rates.
+			foreach ( $taxes['line_items'] as $line_item_key => $line_item ) {
+				$line_item_key_chunks = explode( '-', $line_item_key );
+				$product_id           = $line_item_key_chunks[0];
+				$product              = wc_get_product( $product_id );
 
-					$tax_class = '';
-					if ( $product ) {
-						$tax_class = $product->get_tax_class();
-					} elseif ( isset( $this->backend_tax_classes[ $product_id ] ) ) {
-						$tax_class = $this->backend_tax_classes[ $product_id ];
-					}
-
-					$_tax_rates = (array) $line_item;
-					$priority   = 1;
-					foreach ( $_tax_rates as $tax_rate_name => $tax_rate ) {
-						if ( 'combined_tax_rate' === $tax_rate_name || false === strpos( $tax_rate_name, '_tax_rate' ) ) {
-							continue;
-						}
-						$taxes['rate_ids'][ $line_item_key ][] = $this->create_or_update_tax_rate(
-							$location,
-							round( $tax_rate * 100, 4 ),
-							$tax_class,
-							$taxes['freight_taxable'],
-							$priority,
-							self::generate_itemized_tax_rate_name( $tax_rate_name, $to_country, $jurisdictions )
-						);
-
-						++$priority;
-					}
+				$tax_class = '';
+				if ( $product ) {
+					$tax_class = $product->get_tax_class();
+				} elseif ( isset( $this->backend_tax_classes[ $product_id ] ) ) {
+					$tax_class = $this->backend_tax_classes[ $product_id ];
 				}
 
-				// Add shipping tax rate.
-				$_tax_rates = isset( $taxjar_taxes->breakdown->shipping ) ? (array) $taxjar_taxes->breakdown->shipping : array();
+				$_tax_rates = (array) $line_item;
 				$priority   = 1;
 				foreach ( $_tax_rates as $tax_rate_name => $tax_rate ) {
 					if ( 'combined_tax_rate' === $tax_rate_name || false === strpos( $tax_rate_name, '_tax_rate' ) ) {
 						continue;
 					}
-					$taxes['rate_ids']['shipping'][] = $this->create_or_update_tax_rate(
+					$taxes['rate_ids'][ $line_item_key ][] = $this->create_or_update_tax_rate(
 						$location,
 						round( $tax_rate * 100, 4 ),
-						'',
+						$tax_class,
 						$taxes['freight_taxable'],
 						$priority,
 						self::generate_itemized_tax_rate_name( $tax_rate_name, $to_country, $jurisdictions )
@@ -1597,8 +1622,28 @@ class WC_Connect_TaxJar_Integration {
 				}
 			}
 
-			return $taxes;
+			// Add shipping tax rate.
+			$_tax_rates = isset( $taxjar_taxes->breakdown->shipping ) ? (array) $taxjar_taxes->breakdown->shipping : array();
+			$priority   = 1;
+			foreach ( $_tax_rates as $tax_rate_name => $tax_rate ) {
+				if ( 'combined_tax_rate' === $tax_rate_name || false === strpos( $tax_rate_name, '_tax_rate' ) ) {
+					continue;
+				}
+				$taxes['rate_ids']['shipping'][] = $this->create_or_update_tax_rate(
+					$location,
+					round( $tax_rate * 100, 4 ),
+					'',
+					$taxes['freight_taxable'],
+					$priority,
+					self::generate_itemized_tax_rate_name( $tax_rate_name, $to_country, $jurisdictions )
+				);
+
+				++$priority;
+			}
 		}
+
+		return $taxes;
+	}
 
 		/**
 		 * Add or update WooCommerce tax rate.
@@ -1612,96 +1657,96 @@ class WC_Connect_TaxJar_Integration {
 		 *
 		 * @return int
 		 */
-		public function create_or_update_tax_rate( $location, $rate, $tax_class = '', $freight_taxable = 1, $rate_priority = 1, $tax_rate_name = 'Tax' ) {
-			// Prevent filling "State code" column for countries with VAT tax.
-			// VAT tax is country wide.
-			$to_state      = 'VAT' === $tax_rate_name ? '' : strtoupper( $location['to_state'] );
-			$rate_priority = absint( $rate_priority );
+	public function create_or_update_tax_rate( $location, $rate, $tax_class = '', $freight_taxable = 1, $rate_priority = 1, $tax_rate_name = 'Tax' ) {
+		// Prevent filling "State code" column for countries with VAT tax.
+		// VAT tax is country wide.
+		$to_state      = 'VAT' === $tax_rate_name ? '' : strtoupper( $location['to_state'] );
+		$rate_priority = absint( $rate_priority );
 
-			/**
-			 * @see https://github.com/Automattic/woocommerce-services/issues/2531
-			 * @see https://floridarevenue.com/faq/Pages/FAQDetails.aspx?FAQID=1277&IsDlg=1
-			 *
-			 * According to the Florida Department of Revenue, sales tax must be charged on
-			 * shipping costs if the customer does not have an option to avoid paying the
-			 * merchant for shipping costs by either picking up the merchandise themselves
-			 * or arranging for a third party to pick up the merchandise and deliver it to
-			 * them.
-			 *
-			 * Normally TaxJar enables taxes on shipping by default for Florida to
-			 * Florida shipping, but because WooCommerce uses a single account, a nexus
-			 * cannot be added for Florida (or any state) which means the shipping tax
-			 * is not enabled. So, we will enable it here by default and give merchants
-			 * the option to disable it if needed via filter.
-			 *
-			 * @since 1.26.0
-			 */
-			if ( true === apply_filters( 'woocommerce_taxjar_enable_florida_shipping_tax', true ) && 'US' === $location['to_country'] && 'FL' === $location['from_state'] && 'FL' === $location['to_state'] ) {
-				$freight_taxable = 1;
-			}
-
-			$tax_rate = array(
-				'tax_rate_country'  => $location['to_country'],
-				'tax_rate_state'    => $to_state,
-				// For the US, we're going to modify the name of the tax rate to simplify the reporting and distinguish between the tax rates at the counties level.
-				// I would love to do this for other locations, but it looks like that would create issues.
-				// For example, for the UK it would continuously rename the rate name with an updated `state` "piece", each time a request is made
-				'tax_rate_name'     => $tax_rate_name,
-				'tax_rate_priority' => $rate_priority,
-				'tax_rate_compound' => false,
-				'tax_rate_shipping' => $freight_taxable,
-				'tax_rate'          => $rate,
-				'tax_rate_class'    => $tax_class,
-			);
-
-			$wc_rates = WC_Tax::find_rates(
-				array(
-					'country'   => $location['to_country'],
-					'state'     => str_replace( ' ', '', $to_state ),
-					'postcode'  => $location['to_zip'],
-					'city'      => strtoupper( $location['to_city'] ),
-					'tax_class' => $tax_class,
-				)
-			);
-
-			$wc_rates_ids = is_array( $wc_rates ) ? array_keys( $wc_rates ) : array();
-			if ( isset( $wc_rates_ids[ $rate_priority - 1 ] ) ) {
-				$wc_rate[ $wc_rates_ids[ $rate_priority - 1 ] ] = $wc_rates[ $wc_rates_ids[ $rate_priority - 1 ] ];
-			} else {
-				$wc_rate = array();
-			}
-
-			if ( ! empty( $wc_rate ) ) {
-				$this->_log( ':: Tax Rate Found ::' );
-				$this->_log( $wc_rate );
-
-				// Get the existing ID
-				$rate_id = key( $wc_rate );
-
-				// Update Tax Rates with TaxJar rates ( rates might be coming from a cached taxjar rate )
-				$this->_log( ':: Updating Tax Rate To ::' );
-				$this->_log( $tax_rate );
-				if ( $wc_rate[ $rate_id ]['label'] !== $tax_rate_name || (float) $wc_rate[ $rate_id ]['rate'] !== (float) $rate ) {
-					// Allow to manually change is Shipping taxable, won't be overwritten automatically.
-					$tax_rate['tax_rate_shipping'] = wc_string_to_bool( $wc_rate[ $rate_id ]['shipping'] );
-					WC_Tax::_update_tax_rate( $rate_id, $tax_rate );
-				}
-			} else {
-				// Insert a rate if we did not find one
-				$this->_log( ':: Adding New Tax Rate ::' );
-				$this->_log( $tax_rate );
-				$rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
-				// VAT is always country wide, no need to create separate entires for each zip and city.
-				if ( 'VAT' !== $tax_rate_name ) {
-					WC_Tax::_update_tax_rate_postcodes( $rate_id, wc_normalize_postcode( wc_clean( $location['to_zip'] ) ) );
-					WC_Tax::_update_tax_rate_cities( $rate_id, wc_clean( $location['to_city'] ) );
-				}
-			}
-
-			$this->_log( 'Tax Rate ID Set for ' . $rate_id );
-
-			return $rate_id;
+		/**
+		 * @see https://github.com/Automattic/woocommerce-services/issues/2531
+		 * @see https://floridarevenue.com/faq/Pages/FAQDetails.aspx?FAQID=1277&IsDlg=1
+		 *
+		 * According to the Florida Department of Revenue, sales tax must be charged on
+		 * shipping costs if the customer does not have an option to avoid paying the
+		 * merchant for shipping costs by either picking up the merchandise themselves
+		 * or arranging for a third party to pick up the merchandise and deliver it to
+		 * them.
+		 *
+		 * Normally TaxJar enables taxes on shipping by default for Florida to
+		 * Florida shipping, but because WooCommerce uses a single account, a nexus
+		 * cannot be added for Florida (or any state) which means the shipping tax
+		 * is not enabled. So, we will enable it here by default and give merchants
+		 * the option to disable it if needed via filter.
+		 *
+		 * @since 1.26.0
+		 */
+		if ( true === apply_filters( 'woocommerce_taxjar_enable_florida_shipping_tax', true ) && 'US' === $location['to_country'] && 'FL' === $location['from_state'] && 'FL' === $location['to_state'] ) {
+			$freight_taxable = 1;
 		}
+
+		$tax_rate = array(
+			'tax_rate_country'  => $location['to_country'],
+			'tax_rate_state'    => $to_state,
+			// For the US, we're going to modify the name of the tax rate to simplify the reporting and distinguish between the tax rates at the counties level.
+			// I would love to do this for other locations, but it looks like that would create issues.
+			// For example, for the UK it would continuously rename the rate name with an updated `state` "piece", each time a request is made
+			'tax_rate_name'     => $tax_rate_name,
+			'tax_rate_priority' => $rate_priority,
+			'tax_rate_compound' => false,
+			'tax_rate_shipping' => $freight_taxable,
+			'tax_rate'          => $rate,
+			'tax_rate_class'    => $tax_class,
+		);
+
+		$wc_rates = WC_Tax::find_rates(
+			array(
+				'country'   => $location['to_country'],
+				'state'     => str_replace( ' ', '', $to_state ),
+				'postcode'  => $location['to_zip'],
+				'city'      => strtoupper( $location['to_city'] ),
+				'tax_class' => $tax_class,
+			)
+		);
+
+		$wc_rates_ids = is_array( $wc_rates ) ? array_keys( $wc_rates ) : array();
+		if ( isset( $wc_rates_ids[ $rate_priority - 1 ] ) ) {
+			$wc_rate[ $wc_rates_ids[ $rate_priority - 1 ] ] = $wc_rates[ $wc_rates_ids[ $rate_priority - 1 ] ];
+		} else {
+			$wc_rate = array();
+		}
+
+		if ( ! empty( $wc_rate ) ) {
+			$this->_log( ':: Tax Rate Found ::' );
+			$this->_log( $wc_rate );
+
+			// Get the existing ID
+			$rate_id = key( $wc_rate );
+
+			// Update Tax Rates with TaxJar rates ( rates might be coming from a cached taxjar rate )
+			$this->_log( ':: Updating Tax Rate To ::' );
+			$this->_log( $tax_rate );
+			if ( $wc_rate[ $rate_id ]['label'] !== $tax_rate_name || (float) $wc_rate[ $rate_id ]['rate'] !== (float) $rate ) {
+				// Allow to manually change is Shipping taxable, won't be overwritten automatically.
+				$tax_rate['tax_rate_shipping'] = wc_string_to_bool( $wc_rate[ $rate_id ]['shipping'] );
+				WC_Tax::_update_tax_rate( $rate_id, $tax_rate );
+			}
+		} else {
+			// Insert a rate if we did not find one
+			$this->_log( ':: Adding New Tax Rate ::' );
+			$this->_log( $tax_rate );
+			$rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
+			// VAT is always country wide, no need to create separate entires for each zip and city.
+			if ( 'VAT' !== $tax_rate_name ) {
+				WC_Tax::_update_tax_rate_postcodes( $rate_id, wc_normalize_postcode( wc_clean( $location['to_zip'] ) ) );
+				WC_Tax::_update_tax_rate_cities( $rate_id, wc_clean( $location['to_city'] ) );
+			}
+		}
+
+		$this->_log( 'Tax Rate ID Set for ' . $rate_id );
+
+		return $rate_id;
+	}
 
 		/**
 		 * Validate TaxJar API request json value and add the error to log.
@@ -1710,62 +1755,62 @@ class WC_Connect_TaxJar_Integration {
 		 *
 		 * @return bool
 		 */
-		public function validate_taxjar_request( $json ) {
-			$this->_log( ':::: TaxJar API request validation ::::' );
+	public function validate_taxjar_request( $json ) {
+		$this->_log( ':::: TaxJar API request validation ::::' );
 
-			$body    = json_decode( $json, true );
-			$address = $this->get_address_parts( $body );
+		$body    = json_decode( $json, true );
+		$address = $this->get_address_parts( $body );
 
-			if ( empty( $address['from_country'] ) ) {
-				$this->_error( 'API request is stopped. Empty origin country.' );
+		if ( empty( $address['from_country'] ) ) {
+			$this->_error( 'API request is stopped. Empty origin country.' );
 
-				return false;
-			}
-
-			if ( empty( $address['to_country'] ) ) {
-				$this->_error( 'API request is stopped. Empty destination country.' );
-
-				return false;
-			}
-
-			if ( ( 'US' === $address['to_country'] || 'CA' === $address['to_country'] ) && empty( $address['to_state'] ) ) {
-				$this->_error( 'API request is stopped. Country destination is set to US or CA but the state is empty.' );
-
-				return false;
-			}
-
-			if ( 'US' === $address['to_country'] && empty( $address['to_zip'] ) ) {
-				$this->_error( 'API request is stopped. Country destination is set to US but the zip code is empty.' );
-
-				return false;
-			}
-
-			if (
-			'US' === $address['to_country'] && 'US' === $address['from_country']
-			&& $address['from_state'] !== $address['to_state']
-			) {
-				$this->_error( 'API request is stopped. US from_state !== to_state, tax don\'t apply.' );
-
-				return false;
-			}
-
-			// Apply this validation only if the destination country is the US and the zip code is 5 or 10 digits long.
-			if ( 'US' === $address['to_country'] && in_array( strlen( $address['to_zip'] ), array( 5, 10 ) ) && ! WC_Validation::is_postcode( $address['to_zip'], $address['to_country'] ) ) {
-				$this->_error( 'API request is stopped. Country destination is set to US but the zip code has incorrect format.' );
-
-				return false;
-			}
-
-			if ( 'US' === $address['from_country'] && ! WC_Validation::is_postcode( $address['from_zip'], $address['from_country'] ) ) {
-				$this->_error( 'API request is stopped. Country store is set to US but the zip code has incorrect format.' );
-
-				return false;
-			}
-
-			$this->_log( 'API request is in good format.' );
-
-			return true;
+			return false;
 		}
+
+		if ( empty( $address['to_country'] ) ) {
+			$this->_error( 'API request is stopped. Empty destination country.' );
+
+			return false;
+		}
+
+		if ( ( 'US' === $address['to_country'] || 'CA' === $address['to_country'] ) && empty( $address['to_state'] ) ) {
+			$this->_error( 'API request is stopped. Country destination is set to US or CA but the state is empty.' );
+
+			return false;
+		}
+
+		if ( 'US' === $address['to_country'] && empty( $address['to_zip'] ) ) {
+			$this->_error( 'API request is stopped. Country destination is set to US but the zip code is empty.' );
+
+			return false;
+		}
+
+		if (
+		'US' === $address['to_country'] && 'US' === $address['from_country']
+		&& $address['from_state'] !== $address['to_state']
+		) {
+			$this->_error( 'API request is stopped. US from_state !== to_state, tax don\'t apply.' );
+
+			return false;
+		}
+
+		// Apply this validation only if the destination country is the US and the zip code is 5 or 10 digits long.
+		if ( 'US' === $address['to_country'] && in_array( strlen( $address['to_zip'] ), array( 5, 10 ) ) && ! WC_Validation::is_postcode( $address['to_zip'], $address['to_country'] ) ) {
+			$this->_error( 'API request is stopped. Country destination is set to US but the zip code has incorrect format.' );
+
+			return false;
+		}
+
+		if ( 'US' === $address['from_country'] && ! WC_Validation::is_postcode( $address['from_zip'], $address['from_country'] ) ) {
+			$this->_error( 'API request is stopped. Country store is set to US but the zip code has incorrect format.' );
+
+			return false;
+		}
+
+		$this->_log( 'API request is in good format.' );
+
+		return true;
+	}
 
 		/**
 		 * Wrap SmartCalcs API requests in a transient-based caching layer.
@@ -1778,77 +1823,77 @@ class WC_Connect_TaxJar_Integration {
 		 *
 		 * @return mixed|WP_Error
 		 */
-		public function smartcalcs_cache_request( $json, $from_state ) {
-			$cache_key           = 'tj_tax_' . hash( 'md5', $json );
-			$zip_state_cache_key = false;
-			$request             = json_decode( $json );
-			$to_zip              = isset( $request->to_zip ) ? (string) $request->to_zip : false;
-			$to_state            = isset( $request->to_state ) ? strtoupper( (string) $request->to_state ) : false;
-			if ( $to_zip && $to_state ) {
-				$zip_state_cache_key = strtolower( 'tj_tax_' . $to_zip . '_' . $to_state );
-				$response            = get_transient( $zip_state_cache_key );
+	public function smartcalcs_cache_request( $json, $from_state ) {
+		$cache_key           = 'tj_tax_' . hash( 'md5', $json );
+		$zip_state_cache_key = false;
+		$request             = json_decode( $json );
+		$to_zip              = isset( $request->to_zip ) ? (string) $request->to_zip : false;
+		$to_state            = isset( $request->to_state ) ? strtoupper( (string) $request->to_state ) : false;
+		if ( $to_zip && $to_state ) {
+			$zip_state_cache_key = strtolower( 'tj_tax_' . $to_zip . '_' . $to_state );
+			$response            = get_transient( $zip_state_cache_key );
+		}
+		$response = ! empty( $response ) ? $response : get_transient( $cache_key );
+		if ( $response && 'CA' !== $from_state ) {
+			// If $from_state is not California, we need to check for incorrect California tax nexus.
+			try {
+				$this->check_for_incorrect_california_tax_nexus( $response['body'], true, $from_state );
+			} catch ( Exception $e ) {
+				$this->_log( 'Error checking for incorrect California tax nexus: ' . $e->getMessage() );
 			}
-			$response = ! empty( $response ) ? $response : get_transient( $cache_key );
-			if ( $response && 'CA' !== $from_state ) {
+		}
+		$response_code    = wp_remote_retrieve_response_code( $response );
+		$save_error_codes = array( 404, 400 );
+
+		// Clear the taxjar notices before calculating taxes or using cached response.
+		$this->notifier->clear_notices( 'taxjar' );
+
+		if ( false === $response ) {
+			$response      = $this->smartcalcs_request( $json );
+			$response_code = wp_remote_retrieve_response_code( $response );
+			$body          = json_decode( wp_remote_retrieve_body( $response ) );
+			if ( 'CA' !== $from_state ) {
 				// If $from_state is not California, we need to check for incorrect California tax nexus.
 				try {
-					$this->check_for_incorrect_california_tax_nexus( $response['body'], true, $from_state );
+					$this->check_for_incorrect_california_tax_nexus( $body, false, $from_state );
 				} catch ( Exception $e ) {
 					$this->_log( 'Error checking for incorrect California tax nexus: ' . $e->getMessage() );
 				}
 			}
-			$response_code    = wp_remote_retrieve_response_code( $response );
-			$save_error_codes = array( 404, 400 );
+			$is_zip_to_state_mismatch = (
+			isset( $body->detail )
+			&& is_string( $body->detail )
+			&& $to_zip
+			&& $to_state
+			&& false !== strpos( $body->detail, 'to_zip ' . $to_zip )
+			&& false !== strpos( $body->detail, 'to_state ' . $to_state )
+			);
+			$transient_set            = false;
 
-			// Clear the taxjar notices before calculating taxes or using cached response.
-			$this->notifier->clear_notices( 'taxjar' );
-
-			if ( false === $response ) {
-				$response      = $this->smartcalcs_request( $json );
-				$response_code = wp_remote_retrieve_response_code( $response );
-				$body          = json_decode( wp_remote_retrieve_body( $response ) );
-				if ( 'CA' !== $from_state ) {
-					// If $from_state is not California, we need to check for incorrect California tax nexus.
-					try {
-						$this->check_for_incorrect_california_tax_nexus( $body, false, $from_state );
-					} catch ( Exception $e ) {
-						$this->_log( 'Error checking for incorrect California tax nexus: ' . $e->getMessage() );
-					}
+			if ( 200 == $response_code ) {
+				set_transient( $cache_key, $response, $this->cache_time );
+			} elseif ( in_array( $response_code, $save_error_codes ) ) {
+				if ( 400 == $response_code
+				&& $is_zip_to_state_mismatch
+				&& $zip_state_cache_key
+				) {
+					$transient_set = set_transient( $zip_state_cache_key, $response, $this->address_cache_time );
 				}
-				$is_zip_to_state_mismatch = (
-				isset( $body->detail )
-				&& is_string( $body->detail )
-				&& $to_zip
-				&& $to_state
-				&& false !== strpos( $body->detail, 'to_zip ' . $to_zip )
-				&& false !== strpos( $body->detail, 'to_state ' . $to_state )
-				);
-				$transient_set            = false;
 
-				if ( 200 == $response_code ) {
-					set_transient( $cache_key, $response, $this->cache_time );
-				} elseif ( in_array( $response_code, $save_error_codes ) ) {
-					if ( 400 == $response_code
-					&& $is_zip_to_state_mismatch
-					&& $zip_state_cache_key
-					) {
-						$transient_set = set_transient( $zip_state_cache_key, $response, $this->address_cache_time );
-					}
-
-					if ( ! $transient_set ) {
-						set_transient( $cache_key, $response, $this->error_cache_time );
-					}
+				if ( ! $transient_set ) {
+					set_transient( $cache_key, $response, $this->error_cache_time );
 				}
 			}
-
-			if ( in_array( $response_code, $save_error_codes ) ) {
-				$this->_log( 'Retrieved the error from the cache. Received (' . $response['response']['code'] . '): ' . $response['body'] );
-				$this->_error( 'Error retrieving the tax rates. Received (' . $response['response']['code'] . '): ' . $response['body'] );
-				return false;
-			}
-
-			return $response;
 		}
+
+		if ( in_array( $response_code, $save_error_codes ) ) {
+			$this->_log( 'Retrieved the error from the cache. Received (' . $response['response']['code'] . '): ' . $response['body'] );
+			$this->_error( 'Error retrieving the tax rates. Received (' . $response['response']['code'] . '): ' . $response['body'] );
+			return false;
+		}
+
+		return $response;
+	}
 
 		/**
 		 * Make a TaxJar SmartCalcs API request through the WCS proxy.
@@ -1860,39 +1905,39 @@ class WC_Connect_TaxJar_Integration {
 		 *
 		 * @return array|WP_Error
 		 */
-		public function smartcalcs_request( $json ) {
-			$path = trailingslashit( self::PROXY_PATH ) . 'taxes';
+	public function smartcalcs_request( $json ) {
+		$path = trailingslashit( self::PROXY_PATH ) . 'taxes';
 
-			// Validate the request before sending a request.
-			if ( ! $this->validate_taxjar_request( $json ) ) {
-				return false;
-			}
-
-			$this->_log( 'Requesting: ' . $path . ' - ' . $json );
-
-			$response = $this->api_client->proxy_request(
-				$path,
-				array(
-					'method'  => 'POST',
-					'headers' => array(
-						'Content-Type' => 'application/json',
-					),
-					'body'    => $json,
-				)
-			);
-
-			if ( is_wp_error( $response ) ) {
-				$this->_error( 'Error retrieving the tax rates. Received (' . $response->get_error_code() . '): ' . $response->get_error_message() );
-			} elseif ( 200 == $response['response']['code'] ) {
-				return $response;
-			} elseif ( 404 == $response['response']['code'] || 400 == $response['response']['code'] ) {
-				$this->_error( 'Error retrieving the tax rates. Received (' . $response['response']['code'] . '): ' . $response['body'] );
-
-				return $response;
-			} else {
-				$this->_error( 'Error retrieving the tax rates. Received (' . $response['response']['code'] . '): ' . $response['body'] );
-			}
+		// Validate the request before sending a request.
+		if ( ! $this->validate_taxjar_request( $json ) ) {
+			return false;
 		}
+
+		$this->_log( 'Requesting: ' . $path . ' - ' . $json );
+
+		$response = $this->api_client->proxy_request(
+			$path,
+			array(
+				'method'  => 'POST',
+				'headers' => array(
+					'Content-Type' => 'application/json',
+				),
+				'body'    => $json,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			$this->_error( 'Error retrieving the tax rates. Received (' . $response->get_error_code() . '): ' . $response->get_error_message() );
+		} elseif ( 200 == $response['response']['code'] ) {
+			return $response;
+		} elseif ( 404 == $response['response']['code'] || 400 == $response['response']['code'] ) {
+			$this->_error( 'Error retrieving the tax rates. Received (' . $response['response']['code'] . '): ' . $response['body'] );
+
+			return $response;
+		} else {
+			$this->_error( 'Error retrieving the tax rates. Received (' . $response['response']['code'] . '): ' . $response['body'] );
+		}
+	}
 
 		/**
 		 * Exports existing tax rates to a CSV and clears the table.
@@ -1900,64 +1945,64 @@ class WC_Connect_TaxJar_Integration {
 		 * Ported from TaxJar's plugin.
 		 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/42cd4cd0/taxjar-woocommerce.php#L75
 		 */
-		public function backup_existing_tax_rates() {
+	public function backup_existing_tax_rates() {
 
-			// Back up all tax rates to a csv file
-			$backed_up = WC_Connect_Functions::backup_existing_tax_rates();
+		// Back up all tax rates to a csv file
+		$backed_up = WC_Connect_Functions::backup_existing_tax_rates();
 
-			if ( ! $backed_up ) {
-				return;
-			}
-
-			global $wpdb;
-
-			// Delete all tax rates
-			$wpdb->query( 'TRUNCATE ' . $wpdb->prefix . 'woocommerce_tax_rates' );
-			$wpdb->query( 'TRUNCATE ' . $wpdb->prefix . 'woocommerce_tax_rate_locations' );
+		if ( ! $backed_up ) {
+			return;
 		}
+
+		global $wpdb;
+
+		// Delete all tax rates
+		$wpdb->query( 'TRUNCATE ' . $wpdb->prefix . 'woocommerce_tax_rates' );
+		$wpdb->query( 'TRUNCATE ' . $wpdb->prefix . 'woocommerce_tax_rate_locations' );
+	}
 
 		/**
 		 * Checks if currently on the WooCommerce order page.
 		 *
 		 * @return boolean
 		 */
-		public function on_order_page() {
-			if ( ! function_exists( 'get_current_screen' ) ) {
-				return false;
-			}
-
-			$screen = get_current_screen();
-			if ( ! $screen || ! isset( $screen->id ) ) {
-				return false;
-			}
-
-			if ( ! function_exists( 'wc_get_page_screen_id' ) ) {
-				return false;
-			}
-
-			$wc_order_screen_id = wc_get_page_screen_id( 'shop_order' );
-			if ( ! $wc_order_screen_id ) {
-				return false;
-			}
-
-			// If HPOS is enabled, and we're on the Orders list page, return false.
-			if ( 'woocommerce_page_wc-orders' === $wc_order_screen_id && ! isset( $_GET['action'] ) ) {
-				return false;
-			}
-
-			return $screen->id === $wc_order_screen_id;
+	public function on_order_page() {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return false;
 		}
+
+		$screen = get_current_screen();
+		if ( ! $screen || ! isset( $screen->id ) ) {
+			return false;
+		}
+
+		if ( ! function_exists( 'wc_get_page_screen_id' ) ) {
+			return false;
+		}
+
+		$wc_order_screen_id = wc_get_page_screen_id( 'shop_order' );
+		if ( ! $wc_order_screen_id ) {
+			return false;
+		}
+
+		// If HPOS is enabled, and we're on the Orders list page, return false.
+		if ( 'woocommerce_page_wc-orders' === $wc_order_screen_id && ! isset( $_GET['action'] ) ) {
+			return false;
+		}
+
+		return $screen->id === $wc_order_screen_id;
+	}
 
 		/**
 		 * Admin New Order Assets
 		 */
-		public function load_taxjar_admin_new_order_assets() {
-			if ( ! $this->on_order_page() ) {
-				return;
-			}
-			// Load Javascript for WooCommerce new order page
-			wp_enqueue_script( 'wc-taxjar-order', $this->wc_connect_base_url . 'woocommerce-services-new-order-taxjar-' . WC_Connect_Loader::get_wcs_version() . '.js', array( 'jquery' ), null, true );
+	public function load_taxjar_admin_new_order_assets() {
+		if ( ! $this->on_order_page() ) {
+			return;
 		}
+		// Load Javascript for WooCommerce new order page
+		wp_enqueue_script( 'wc-taxjar-order', $this->wc_connect_base_url . 'woocommerce-services-new-order-taxjar-' . WC_Connect_Loader::get_wcs_version() . '.js', array( 'jquery' ), null, true );
+	}
 
 		/**
 		 * Check for incorrect California tax nexus in the TaxJar API response or cached response.
@@ -1967,33 +2012,33 @@ class WC_Connect_TaxJar_Integration {
 		 *
 		 * @return void
 		 */
-		private function check_for_incorrect_california_tax_nexus( $response_body, $cached, $from_state ): void {
-			$log_suffix = 'in TaxJar API response.';
+	private function check_for_incorrect_california_tax_nexus( $response_body, $cached, $from_state ): void {
+		$log_suffix = 'in TaxJar API response.';
 
-			if ( $cached ) {
-				$response_body = json_decode( $response_body );
-				$log_suffix    = 'in cached response.';
-			}
+		if ( $cached ) {
+			$response_body = json_decode( $response_body );
+			$log_suffix    = 'in cached response.';
+		}
 
-			$to_state   = isset( $response_body->tax->jurisdictions->state ) ? strtoupper( $response_body->tax->jurisdictions->state ) : 'not set';
-			$to_country = isset( $response_body->tax->jurisdictions->country ) ? strtoupper( $response_body->tax->jurisdictions->country ) : 'not set';
-			$has_nexus  = isset( $response_body->tax->has_nexus ) ? $response_body->tax->has_nexus : null;
+		$to_state   = isset( $response_body->tax->jurisdictions->state ) ? strtoupper( $response_body->tax->jurisdictions->state ) : 'not set';
+		$to_country = isset( $response_body->tax->jurisdictions->country ) ? strtoupper( $response_body->tax->jurisdictions->country ) : 'not set';
+		$has_nexus  = isset( $response_body->tax->has_nexus ) ? $response_body->tax->has_nexus : null;
 
-			if ( 'CA' === $to_state && 'US' === $to_country && true === $has_nexus ) {
-				$this->_log(
-					sprintf(
-						'Incorrect California tax nexus detected %1$s (from_state: %2$s, to_state: %3$s, to_country: %4$s, has_nexus: %5$s).',
-						$log_suffix,
-						$from_state ?: 'unknown',
-						$to_state,
-						$to_country,
-						json_encode( $has_nexus ),
-					)
-				);
-			}
+		if ( 'CA' === $to_state && 'US' === $to_country && true === $has_nexus ) {
+			$this->_log(
+				sprintf(
+					'Incorrect California tax nexus detected %1$s (from_state: %2$s, to_state: %3$s, to_country: %4$s, has_nexus: %5$s).',
+					$log_suffix,
+					$from_state ?: 'unknown',
+					$to_state,
+					$to_country,
+					json_encode( $has_nexus ),
+				)
+			);
+		}
 
-			if ( 'not set' === $to_state || 'not set' === $to_country || null === $has_nexus ) {
-				throw new Exception( sprintf( 'One or more values are not set : to_state=>%1$s, to_country=>%2$s, has_nexus=>%3$s', $to_state, $to_country, json_encode( $has_nexus ) ) );
-			}
+		if ( 'not set' === $to_state || 'not set' === $to_country || null === $has_nexus ) {
+			throw new Exception( sprintf( 'One or more values are not set : to_state=>%1$s, to_country=>%2$s, has_nexus=>%3$s', $to_state, $to_country, json_encode( $has_nexus ) ) );
 		}
 	}
+}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -229,6 +229,7 @@ class WC_Connect_TaxJar_Integration {
 		add_filter( 'woocommerce_calc_tax', array( $this, 'override_woocommerce_tax_rates' ), 10, 3 );
 		add_filter( 'woocommerce_matched_rates', array( $this, 'allow_street_address_for_matched_rates' ), 10, 2 );
 		add_filter( 'woocommerce_cart_totals_get_item_tax_rates', array( $this, 'override_item_tax_rates' ), 10, 3 );
+		add_action( 'woocommerce_order_item_after_calculate_taxes', array( $this, 'override_order_item_taxes' ), 10, 2 );
 
 		add_filter( 'woocommerce_rate_label', array( $this, 'cleanup_tax_label' ) );
 		add_filter( 'woocommerce_cart_tax_totals', array( $this, 'aggregate_tax_totals' ), 10, 2 );

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.4.1 - 2026-xx-xx =
+* Add   - Itemized tax calculation for mixed carts with per-item tax locations.
+
 = 3.4.0 - 2026-02-03 =
 * Add   - Optimize Woo Tax API calls by restricting same-state tax checks.
 * Add   - Country validation for TaxJar requests.

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -716,7 +716,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		// Create a partial mock that stubs calculate_tax and get_address.
 		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
 			->disableOriginalConstructor()
-			->onlyMethods( array( 'calculate_tax', 'get_address' ) )
+			->onlyMethods( array( 'calculate_tax', 'get_address', '_log' ) )
 			->getMock();
 
 		$integration->method( 'get_address' )->willReturnCallback(
@@ -765,7 +765,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 
 		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
 			->disableOriginalConstructor()
-			->onlyMethods( array( 'calculate_tax', 'get_address' ) )
+			->onlyMethods( array( 'calculate_tax', 'get_address', '_log' ) )
 			->getMock();
 
 		$integration->method( 'get_address' )->willReturn(
@@ -809,7 +809,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	public function test_calculate_taxes_by_location_returns_false_on_error() {
 		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
 			->disableOriginalConstructor()
-			->onlyMethods( array( 'calculate_tax', 'get_address' ) )
+			->onlyMethods( array( 'calculate_tax', 'get_address', '_log' ) )
 			->getMock();
 
 		$integration->method( 'get_address' )->willReturn(
@@ -851,7 +851,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 
 		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
 			->disableOriginalConstructor()
-			->onlyMethods( array( 'calculate_tax', 'get_address', 'get_store_settings' ) )
+			->onlyMethods( array( 'calculate_tax', 'get_address', 'get_store_settings', '_log' ) )
 			->getMock();
 
 		// Store is in CA.
@@ -930,7 +930,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	public function test_calculate_taxes_by_location_all_empty_returns_false() {
 		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
 			->disableOriginalConstructor()
-			->onlyMethods( array( 'calculate_tax', 'get_address' ) )
+			->onlyMethods( array( 'calculate_tax', 'get_address', '_log' ) )
 			->getMock();
 
 		$integration->method( 'get_address' )->willReturn(
@@ -1007,52 +1007,5 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$this->assertEmpty( $result['rate_ids'] );
 		$this->assertEmpty( $result['line_items'] );
 		$this->assertEquals( 0, $result['has_nexus'] );
-	}
-
-	/**
-	 * Test same-state does not trigger cross-state early return.
-	 *
-	 * Note: This test verifies the cross-state check does NOT fire
-	 * for same-state. The actual API call will fail (mocked client),
-	 * but the important thing is it gets past the cross-state check.
-	 */
-	public function test_calculate_tax_same_state_does_not_trigger_cross_state() {
-		// Set store to California.
-		update_option( 'woocommerce_default_country', 'US:CA' );
-
-		WC()->customer->set_is_vat_exempt( false );
-
-		$result = $this->invoke_protected_method(
-			'calculate_tax',
-			array(
-				array(
-					'to_country'      => 'US',
-					'to_state'        => 'CA',
-					'to_zip'          => '94110',
-					'to_city'         => 'San Francisco',
-					'to_street'       => '60 29th St',
-					'shipping_amount' => 0,
-					'line_items'      => array(
-						array(
-							'id'         => 'test-item',
-							'quantity'   => 1,
-							'unit_price' => '25.00',
-						),
-					),
-				),
-			)
-		);
-
-		// Same-state should NOT return the empty taxes array.
-		// It will return false because the mocked API client returns nothing,
-		// but crucially it should NOT be an array with empty rate_ids
-		// (which is what the cross-state check returns).
-		if ( is_array( $result ) ) {
-			// If it somehow got a response, it should have gone past cross-state check.
-			$this->assertTrue( true );
-		} else {
-			// Expected: false from the API call failing (not from cross-state).
-			$this->assertFalse( $result );
-		}
 	}
 }

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -706,6 +706,101 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	// -------------------------------------------------------------------------
+	// override_order_item_taxes() tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test no-op when response_rate_ids is empty (no TaxJar calc this request).
+	 */
+	public function test_override_order_item_taxes_noop_when_no_response() {
+		$order = WC_Helper_Order::create_order();
+		$items = $order->get_items();
+		$item  = reset( $items );
+		$orig  = $item->get_taxes();
+
+		$this->integration->override_order_item_taxes( $item, array() );
+
+		$this->assertSame( $orig, $item->get_taxes() );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test no-op when item is not a WC_Order_Item_Product (e.g. fee or shipping).
+	 */
+	public function test_override_order_item_taxes_skips_non_product_items() {
+		$this->set_private_property( 'response_rate_ids', array( '10-abc' => array( 1 ) ) );
+
+		$fee = new WC_Order_Item_Fee();
+		$fee->set_total( '5.00' );
+
+		// Should not throw or modify.
+		$this->integration->override_order_item_taxes( $fee, array() );
+
+		$this->assertEmpty( $fee->get_taxes()['total'] );
+	}
+
+	/**
+	 * Test no-op when the product is not found in response_rate_ids (cross-state item).
+	 */
+	public function test_override_order_item_taxes_skips_unmatched_product() {
+		$this->set_private_property( 'response_rate_ids', array( '999-abc' => array( 1 ) ) );
+
+		$order = WC_Helper_Order::create_order();
+		$items = $order->get_items();
+		$item  = reset( $items );
+		$orig  = $item->get_taxes();
+
+		$this->integration->override_order_item_taxes( $item, array() );
+
+		$this->assertSame( $orig, $item->get_taxes() );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that TaxJar rates are applied for a matched base-group item.
+	 */
+	public function test_override_order_item_taxes_applies_taxjar_rates_when_matched() {
+		$this->product = WC_Helper_Product::create_simple_product();
+		$this->product->set_regular_price( '20.00' );
+		$this->product->save();
+
+		// Insert a tax rate into the database.
+		$rate_id = WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => 'US',
+				'tax_rate_state'    => 'CA',
+				'tax_rate'          => '10.0000',
+				'tax_rate_name'     => 'CA Tax',
+				'tax_rate_shipping' => 'no',
+				'tax_rate_compound' => 'no',
+				'tax_rate_priority' => 1,
+				'tax_rate_class'    => '',
+			)
+		);
+
+		$product_id = $this->product->get_id();
+		$this->set_private_property( 'response_rate_ids', array( $product_id . '-abc123' => array( $rate_id ) ) );
+
+		// Create an order item.
+		$item = new WC_Order_Item_Product();
+		$item->set_product( $this->product );
+		$item->set_quantity( 1 );
+		$item->set_total( '20.00' );
+		$item->set_subtotal( '20.00' );
+
+		$this->integration->override_order_item_taxes( $item, array() );
+
+		$taxes = $item->get_taxes();
+		$this->assertArrayHasKey( $rate_id, $taxes['total'] );
+		$this->assertEquals( 2.0, (float) $taxes['total'][ $rate_id ] );
+		$this->assertArrayHasKey( $rate_id, $taxes['subtotal'] );
+		$this->assertEquals( 2.0, (float) $taxes['subtotal'][ $rate_id ] );
+
+		// Clean up.
+		WC_Tax::_delete_tax_rate( $rate_id );
+	}
+
+	// -------------------------------------------------------------------------
 	// calculate_taxes_by_location() tests
 	// -------------------------------------------------------------------------
 

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -99,6 +99,18 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Helper to set private properties via reflection.
+	 *
+	 * @param string $property_name Property name.
+	 * @param mixed  $value         Value to set.
+	 */
+	private function set_private_property( $property_name, $value ) {
+		$reflection = new ReflectionProperty( 'WC_Connect_TaxJar_Integration', $property_name );
+		$reflection->setAccessible( true );
+		$reflection->setValue( $this->integration, $value );
+	}
+
+	/**
 	 * Test that get_line_items includes tax_location key with default value.
 	 */
 	public function test_get_line_items_includes_tax_location_with_default() {
@@ -372,5 +384,675 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 
 		// Assert quantity.
 		$this->assertEquals( 2, $item['quantity'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// group_items_by_location() tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test grouping items by tax_location key.
+	 */
+	public function test_group_items_by_location_groups_by_tax_location() {
+		$line_items = array(
+			array(
+				'id'           => 'item-1',
+				'tax_location' => 'shipping',
+			),
+			array(
+				'id'           => 'item-2',
+				'tax_location' => 'base',
+			),
+			array(
+				'id'           => 'item-3',
+				'tax_location' => 'shipping',
+			),
+		);
+
+		$groups = $this->invoke_protected_method( 'group_items_by_location', array( $line_items, false ) );
+
+		$this->assertCount( 2, $groups );
+		$this->assertArrayHasKey( 'shipping', $groups );
+		$this->assertArrayHasKey( 'base', $groups );
+		$this->assertCount( 2, $groups['shipping'] );
+		$this->assertCount( 1, $groups['base'] );
+		$this->assertEquals( 'item-2', $groups['base'][0]['id'] );
+	}
+
+	/**
+	 * Test local pickup forces all items to base.
+	 */
+	public function test_group_items_by_location_local_pickup_forces_base() {
+		$line_items = array(
+			array(
+				'id'           => 'item-1',
+				'tax_location' => 'shipping',
+			),
+			array(
+				'id'           => 'item-2',
+				'tax_location' => 'billing',
+			),
+		);
+
+		$groups = $this->invoke_protected_method( 'group_items_by_location', array( $line_items, true ) );
+
+		$this->assertCount( 1, $groups );
+		$this->assertArrayHasKey( 'base', $groups );
+		$this->assertCount( 2, $groups['base'] );
+	}
+
+	/**
+	 * Test missing tax_location uses woocommerce_tax_based_on default.
+	 */
+	public function test_group_items_by_location_uses_default_when_missing() {
+		update_option( 'woocommerce_tax_based_on', 'billing' );
+
+		$line_items = array(
+			array( 'id' => 'item-1' ), // No tax_location key.
+		);
+
+		$groups = $this->invoke_protected_method( 'group_items_by_location', array( $line_items, false ) );
+
+		$this->assertArrayHasKey( 'billing', $groups );
+		$this->assertCount( 1, $groups['billing'] );
+
+		delete_option( 'woocommerce_tax_based_on' );
+	}
+
+	/**
+	 * Test empty input returns empty groups.
+	 */
+	public function test_group_items_by_location_empty_input() {
+		$groups = $this->invoke_protected_method( 'group_items_by_location', array( array(), false ) );
+
+		$this->assertIsArray( $groups );
+		$this->assertEmpty( $groups );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_taxable_address() tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test that location_type 'base' returns store address.
+	 */
+	public function test_get_taxable_address_base_returns_store_address() {
+		$store_country = WC()->countries->get_base_country();
+		$store_state   = WC()->countries->get_base_state();
+
+		$address = $this->invoke_protected_method( 'get_taxable_address', array( 'base' ) );
+
+		$this->assertIsArray( $address );
+		$this->assertEquals( $store_country, $address[0] );
+		$this->assertEquals( $store_state, $address[1] );
+	}
+
+	/**
+	 * Test that location_type 'shipping' returns customer shipping address.
+	 */
+	public function test_get_taxable_address_shipping_returns_customer_address() {
+		WC()->customer->set_shipping_country( 'US' );
+		WC()->customer->set_shipping_state( 'NY' );
+		WC()->customer->set_shipping_postcode( '10001' );
+
+		$address = $this->invoke_protected_method( 'get_taxable_address', array( 'shipping' ) );
+
+		$this->assertEquals( 'US', $address[0] );
+		$this->assertEquals( 'NY', $address[1] );
+		$this->assertEquals( '10001', $address[2] );
+	}
+
+	/**
+	 * Test that location_type 'billing' returns customer billing address.
+	 */
+	public function test_get_taxable_address_billing_returns_billing_address() {
+		WC()->customer->set_billing_country( 'US' );
+		WC()->customer->set_billing_state( 'TX' );
+		WC()->customer->set_billing_postcode( '73301' );
+
+		$address = $this->invoke_protected_method( 'get_taxable_address', array( 'billing' ) );
+
+		$this->assertEquals( 'US', $address[0] );
+		$this->assertEquals( 'TX', $address[1] );
+		$this->assertEquals( '73301', $address[2] );
+	}
+
+	/**
+	 * Test that null location_type uses woocommerce_tax_based_on option (backward compat).
+	 */
+	public function test_get_taxable_address_null_uses_option() {
+		update_option( 'woocommerce_tax_based_on', 'base' );
+
+		$store_country = WC()->countries->get_base_country();
+
+		$address = $this->invoke_protected_method( 'get_taxable_address', array( null ) );
+
+		$this->assertEquals( $store_country, $address[0] );
+
+		delete_option( 'woocommerce_tax_based_on' );
+	}
+
+	// -------------------------------------------------------------------------
+	// aggregate_tax_totals() tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test aggregation combines entries with same label.
+	 */
+	public function test_aggregate_tax_totals_combines_same_labels() {
+		$tax_a         = new stdClass();
+		$tax_a->label  = 'County Tax';
+		$tax_a->amount = 0.25;
+
+		$tax_b         = new stdClass();
+		$tax_b->label  = 'County Tax';
+		$tax_b->amount = 0.12;
+
+		$tax_c         = new stdClass();
+		$tax_c->label  = 'State Tax';
+		$tax_c->amount = 1.50;
+
+		$tax_totals = array(
+			'US-CA-1' => $tax_a,
+			'US-NY-1' => $tax_b,
+			'US-CA-2' => $tax_c,
+		);
+
+		$result = $this->integration->aggregate_tax_totals( $tax_totals, WC()->cart );
+
+		$this->assertCount( 2, $result );
+		$this->assertArrayHasKey( 'County Tax', $result );
+		$this->assertArrayHasKey( 'State Tax', $result );
+		$this->assertEquals( 0.37, $result['County Tax']->amount );
+		$this->assertEquals( 1.50, $result['State Tax']->amount );
+	}
+
+	/**
+	 * Test aggregation returns input unchanged when count <= 1.
+	 */
+	public function test_aggregate_tax_totals_single_entry_unchanged() {
+		$tax         = new stdClass();
+		$tax->label  = 'Tax';
+		$tax->amount = 1.00;
+
+		$tax_totals = array( 'US-1' => $tax );
+
+		$result = $this->integration->aggregate_tax_totals( $tax_totals, WC()->cart );
+
+		$this->assertSame( $tax_totals, $result );
+	}
+
+	/**
+	 * Test aggregation returns input unchanged when not an array.
+	 */
+	public function test_aggregate_tax_totals_non_array_unchanged() {
+		$result = $this->integration->aggregate_tax_totals( null, WC()->cart );
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test aggregation does not mutate original objects.
+	 */
+	public function test_aggregate_tax_totals_clones_objects() {
+		$tax_a         = new stdClass();
+		$tax_a->label  = 'Tax';
+		$tax_a->amount = 1.00;
+
+		$tax_b         = new stdClass();
+		$tax_b->label  = 'Tax';
+		$tax_b->amount = 2.00;
+
+		$tax_totals = array(
+			'A' => $tax_a,
+			'B' => $tax_b,
+		);
+
+		$result = $this->integration->aggregate_tax_totals( $tax_totals, WC()->cart );
+
+		// Original objects should not be modified.
+		$this->assertEquals( 1.00, $tax_a->amount );
+		$this->assertEquals( 2.00, $tax_b->amount );
+
+		// Aggregated result should have combined amount.
+		$this->assertEquals( 3.00, $result['Tax']->amount );
+	}
+
+	// -------------------------------------------------------------------------
+	// override_item_tax_rates() tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test returns original rates when response_rate_ids is empty.
+	 */
+	public function test_override_item_tax_rates_returns_original_when_no_response() {
+		$original_rates = array( 1 => array( 'rate' => 8.5 ) );
+		$item           = new stdClass();
+		$item->product  = null;
+
+		$result = $this->integration->override_item_tax_rates( $original_rates, $item, WC()->cart );
+
+		$this->assertSame( $original_rates, $result );
+	}
+
+	/**
+	 * Test returns original rates when item has no product.
+	 */
+	public function test_override_item_tax_rates_returns_original_when_no_product() {
+		$this->set_private_property( 'response_rate_ids', array( '10-abc' => array( 1, 2 ) ) );
+
+		$original_rates = array( 1 => array( 'rate' => 8.5 ) );
+		$item           = new stdClass();
+
+		$result = $this->integration->override_item_tax_rates( $original_rates, $item, WC()->cart );
+
+		$this->assertSame( $original_rates, $result );
+	}
+
+	/**
+	 * Test returns original rates when no matching product in response_rate_ids.
+	 */
+	public function test_override_item_tax_rates_returns_original_when_no_match() {
+		$this->set_private_property( 'response_rate_ids', array( '999-abc' => array( 1, 2 ) ) );
+
+		$this->product = WC_Helper_Product::create_simple_product();
+		$this->product->save();
+
+		$original_rates = array( 1 => array( 'rate' => 8.5 ) );
+		$item           = new stdClass();
+		$item->product  = $this->product;
+
+		$result = $this->integration->override_item_tax_rates( $original_rates, $item, WC()->cart );
+
+		$this->assertSame( $original_rates, $result );
+	}
+
+	/**
+	 * Test returns TaxJar rates when matching product found.
+	 */
+	public function test_override_item_tax_rates_returns_taxjar_rates_when_matched() {
+		$this->product = WC_Helper_Product::create_simple_product();
+		$this->product->save();
+
+		// Insert a tax rate into the database.
+		$rate_id = WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => 'US',
+				'tax_rate_state'    => 'CA',
+				'tax_rate'          => '8.5',
+				'tax_rate_name'     => 'CA Tax',
+				'tax_rate_shipping' => 'no',
+				'tax_rate_compound' => 'no',
+				'tax_rate_priority' => 1,
+				'tax_rate_class'    => '',
+			)
+		);
+
+		$product_id = $this->product->get_id();
+		$this->set_private_property( 'response_rate_ids', array( $product_id . '-abc123' => array( $rate_id ) ) );
+
+		$original_rates = array();
+		$item           = new stdClass();
+		$item->product  = $this->product;
+
+		$result = $this->integration->override_item_tax_rates( $original_rates, $item, WC()->cart );
+
+		$this->assertNotEmpty( $result );
+		$this->assertArrayHasKey( $rate_id, $result );
+		$this->assertEquals( 8.5, $result[ $rate_id ]['rate'] );
+		$this->assertEquals( 'CA Tax', $result[ $rate_id ]['label'] );
+
+		// Clean up.
+		WC_Tax::_delete_tax_rate( $rate_id );
+	}
+
+	// -------------------------------------------------------------------------
+	// calculate_taxes_by_location() tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test merges results from multiple location groups.
+	 */
+	public function test_calculate_taxes_by_location_merges_groups() {
+		// Create a partial mock that stubs calculate_tax and get_address.
+		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'calculate_tax', 'get_address' ) )
+			->getMock();
+
+		$integration->method( 'get_address' )->willReturnCallback(
+			function ( $type ) {
+				return array(
+					'to_country' => 'US',
+					'to_state'   => 'CA',
+					'to_zip'     => '94110',
+					'to_city'    => 'San Francisco',
+					'to_street'  => '123 Main St',
+				);
+			}
+		);
+
+		$integration->method( 'calculate_tax' )->willReturnCallback(
+			function ( $options ) {
+				$has_shipping = ! empty( $options['shipping_amount'] );
+				return array(
+					'rate_ids'   => $has_shipping ? array( 'ship-item' => array( 5 ) ) : array( 'base-item' => array( 6 ) ),
+					'line_items' => $has_shipping ? array( 'ship-item' => array( 'tax' => 1.0 ) ) : array( 'base-item' => array( 'tax' => 0.5 ) ),
+				);
+			}
+		);
+
+		$items_by_location = array(
+			'shipping' => array( array( 'id' => 'ship-item' ) ),
+			'base'     => array( array( 'id' => 'base-item' ) ),
+		);
+
+		$reflection = new ReflectionMethod( 'WC_Connect_TaxJar_Integration', 'calculate_taxes_by_location' );
+		$reflection->setAccessible( true );
+		$result = $reflection->invokeArgs( $integration, array( $items_by_location, 10.0 ) );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'ship-item', $result['rate_ids'] );
+		$this->assertArrayHasKey( 'base-item', $result['rate_ids'] );
+		$this->assertArrayHasKey( 'ship-item', $result['line_items'] );
+		$this->assertArrayHasKey( 'base-item', $result['line_items'] );
+	}
+
+	/**
+	 * Test shipping amount only applied to shipping group.
+	 */
+	public function test_calculate_taxes_by_location_shipping_only_on_shipping_group() {
+		$received_options = array();
+
+		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'calculate_tax', 'get_address' ) )
+			->getMock();
+
+		$integration->method( 'get_address' )->willReturn(
+			array(
+				'to_country' => 'US',
+				'to_state'   => 'CA',
+				'to_zip'     => '94110',
+				'to_city'    => 'San Francisco',
+				'to_street'  => '',
+			)
+		);
+
+		$integration->method( 'calculate_tax' )->willReturnCallback(
+			function ( $options ) use ( &$received_options ) {
+				$received_options[] = $options;
+				return array(
+					'rate_ids'   => array( 'x' => array( 1 ) ),
+					'line_items' => array( 'x' => array() ),
+				);
+			}
+		);
+
+		$items_by_location = array(
+			'base'     => array( array( 'id' => 'item-1' ) ),
+			'shipping' => array( array( 'id' => 'item-2' ) ),
+		);
+
+		$reflection = new ReflectionMethod( 'WC_Connect_TaxJar_Integration', 'calculate_taxes_by_location' );
+		$reflection->setAccessible( true );
+		$reflection->invokeArgs( $integration, array( $items_by_location, 15.0 ) );
+
+		// Base group should have 0 shipping.
+		$this->assertEquals( 0, $received_options[0]['shipping_amount'] );
+		// Shipping group should have full shipping amount.
+		$this->assertEquals( 15.0, $received_options[1]['shipping_amount'] );
+	}
+
+	/**
+	 * Test returns false when calculate_tax returns false for any group.
+	 */
+	public function test_calculate_taxes_by_location_returns_false_on_error() {
+		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'calculate_tax', 'get_address' ) )
+			->getMock();
+
+		$integration->method( 'get_address' )->willReturn(
+			array(
+				'to_country' => 'US',
+				'to_state'   => 'CA',
+				'to_zip'     => '94110',
+				'to_city'    => 'San Francisco',
+				'to_street'  => '',
+			)
+		);
+
+		// First group succeeds, second group fails.
+		$integration->method( 'calculate_tax' )->willReturnOnConsecutiveCalls(
+			array(
+				'rate_ids'   => array( 'a' => array( 1 ) ),
+				'line_items' => array( 'a' => array() ),
+			),
+			false
+		);
+
+		$items_by_location = array(
+			'base'     => array( array( 'id' => 'item-1' ) ),
+			'shipping' => array( array( 'id' => 'item-2' ) ),
+		);
+
+		$reflection = new ReflectionMethod( 'WC_Connect_TaxJar_Integration', 'calculate_taxes_by_location' );
+		$reflection->setAccessible( true );
+		$result = $reflection->invokeArgs( $integration, array( $items_by_location, 0 ) );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test cross-state group returns empty taxes, other groups still proceed.
+	 */
+	public function test_calculate_taxes_by_location_cross_state_skips_group() {
+		$call_count = 0;
+
+		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'calculate_tax', 'get_address', 'get_store_settings' ) )
+			->getMock();
+
+		// Store is in CA.
+		$integration->method( 'get_store_settings' )->willReturn(
+			array(
+				'country'  => 'US',
+				'state'    => 'CA',
+				'postcode' => '94110',
+				'city'     => 'San Francisco',
+				'street'   => '',
+			)
+		);
+
+		$integration->method( 'get_address' )->willReturnCallback(
+			function ( $type ) {
+				if ( 'base' === $type ) {
+					return array(
+						'to_country' => 'US',
+						'to_state'   => 'CA',
+						'to_zip'     => '94110',
+						'to_city'    => 'San Francisco',
+						'to_street'  => '',
+					);
+				}
+				// Shipping group goes to NY (cross-state).
+				return array(
+					'to_country' => 'US',
+					'to_state'   => 'NY',
+					'to_zip'     => '10001',
+					'to_city'    => 'New York',
+					'to_street'  => '',
+				);
+			}
+		);
+
+		$integration->method( 'calculate_tax' )->willReturnCallback(
+			function ( $options ) use ( &$call_count ) {
+				$call_count++;
+				$to_state = strtoupper( $options['to_state'] );
+				// Cross-state returns empty taxes (the behavior under test).
+				if ( 'NY' === $to_state ) {
+					return array(
+						'freight_taxable' => 1,
+						'has_nexus'       => 0,
+						'line_items'      => array(),
+						'rate_ids'        => array(),
+						'tax_rate'        => 0,
+					);
+				}
+				return array(
+					'rate_ids'   => array( 'base-item' => array( 1, 2 ) ),
+					'line_items' => array( 'base-item' => array( 'tax' => 1.04 ) ),
+				);
+			}
+		);
+
+		$items_by_location = array(
+			'base'     => array( array( 'id' => 'base-item' ) ),
+			'shipping' => array( array( 'id' => 'ship-item' ) ),
+		);
+
+		$reflection = new ReflectionMethod( 'WC_Connect_TaxJar_Integration', 'calculate_taxes_by_location' );
+		$reflection->setAccessible( true );
+		$result = $reflection->invokeArgs( $integration, array( $items_by_location, 0 ) );
+
+		// Should not be false — base group has taxes.
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'base-item', $result['rate_ids'] );
+		// Both groups were called.
+		$this->assertEquals( 2, $call_count );
+	}
+
+	/**
+	 * Test all groups empty (all cross-state) returns false.
+	 */
+	public function test_calculate_taxes_by_location_all_empty_returns_false() {
+		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'calculate_tax', 'get_address' ) )
+			->getMock();
+
+		$integration->method( 'get_address' )->willReturn(
+			array(
+				'to_country' => 'US',
+				'to_state'   => 'NY',
+				'to_zip'     => '10001',
+				'to_city'    => 'New York',
+				'to_street'  => '',
+			)
+		);
+
+		// All groups return empty taxes (cross-state).
+		$integration->method( 'calculate_tax' )->willReturn(
+			array(
+				'freight_taxable' => 1,
+				'has_nexus'       => 0,
+				'line_items'      => array(),
+				'rate_ids'        => array(),
+				'tax_rate'        => 0,
+			)
+		);
+
+		$items_by_location = array(
+			'shipping' => array( array( 'id' => 'item-1' ) ),
+		);
+
+		$reflection = new ReflectionMethod( 'WC_Connect_TaxJar_Integration', 'calculate_taxes_by_location' );
+		$reflection->setAccessible( true );
+		$result = $reflection->invokeArgs( $integration, array( $items_by_location, 0 ) );
+
+		$this->assertFalse( $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// calculate_tax() cross-state change tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test US cross-state returns empty taxes array, not false.
+	 */
+	public function test_calculate_tax_cross_state_returns_empty_taxes() {
+		// Set store to California.
+		update_option( 'woocommerce_default_country', 'US:CA' );
+
+		// Set customer to not VAT exempt so the early return doesn't trigger.
+		WC()->customer->set_is_vat_exempt( false );
+
+		$result = $this->invoke_protected_method(
+			'calculate_tax',
+			array(
+				array(
+					'to_country'      => 'US',
+					'to_state'        => 'NY',
+					'to_zip'          => '10001',
+					'to_city'         => 'New York',
+					'to_street'       => '123 Broadway',
+					'shipping_amount' => 0,
+					'line_items'      => array(
+						array(
+							'id'         => 'test-item',
+							'quantity'   => 1,
+							'unit_price' => '25.00',
+						),
+					),
+				),
+			)
+		);
+
+		// Should be an array (empty taxes), not false.
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'rate_ids', $result );
+		$this->assertArrayHasKey( 'line_items', $result );
+		$this->assertEmpty( $result['rate_ids'] );
+		$this->assertEmpty( $result['line_items'] );
+		$this->assertEquals( 0, $result['has_nexus'] );
+	}
+
+	/**
+	 * Test same-state does not trigger cross-state early return.
+	 *
+	 * Note: This test verifies the cross-state check does NOT fire
+	 * for same-state. The actual API call will fail (mocked client),
+	 * but the important thing is it gets past the cross-state check.
+	 */
+	public function test_calculate_tax_same_state_does_not_trigger_cross_state() {
+		// Set store to California.
+		update_option( 'woocommerce_default_country', 'US:CA' );
+
+		WC()->customer->set_is_vat_exempt( false );
+
+		$result = $this->invoke_protected_method(
+			'calculate_tax',
+			array(
+				array(
+					'to_country'      => 'US',
+					'to_state'        => 'CA',
+					'to_zip'          => '94110',
+					'to_city'         => 'San Francisco',
+					'to_street'       => '60 29th St',
+					'shipping_amount' => 0,
+					'line_items'      => array(
+						array(
+							'id'         => 'test-item',
+							'quantity'   => 1,
+							'unit_price' => '25.00',
+						),
+					),
+				),
+			)
+		);
+
+		// Same-state should NOT return the empty taxes array.
+		// It will return false because the mocked API client returns nothing,
+		// but crucially it should NOT be an array with empty rate_ids
+		// (which is what the cross-state check returns).
+		if ( is_array( $result ) ) {
+			// If it somehow got a response, it should have gone past cross-state check.
+			$this->assertTrue( true );
+		} else {
+			// Expected: false from the API call failing (not from cross-state).
+			$this->assertFalse( $result );
+		}
 	}
 }

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -532,6 +532,49 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		delete_option( 'woocommerce_tax_based_on' );
 	}
 
+	/**
+	 * Test get_taxable_address returns early with empty array when WC()->customer is null.
+	 */
+	public function test_get_taxable_address_returns_empty_when_customer_is_null() {
+		$original_customer = WC()->customer;
+		WC()->customer     = null;
+
+		$address = $this->invoke_protected_method( 'get_taxable_address', array( 'shipping' ) );
+
+		$this->assertEquals( array( '', '', '', '', '' ), $address );
+
+		WC()->customer = $original_customer;
+	}
+
+	/**
+	 * Test get_taxable_address returns early for billing type when WC()->customer is null.
+	 */
+	public function test_get_taxable_address_billing_returns_empty_when_customer_is_null() {
+		$original_customer = WC()->customer;
+		WC()->customer     = null;
+
+		$address = $this->invoke_protected_method( 'get_taxable_address', array( 'billing' ) );
+
+		$this->assertEquals( array( '', '', '', '', '' ), $address );
+
+		WC()->customer = $original_customer;
+	}
+
+	/**
+	 * Test get_taxable_address base type still works when WC()->customer is null.
+	 */
+	public function test_get_taxable_address_base_works_when_customer_is_null() {
+		$original_customer = WC()->customer;
+		WC()->customer     = null;
+
+		$store_country = WC()->countries->get_base_country();
+		$address       = $this->invoke_protected_method( 'get_taxable_address', array( 'base' ) );
+
+		$this->assertEquals( $store_country, $address[0] );
+
+		WC()->customer = $original_customer;
+	}
+
 	// -------------------------------------------------------------------------
 	// aggregate_tax_totals() tests
 	// -------------------------------------------------------------------------

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -618,18 +618,18 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	// -------------------------------------------------------------------------
-	// override_item_tax_rates() tests
+	// override_cart_item_tax_rates() tests
 	// -------------------------------------------------------------------------
 
 	/**
 	 * Test returns original rates when response_rate_ids is empty.
 	 */
-	public function test_override_item_tax_rates_returns_original_when_no_response() {
+	public function test_override_cart_item_tax_rates_returns_original_when_no_response() {
 		$original_rates = array( 1 => array( 'rate' => 8.5 ) );
 		$item           = new stdClass();
 		$item->product  = null;
 
-		$result = $this->integration->override_item_tax_rates( $original_rates, $item, WC()->cart );
+		$result = $this->integration->override_cart_item_tax_rates( $original_rates, $item, WC()->cart );
 
 		$this->assertSame( $original_rates, $result );
 	}
@@ -637,13 +637,13 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	/**
 	 * Test returns original rates when item has no product.
 	 */
-	public function test_override_item_tax_rates_returns_original_when_no_product() {
+	public function test_override_cart_item_tax_rates_returns_original_when_no_product() {
 		$this->set_private_property( 'response_rate_ids', array( '10-abc' => array( 1, 2 ) ) );
 
 		$original_rates = array( 1 => array( 'rate' => 8.5 ) );
 		$item           = new stdClass();
 
-		$result = $this->integration->override_item_tax_rates( $original_rates, $item, WC()->cart );
+		$result = $this->integration->override_cart_item_tax_rates( $original_rates, $item, WC()->cart );
 
 		$this->assertSame( $original_rates, $result );
 	}
@@ -651,7 +651,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	/**
 	 * Test returns original rates when no matching product in response_rate_ids.
 	 */
-	public function test_override_item_tax_rates_returns_original_when_no_match() {
+	public function test_override_cart_item_tax_rates_returns_original_when_no_match() {
 		$this->set_private_property( 'response_rate_ids', array( '999-abc' => array( 1, 2 ) ) );
 
 		$this->product = WC_Helper_Product::create_simple_product();
@@ -661,7 +661,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$item           = new stdClass();
 		$item->product  = $this->product;
 
-		$result = $this->integration->override_item_tax_rates( $original_rates, $item, WC()->cart );
+		$result = $this->integration->override_cart_item_tax_rates( $original_rates, $item, WC()->cart );
 
 		$this->assertSame( $original_rates, $result );
 	}
@@ -669,7 +669,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	/**
 	 * Test returns TaxJar rates when matching product found.
 	 */
-	public function test_override_item_tax_rates_returns_taxjar_rates_when_matched() {
+	public function test_override_cart_item_tax_rates_returns_taxjar_rates_when_matched() {
 		$this->product = WC_Helper_Product::create_simple_product();
 		$this->product->save();
 
@@ -694,7 +694,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$item           = new stdClass();
 		$item->product  = $this->product;
 
-		$result = $this->integration->override_item_tax_rates( $original_rates, $item, WC()->cart );
+		$result = $this->integration->override_cart_item_tax_rates( $original_rates, $item, WC()->cart );
 
 		$this->assertNotEmpty( $result );
 		$this->assertArrayHasKey( $rate_id, $result );


### PR DESCRIPTION
## Description

Modify `calculate_totals()` to support multiple tax locations in a single cart. This enables mixed carts containing both physical products (taxed at customer's shipping address) and services/bookings (taxed at store base address) by grouping items by their `tax_location` and making separate TaxJar API calls per group.

**Key changes:**
- **`group_items_by_location()`** — Groups line items by their `tax_location` key (set by the `woocommerce_tax_line_item_location` filter from [#2917](https://github.com/Automattic/woocommerce-services/pull/2917))
- **`calculate_taxes_by_location()`** — Loops over groups, makes separate API calls, merges results
- **`get_taxable_address()` / `get_address()`** — Extended with `$location_type` parameter to resolve addresses per group
- **`is_local_pickup()`** — Extracted from `get_taxable_address()` for reuse; forces all items to `'base'` when local pickup is selected
- **`override_cart_item_tax_rates()`** — Hooks into `woocommerce_cart_totals_get_item_tax_rates` to ensure WooCommerce applies the correct per-item rates from TaxJar (not its native rate lookup) during cart totals calculation
- **`override_order_item_taxes()`** — Hooks into `woocommerce_order_item_after_calculate_taxes` to re-apply TaxJar-calculated taxes when the Store API creates an order from a cart. Without this, WooCommerce's `$order->calculate_taxes()` would look up rates using only the customer's address, zeroing out taxes for base-taxed items in mixed-location carts
- **`aggregate_tax_totals()`** — Combines duplicate tax labels from different locations into single display lines (e.g., two "County Tax" entries become one)
- **Cross-state handling** — When a group targets a different US state (no nexus), `calculate_tax()` returns empty taxes instead of `false`, allowing other groups to proceed. A safety net returns `false` if all groups produce empty taxes.

### Related issue(s)

Fixes [WOOTAX-250](https://linear.app/a8c/issue/WOOTAX-250/implement-itemized-tax-calculation-for-mixed-carts-services-products)

### Prerequisites

1. Ensure automated taxes are enabled at **WooCommerce > Settings > Tax** (`/wp-admin/admin.php?page=next-admin&p=%2Fwoocommerce%2Fsettings%2Ftaxes`)
2. Make sure the **Tax rates** table is empty at **WooCommerce > Settings > Tax > Tax rates** (`/wp-admin/admin.php?page=next-admin&p=%2Fwoocommerce%2Fsettings%2Ftaxes%2Frates`) — stale rates from previous sessions can cause incorrect taxes
3. Have at least 2 simple products in the store (e.g., "Jacket" at $25 and "Hat" at $12)

### Setup

1. Check out the branch locally and on CIAB

2. Create the test mu-plugin in your CIAB container to simulate a mixed cart (forces every other cart item to use the store's base address for tax):

```bash
docker exec <CONTAINER_ID> bash -c 'cat > /var/www/html/wp-content/mu-plugins/wootax-250-test.php << '\''PLUGIN'\''
<?php
/**
 * WOOTAX-250 Test: Hat is a "service" taxed at base, everything else at shipping.
 */
add_filter( "woocommerce_tax_line_item_location", function( $location, $product ) {
	if ( ! $product ) {
		return $location;
	}

	$name = $product->get_name();
	$new_location = ( stripos( $name, "hat" ) !== false ) ? "base" : $location;

	error_log( sprintf(
		"[WOOTAX-250 Test] %s | original: %s | applied: %s",
		$name,
		$location,
		$new_location
	) );

	return $new_location;
}, 10, 2 );
PLUGIN'
```

Replace `<CONTAINER_ID>` with your WordPress container ID (`docker ps`).

### Test scenarios

**Test 1: Cross-state — customer in a different US state**

1. Set store address to a US location (e.g., San Francisco, CA 94110)
2. Add both products to cart (e.g., Jacket + Hat)
3. Go to checkout, enter a shipping address in a **different US state** (e.g., New York, NY 10001)
4. **Expected:** Only the "base" group item (Hat) is taxed at the store's CA rates. The "shipping" group item (Jacket) gets no tax (cross-state, no nexus). You should see tax lines like:
   - County Tax — on Hat only
   - Special Tax — on Hat only
   - State Sales Tax — on Hat only
5. Check `wp-content/debug.log` (`docker exec -it <CONTAINER_ID> tail -f /var/www/html/wp-content/debug.log
`):
   ```
   [WOOTAX-250 Test] #1 Jacket | original: shipping | applied: shipping
   [WOOTAX-250 Test] #2 Hat | original: shipping | applied: base
   US from_state and to_state are different. No tax applies.
   ```
6. Place the order and remember the order ID and the cart amount.

**Test 2: In-state — customer in the same US state**

1. Same store address (San Francisco, CA 94110)
2. Same products in cart
3. Change shipping address to a **same-state** but **different city** location (e.g., San Jose, CA 95110)
4. **Expected:** Both items are taxed — Hat at SF rates (base group), Jacket at San Jose rates (shipping group). Tax lines should show aggregated amounts from both locations:
   - County Tax — combined from both jurisdictions
   - Special Tax — combined
   - State Sales Tax — combined
5. Total should be higher than Test 1 since all items are taxed
6. Place the order and remember the order ID and the cart amount.

**Test 3: Single location cart (no regression)**

1. Remove the test mu-plugin (`docker exec <CONTAINER_ID> rm /var/www/html/wp-content/mu-plugins/wootax-250-test.php`)
2. Add products to cart, go to checkout with any US address
3. **Expected:** Taxes calculate normally — all items grouped under one location, single API call, same behavior as before this PR
4. Place the order and remember the order ID and the cart amount.


| Cart | Order page |
| ------ | ----- |
| <img width="1433" height="754" alt="image" src="https://github.com/user-attachments/assets/1139a280-da6c-40e8-bdee-c343943cd695" /> | <img width="1024" height="706" alt="image" src="https://github.com/user-attachments/assets/ed35de57-2524-415f-b4e0-923beefa8c01" /> |
| <img width="1429" height="732" alt="image" src="https://github.com/user-attachments/assets/79cf221e-a0e5-4afa-927c-98e4a0d538d8" /> | <img width="975" height="708" alt="image" src="https://github.com/user-attachments/assets/04958787-89a5-4090-8f06-a25b8d2525b5" /> |

### Checklist

- [x] unit tests
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added