### PR TITLE
Fix WOOTAX-17 Remove nexus addresses workaround

### DIFF
--- a/.github/workflows/legacy_qit.yml
+++ b/.github/workflows/legacy_qit.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Build plugin zip
         run: npm run build
 
+      # Switch to a modern Node for QIT CLI internals (CTRF merge requires Node 12+).
+      # The npm build above already completed on Node 10 from .nvmrc.
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '20'
+
       - name: Unzip woocommerce-services.zip
         run: unzip woocommerce-services.zip -d woocommerce-services
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.5.2 - 2026-xx-xx =
+* Fix   - Remove nexus address workaround.
+
 = 3.5.1 - 2026-03-10 =
 * Fix   - Fix plugin translation files located in i18n/languages folder.
 * Tweak - Unify tax rate naming, use full jurisdictions for all tax rates.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Tax Changelog ***
 
 = 3.5.2 - 2026-xx-xx =
-* Fix   - Remove nexus address workaround.
+* Fix   - Correct nexus address handling for stores in CO, AZ, and OH (US) and QC (CA).
 
 = 3.5.1 - 2026-03-10 =
 * Fix   - Fix plugin translation files located in i18n/languages folder.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -191,6 +191,15 @@ class WC_Connect_TaxJar_Integration {
 			return;
 		}
 
