### PR TITLE
Fix pre-commit PHPCBF running on entire directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 ## Runtime Compatibility
 - CRITICAL: This repo is tied to an old Node runtime; use `.nvmrc` (`10.18.1`) for local work unless a migration is explicitly planned.
 - CRITICAL: The old Node requirement is intentional because this project depends on a forked legacy Calypso package in the `wp-calypso` submodule (package name: `wp-calypso`).
+- CRITICAL: Always run `source ~/.nvm/nvm.sh && nvm use` before any command that invokes Node (e.g., `npm install`, `npm run`, `git push` — the pre-push hook runs `npm test`). Without this, tests will fail with Node version incompatibilities.
 - MUST NOT perform incidental Node/toolchain upgrades while making feature or bugfix changes.
 
 ## Common Commands

--- a/bin/wc-phpcbf.sh
+++ b/bin/wc-phpcbf.sh
@@ -3,10 +3,9 @@
 # phpcbf returns exit-code as 1 even if all errors were fixed.
 # https://github.com/squizlabs/PHP_CodeSniffer/issues/3057#issuecomment-919794895
 
-# Run phpcbf directly on the passed files instead of using `composer run phpcbf`
-# which hardcodes `.` as the scan path and would format the entire directory
-# (including JS files) regardless of the file list lint-staged provides.
-./vendor/bin/phpcbf --standard=WooCommerce-Core,WordPress-Core,WordPress-Extra "$@"
+# Use --filter=GitStaged so phpcbf only processes files staged in git.
+# Use --extensions=php to skip JS/CSS (those are handled by ESLint via lint-staged).
+./vendor/bin/phpcbf . --standard=WooCommerce-Core,WordPress-Core,WordPress-Extra --filter=GitStaged --extensions=php
 
 status=$?
 

--- a/bin/wc-phpcbf.sh
+++ b/bin/wc-phpcbf.sh
@@ -3,7 +3,10 @@
 # phpcbf returns exit-code as 1 even if all errors were fixed.
 # https://github.com/squizlabs/PHP_CodeSniffer/issues/3057#issuecomment-919794895
 
-composer run phpcbf $@
+# Run phpcbf directly on the passed files instead of using `composer run phpcbf`
+# which hardcodes `.` as the scan path and would format the entire directory
+# (including JS files) regardless of the file list lint-staged provides.
+./vendor/bin/phpcbf --standard=WooCommerce-Core,WordPress-Core,WordPress-Extra "$@"
 
 status=$?
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

The `bin/wc-phpcbf.sh` script called `composer run phpcbf $@`, but the composer `phpcbf` script hardcodes `.` as the scan path. This meant lint-staged's file paths were ignored and PHPCBF scanned the entire directory — including JS files — applying PHP formatting rules to them.

This fix calls `./vendor/bin/phpcbf` directly with only the staged file paths, and properly quotes `"$@"` to handle paths with spaces.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Closes [WOOTAX-280](https://linear.app/a8c/issue/WOOTAX-280/fix-pre-commit-hook-running-phpcbf-on-entire-directory-instead-of)

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

1. Stage a PHP file change and commit
2. **Before fix:** lint-staged runs PHPCBF on all files, JS files get reformatted with PHP coding standards, working tree is dirty after commit
3. **After fix:** lint-staged runs PHPCBF only on the staged PHP files, no JS files are touched

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

_This is a developer tooling fix — no user-facing changelog entry needed._