### PR TITLE
[WOOTAX-279] Tweak - WooCommerce 10.7 Compatibility.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 3.6.0 - 2026-xx-xx =
 * Fix   - Prevent unauthenticated downloads of tax rate backup CSV files.
+* Tweak - WooCommerce 10.7 Compatibility.
 
 = 3.5.2 - 2026-04-06 =
 * Fix   - Correct nexus address handling for stores in CO, AZ, and OH (US) and QC (CA).

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Requires PHP: 7.4
 Requires at least: 6.7
 Requires Plugins: woocommerce
 Tested up to: 6.9
-WC requires at least: 10.4
-WC tested up to: 10.6
+WC requires at least: 10.5
+WC tested up to: 10.7
 Stable tag: 3.5.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -72,6 +72,7 @@ This plugin relies on the following external services:
 
 = 3.6.0 - 2026-xx-xx =
 * Add   - Prevent unauthenticated downloads of tax rate backup CSV files.
+* Tweak - WooCommerce 10.7 Compatibility.
 
 = 3.5.2 - 2026-04-06 =
 * Fix   - Correct nexus address handling for stores in CO, AZ, and OH (US) and QC (CA).

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -13,8 +13,8 @@
  * Requires PHP: 7.4
  * Requires at least: 6.7
  * Tested up to: 6.9
- * WC requires at least: 10.4
- * WC tested up to: 10.6
+ * WC requires at least: 10.5
+ * WC tested up to: 10.7
  *
  * Copyright (c) 2017-2023 Automattic
  *


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Bumps WooCommerce compatibility to 10.7 and minimum required version to 10.5.

### Related issue(s)

Fixes WOOTAX-279

### Steps to reproduce & screenshots/GIFs

1. Install the plugin on a WordPress site running WooCommerce 10.7.
2. Verify the plugin activates without errors and functions as expected.

### Checklist

- [ ] unit tests
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added