### PR TITLE
[WOOTAX-260] Tweak - WooCommerce 10.6 Compatibility.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 3.5.1 - 2026-xx-xx =
 * Fix   - Fix plugin translation files located in i18n/languages folder.
 * Tweak - Unify tax rate naming, use full jurisdictions for all tax rates.
+* Tweak - WooCommerce 10.6 Compatibility.
 
 = 3.5.0 - 2026-02-23 =
 * Add   - Add informational banner for non-connection-owner administrators when WooCommerce Tax Terms of Service have not been accepted, displaying the Jetpack connection owner's name.

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Requires PHP: 7.4
 Requires at least: 6.7
 Requires Plugins: woocommerce
 Tested up to: 6.9
-WC requires at least: 10.3
-WC tested up to: 10.5
+WC requires at least: 10.4
+WC tested up to: 10.6
 Stable tag: 3.5.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -73,6 +73,7 @@ This plugin relies on the following external services:
 = 3.5.1 - 2026-xx-xx =
 * Fix   - Fix plugin translation files located in i18n/languages folder.
 * Tweak - Unify tax rate naming, use full jurisdictions for all tax rates.
+* Tweak - WooCommerce 10.6 Compatibility.
 
 = 3.5.0 - 2026-02-23 =
 * Add   - Add informational banner for non-connection-owner administrators when WooCommerce Tax Terms of Service have not been accepted, displaying the Jetpack connection owner's name.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -13,8 +13,8 @@
  * Requires PHP: 7.4
  * Requires at least: 6.7
  * Tested up to: 6.9
- * WC requires at least: 10.3
- * WC tested up to: 10.5
+ * WC requires at least: 10.4
+ * WC tested up to: 10.6
  *
  * Copyright (c) 2017-2023 Automattic
  *


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Bumps WooCommerce compatibility to 10.6 and minimum required version to 10.4.

### Related issue(s)

Fixes WOOTAX-260

### Steps to reproduce & screenshots/GIFs

1. Install the plugin on a WordPress site running WooCommerce 10.6.
2. Verify the plugin activates without errors and functions as expected.

### Checklist

- [ ] unit tests
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added