### PR TITLE
Fix/issue wootax 56 - Add Informational Banner for non JP owner admin

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.5.0 - 2026-xx-xx =
+* Add   - Add informational banner for non-connection-owner administrators when WooCommerce Tax Terms of Service have not been accepted, displaying the Jetpack connection owner's name. 
+
 = 3.4.1 - 2026-02-09 =
 * Add   - Itemized tax calculation for mixed carts with per-item tax locations.
 

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -257,6 +257,15 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 						return 'tos_only_banner';
 					}
 
+					// TOS not accepted, but current user is not the connection owner.
+					// Show an informational banner directing them to the connection owner.
+					if (
+						isset( $status['tos_accepted'] )
+						&& ! $status['tos_accepted']
+					) {
+						return 'tos_informational_banner';
+					}
+
 					return false;
 				default:
 					return false;
@@ -399,6 +408,10 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					wp_enqueue_style( 'wc_connect_banner' );
 					add_action( 'admin_notices', array( $this, 'show_banner_after_connection' ) );
 					break;
+				case 'tos_informational_banner':
+					wp_enqueue_style( 'wc_connect_banner' );
+					add_action( 'admin_notices', array( $this, 'show_tos_informational_banner' ) );
+					break;
 			}
 
 			add_action( 'wp_ajax_wc_connect_dismiss_notice', array( $this, 'ajax_dismiss_notice' ) );
@@ -529,6 +542,25 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			);
 		}
 
+		public function show_tos_informational_banner() {
+			if ( ! $this->should_display_nux_notice_for_current_store_locale() ) {
+				return;
+			}
+
+			if ( ! $this->should_display_nux_notice_on_screen( get_current_screen() ) ) {
+				return;
+			}
+
+			$this->show_nux_banner(
+				array(
+					'title'             => __( 'WooCommerce Tax requires Terms of Service acceptance', 'woocommerce-services' ),
+					'description'       => __( 'The Jetpack connection owner needs to accept the Terms of Service to activate WooCommerce Tax features.', 'woocommerce-services' ),
+					'image_url'         => plugins_url( 'images/wcs-notice.png', __DIR__ ),
+					'should_show_terms' => false,
+				)
+			);
+		}
+
 		public function show_nux_banner( $content ) {
 			if ( isset( $content['dismissible_id'] ) && $this->is_notice_dismissed( sanitize_key( $content['dismissible_id'] ) ) ) {
 				return;
@@ -566,14 +598,15 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 							?>
 						</p>
 					<?php endif; ?>
-					<?php if ( isset( $content['button_link'] ) ) : ?>
+					<?php if ( isset( $content['button_text'] ) ) : ?>
+						<?php if ( isset( $content['button_link'] ) ) : ?>
 						<a
 							class="wcs-nux__notice-content-button button button-primary"
 							href="<?php echo esc_url( $content['button_link'] ); ?>"
 						>
 							<?php echo esc_html( $content['button_text'] ); ?>
 						</a>
-					<?php else : ?>
+						<?php else : ?>
 						<form action="<?php echo esc_attr( admin_url( 'admin-post.php' ) ); ?>" method="post">
 							<input type="hidden" name="action" value="register_woocommerce_services_jetpack"/>
 							<input type="hidden" name="redirect_url"
@@ -586,6 +619,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 								<?php echo esc_html( $content['button_text'] ); ?>
 							</button>
 						</form>
+						<?php endif; ?>
 					<?php endif; ?>
 				</div>
 			</div>

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -551,10 +551,18 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				return;
 			}
 
+			$connection_owner = WC_Connect_Jetpack::get_connection_owner();
+			if ( $connection_owner ) {
+				/* translators: %s: display name of the Jetpack connection owner */
+				$description = sprintf( __( 'The Jetpack connection owner (%s) needs to accept the Terms of Service to activate WooCommerce Tax features.', 'woocommerce-services' ), $connection_owner->display_name );
+			} else {
+				$description = __( 'The Jetpack connection owner needs to accept the Terms of Service to activate WooCommerce Tax features.', 'woocommerce-services' );
+			}
+
 			$this->show_nux_banner(
 				array(
 					'title'             => __( 'WooCommerce Tax requires Terms of Service acceptance', 'woocommerce-services' ),
-					'description'       => __( 'The Jetpack connection owner needs to accept the Terms of Service to activate WooCommerce Tax features.', 'woocommerce-services' ),
+					'description'       => $description,
 					'image_url'         => plugins_url( 'images/wcs-notice.png', __DIR__ ),
 					'should_show_terms' => false,
 				)

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.5.0 - 2026-xx-xx =
+* Add   - Add informational banner for non-connection-owner administrators when WooCommerce Tax Terms of Service have not been accepted, displaying the Jetpack connection owner's name. 
+
 = 3.4.1 - 2026-02-09 =
 * Add   - Itemized tax calculation for mixed carts with per-item tax locations.
 

--- a/tests/php/test-class_wc-connect-nux.php
+++ b/tests/php/test-class_wc-connect-nux.php
@@ -16,7 +16,7 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 					'should_display_after_cxn_banner' => false,
 				)
 			),
