### PR TITLE
Fix/issue wooship 1946 - Fix missing Sift tracker script 404 by inlining it via `wp_add_inline_script`

### DIFF
--- a/assets/javascript/sift.js
+++ b/assets/javascript/sift.js
@@ -1,8 +1,0 @@
-/* global wcServicesSiftConfig */
-
-if ( typeof wcServicesSiftConfig !== 'undefined' && wcServicesSiftConfig.beacon_key && wcServicesSiftConfig.user_id ) {
-	const _sift = window._sift || [];
-	_sift.push( [ '_setAccount', wcServicesSiftConfig.beacon_key ] );
-	_sift.push( [ '_setUserId', wcServicesSiftConfig.user_id ] );
-	_sift.push( [ '_trackPageview' ] );
-}

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.4.1 - 2026-xx-xx =
+* Fix   - Fix missing Sift tracker script by inlining it instead of loading a non-distributed file.
+
 = 3.4.0 - 2026-02-03 =
 * Add   - Optimize Woo Tax API calls by restricting same-state tax checks.
 * Add   - Country validation for TaxJar requests.

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.4.1 - 2026-xx-xx =
+* Fix   - Fix missing Sift tracker script by inlining it instead of loading a non-distributed file.
+
 = 3.4.0 - 2026-02-03 =
 * Add   - Optimize Woo Tax API calls by restricting same-state tax checks.
 * Add   - Country validation for TaxJar requests.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -2029,7 +2029,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			);
 
 			$inline_script = sprintf(
-				'var _sift = window._sift || [];' .
+				'var _sift = window._sift = window._sift || [];' .
 				'_sift.push(["_setAccount", %s]);' .
 				'_sift.push(["_setUserId", %s]);' .
 				'_sift.push(["_trackPageview"]);',

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -69,10 +69,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 	define( 'WCSERVICES_PLUGIN_DIST_URL', plugin_dir_url( WCSERVICES_PLUGIN_FILE ) . 'dist/' );
 	define( 'WCSERVICES_ASSETS_URL', WCSERVICES_PLUGIN_URL . 'assets/' );
 	define( 'WCSERVICES_STYLESHEETS_URL', WCSERVICES_ASSETS_URL . 'stylesheets/' );
-	define( 'WCSERVICES_JAVASCRIPT_URL', WCSERVICES_ASSETS_URL . 'javascript/' );
 	define( 'WCSERVICES_ASSETS_DIR', WCSERVICES_PLUGIN_DIR . '/assets/' );
 	define( 'WCSERVICES_STYLESHEETS_DIR', WCSERVICES_ASSETS_DIR . 'stylesheets/' );
-	define( 'WCSERVICES_JAVASCRIPT_DIR', WCSERVICES_ASSETS_URL . 'javascript/' );
 
 	class WC_Connect_Loader {
 
@@ -2019,11 +2017,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				return;
 			}
 
-			$fraud_config = array(
-				'beacon_key' => $sift_configurations->beacon_key,
-				'user_id'    => $connected_data['ID'],
-			);
-
 			wp_register_script(
 				'sift-science',
 				'https://cdn.sift.com/s.js',
@@ -2035,21 +2028,18 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				)
 			);
 
-			wp_register_script(
-				'wc-services-sift',
-				WCSERVICES_JAVASCRIPT_URL . 'sift.js',
-				array( 'sift-science' ),
-				self::get_wcs_version(),
-				array( 'in_footer' => true )
+			$inline_script = sprintf(
+				'var _sift = window._sift || [];' .
+				'_sift.push(["_setAccount", %s]);' .
+				'_sift.push(["_setUserId", %s]);' .
+				'_sift.push(["_trackPageview"]);',
+				wp_json_encode( $sift_configurations->beacon_key ),
+				wp_json_encode( $connected_data['ID'] )
 			);
 
-			wp_add_inline_script(
-				'wc-services-sift',
-				'var wcServicesSiftConfig = ' . wp_json_encode( $fraud_config ) . ';',
-				'before'
-			);
+			wp_add_inline_script( 'sift-science', $inline_script, 'after' );
 
-			wp_enqueue_script( 'wc-services-sift' );
+			wp_enqueue_script( 'sift-science' );
 		}
 
 		/**


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

After updating to WooCommerce Services / WooCommerce Tax 3.4.0, WP-Admin pages load a script tag pointing to a non-existent local asset: `/wp-content/plugins/woocommerce-services/assets/javascript/sift.js`. This results in a 404 error on every admin page load.

The root cause is that `assets/javascript/sift.js` was introduced in #2913 but the `assets/` directory is not included in the release build (`tasks/release.js` only copies `classes/`, `dist/`, `i18n/`, `images/`, `vendor/`, and `src/`).

This PR fixes the issue by inlining the Sift tracker initialization script via `wp_add_inline_script` on the `sift-science` CDN script handle, eliminating the need for a separate local JS file entirely. The standalone `assets/javascript/sift.js` file and the unused `WCSERVICES_JAVASCRIPT_URL` / `WCSERVICES_JAVASCRIPT_DIR` constants have been removed.

### Related issue(s)

Fixes [WOOSHIP-1946](https://linear.app/a8c/issue/WOOSHIP-1946/admin-console-404-error-for-missing-assetsjavascriptsiftjs-after)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

1. Install WooCommerce Tax 3.4.0
2. Enable automated taxes in WooCommerce → Settings → Tax
3. Log into WP-Admin
4. Open browser dev tools → Console / Network

**Before:** `GET .../assets/javascript/sift.js?ver=3.4.0` returns `404 (Not Found)`

**After:** No 404 error. The Sift tracker script is inlined directly after the Sift CDN script.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added
