### PR TITLE
Tweak - WooCommerce 10.8 Compatibility.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.6.2 - 2026-xx-xx =
+* Tweak - WooCommerce 10.8 Compatibility.
+
 = 3.6.1 - 2026-04-20 =
 * Fix   - Prevent informational tax logs from being written to debug.log when debug logging is disabled.
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Requires PHP: 7.4
 Requires at least: 6.8
 Requires Plugins: woocommerce
 Tested up to: 6.9
-WC requires at least: 10.5
-WC tested up to: 10.7
+WC requires at least: 10.6
+WC tested up to: 10.8
 Stable tag: 3.6.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -69,6 +69,9 @@ This plugin relies on the following external services:
 2. Checking on the health of WooCommerce Tax
 
 == Changelog ==
+
+= 3.6.2 - 2026-xx-xx =
+* Tweak - WooCommerce 10.8 Compatibility.
 
 = 3.6.1 - 2026-04-20 =
 * Fix   - Prevent informational tax logs from being written to debug.log when debug logging is disabled.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -13,8 +13,8 @@
  * Requires PHP: 7.4
  * Requires at least: 6.8
  * Tested up to: 6.9
- * WC requires at least: 10.5
- * WC tested up to: 10.7
+ * WC requires at least: 10.6
+ * WC tested up to: 10.8
  *
  * Copyright (c) 2017-2023 Automattic
  *


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

Declares compatibility with WooCommerce 10.8 and bumps the minimum required WooCommerce version.

### How to test the changes in this Pull Request:

1. Install the plugin alongside WooCommerce 10.8.
2. Verify the plugin activates without errors.
3. Confirm core functionality works correctly with no errors logged.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

> Tweak - WooCommerce 10.8 Compatibility.