+		// Notify developers still using the removed filter.
+		if ( has_filter( 'woocommerce_apply_taxjar_nexus_addresses_workaround' ) ) {
+			_doing_it_wrong(
+				'woocommerce_apply_taxjar_nexus_addresses_workaround',
+				esc_html__( 'The woocommerce_apply_taxjar_nexus_addresses_workaround filter has been removed. Use the woocommerce_taxjar_nexus_address filter instead.', 'woocommerce-services' ),
+				'3.5.2'
+			);
+		}
+
 		// Scripts / Stylesheets
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_taxjar_admin_new_order_assets' ) );
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1345,82 +1345,6 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	/**
-	 * Maybe apply a temporary workaround for the TaxJar API to get the correct rates for
-	 * specific edge cases.
-	 *
-	 * For these specific edge cases a "nexus_addresses" element needs to be added to the
-	 * TaxJar request body and the "from" address needs to be removed from it in order to
-	 * get the correct rates. This is due to a limitation/miscalculation at the TaxJar API.
-	 *
-	 * This method returns a nexus address to be used as a workaround
-	 * if the workaround is enabled and an address case is matched.
-	 *
-	 * New edge cases can be added to the $cases array as needed.
-	 *
-	 * @param array $body Request body.
-	 *
-	 * @return array
-	 */
-	private function maybe_apply_taxjar_nexus_addresses_workaround( $body ) {
-		$workaround_nexus_addresses = array();
-		if ( true !== apply_filters( 'woocommerce_apply_taxjar_nexus_addresses_workaround', true ) ) {
-			return $workaround_nexus_addresses;
-		}
-
-		$cases = array(
-			'CA-QC' => array(
-				'to_country'   => 'CA',
-				'to_state'     => 'QC',
-				'from_country' => 'CA',
-			),
-			'US-CO' => array(
-				'to_country'   => 'US',
-				'to_state'     => 'CO',
-				'from_country' => 'US',
-				'from_state'   => 'CO',
-			),
-			'US-AZ' => array(
-				'to_country'   => 'US',
-				'to_state'     => 'AZ',
-				'from_country' => 'US',
-				'from_state'   => 'AZ',
-			),
-			'US-OH' => array(
-				'to_country'   => 'US',
-				'to_state'     => 'OH',
-				'from_country' => 'US',
-				'from_state'   => 'OH',
-			),
-		);
-
-		foreach ( $cases as $case ) {
-
-			/**
-			 * Ensure the body has all the required address keys, and that the body address
-			 * values match the case address values before applying the workaround.
-			 */
-			$address_keys = array_keys( $case );
-			foreach ( $address_keys as $address_key ) {
-				if ( ! isset( $body[ $address_key ] ) || $body[ $address_key ] !== $case[ $address_key ] ) {
-					continue 2;
-				}
-			}
-
-			$workaround_nexus_addresses = array(
-				'country' => $body['to_country'],
-				'zip'     => $body['to_zip'],
-				'state'   => $body['to_state'],
-				'city'    => $body['to_city'],
-				'street'  => $body['to_street'],
-			);
-
-			break;
-		}
-
-		return $workaround_nexus_addresses;
-	}
-
-	/**
 	 * Validates TaxJar nexus address.
 	 *
 	 * @param  array $address
@@ -1593,18 +1517,13 @@ class WC_Connect_TaxJar_Integration {
 			'plugin'       => 'woo',
 		);
 
-		$nexus_address = $this->maybe_apply_taxjar_nexus_addresses_workaround( $body );
-
-		// If workaround empty use default store address as nexus address.
-		if ( empty( $nexus_address ) ) {
-			$nexus_address = array(
-				'country' => $body['from_country'],
-				'zip'     => $body['from_zip'],
-				'state'   => $body['from_state'],
-				'city'    => $body['from_city'],
-				'street'  => $body['from_street'],
-			);
-		}
+		$nexus_address = array(
+			'country' => $body['from_country'],
+			'zip'     => $body['from_zip'],
+			'state'   => $body['from_state'],
+			'city'    => $body['from_city'],
+			'street'  => $body['from_street'],
+		);
 
 		/**
 		 * Filter to modify or disable the nexus address sent to TaxJar API.

--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,7 @@ This plugin relies on the following external services:
 == Changelog ==
 
 = 3.5.2 - 2026-xx-xx =
-* Fix   - Remove nexus address workaround.
+* Fix   - Correct nexus address handling for stores in CO, AZ, and OH (US) and QC (CA).
 
 = 3.5.1 - 2026-03-10 =
 * Fix   - Fix plugin translation files located in i18n/languages folder.

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.5.2 - 2026-xx-xx =
+* Fix   - Remove nexus address workaround.
+
 = 3.5.1 - 2026-03-10 =
 * Fix   - Fix plugin translation files located in i18n/languages folder.
 * Tweak - Unify tax rate naming, use full jurisdictions for all tax rates.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

The `maybe_apply_taxjar_nexus_addresses_workaround()` method was a hack that set the **destination address as the nexus address** for specific edge cases (CA-QC, US-CO, US-AZ, US-OH). This workaround existed because users compared rates to the TaxJar web calculator, which only accepts a destination address and assumes nexus is in the same jurisdiction — leading to misleading "bug" reports.

Since PR #2904 added `nexus_addresses` to every request using the store address, this workaround is no longer needed. TaxJar handles origin-based vs destination-based tax sourcing automatically when given proper `nexus_addresses` with the merchant's store address. This was confirmed by George Jeng testing both origin-based states (Texas, Ohio) and destination-based states (New York).

**Changes:**
- Remove `maybe_apply_taxjar_nexus_addresses_workaround()` method and its 4 edge cases (CA-QC, US-CO, US-AZ, US-OH)
- Simplify nexus address to always use store address (the fallback path becomes the only path)
- Remove `woocommerce_apply_taxjar_nexus_addresses_workaround` filter (workaround is gone, filter is meaningless)
- The `woocommerce_taxjar_nexus_address` filter remains for merchant customization

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Closes [WOOTAX-17](https://linear.app/a8c/issue/WOOTAX-17/workaround-for-setting-destination-as-nexus-address-is-incorrect)
Closes [WOOTAX-269](https://linear.app/a8c/issue/WOOTAX-269/support-origin-based-sales-tax-for-relevant-states)

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

1. Set store address to an origin-based state (e.g., TX, OH, MO)
2. Place an intrastate order (same state for store and customer)
3. Verify TaxJar returns `tax_source: "origin"` with store jurisdiction rates
4. Place a cross-state order — should early-exit with "No tax applies"
5. Set store to a destination-based state (e.g., NY, CA) and place an intrastate order
6. Verify TaxJar returns `tax_source: "destination"` with customer jurisdiction rates

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added