### PR TITLE
Unify tax rate naming with full jurisdiction prefix

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Tax Changelog ***
 
 = 3.5.1 - 2026-xx-xx =
-* Tweak - Unify tax rate naming.
+* Tweak - Unify tax rate naming, use full jurisdictions for all tax rates.
 
 = 3.5.0 - 2026-02-23 =
 * Add   - Add informational banner for non-connection-owner administrators when WooCommerce Tax Terms of Service have not been accepted, displaying the Jetpack connection owner's name.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,10 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.5.1 - 2026-xx-xx =
+* Tweak - Unify tax rate naming.
+
 = 3.5.0 - 2026-02-23 =
-* Add   - Add informational banner for non-connection-owner administrators when WooCommerce Tax Terms of Service have not been accepted, displaying the Jetpack connection owner's name. 
+* Add   - Add informational banner for non-connection-owner administrators when WooCommerce Tax Terms of Service have not been accepted, displaying the Jetpack connection owner's name.
 * Fix   - Fix missing Sift tracker script by inlining it instead of loading a non-distributed file.
 * Fix   - Fix zip file structure in GitHub workflow build process.
 * Fix   - Update Docker Compose version to 2.24.0 in E2E Tests GitHub workflow.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -154,28 +154,11 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		// United States specific naming enhancements.
-		$county = isset( $jurisdictions['county'] ) ? trim( (string) $jurisdictions['county'] ) : '';
-		$city   = isset( $jurisdictions['city'] ) ? trim( (string) $jurisdictions['city'] ) : '';
+		$county       = isset( $jurisdictions['county'] ) ? trim( (string) $jurisdictions['county'] ) : '';
+		$city         = isset( $jurisdictions['city'] ) ? trim( (string) $jurisdictions['city'] ) : '';
+		$jurisdiction = trim( $county . ' ' . $city );
 
