### PR TITLE
chore: exclude AI instruction files from archive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,5 +67,11 @@
 		"test": [
 			"phpunit --testdox"
 		]
+	},
+	"archive": {
+		"exclude": [
+			"AGENTS.md",
+			"CLAUDE.md"
+		]
 	}
 }


### PR DESCRIPTION
Excludes `AGENTS.md` and/or `CLAUDE.md` from the Composer archive zip to keep the distributed plugin package clean. These files are for AI coding agents and are not needed by end users.