### PR TITLE
Update E2E workflow's docker-compose to 2.24.0

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -45,7 +45,7 @@ jobs:
             npm run dist
       - name: Install docker-compose
         run: |
-          sudo curl -L "https://github.com/docker/compose/releases/download/v2.3.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo curl -L "https://github.com/docker/compose/releases/download/v2.24.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
       - name: Setup E2E container
         run: |

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 3.4.2 - 2026-xx-xx =
 * Fix   - Fix missing Sift tracker script by inlining it instead of loading a non-distributed file.
 * Fix   - Fix zip file structure in GitHub workflow build process.
+* Fix   - Update Docker Compose version to 2.24.0 in E2E Tests GitHub workflow.
 
 = 3.4.1 - 2026-02-09 =
 * Add   - Itemized tax calculation for mixed carts with per-item tax locations.

--- a/readme.txt
+++ b/readme.txt
@@ -73,6 +73,7 @@ This plugin relies on the following external services:
 = 3.4.2 - 2026-xx-xx =
 * Fix   - Fix missing Sift tracker script by inlining it instead of loading a non-distributed file.
 * Fix   - Fix zip file structure in GitHub workflow build process.
+* Fix   - Update Docker Compose version to 2.24.0 in E2E Tests GitHub workflow.
 
 = 3.4.1 - 2026-02-09 =
 * Add   - Itemized tax calculation for mixed carts with per-item tax locations.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Previously, we were using Docker Compose version `2.3.3` in the `.github/workflows/e2e_tests.yml` workflow file. This is a very old version of Docker Compose and recently the workflow started to fail with the following error:

```
Error response from daemon: client version 1.42 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version
Docker exit code: 1
```

I tracked down a [similar issue reported in the Docker Compose repo](https://github.com/docker/compose/issues/13389) and the suggested fix was to simply update Docker Compose.  

This PR updates the Docker Compose version from `2.3.3` to `2.24.0` in the `.github/workflows/e2e_tests.yml` workflow file. 

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Fixes WOOTAX-263

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

1. Visit the [E2E test workflow action page](https://github.com/Automattic/woocommerce-services/actions/workflows/e2e_tests.yml).
2. Click the run workflow drop down.
3. Choose this PR branch as the branch for the workflow: `fix/WOOTAX-263-e2e-docker-compose-client`
4. Click run workflow.
5. Verify that the workflow completes successfully and that all E2E tests pass.

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