-		switch ( $taxjar_rate_name ) {
-			case 'city_tax_rate':
-			case 'special_tax_rate':
-				// Example: "Some County Some City : City Tax".
-				$prefix = trim( $county . ' ' . $city );
-				return ( '' !== $prefix ? $prefix . ' : ' : '' ) . $rate_name;
-
-			case 'county_tax_rate':
-				// Example: "Some County : County Tax".
-				return ( '' !== $county ? $county . ' : ' : '' ) . $rate_name;
-
-			case 'state_sales_tax_rate':
-				// Example: "State Sales Tax" (no jurisdiction prefix).
-				return $rate_name;
-
-			default:
-				// Fallback for any other US rate types.
-				return $rate_name;
-		}
+		return ( '' !== $jurisdiction ? $jurisdiction . ' : ' : '' ) . $rate_name;
 	}
 
 	public function init() {

--- a/readme.txt
+++ b/readme.txt
@@ -70,8 +70,11 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.5.1 - 2026-xx-xx =
+* Tweak - Unify tax rate naming.
+
 = 3.5.0 - 2026-02-23 =
-* Add   - Add informational banner for non-connection-owner administrators when WooCommerce Tax Terms of Service have not been accepted, displaying the Jetpack connection owner's name. 
+* Add   - Add informational banner for non-connection-owner administrators when WooCommerce Tax Terms of Service have not been accepted, displaying the Jetpack connection owner's name.
 * Fix   - Fix missing Sift tracker script by inlining it instead of loading a non-distributed file.
 * Fix   - Fix zip file structure in GitHub workflow build process.
 * Fix   - Update Docker Compose version to 2.24.0 in E2E Tests GitHub workflow.

--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,7 @@ This plugin relies on the following external services:
 == Changelog ==
 
 = 3.5.1 - 2026-xx-xx =
-* Tweak - Unify tax rate naming.
+* Tweak - Unify tax rate naming, use full jurisdictions for all tax rates.
 
 = 3.5.0 - 2026-02-23 =
 * Add   - Add informational banner for non-connection-owner administrators when WooCommerce Tax Terms of Service have not been accepted, displaying the Jetpack connection owner's name.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

In PR #2899 (WOOTAX-14), itemized tax rate names were introduced with jurisdiction prefixes that varied by rate type:

- **City/Special rates**: `COUNTY CITY : City Tax`
- **County rates**: `COUNTY : County Tax`
- **State rates**: `State Sales Tax` (no jurisdiction prefix)

This was a deliberate design — each rate showed only the jurisdiction level it originated from. However, in WooCommerce Analytics the `COUNTRY-STATE-` prefix is automatically prepended to all rate names, resulting in entries like `US-CA-STATE SALES TAX-4` or `US-FL-MIAMI-DADE-COUNTY TAX-2` where the full county/city location is not visible for state and county level rates.

Merchants (particularly in California and New York) who previously relied on the pre-3.2.0 format — where a single combined rate included the full `COUNTRY-STATE-COUNTY-CITY` location — have reported they can no longer identify which jurisdiction each tax line belongs to in analytics reports and CSV exports, making it difficult to file taxes.

This PR unifies the naming format so that **all** tax rate types include the full jurisdiction prefix:

```text
COUNTY CITY : Rate Name
```

In analytics this results in consistent entries like:
- `US-FL-MIAMI-DADE HOMESTEAD : CITY TAX-1`
- `US-FL-MIAMI-DADE HOMESTEAD : COUNTY TAX-2`
- `US-FL-MIAMI-DADE HOMESTEAD : SPECIAL TAX-3`
- `US-FL-MIAMI-DADE HOMESTEAD : STATE SALES TAX-4`

This is the first step in a multi-part effort to address the reporting issues (WOOTAX-255). Future PRs will add display toggle controls for the Order Edit view and analytics report aggregation.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

- Linear: [WOOTAX-274 — Unify tax rate naming with full jurisdiction prefix](https://linear.app/a8c/issue/WOOTAX-274/unify-tax-rate-naming-with-full-jurisdiction-prefix)
- Follows up on: [PR #2899](https://github.com/Automattic/woocommerce-services/pull/2899) (WOOTAX-14 — tax rate naming with jurisdiction prefixes)

### Research: Does state-level tax need jurisdiction detail?

<details>
<summary>Click to expand full research findings</summary>

#### State tax rates are uniform within a state

The state sales tax rate (e.g., CA 7.25%) is the same regardless of county/city — the rate value doesn't change by jurisdiction. This raised the question of whether adding jurisdiction to state-level names is correct.

#### Filing requirements DO require jurisdiction attribution

Even though the state rate is uniform, **destination-based states** require merchants to attribute all tax components — including the state portion — to specific jurisdictions when filing:

- **California (CDTFA)** requires filing across multiple schedules: Schedule B (sales by county), Schedule C (sales by city), and Schedule A (district-level taxes). All tax components must be attributable to a jurisdiction.
- **New York** requires county-level "reporting codes" — merchants must map sales to counties. A merchant pinned the plugin at v3.1.1 specifically because they needed county info in tax names to attribute state taxes to NY counties.
- **Texas, South Carolina, Georgia** also require jurisdiction-level reporting.
- **Origin-based states** generally don't need jurisdiction breakdown.

#### TaxJar's own reports provide jurisdiction breakdowns

TaxJar provides "a breakdown by county, city, and jurisdiction to help simplify the process of filing" for destination-based state reports — validating that jurisdiction-level attribution is expected for all rate types.

#### No duplicate rate concern

The `create_or_update_tax_rate()` method matches existing rates by **location** (country, state, postcode, city) and **priority position**, not by name. Changing the rate name updates the existing row rather than creating a duplicate.

#### Conclusion

Adding jurisdiction to state-level tax names is correct and beneficial for filing purposes. The unified naming format aligns with how destination-based states expect merchants to report taxes.

#### Sources

- [TaxJar: Jurisdiction breakdowns in reports](https://support.taxjar.com/article/208-jurisdiction-breakdowns-in-reports)
- [California CDTFA filing instructions](https://cdtfa.ca.gov/cros/online-filing-instructions.htm)
- [NY Pub 718: Sales Tax Rates by Jurisdiction](https://www.tax.ny.gov/pdf/publications/sales/pub718.pdf)
- [How to Report Sales Tax in California](https://handsoffsalestax.com/how-to-report-sales-tax-in-california/)

</details>

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

1. Set up a store with a US address (e.g., California) and enable Automated Taxes.
2. Place an order with a US address that has multiple tax jurisdictions (e.g., San Lorenzo, CA 94580).
3. Navigate to **WooCommerce > Analytics > Taxes** or export the tax CSV report.

**Before (varied jurisdiction levels per rate type):**
In analytics, rate names appear with `COUNTRY-STATE-` auto-prefixed by WooCommerce:
- `US-FL-MIAMI-DADE HOMESTEAD : CITY TAX-1` (city/special — had full jurisdiction)
- `US-FL-MIAMI-DADE : COUNTY TAX-2` (county — missing city)
- `US-FL-STATE SALES TAX-4` (state — missing county and city)

Merchants could not easily identify which county/city a state or county rate belonged to.

**After (unified jurisdiction on all rate types):**
All rate types now include the full `COUNTY CITY` prefix:
- `US-FL-MIAMI-DADE HOMESTEAD : CITY TAX-1`
- `US-FL-MIAMI-DADE HOMESTEAD : COUNTY TAX-2`
- `US-FL-MIAMI-DADE HOMESTEAD : SPECIAL TAX-3`
- `US-FL-MIAMI-DADE HOMESTEAD : STATE SALES TAX-4`

Every tax line is now clearly attributable to a specific location in reports and CSV exports.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added
