### PR TITLE
Update changelogs to fix missing fix in previous release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,10 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.4.2 - 2026-xx-xx =
+* Fix   - Fix missing Sift tracker script by inlining it instead of loading a non-distributed file.
+
 = 3.4.1 - 2026-02-09 =
 * Add   - Itemized tax calculation for mixed carts with per-item tax locations.
-* Fix   - Fix missing Sift tracker script by inlining it instead of loading a non-distributed file.
 
 = 3.4.0 - 2026-02-03 =
 * Add   - Optimize Woo Tax API calls by restricting same-state tax checks.

--- a/readme.txt
+++ b/readme.txt
@@ -70,9 +70,11 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.4.2 - 2026-xx-xx =
+* Fix   - Fix missing Sift tracker script by inlining it instead of loading a non-distributed file.
+
 = 3.4.1 - 2026-02-09 =
 * Add   - Itemized tax calculation for mixed carts with per-item tax locations.
-* Fix   - Fix missing Sift tracker script by inlining it instead of loading a non-distributed file.
 
 = 3.4.0 - 2026-02-03 =
 * Add   - Optimize Woo Tax API calls by restricting same-state tax checks.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

[PR 2922](https://github.com/Automattic/woocommerce-services/pull/2922) was merged into trunk the day after I released 3.4.1, but the changelog entries were added to the already released [3.4.1 change log entries](https://github.com/Automattic/woocommerce-services/blob/trunk/changelog.txt).

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Closes [WOOTAX-262](https://linear.app/a8c/issue/WOOTAX-262/update-change-log-for-feature-that-was-added-but-not-shipped)

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

No code changes. Just moving the changelog entries for a fix that was added to the 3.4.1 entry after 3.4.1 was already released.

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

