### PR TITLE
Tweak - Declare WordPress 7.0 Compatibility

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.6.3 - 2026-xx-xx =
+* Tweak - WordPress 7.0 Compatibility.
+
 = 3.6.2 - 2026-05-18 =
 * Tweak - WooCommerce 10.8 Compatibility.
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: woocommerce, automattic, woothemes, allendav, kellychoffman, jkudish, jeffstieler, nabsul, robobot3000, danreylop, mikeyarce, shaunkuschel, orangesareorange, pauldechov, dappermountain, radogeorgiev, bor0, royho, cshultz88, bartoszbudzanowski, harriswong, ferdev, superdav42
 Tags: tax, vat, gst, woocommerce, payment
 Requires PHP: 7.4
-Requires at least: 6.8
+Requires at least: 6.9
 Requires Plugins: woocommerce
-Tested up to: 6.9
+Tested up to: 7.0
 WC requires at least: 10.6
 WC tested up to: 10.8
 Stable tag: 3.6.2
@@ -69,6 +69,9 @@ This plugin relies on the following external services:
 2. Checking on the health of WooCommerce Tax
 
 == Changelog ==
+
+= 3.6.3 - 2026-xx-xx =
+* Tweak - WordPress 7.0 Compatibility.
 
 = 3.6.2 - 2026-05-18 =
 * Tweak - WooCommerce 10.8 Compatibility.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -11,8 +11,8 @@
  * Version: 3.6.2
  * Requires Plugins: woocommerce
  * Requires PHP: 7.4
- * Requires at least: 6.8
- * Tested up to: 6.9
+ * Requires at least: 6.9
+ * Tested up to: 7.0
  * WC requires at least: 10.6
  * WC tested up to: 10.8
  *


### PR DESCRIPTION
### Related Issue(s)
- Fixes WOOTAX-291

### Description
Declares compatibility with WordPress 7.0:
- Bumps `Tested up to` from 6.9 to 7.0
- Bumps `Requires at least` from 6.8 to 6.9
- Adds a 3.6.3 changelog entry in both `changelog.txt` and `readme.txt`

### Testing Instructions
1. Check out this branch on your local environment.
2. On a site running WordPress 7.0, activate WooCommerce Tax and confirm the plugin loads with no errors/warnings.
3. Smoke test core flows (tax calculation, settings page) to confirm no regressions.
4. In the plugin header (`woocommerce-services.php`) and `readme.txt`, verify `Tested up to: 7.0` and `Requires at least: 6.9`.
5. Verify the `3.6.3` entry appears in both `changelog.txt` and the `Changelog` section of `readme.txt`.

### Screenshots (if applicable):
N/A — header/changelog metadata only, no visual changes.

### Types of changes:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore, refactoring or updating dependencies (code change that does not change functionality)

### Checklist:
- [x] My code follows the [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/) and [Security Best Practices](https://developer.wordpress.org/apis/security/).
- [ ] My change requires an update to our documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a `changelog.txt` entry.
- [x] I have added a changelog entry to the `readme.txt` file.
- [x] My PR doesn't impact Woo mobile apps, OR I've tested and confirmed it works fine on Woo mobile (if it impacts mobile, add the `impacts-woo-mobile` label)