### PR TITLE
[WOOTAX-278] Fix - Respect debug toggle for TaxJar informational logs.

### DIFF
--- a/.agents/skills/write-changelog/SKILL.md
+++ b/.agents/skills/write-changelog/SKILL.md
@@ -105,12 +105,14 @@ Check current version in `readme.txt` (line 10: `Stable tag: X.Y.Z`):
 Insert the new version block at the **top** of the changelog, after line 2:
 
 ```
-= X.Y.Z - YYYY-MM-DD =
+= X.Y.Z - YYYY-xx-xx =
 * Add   - New feature description.
 * Fix   - Bug fix description.
 * Tweak - Improvement description.
 
 ```
+
+**Date format:** Use `<current-year>-xx-xx` (e.g. `2026-xx-xx`) as a placeholder. The release script (`woorelease`) substitutes the actual release date on deploy. Do NOT write the real date — that change would be overwritten and creates merge churn when multiple PRs add entries before release.
 
 Note: Leave one blank line after the entries, before the previous version.
 
@@ -121,16 +123,18 @@ Location: `changelog.txt` (in the repository root)
 Insert the same version block in the `== Changelog ==` section (around line 131):
 
 ```
-= X.Y.Z - YYYY-MM-DD =
+= X.Y.Z - YYYY-xx-xx =
 * Add   - New feature description.
 * Fix   - Bug fix description.
 * Tweak - Improvement description.
 
 ```
 
-Also update `Stable tag:` on line 10 if this is a release.
+Use the same `<current-year>-xx-xx` placeholder format as in `changelog.txt`.
 
-Location: `/Users/samnajian/Dev/woocommerce-shipping/readme.txt`
+Do NOT update `Stable tag:` on line 10 from a feature/fix PR. The `woorelease` automation handles the stable tag bump on actual release.
+
+Location: `readme.txt` (in the repository root)
 
 ### Step 8: Copy to Clipboard
 
@@ -188,8 +192,9 @@ Before finalizing, verify:
 - [ ] Entry is user-facing (no code details)
 - [ ] Entry ends with a period
 - [ ] Version number follows semver
-- [ ] Date format is `YYYY-MM-DD`
+- [ ] Date is `<current-year>-xx-xx` placeholder (NOT the actual date — `woorelease` fills it in)
 - [ ] Entry added to both `changelog.txt` and `readme.txt`
+- [ ] `Stable tag` in `readme.txt` line 10 is NOT touched
 - [ ] Entries are in order: Add → Fix → Tweak → Dev
 
 ## Output Format

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.6.1 - 2026-xx-xx =
+* Fix   - Prevent informational tax logs from being written to debug.log when debug logging is disabled.
+
 = 3.6.0 - 2026-04-13 =
 * Fix   - Prevent unauthenticated downloads of tax rate backup CSV files.
 * Tweak - WooCommerce 10.7 Compatibility.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -450,6 +450,10 @@ class WC_Connect_TaxJar_Integration {
 	 * @param $message
 	 */
 	public function _log( $message ) {
+		if ( ! $this->logger->is_logging_enabled() ) {
+			return;
+		}
+
 		$formatted_message = is_scalar( $message ) ? $message : json_encode( $message );
 
 		$this->logger->log( $formatted_message, 'WCS Tax' );

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.6.1 - 2026-xx-xx =
+* Fix   - Prevent informational tax logs from being written to debug.log when debug logging is disabled.
+
 = 3.6.0 - 2026-04-13 =
 * Add   - Prevent unauthenticated downloads of tax rate backup CSV files.
 * Tweak - WooCommerce 10.7 Compatibility.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

The TaxJar integration's `_log()` method flooded `debug.log` on every tax calculation regardless of the "Debug logging" setting in WooCommerce Tax. `WC_Connect_Logger::log()` (at `classes/class-wc-connect-logger.php:112-115`) calls PHP's `error_log()` unconditionally when `WP_DEBUG` is defined, which bypasses its own `is_logging_enabled()` gate a few lines later. With ~35 informational `_log()` call sites in the TaxJar integration, any store with `WP_DEBUG_LOG` enabled saw routine messages like `:::: TaxJar Plugin requested ::::`, `:::: TaxJar API called ::::`, and full API request/response dumps flooding their debug log on every tax calculation.

This PR gates `_log()` at the caller on `$this->logger->is_logging_enabled()`, so informational TaxJar messages only fire when the merchant explicitly enables debug logging. `_error()` is unchanged — it still forces through the logger for genuinely useful error signals (missing countries, bad ZIPs, failed API responses).

The second commit is an incidental improvement to the project's `write-changelog` skill documentation: clarifies that changelog entries use `<year>-xx-xx` as a placeholder (filled by `woorelease` at release time) and that `Stable tag` in `readme.txt` should not be touched from feature PRs.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Closes [WOOTAX-278](https://linear.app/a8c/issue/WOOTAX-278)

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

**Repro (before fix):**
1. On a store with `WP_DEBUG` and `WP_DEBUG_LOG` enabled in `wp-config.php`, install WooCommerce Tax.
2. In **WooCommerce → Settings → Shipping → WooCommerce Services → Other**, ensure *Debug logging* is **OFF**.
3. Add a product to the cart and proceed to checkout with a taxable address.
4. Tail `wp-content/debug.log` — observe `WCS Tax` entries (`:::: TaxJar …`, API request/response bodies, tax rate lookups) flooding the file despite debug logging being off.

**Verify (with fix applied):**
1. Repeat steps 1–3 above.
2. Tail `wp-content/debug.log` — confirm no `WCS Tax` / `TaxJar …` informational entries appear.
3. Toggle *Debug logging* **ON**, trigger another tax calculation.
4. Tail `debug.log` again — confirm the TaxJar log lines return as expected.
5. **Error-path regression check:** with *Debug logging* **OFF**, trigger an error path (e.g., set shipping destination with an empty country, or enter a malformed ZIP). Confirm the corresponding `_error()` message still lands in `debug.log` and the `wc-services-tax` log — proves `_error()` remains always-on.

Existing PHP suite: `composer test` passes (179 tests, 387 assertions).

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added