### PR TITLE
Tweak - Replace deprecated PHPCS comma-separated array property syntax

### DIFF
--- a/.phpcs.security.xml
+++ b/.phpcs.security.xml
@@ -15,13 +15,28 @@
 	<rule ref="WordPress.Security.EscapeOutput"/>
 	<rule ref="WordPress.Security.EscapeOutput">
 		<properties>
-			<property name="customEscapingFunctions" type="array" value="wc_help_tip,wc_sanitize_tooltip,wc_selected,wc_kses_notice,wc_esc_json,wc_query_string_form_fields,wc_make_phone_clickable" />
+			<property name="customEscapingFunctions" type="array">
+				<element value="wc_help_tip"/>
+				<element value="wc_sanitize_tooltip"/>
+				<element value="wc_selected"/>
+				<element value="wc_kses_notice"/>
+				<element value="wc_esc_json"/>
+				<element value="wc_query_string_form_fields"/>
+				<element value="wc_make_phone_clickable"/>
+			</property>
 		</properties>
 	</rule>
 	<rule ref="WordPress.Security.ValidatedSanitizedInput.InputNotSanitized"/>
 	<rule ref="WordPress.Security.ValidatedSanitizedInput">
 		<properties>
-			<property name="customSanitizingFunctions" type="array" value="wc_clean,wc_sanitize_tooltip,wc_format_decimal,wc_stock_amount,wc_sanitize_permalink,wc_sanitize_textarea" />
+			<property name="customSanitizingFunctions" type="array">
+				<element value="wc_clean"/>
+				<element value="wc_sanitize_tooltip"/>
+				<element value="wc_format_decimal"/>
+				<element value="wc_stock_amount"/>
+				<element value="wc_sanitize_permalink"/>
+				<element value="wc_sanitize_textarea"/>
+			</property>
 		</properties>
 	</rule>
 	<!-- Encourage use of wp_safe_redirect() to avoid open redirect vulnerabilities.


### PR DESCRIPTION
## Summary

- PHP_CodeSniffer 3.3.0 deprecated passing array values to a `<property>` via a comma-separated `value="a,b,c"` string; support is removed in 4.0. Every `composer run check-security` run prints a `DEPRECATED` notice for each affected property.
- Convert `customEscapingFunctions` (`WordPress.Security.EscapeOutput`) and `customSanitizingFunctions` (`WordPress.Security.ValidatedSanitizedInput`) in `.phpcs.security.xml` to the `<element value="..."/>` child-node form. Function lists preserved exactly.
- No behavioral change; silences two deprecation notices and future-proofs against PHPCS 4.0.

## Linear

Closes WOOTAX-284 — https://linear.app/a8c/issue/WOOTAX-284

## Test plan

- [ ] `composer run check-security` runs clean — no `DEPRECATED: Passing an array of values to a property using a comma-separated string` notices for `customEscapingFunctions` or `customSanitizingFunctions`.