-			false
+			'tos_informational_banner'
 		);
 
 		$this->assertEquals(

--- a/tests/php/test-class_wc-connect-nux.php
+++ b/tests/php/test-class_wc-connect-nux.php
@@ -10,13 +10,10 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 		$this->assertEquals(
 			WC_Connect_Nux::get_banner_type_to_display(
 				array(
-					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_OFFLINE_MODE,
-					'tos_accepted'                    => false,
-					'can_accept_tos'                  => false,
-					'should_display_after_cxn_banner' => false,
+					'jetpack_connection_status' => WC_Connect_Nux::JETPACK_OFFLINE_MODE,
 				)
 			),
-			'tos_informational_banner'
+			false
 		);
 
 		$this->assertEquals(
@@ -149,6 +146,21 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 				)
 			),
 			'after_jetpack_connection'
+		);
+	}
+
+	public function test_get_banner_type_to_display_with_jp_cxn_without_tos_acceptance_non_owner() {
+		// Jetpack is already connected, TOS was not yet accepted, user is not the connection owner
+		$this->assertEquals(
+			WC_Connect_Nux::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_CONNECTED,
+					'tos_accepted'                    => false,
+					'can_accept_tos'                  => false,
+					'should_display_after_cxn_banner' => false,
+				)
+			),
+			'tos_informational_banner'
 		);
 	}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

When the WooCommerce Tax plugin is active and Jetpack is connected, but the Terms of Service (TOS) have not been accepted, non-connection-owner administrators see no banner or prompt at all. This leaves them stuck with no way to understand why the plugin isn't working, and in some cases forces manual database edits to resolve.

This PR adds an informational banner for non-connection-owner administrators that explains the Jetpack connection owner needs to accept the TOS. The banner displays the connection owner's display name so the admin knows who to contact.

### Changes
- Added a new `tos_informational_banner` type in `get_banner_type_to_display()` for when TOS is not accepted and the current user is not the connection owner.
- Added `show_tos_informational_banner()` method that displays the owner's name using `WC_Connect_Jetpack::get_connection_owner()`.
- Updated `show_nux_banner()` to support rendering banners without a button.

### Related issue(s)

Closes [WOOTAX-56](https://linear.app/a8c/issue/WOOTAX-56/tos-prompts-should-always-appear-when-tos-has-not-been-accepted-but)
<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

**Before (bug):**
1. Please login as admin with JP connection owner.
2. Install and activate both Jetpack and WooCommerce Tax plugins.
3. Connect to Jetpack by clicking connect in the banner.
4. Now, search for `wc_connect_options` from `wp_options` table in the db.
5. Remove `s:12:"tos_accepted";b:1;` that portion of string and click update.
6. Go to WooCommerce > Settings. The banner will be displayed again.
7. Log in as a different administrator (not the Jetpack connection owner).
8. Navigate to WooCommerce settings.
9. **Result:** An informational banner appears: *"The Jetpack connection owner (Owner Name) needs to accept the Terms of Service to activate WooCommerce Tax features."*

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added
