### PR TITLE
Remove forced AI attribution from agent configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,12 +50,6 @@ composer phpcs
 - Regressing legacy label purchase support for eligible installs.
 - Treating shipping migrations as feature expansion instead of compatibility maintenance.
 
-## Commit Attribution
-- AI commits MUST include:
-```text
-Co-Authored-By: Codex (GPT-5) <codex@openai.com>
-```
-
 ## Local Skills
 - Use `create-pr` for PR preparation workflows. See `.agents/skills/create-pr/SKILL.md`.
 - Use `write-changelog` for changelog entry workflows. See `.agents/skills/write-changelog/SKILL.md`.


### PR DESCRIPTION
## Description

Removes the "Commit Attribution" section from `AGENTS.md` that forced AI agents to append a `Co-Authored-By: Codex (GPT-5) <codex@openai.com>` trailer to every commit. This forced attribution is unnecessary and should not be enforced through agent configuration files.

### Checklist:
- [x] (Shipping) My PR doesn't impact Woo mobile apps, OR I've tested and confirmed it works fine on Woo mobile (if it impacts mobile, add the `impacts-woo-mobile` label)