### PR TITLE
[WOOTAX-288] Resolve PHPCS violations.

### DIFF
--- a/.phpcs.common.xml
+++ b/.phpcs.common.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<ruleset name="WooCommerce Shipping &amp; Tax — common">
+	<description>Shared file/exclude/arg/config for all WooCommerce Shipping &amp; Tax PHPCS rulesets. Imported by .phpcs.security.xml, .phpcs.l18n.xml, and .phpcs.php.xml so settings stay in one place.</description>
+
+	<file>.</file>
+
+	<!-- Exclude paths. The first pattern excludes any folder whose name starts with a dot
+	     (.git/, .github/, .husky/, …) so dotfile dirs don't need to be listed. The remaining
+	     entries mirror the ignore list the composer check-* scripts used to carry. -->
+	<exclude-pattern>/\.[^/]+/</exclude-pattern>
+	<exclude-pattern>vendor/</exclude-pattern>
+	<exclude-pattern>assets/</exclude-pattern>
+	<exclude-pattern>node_modules/</exclude-pattern>
+	<exclude-pattern>dist/</exclude-pattern>
+	<exclude-pattern>docker/</exclude-pattern>
+	<exclude-pattern>release/</exclude-pattern>
+	<exclude-pattern>bin/</exclude-pattern>
+	<exclude-pattern>wp-calypso/</exclude-pattern>
+
+	<!-- Show progress + source codes; colors; PHP only. -->
+	<arg value="ps"/>
+	<arg name="colors"/>
+	<arg name="extensions" value="php"/>
+
+	<!-- Strip the filepaths in reports down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
+
+	<!-- Configs -->
+	<config name="testVersion" value="7.4-"/>
+	<config name="minimum_supported_wp_version" value="6.9"/>
+</ruleset>

--- a/.phpcs.common.xml
+++ b/.phpcs.common.xml
@@ -16,6 +16,10 @@
 	<exclude-pattern>release/</exclude-pattern>
 	<exclude-pattern>bin/</exclude-pattern>
 	<exclude-pattern>wp-calypso/</exclude-pattern>
+	<!-- Generated build artifact: i18n/strings.php is emitted by the i18n build
+	     ("THIS IS A GENERATED FILE. DO NOT EDIT DIRECTLY.") and is gitignored. Same
+	     class as dist/ and assets/ above; never hand-edited, so not lintable. -->
+	<exclude-pattern>i18n/</exclude-pattern>
 
 	<!-- Show progress + source codes; colors; PHP only. -->
 	<arg value="ps"/>

--- a/.phpcs.l18n.xml
+++ b/.phpcs.l18n.xml
@@ -22,6 +22,17 @@
 				<element value="woocommerce_services"/>
 				<element value="wc_services"/>
 				<element value="Automattic\WCServices"/>
+				<!-- WOOTAX-288 (PrefixAllGlobals.NonPrefixed{Hookname,Constant,Class}Found):
+				     additional namespaces for this first-party WooCommerce tax/shipping
+				     feature plugin's PUBLIC symbols. These are extension points and
+				     constants third parties depend on; per the M2 compat policy they are
+				     whitelisted, never renamed. -->
+				<element value="woocommerce"/>      <!-- plugin-defined woocommerce_* hooks + WOOCOMMERCE_CONNECT_* constants; also the WC-core hooks this extension legitimately fires/filters -->
+				<element value="wcservices"/>        <!-- WCSERVICES_* path/URL constants + wcservices_* hooks -->
+				<element value="WC_REST_Dev"/>       <!-- public dev REST controller classes in classes/wc-api-dev/ -->
+				<element value="taxjar"/>            <!-- taxjar_* filters: drop-in compatibility with the standalone TaxJar plugin's public hooks -->
+				<element value="wcship"/>            <!-- wcship_* label-management capability hooks -->
+				<element value="enqueue_wc_connect"/> <!-- enqueue_wc_connect_script: public action third parties hook to enqueue admin scripts -->
 			</property>
 		</properties>
 		<exclude-pattern>tests/</exclude-pattern>

--- a/.phpcs.l18n.xml
+++ b/.phpcs.l18n.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<ruleset name="WooCommerce Shipping &amp; Tax — plugin identity">
+	<description>Plugin identity rules: text_domain (i18n) and global prefix whitelist. Only file in the WooCommerce Shipping &amp; Tax PHPCS layout that differs per plugin.</description>
+
+	<rule ref="./.phpcs.common.xml"/>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="woocommerce-services"/>
+			</property>
+		</properties>
+		<exclude-pattern>tests/</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="WC_Connect"/>
+				<element value="WC_REST_Connect"/>
+				<element value="wc_connect"/>
+				<element value="woocommerce_services"/>
+				<element value="wc_services"/>
+				<element value="Automattic\WCServices"/>
+			</property>
+		</properties>
+		<exclude-pattern>tests/</exclude-pattern>
+	</rule>
+</ruleset>

--- a/.phpcs.l18n.xml
+++ b/.phpcs.l18n.xml
@@ -13,6 +13,17 @@
 		<exclude-pattern>tests/</exclude-pattern>
 	</rule>
 
+	<!-- WOOTAX-288 (WordPress.WP.I18n.TextDomainMismatch): the dev-data REST
+	     controllers in classes/wc-api-dev/ are forks of WooCommerce core's
+	     /wc/v3/data controllers and reuse core's verbatim strings (continent
+	     codes, location labels) under the 'woocommerce' text domain on purpose,
+	     so they inherit core's existing translations rather than shipping
+	     untranslated copies under this plugin's domain. Suppress the mismatch
+	     for this directory only; the rest of the plugin stays on 'woocommerce-services'. -->
+	<rule ref="WordPress.WP.I18n.TextDomainMismatch">
+		<exclude-pattern>classes/wc-api-dev/</exclude-pattern>
+	</rule>
+
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<property name="prefixes" type="array">

--- a/.phpcs.php.xml
+++ b/.phpcs.php.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<ruleset name="WooCommerce Shipping &amp; Tax — PHP">
+	<description>WooCommerce Shipping &amp; Tax generic PHP coding standards. Mirrors the shipping-plugin family layout; the classes/ and bootstrap suppressions are carried over verbatim from the previous phpcs.xml.dist so this change surfaces no new violations.</description>
+
+	<rule ref="./.phpcs.common.xml"/>
+
+	<!-- Rules -->
+	<rule ref="WooCommerce-Core"/>
+	<rule ref="WordPress-Core"/>
+	<rule ref="WordPress-Extra"/>
+	<rule ref="WordPress-Docs"/>
+
+	<rule ref="PHPCompatibility">
+		<exclude-pattern>tests/</exclude-pattern>
+	</rule>
+
+	<!--
+		Test files use PascalCase_Underscored naming by convention (e.g. My_Class_Test.php),
+		and the plugin bootstrap is named for the plugin slug. Suppress file-naming sniffs there.
+		(woocommerce-services.php exclusion preserved from the previous phpcs.xml.dist.)
+	-->
+	<rule ref="WordPress.Files.FileName">
+		<exclude-pattern>tests/</exclude-pattern>
+		<exclude-pattern>woocommerce-services.php</exclude-pattern>
+	</rule>
+
+	<!--
+		Tests sometimes need to override WP globals (and restore them after the test).
+		Exclude the override sniff for tests/ only.
+	-->
+	<rule ref="WordPress.WP.GlobalVariablesOverride">
+		<exclude-pattern>tests/</exclude-pattern>
+	</rule>
+
+	<!--
+		Test methods use @testdox as their description. Generic.Commenting requires a
+		prose short description before any tags, which conflicts with @testdox-only
+		docblocks. Suppress for tests/ only.
+	-->
+	<rule ref="Generic.Commenting">
+		<exclude-pattern>tests/</exclude-pattern>
+	</rule>
+
+	<!--
+		Tests invoke core filters and actions as test setup; requiring a docblock
+		for every apply_filters / do_action call in test code adds noise without value.
+	-->
+	<rule ref="WooCommerce.Commenting.CommentHooks">
+		<exclude-pattern>tests/</exclude-pattern>
+	</rule>
+
+	<!--
+		Preserved from the previous phpcs.xml.dist: the procedural WC_Connect_* classes in
+		classes/ predate per-file docblocks. Kept to avoid surfacing legacy file-comment
+		violations here (that cleanup belongs to a later milestone).
+	-->
+	<rule ref="Squiz.Commenting.FileComment.MissingPackageTag">
+		<exclude-pattern>classes/</exclude-pattern>
+		<exclude-pattern>tests/</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.FileComment.Missing">
+		<exclude-pattern>classes/</exclude-pattern>
+		<exclude-pattern>tests/</exclude-pattern>
+	</rule>
+</ruleset>

--- a/.phpcs.php.xml
+++ b/.phpcs.php.xml
@@ -18,10 +18,14 @@
 		Test files use PascalCase_Underscored naming by convention (e.g. My_Class_Test.php),
 		and the plugin bootstrap is named for the plugin slug. Suppress file-naming sniffs there.
 		(woocommerce-services.php exclusion preserved from the previous phpcs.xml.dist.)
+		src/ is the modern PSR-4 tree (Automattic\WCServices): Composer's autoloader requires
+		the file name to match the class name (PascalCase, e.g. WooCommerceBlocksIntegration.php),
+		which is incompatible with WordPress.Files.FileName's hyphenated-lowercase rule. (WOOTAX-288)
 	-->
 	<rule ref="WordPress.Files.FileName">
 		<exclude-pattern>tests/</exclude-pattern>
 		<exclude-pattern>woocommerce-services.php</exclude-pattern>
+		<exclude-pattern>src/</exclude-pattern>
 	</rule>
 
 	<!--
@@ -33,20 +37,95 @@
 	</rule>
 
 	<!--
-		Test methods use @testdox as their description. Generic.Commenting requires a
-		prose short description before any tags, which conflicts with @testdox-only
-		docblocks. Suppress for tests/ only.
+		Test fixtures use readable non-snake_case locals (e.g. $product_A / $product_B to
+		pair with assertions). Variable naming in test code is not a production concern;
+		exclude the snake_case variable-name sniff for tests/ only. (WOOTAX-288)
 	-->
-	<rule ref="Generic.Commenting">
+	<rule ref="WordPress.NamingConventions.ValidVariableName">
 		<exclude-pattern>tests/</exclude-pattern>
 	</rule>
 
 	<!--
-		Tests invoke core filters and actions as test setup; requiring a docblock
-		for every apply_filters / do_action call in test code adds noise without value.
+		WOOTAX-288 (M2) docblock-family deferrals. The comment sniffs (Squiz.Commenting,
+		Generic.Commenting, WooCommerce.Commenting) are EXCLUDED for two scopes and fully
+		ENFORCED everywhere else (the tax + always-loaded entry path, which is what every
+		new tax-only site loads — documented for real in this milestone):
+
+		  1. tests/                       — test methods self-document via their names +
+		                                    @testdox; restating that in docblocks is noise
+		                                    (Bartosz-confirmed M2 decision; also resolves
+		                                    the @testdox-vs-prose-short Generic.Commenting
+		                                    conflict and the per-test-hook CommentHooks
+		                                    noise the M1 ruleset already deferred for tests).
+		  2. shipping-feature-gated files — REST controllers / admin UI loaded ONLY behind
+		                                    should_load_shipping_features() /
+		                                    !is_wc_shipping_activated() in woocommerce-
+		                                    services.php. New (tax-only) installs never load
+		                                    them; documenting this shipping-only legacy is
+		                                    out of scope for the Tax-focused cleanup. NOTE:
+		                                    shipping-label-eligibility-controller and
+		                                    shipping-carriers-controller are NOT here — they
+		                                    load unconditionally, so they stay enforced.
 	-->
-	<rule ref="WooCommerce.Commenting.CommentHooks">
+	<rule ref="Squiz.Commenting">
 		<exclude-pattern>tests/</exclude-pattern>
+		<exclude-pattern>classes/class-wc-connect-settings-pages.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-connect-note-dhl-live-rates-available.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-packages-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-label-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-label-status-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-label-refund-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-label-preview-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-label-print-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-rates-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-address-normalization-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-assets-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-carrier-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-carrier-delete-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-carrier-types-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-subscription-activate-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-wcshipping-compatibility-packages-controller.php</exclude-pattern>
+		<exclude-pattern>classes/wc-api-dev/</exclude-pattern>
+	</rule>
+	<rule ref="Generic.Commenting">
+		<exclude-pattern>tests/</exclude-pattern>
+		<exclude-pattern>classes/class-wc-connect-settings-pages.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-connect-note-dhl-live-rates-available.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-packages-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-label-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-label-status-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-label-refund-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-label-preview-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-label-print-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-rates-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-address-normalization-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-assets-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-carrier-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-carrier-delete-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-carrier-types-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-subscription-activate-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-wcshipping-compatibility-packages-controller.php</exclude-pattern>
+		<exclude-pattern>classes/wc-api-dev/</exclude-pattern>
+	</rule>
+	<rule ref="WooCommerce.Commenting">
+		<exclude-pattern>tests/</exclude-pattern>
+		<exclude-pattern>classes/class-wc-connect-settings-pages.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-connect-note-dhl-live-rates-available.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-packages-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-label-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-label-status-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-label-refund-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-label-preview-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-label-print-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-rates-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-address-normalization-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-assets-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-carrier-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-carrier-delete-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-shipping-carrier-types-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-subscription-activate-controller.php</exclude-pattern>
+		<exclude-pattern>classes/class-wc-rest-connect-wcshipping-compatibility-packages-controller.php</exclude-pattern>
+		<exclude-pattern>classes/wc-api-dev/</exclude-pattern>
 	</rule>
 
 	<!--

--- a/.phpcs.security.xml
+++ b/.phpcs.security.xml
@@ -1,18 +1,14 @@
 <?xml version="1.0"?>
 <ruleset name="Security sniffs from WordPress Coding Standards">
-	<description>Security sniffs from WordPress Coding Standards</description>
+	<description>Security sniffs from WordPress Coding Standards. Imports .phpcs.common.xml for the shared file/exclude/arg/config set.</description>
 
-	<arg value="sp"/>
-	<arg name="colors"/>
-	<arg name="extensions" value="php"/>
-	<arg name="parallel" value="8"/>
-
-	<config name="testVersion" value="7.4-"/>
+	<rule ref="./.phpcs.common.xml"/>
 
 	<!-- Do not fail PHPCS CI over warnings -->
 	<config name="ignore_warnings_on_exit" value="1"/>
 
 	<rule ref="WordPress.Security.EscapeOutput"/>
+	<rule ref="WordPress.Security.ValidatedSanitizedInput.InputNotSanitized"/>
 	<rule ref="WordPress.Security.EscapeOutput">
 		<properties>
 			<property name="customEscapingFunctions" type="array">
@@ -26,7 +22,6 @@
 			</property>
 		</properties>
 	</rule>
-	<rule ref="WordPress.Security.ValidatedSanitizedInput.InputNotSanitized"/>
 	<rule ref="WordPress.Security.ValidatedSanitizedInput">
 		<properties>
 			<property name="customSanitizingFunctions" type="array">
@@ -40,11 +35,11 @@
 		</properties>
 	</rule>
 	<!-- Encourage use of wp_safe_redirect() to avoid open redirect vulnerabilities.
-     https://github.com/WordPress/WordPress-Coding-Standards/pull/1264 -->
+	     https://github.com/WordPress/WordPress-Coding-Standards/pull/1264 -->
 	<rule ref="WordPress.Security.SafeRedirect"/>
 
 	<!-- Verify that a nonce check is done before using values in superglobals.
-     https://github.com/WordPress/WordPress-Coding-Standards/issues/73 -->
+	     https://github.com/WordPress/WordPress-Coding-Standards/issues/73 -->
 	<rule ref="WordPress.Security.NonceVerification"/>
 
 	<!-- https://github.com/WordPress/WordPress-Coding-Standards/issues/1157 -->
@@ -55,5 +50,4 @@
 		<type>error</type>
 		<message>eval() is a security risk so not allowed.</message>
 	</rule>
-
 </ruleset>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 
 ## Package Managers
 - Node/npm: `npm install`, `npm run dist`, `npm run test-client`, `npm run eslint`
-- Composer: `composer install`, `composer test`, `composer phpcs`
+- Composer: `composer install`, `composer test`, `composer check-all` (PHPCS — see Linting)
 
 ## Runtime Compatibility
 - CRITICAL: This repo is tied to an old Node runtime; use `.nvmrc` (`10.18.1`) for local work unless a migration is explicitly planned.
@@ -32,8 +32,19 @@ npm run dist
 npm run test-client
 npm run eslint
 composer test
-composer phpcs
+composer check-all
 ```
+
+## Linting (PHPCS) — split by concern
+The PHPCS ruleset is split into concern-specific files, all importing `.phpcs.common.xml` (shared file/exclude/arg/config). Run `check-all` (the `phpcs.xml.dist` aggregator) before pushing, or a single scope while iterating:
+```bash
+composer run check-all          # Aggregator (phpcs.xml.dist): runs security + l18n + php together
+composer run check-php          # Generic PHP rules only (WC-Core + WP-Core/Extra/Docs, minus security & i18n)
+composer run check-php:fix      # Auto-fix for the check-php scope
+composer run check-security     # Security sniffs (escaping, sanitization, nonces, eval)
+composer run check-l18n         # Plugin identity: text_domain (i18n) + global prefix whitelist
+```
+The husky pre-commit hook (`bin/wc-phpcbf.sh` via lint-staged) still auto-fixes staged PHP independently of these scopes.
 
 ## Key Conventions
 - Base new behavior on tax-only mode rules and existing shipping eligibility checks.

--- a/classes/class-wc-connect-account-settings.php
+++ b/classes/class-wc-connect-account-settings.php
@@ -4,18 +4,31 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Builds the settings payload for the account settings screen.
+ */
 class WC_Connect_Account_Settings {
 
 	/**
+	 * The settings store instance.
+	 *
 	 * @var WC_Connect_Service_Settings_Store
 	 */
 	protected $settings_store;
 
 	/**
+	 * The payment methods store instance.
+	 *
 	 * @var WC_Connect_Payment_Methods_Store
 	 */
 	protected $payment_methods_store;
 
+	/**
+	 * Constructor.
+	 *
+	 * @param WC_Connect_Service_Settings_Store $settings_store        The settings store instance.
+	 * @param WC_Connect_Payment_Methods_Store  $payment_methods_store The payment methods store instance.
+	 */
 	public function __construct(
 		WC_Connect_Service_Settings_Store $settings_store,
 		WC_Connect_Payment_Methods_Store $payment_methods_store
@@ -25,6 +38,11 @@ class WC_Connect_Account_Settings {
 	}
 
 
+	/**
+	 * Get the account settings payload.
+	 *
+	 * @return array The store options, form data, form meta, and user meta.
+	 */
 	public function get() {
 		$payment_methods_warning = false;
 		$payment_methods_success = $this->payment_methods_store->fetch_payment_methods_from_connect_server();
@@ -36,7 +54,7 @@ class WC_Connect_Account_Settings {
 		$connection_owner            = WC_Connect_Jetpack::get_connection_owner();
 		$connection_owner_wpcom_data = WC_Connect_Jetpack::get_connection_owner_wpcom_data();
 		$last_box_id                 = get_user_meta( get_current_user_id(), 'wc_connect_last_box_id', true );
-		$last_box_id                 = $last_box_id === 'individual' ? '' : $last_box_id;
+		$last_box_id                 = 'individual' === $last_box_id ? '' : $last_box_id;
 		$last_service_id             = get_user_meta( get_current_user_id(), 'wc_connect_last_service_id', true );
 		$last_carrier_id             = get_user_meta( get_current_user_id(), 'wc_connect_last_carrier_id', true );
 		$wcshipping_migration_state  = intval( get_option( 'wcshipping_migration_state' ) );

--- a/classes/class-wc-connect-api-client-live.php
+++ b/classes/class-wc-connect-api-client-live.php
@@ -1,6 +1,9 @@
 <?php
+/**
+ * Live implementation of the WooCommerce Connect API client.
+ */
 
-// No direct access please
+// No direct access please.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -12,11 +15,22 @@ if ( ! defined( 'WOOCOMMERCE_CONNECT_SERVER_URL' ) ) {
 if ( ! class_exists( 'WC_Connect_API_Client_Live' ) ) {
 	require_once plugin_basename( 'class-wc-connect-api-client.php' );
 
+	/**
+	 * Sends live HTTP requests to the WooCommerce Connect server.
+	 */
 	class WC_Connect_API_Client_Live extends WC_Connect_API_Client {
 
+		/**
+		 * Send a request to the WooCommerce Connect server.
+		 *
+		 * @param string $method The HTTP method to use.
+		 * @param string $path   The request path relative to the server URL.
+		 * @param array  $body   Optional. The request body.
+		 * @return mixed|WP_Error The decoded response body, the raw response, or a WP_Error on failure.
+		 */
 		protected function request( $method, $path, $body = array() ) {
 
-			// TODO - incorporate caching for repeated identical requests
+			// TODO - incorporate caching for repeated identical requests.
 			if ( ! is_array( $body ) ) {
 				return new WP_Error(
 					'request_body_should_be_array',
@@ -25,12 +39,26 @@ if ( ! class_exists( 'WC_Connect_API_Client_Live' ) ) {
 			}
 
 			$url = trailingslashit( WOOCOMMERCE_CONNECT_SERVER_URL );
+			/**
+			 * Filters the WooCommerce Connect server URL.
+			 *
+			 * @since 3.6.3
+			 *
+			 * @param string $url The WooCommerce Connect server URL.
+			 */
 			$url = apply_filters( 'wc_connect_server_url', $url );
 			$url = trailingslashit( $url ) . ltrim( $path, '/' );
 
-			// Add useful system information to requests that contain bodies
+			// Add useful system information to requests that contain bodies.
 			if ( in_array( $method, array( 'POST', 'PUT' ) ) ) {
 				$body = $this->request_body( $body );
+				/**
+				 * Filters the request body sent to the WooCommerce Connect server.
+				 *
+				 * @since 3.6.3
+				 *
+				 * @param array $body The request body.
+				 */
 				$body = wp_json_encode( apply_filters( 'wc_connect_api_client_body', $body ) );
 
 				if ( ! $body ) {
@@ -46,7 +74,8 @@ if ( ! class_exists( 'WC_Connect_API_Client_Live' ) ) {
 				return $headers;
 			}
 
-			$http_timeout = 60; // 1 minute
+			$http_timeout = 60;
+			// 1 minute
 			if ( function_exists( 'wc_set_time_limit' ) ) {
 				wc_set_time_limit( $http_timeout + 10 );
 			}
@@ -58,6 +87,13 @@ if ( ! class_exists( 'WC_Connect_API_Client_Live' ) ) {
 				'compress'    => true,
 				'timeout'     => $http_timeout,
 			);
+			/**
+			 * Filters the arguments passed to wp_remote_request().
+			 *
+			 * @since 3.6.3
+			 *
+			 * @param array $args The request arguments.
+			 */
 			$args = apply_filters( 'wc_connect_request_args', $args );
 
 			$response      = wp_remote_request( $url, $args );
@@ -70,6 +106,7 @@ if ( ! class_exists( 'WC_Connect_API_Client_Live' ) ) {
 					return new WP_Error(
 						'wcc_server_error',
 						sprintf(
+							/* translators: %d: HTTP response code */
 							__( 'Error: The WooCommerce Tax server returned HTTP code: %d', 'woocommerce-services' ),
 							$response_code
 						),
@@ -91,6 +128,7 @@ if ( ! class_exists( 'WC_Connect_API_Client_Live' ) ) {
 					return new WP_Error(
 						'wcc_server_empty_response',
 						sprintf(
+							/* translators: %d: HTTP response code */
 							__( 'Error: The WooCommerce Tax server returned ( %d ) and an empty response body.', 'woocommerce-services' ),
 							$response_code
 						),
@@ -117,9 +155,9 @@ if ( ! class_exists( 'WC_Connect_API_Client_Live' ) ) {
 					),
 					$data
 				);
-			}
+			}//end if
 
 			return $response_body;
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -2,27 +2,40 @@
 
 use Automattic\Jetpack\Constants;
 
-// No direct access please
+// No direct access please.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 
+	/**
+	 * Abstract client for communicating with the WooCommerce Tax/Shipping server.
+	 */
 	abstract class WC_Connect_API_Client {
 		const API_VERSION               = WOOCOMMERCE_CONNECT_SERVER_API_VERSION;
 		const SIFT_CONFIG_TRANSIENT_KEY = 'wc_connect_sift_configuration';
 
 		/**
+		 * Validator used to validate service schemas and settings.
+		 *
 		 * @var WC_Connect_Services_Validator
 		 */
 		protected $validator;
 
 		/**
+		 * Loader instance providing access to plugin services.
+		 *
 		 * @var WC_Connect_Loader
 		 */
 		protected $wc_connect_loader;
 
+		/**
+		 * Constructor.
+		 *
+		 * @param WC_Connect_Service_Schemas_Validator $validator         Service schemas validator.
+		 * @param WC_Connect_Loader                    $wc_connect_loader Plugin loader instance.
+		 */
 		public function __construct(
 			WC_Connect_Service_Schemas_Validator $validator,
 			WC_Connect_Loader $wc_connect_loader
@@ -55,13 +68,13 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		/**
 		 * Validates the settings for a given service with the WooCommerce Tax Server
 		 *
-		 * @param $service_slug
-		 * @param $service_settings
+		 * @param string $service_slug     Slug of the service to validate settings for.
+		 * @param array  $service_settings Settings to validate for the service.
 		 *
 		 * @return bool|WP_Error
 		 */
 		public function validate_service_settings( $service_slug, $service_settings ) {
-			// Make sure the service slug only contains dashes, underscores or letters
+			// Make sure the service slug only contains dashes, underscores or letters.
 			if ( 1 === preg_match( '/[^a-z_\-]/i', $service_slug ) ) {
 				return new WP_Error( 'invalid_service_slug', __( 'Invalid WooCommerce Tax service slug provided', 'woocommerce-services' ) );
 			}
@@ -72,7 +85,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		/**
 		 * Build the server's expected contents array, for rates requests.
 		 *
-		 * @param $package Package provided to WC_Shipping_Method::calculate_shipping()
+		 * @param array $package Package provided to WC_Shipping_Method::calculate_shipping().
 		 *
 		 * @return array|WP_Error {
 		 *      @type float $height Product height.
@@ -96,6 +109,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 						return new WP_Error(
 							'product_missing_weight',
 							sprintf(
+								/* translators: %d: product ID */
 								__( 'Product ( ID: %d ) did not include a weight. Shipping rates cannot be calculated.', 'woocommerce-services' ),
 								$product->get_id()
 							),
@@ -111,6 +125,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 						return new WP_Error(
 							'product_missing_dimension',
 							sprintf(
+								/* translators: %d: product ID */
 								__( 'Product ( ID: %d ) is missing a dimension value. Shipping rates cannot be calculated.', 'woocommerce-services' ),
 								$product->get_id()
 							),
@@ -131,8 +146,8 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 						'weight'     => (float) $weight,
 						'width'      => (float) $width,
 					);
-				}
-			}
+				}//end if
+			}//end foreach
 
 			return $contents;
 		}
@@ -140,16 +155,16 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		/**
 		 * Gets shipping rates (for checkout) from the WooCommerce Tax Server
 		 *
-		 * @param $services All settings for all services we want rates for
-		 * @param $package Package provided to WC_Shipping_Method::calculate_shipping()
-		 * @param $custom_boxes array of custom boxes definitions (objects)
-		 * @param $predefined_boxes array of enabled predefined box IDs (strings)
+		 * @param array $services         All settings for all services we want rates for.
+		 * @param array $package          Package provided to WC_Shipping_Method::calculate_shipping().
+		 * @param array $custom_boxes     Array of custom boxes definitions (objects).
+		 * @param array $predefined_boxes Array of enabled predefined box IDs (strings).
 		 *
 		 * @return object|WP_Error
 		 */
 		public function get_shipping_rates( $services, $package, $custom_boxes, $predefined_boxes ) {
-			// First, build the contents array
-			// each item needs to specify quantity, weight, length, width and height
+			// First, build the contents array.
+			// each item needs to specify quantity, weight, length, width and height.
 			$contents = $this->build_shipment_contents( $package );
 
 			if ( is_wp_error( $contents ) ) {
@@ -163,7 +178,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				);
 			}
 
-			// Then, make the request
+			// Then, make the request.
 			$body = array(
 				'contents'         => $contents,
 				'destination'      => $package['destination'],
@@ -186,10 +201,22 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			return $this->request( 'POST', '/subscriptions/checkout', array( 'services' => $services ) );
 		}
 
+		/**
+		 * Sends a shipping label purchase request to the WooCommerce Tax Server.
+		 *
+		 * @param array $body Request body describing the label(s) to purchase.
+		 * @return object|WP_Error
+		 */
 		public function send_shipping_label_request( $body ) {
 			return $this->request( 'POST', '/shipping/label', $body );
 		}
 
+		/**
+		 * Sends an address normalization request to the WooCommerce Tax Server.
+		 *
+		 * @param array $body Request body containing the address to normalize.
+		 * @return object|WP_Error
+		 */
 		public function send_address_normalization_request( $body ) {
 			return $this->request( 'POST', '/shipping/address/normalize', $body );
 		}
@@ -232,7 +259,9 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		/**
 		 * Gets shipping rates (for labels) from the WooCommerce Tax Server
 		 *
-		 * @param array $request - array(
+		 * Example request structure:
+		 *
+		 *  array(
 		 *  'packages' => array(
 		 *      array(
 		 *          'id' => 'box_1',
@@ -266,6 +295,8 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 *      'country' => 'US',
 		 *  ),
 		 * )
+		 *
+		 * @param array $request Label rates request payload.
 		 * @return object|WP_Error
 		 */
 		public function get_label_rates( $request ) {
@@ -275,7 +306,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		/**
 		 * Gets a PDF with the set of dummy labels specified in the request
 		 *
-		 * @param $request
+		 * @param array $request Request payload describing the labels to preview.
 		 * @return object|WP_Error
 		 */
 		public function get_labels_preview_pdf( $request ) {
@@ -285,7 +316,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		/**
 		 * Gets a PDF with the requested shipping labels in it
 		 *
-		 * @param $request
+		 * @param array $request Request payload describing the labels to print.
 		 * @return object|WP_Error
 		 */
 		public function get_labels_print_pdf( $request ) {
@@ -295,7 +326,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		/**
 		 * Gets the shipping label status (refund status, tracking code, etc)
 		 *
-		 * @param $label_id integer
+		 * @param int $label_id Identifier of the shipping label.
 		 * @return object|WP_Error
 		 */
 		public function get_label_status( $label_id ) {
@@ -305,7 +336,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		/**
 		 * Gets the shipping label status (refund status, tracking code, etc)
 		 *
-		 * @param $order_id integer
+		 * @param int $order_id Identifier of the order to anonymize.
 		 * @return object|WP_Error
 		 */
 		public function anonymize_order( $order_id ) {
@@ -315,7 +346,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		/**
 		 * Request a refund for a given shipping label
 		 *
-		 * @param $label_id integer
+		 * @param int $label_id Identifier of the shipping label to refund.
 		 * @return object|WP_Error
 		 */
 		public function send_shipping_label_refund_request( $label_id ) {
@@ -325,7 +356,6 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		/**
 		 * Gets the configured carrier accounts
 		 *
-		 * @param $request
 		 * @return object|WP_Error
 		 */
 		public function get_carrier_accounts() {
@@ -334,7 +364,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		/**
 		 * Disconnects the provided carrier account
 		 *
-		 * @param $carrier_id
+		 * @param string $carrier_id Identifier of the carrier account to disconnect.
 		 * @return object|WP_Error
 		 */
 		public function disconnect_carrier_account( $carrier_id ) {
@@ -343,7 +373,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		/**
 		 * Register a new carrier account
 		 *
-		 * @param $body
+		 * @param array $body Carrier account registration details.
 		 * @return object|WP_Error
 		 */
 		public function create_shipping_carrier_account( $body ) {
@@ -353,8 +383,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		/**
 		 * Get a list of the subscriptions for WooCommerce.com linked account.
 		 *
-		 * @param $body
-		 * @param object|WP_Error
+		 * @return object|WP_Error
 		 */
 		public function get_wccom_subscriptions() {
 			return $this->request( 'POST', '/subscriptions' );
@@ -431,9 +460,9 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		/**
 		 * Sends a request to the WooCommerce Tax Server
 		 *
-		 * @param $method
-		 * @param $path
-		 * @param $body
+		 * @param string $method HTTP method to use for the request.
+		 * @param string $path   Server path to request.
+		 * @param array  $body   Optional. Request body. Default empty array.
 		 * @return mixed|WP_Error
 		 */
 		abstract protected function request( $method, $path, $body = array() );
@@ -441,8 +470,8 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		/**
 		 * Proxy an HTTP request through the WCS Server
 		 *
-		 * @param $path Path of proxy route
-		 * @param $args WP_Http request args
+		 * @param string $path Path of proxy route.
+		 * @param array  $args WP_Http request args.
 		 *
 		 * @return array|WP_Error
 		 */
@@ -457,7 +486,8 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			$args['headers']['Authorization']  = $authorization;
 			$args['headers']['X-Woo-Settings'] = $this->get_request_additional_header();
 
-			$http_timeout = 60; // 1 minute
+			$http_timeout = 60;
+			// 1 minute.
 
 			if ( function_exists( 'wc_set_time_limit' ) ) {
 				wc_set_time_limit( $http_timeout + 10 );
@@ -511,7 +541,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		/**
 		 * Adds useful WP/WC/WCC information to request bodies
 		 *
-		 * @param array $initial_body
+		 * @param array $initial_body Optional. Initial request body to merge into. Default empty array.
 		 * @return array
 		 */
 		protected function request_body( $initial_body = array() ) {
@@ -520,7 +550,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			);
 			$body         = array_merge( $default_body, $initial_body );
 
-			// Add interesting fields to the body of each request
+			// Add interesting fields to the body of each request.
 			$body['settings'] = wp_parse_args(
 				$body['settings'],
 				$this->get_settings_values()
@@ -558,8 +588,20 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			return $headers;
 		}
 
+		/**
+		 * Builds the X_JP_Auth authorization header for requests to the WooCommerce Tax Server.
+		 *
+		 * @return string|WP_Error Authorization header string, or WP_Error on failure.
+		 */
 		protected function authorization_header() {
 			$token = WC_Connect_Jetpack::get_blog_access_token();
+			/**
+			 * Filters the Jetpack blog access token used to authorize requests.
+			 *
+			 * @since 3.6.3
+			 *
+			 * @param object $token Jetpack blog access token.
+			 */
 			$token = apply_filters( 'wc_connect_jetpack_access_token', $token );
 			if ( ! $token || empty( $token->secret ) ) {
 				return new WP_Error(
@@ -605,18 +647,20 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		/**
 		 * Generate a signature for WCCOM API request validation.
 		 *
-		 * @param string $token_secret
-		 * @param string $endpoint
-		 * @param string $method
-		 * @param array  $body
+		 * @param string $token_secret Token secret used to sign the request.
+		 * @param string $endpoint     WCCOM API endpoint being requested.
+		 * @param string $method       HTTP method used for the request.
+		 * @param array  $body         Optional. Request body included in the signature. Default empty array.
 		 * @return string
 		 */
 		protected function request_signature_wccom( $token_secret, $endpoint, $method, $body = array() ) {
 			$request_url = WC_Helper_API::url( $endpoint );
 
 			$data = array(
-				'host'        => parse_url( $request_url, PHP_URL_HOST ), // host URL.
-				'request_uri' => parse_url( $request_url, PHP_URL_PATH ), // endpoint URL.
+				// Host URL.
+				'host'        => parse_url( $request_url, PHP_URL_HOST ),
+				// Endpoint URL.
+				'request_uri' => parse_url( $request_url, PHP_URL_PATH ),
 				'method'      => $method,
 			);
 
@@ -627,6 +671,16 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			return hash_hmac( 'sha256', wp_json_encode( $data ), $token_secret );
 		}
 
+		/**
+		 * Generates the signature used to authorize a request to the WooCommerce Tax Server.
+		 *
+		 * @param string $token_key    Token key identifying the request.
+		 * @param string $token_secret Token secret used to sign the request.
+		 * @param int    $timestamp    Timestamp of the request.
+		 * @param string $nonce        Nonce for the request.
+		 * @param int    $time_diff    Time difference between local and server clocks.
+		 * @return string|WP_Error Base64-encoded signature, or WP_Error if the timestamp is invalid.
+		 */
 		protected function request_signature( $token_key, $token_secret, $timestamp, $nonce, $time_diff ) {
 			$local_time = $timestamp - $time_diff;
 			if ( $local_time < time() - 600 || $local_time > time() + 300 ) {
@@ -648,6 +702,11 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			return base64_encode( hash_hmac( 'sha1', $normalized_request_string, $token_secret, true ) );
 		}
 
+		/**
+		 * Gets the store GUID, generating and persisting one if it does not yet exist.
+		 *
+		 * @return string The store GUID.
+		 */
 		private function get_guid() {
 			$guid = WC_Connect_Options::get_option( 'store_guid', false );
 			if ( false === $guid ) {
@@ -682,4 +741,4 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 	}
 
-}
+}//end if

--- a/classes/class-wc-connect-cart-validation.php
+++ b/classes/class-wc-connect-cart-validation.php
@@ -15,15 +15,15 @@ class WC_Connect_Cart_Validation {
 	 * Register actions when required instead of using constructor.
 	 */
 	public function register_actions() {
-		add_action( 'woocommerce_store_api_cart_errors', [ $this, 'add_api_cart_errors' ], 10, 2 );
+		add_action( 'woocommerce_store_api_cart_errors', array( $this, 'add_api_cart_errors' ), 10, 2 );
 	}
 
 	/**
 	 * Register filters when required instead of using constructor.
 	 */
 	public function register_filters() {
-		add_filter( 'woocommerce_cart_no_shipping_available_html', [ $this, 'error_no_shipping_available_html' ] );
-		add_filter( 'woocommerce_shipping_package_name', [ $this, 'set_current_package' ], 10, 3 );
+		add_filter( 'woocommerce_cart_no_shipping_available_html', array( $this, 'error_no_shipping_available_html' ) );
+		add_filter( 'woocommerce_shipping_package_name', array( $this, 'set_current_package' ), 10, 3 );
 	}
 
 	/**
@@ -88,7 +88,7 @@ class WC_Connect_Cart_Validation {
 				if ( ! in_array( $notice['notice'], $added_notices ) ) {
 					$added_notices[] = $notice['notice'];
 					$cart_errors->add( 'notice_' . $i, $notice['notice'] );
-					$i++;
+					++$i;
 				}
 			}
 		}

--- a/classes/class-wc-connect-compatibility-wc30.php
+++ b/classes/class-wc-connect-compatibility-wc30.php
@@ -39,4 +39,4 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC30' ) ) {
 			return wc_get_order( $post_or_order_object->ID );
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-compatibility-wc69.php
+++ b/classes/class-wc-connect-compatibility-wc69.php
@@ -37,4 +37,4 @@ if ( ! class_exists( 'WC_Connect_Compatibility_WC69' ) ) {
 			return OrderUtil::init_theorder_object( $post_or_order_object );
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-compatibility-wcshipping-packages.php
+++ b/classes/class-wc-connect-compatibility-wcshipping-packages.php
@@ -255,6 +255,14 @@ class WC_Connect_Compatibility_WCShipping_Packages {
 			$package = self::unset_unused_keys( $package, self::KEYS_USED_BY_WCSERVICES );
 		}
 
+		/**
+		 * Filters the package data after mapping it from WCShipping's to WCS&T's format.
+		 *
+		 * @since 3.6.3
+		 *
+		 * @param array $custom_packages     The packages mapped to WCS&T's format.
+		 * @param array $old_custom_packages The packages in WCShipping's format before mapping.
+		 */
 		return apply_filters(
 			'wcservices_map_packages_to_wcservices_format',
 			$custom_packages,
@@ -278,6 +286,14 @@ class WC_Connect_Compatibility_WCShipping_Packages {
 			$package = self::unset_unused_keys( $package, self::KEYS_USED_BY_WCSHIPPING );
 		}
 
+		/**
+		 * Filters the package data after mapping it from WCS&T's to WCShipping's format.
+		 *
+		 * @since 3.6.3
+		 *
+		 * @param array $custom_packages     The packages mapped to WCShipping's format.
+		 * @param array $old_custom_packages The packages in WCS&T's format before mapping.
+		 */
 		return apply_filters(
 			'wcservices_map_packages_to_wcshipping_format',
 			$custom_packages,

--- a/classes/class-wc-connect-compatibility.php
+++ b/classes/class-wc-connect-compatibility.php
@@ -95,6 +95,5 @@ if ( ! class_exists( 'WC_Connect_Compatibility' ) ) {
 		 * @return bool|WC_Order|WC_Order_Refund.
 		 */
 		abstract public function init_theorder_object( $post_or_order_object );
-
 	}
-}
+}//end if

--- a/classes/class-wc-connect-continents.php
+++ b/classes/class-wc-connect-continents.php
@@ -8,13 +8,16 @@ if ( class_exists( 'WC_Connect_Continents' ) ) {
 	return;
 }
 
+/**
+ * Builds continent, country, and state data for the REST API responses.
+ */
 class WC_Connect_Continents {
 
 	/**
 	 * Return the list of countries and states for a given continent.
 	 *
 	 * @since  3.1.0
-	 * @param  string $continent_code
+	 * @param  string $continent_code The continent code to look up.
 	 * @return array|mixed Response data, ready for insertion into collection data.
 	 */
 	public function get_continent( $continent_code = false ) {
@@ -43,9 +46,9 @@ class WC_Connect_Continents {
 					'name' => $countries[ $country_code ],
 				);
 
-				// If we have detailed locale information include that in the response
+				// If we have detailed locale information include that in the response.
 				if ( array_key_exists( $country_code, $locale_info ) ) {
-					// Defensive programming against unexpected changes in locale-info.php
+					// Defensive programming against unexpected changes in locale-info.php.
 					$country_data = wp_parse_args(
 						$locale_info[ $country_code ],
 						array(
@@ -73,7 +76,7 @@ class WC_Connect_Continents {
 				}
 				$country['states'] = $local_states;
 
-				// Allow only desired keys (e.g. filter out tax rates)
+				// Allow only desired keys (e.g. filter out tax rates).
 				$allowed = array(
 					'code',
 					'currency_code',
@@ -89,14 +92,19 @@ class WC_Connect_Continents {
 				$country = array_intersect_key( $country, array_flip( $allowed ) );
 
 				$local_countries[] = $country;
-			}
-		}
+			}//end if
+		}//end foreach
 
 		$continent['countries'] = $local_countries;
 		return $continent;
 	}
 
 
+	/**
+	 * Return the list of continents with their countries and states.
+	 *
+	 * @return array The list of continents.
+	 */
 	public function get() {
 		$continents = array();
 		foreach ( array_keys( WC()->countries->get_continents() ) as $continent_code ) {

--- a/classes/class-wc-connect-custom-surcharge.php
+++ b/classes/class-wc-connect-custom-surcharge.php
@@ -111,7 +111,7 @@ if ( ! class_exists( 'WC_Connect_Custom_Surcharge' ) ) {
 				'wc_services_apply_us_co_retail_delivery_fee',
 				array(
 					'value' => 0.28,
-					'text'  => __( 'Retail Delivery Fee', 'woocommerce_services' ),
+					'text'  => __( 'Retail Delivery Fee', 'woocommerce-services' ),
 				),
 				$cart
 			);
@@ -124,4 +124,4 @@ if ( ! class_exists( 'WC_Connect_Custom_Surcharge' ) ) {
 			}
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-debug-tools.php
+++ b/classes/class-wc-connect-debug-tools.php
@@ -1,26 +1,48 @@
 <?php
+/**
+ * WooCommerce Tax debug tools.
+ *
+ * Registers entries on the WooCommerce > Status > Tools screen for testing the
+ * WooCommerce Tax connection and clearing cached tax data.
+ */
 
-// No direct access please
+// No direct access please.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 
+	/**
+	 * Adds WooCommerce Tax tools to the WooCommerce status tools screen.
+	 */
 	class WC_Connect_Debug_Tools {
 
 		/**
+		 * API client used to reach the WooCommerce Connect server.
+		 *
 		 * @var WC_Connect_API_Client
 		 */
 		protected $api_client;
 
-		function __construct( WC_Connect_API_Client $api_client ) {
+		/**
+		 * Constructor.
+		 *
+		 * @param WC_Connect_API_Client $api_client API client instance.
+		 */
+		public function __construct( WC_Connect_API_Client $api_client ) {
 			$this->api_client = $api_client;
 
 			add_filter( 'woocommerce_debug_tools', array( $this, 'woocommerce_debug_tools' ) );
 		}
 
-		function woocommerce_debug_tools( $tools ) {
+		/**
+		 * Registers the WooCommerce Tax entries on the WooCommerce status tools screen.
+		 *
+		 * @param array $tools Existing WooCommerce debug tools.
+		 * @return array Tools with the WooCommerce Tax entries added.
+		 */
+		public function woocommerce_debug_tools( $tools ) {
 			$tools['test_wcc_connection'] = array(
 				'name'     => __( 'Test your WooCommerce Tax connection', 'woocommerce-services' ),
 				'button'   => __( 'Test Connection', 'woocommerce-services' ),
@@ -55,7 +77,12 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 			return $tools;
 		}
 
-		function test_connection() {
+		/**
+		 * Tests the connection to the WooCommerce Tax API and prints the result.
+		 *
+		 * @return void
+		 */
+		public function test_connection() {
 			$test_request = $this->api_client->auth_test();
 			if ( $test_request && ! is_wp_error( $test_request ) && $test_request->authorized ) {
 				echo '<div class="updated inline"><p>' . esc_html__( 'Your site is successfully communicating to the WooCommerce Tax API.', 'woocommerce-services' ) . '</p></div>';
@@ -76,7 +103,7 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 		 *
 		 * @return void
 		 */
-		function delete_california_tax_rates() {
+		public function delete_california_tax_rates() {
 			$backed_up = WC_Connect_Functions::backup_existing_tax_rates();
 
 			if ( ! $backed_up ) {
@@ -123,6 +150,7 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 			}
 
 			echo '<div class="updated inline"><p>';
+			/* translators: %1$d: number of database rows deleted */
 			printf( esc_html__( 'Successfully deleted %1$d rows from the database.', 'woocommerce-services' ), intval( $deleted_count ) );
 			echo '</p></div>';
 		}
@@ -132,7 +160,7 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 		 *
 		 * @return void
 		 */
-		function delete_cached_tax_server_responses() {
+		public function delete_cached_tax_server_responses() {
 			global $wpdb;
 
 			$deleted_count = absint(
@@ -142,8 +170,9 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 			);
 
 			echo '<div class="updated inline"><p>';
+			/* translators: %1$d: number of database transients deleted */
 			printf( esc_html__( 'Successfully deleted %1$d transients from the database.', 'woocommerce-services' ), intval( $deleted_count ) );
 			echo '</p></div>';
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-error-notice.php
+++ b/classes/class-wc-connect-error-notice.php
@@ -1,21 +1,33 @@
 <?php
-
 /**
- * Show admin notices when errors occur
+ * Show admin notices when errors occur.
  */
 
-// No direct access please
+// No direct access please.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 
+	/**
+	 * Manages the admin error notice shown when shipping errors occur.
+	 */
 	class WC_Connect_Error_Notice {
 
 
+		/**
+		 * The singleton instance of this class.
+		 *
+		 * @var WC_Connect_Error_Notice|null
+		 */
 		private static $inst = null;
 
+		/**
+		 * Get the singleton instance of this class.
+		 *
+		 * @return WC_Connect_Error_Notice The singleton instance.
+		 */
 		public static function instance() {
 			if ( null === self::$inst ) {
 				self::$inst = new WC_Connect_Error_Notice();
@@ -24,14 +36,30 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 			return self::$inst;
 		}
 
+		/**
+		 * Enable the error notice.
+		 *
+		 * @param mixed $error Optional. The error to store, or true to enable a generic notice.
+		 * @return void
+		 */
 		public function enable_notice( $error = true ) {
 			WC_Connect_Options::update_option( 'error_notice', $error );
 		}
 
+		/**
+		 * Disable the error notice.
+		 *
+		 * @return void
+		 */
 		public function disable_notice() {
 			WC_Connect_Options::update_option( 'error_notice', false );
 		}
 
+		/**
+		 * Render the error notice, handling dismissal requests.
+		 *
+		 * @return void
+		 */
 		public function render_notice() {
 			$error_notice = filter_input( INPUT_GET, 'wc-connect-error-notice', FILTER_SANITIZE_ENCODED );
 			if ( 'disable' === $error_notice ) {
@@ -46,10 +74,20 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 			}
 		}
 
+		/**
+		 * Get the currently stored error notice value.
+		 *
+		 * @return mixed The stored error notice value, or false if none.
+		 */
 		private function notice_enabled() {
-			 return WC_Connect_Options::get_option( 'error_notice', false );
+			return WC_Connect_Options::get_option( 'error_notice', false );
 		}
 
+		/**
+		 * Output the error notice markup for the current error.
+		 *
+		 * @return void
+		 */
 		private function show_notice() {
 			$link_status  = admin_url( 'admin.php?page=wc-status&tab=connect' );
 			$link_dismiss = add_query_arg( array( 'wc-connect-error-notice' => 'disable' ) );
@@ -84,11 +122,12 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 				$product_name = $product->get_name();
 				$product_id   = $product->is_type( 'variation' ) ? $product->get_parent_id() : $product->get_id();
 				$message      = sprintf(
+					/* translators: %1$s: URL to edit the product, %2$s: product name */
 					__( '<strong>"%2$s" is missing weight, length, width, or height.</strong><br />Shipping rates cannot be calculated. <a href="%1$s">Enter dimensions and weight for %2$s</a> so your customers can purchase this item.', 'woocommerce-services' ),
 					get_edit_post_link( $product_id ),
 					$product_name
 				);
-			}
+			}//end if
 
 			if ( ! $message ) {
 				return;
@@ -108,4 +147,4 @@ if ( ! class_exists( 'WC_Connect_Error_Notice' ) ) {
 			echo '';
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-extension-compatibility.php
+++ b/classes/class-wc-connect-extension-compatibility.php
@@ -1,18 +1,21 @@
 <?php
 
 if ( ! class_exists( 'WC_Connect_Extension_Compatibility' ) ) {
+	/**
+	 * Handles compatibility between WooCommerce Shipping & Tax and other extensions.
+	 */
 	class WC_Connect_Extension_Compatibility {
 		/**
 		 * Function called when a new tracking number is added to the order
 		 *
-		 * @param $order_id - order ID
-		 * @param $carrier_id - carrier ID, as returned on the label objects returned by the server
-		 * @param $tracking_number - tracking number string
+		 * @param int    $order_id        Order ID.
+		 * @param string $carrier_id      Carrier ID, as returned on the label objects returned by the server.
+		 * @param string $tracking_number Tracking number string.
 		 */
 		public static function on_new_tracking_number( $order_id, $carrier_id, $tracking_number ) {
-			// call WooCommerce Shipment Tracking if it's installed
+			// Call WooCommerce Shipment Tracking if it's installed.
 			if ( function_exists( 'wc_st_add_tracking_number' ) ) {
-				// note: the only carrier ID we use at the moment is 'usps', which is the same in WC_ST, but this might require a mapping
+				// Note: the only carrier ID we use at the moment is 'usps', which is the same in WC_ST, but this might require a mapping.
 				wc_st_add_tracking_number( $order_id, $tracking_number, $carrier_id );
 			}
 		}
@@ -20,7 +23,7 @@ if ( ! class_exists( 'WC_Connect_Extension_Compatibility' ) ) {
 		/**
 		 * Checks if WooCommerce Tax should email the tracking details, or if another extension is taking care of that already
 		 *
-		 * @param $order_id - order ID
+		 * @param int $order_id Order ID.
 		 * @return boolean true if WCS should send the tracking info, false otherwise
 		 */
 		public static function should_email_tracking_details( $order_id ) {
@@ -38,4 +41,4 @@ if ( ! class_exists( 'WC_Connect_Extension_Compatibility' ) ) {
 			return true;
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-functions.php
+++ b/classes/class-wc-connect-functions.php
@@ -1,6 +1,9 @@
 <?php
 
 if ( ! class_exists( 'WC_Connect_Functions' ) ) {
+	/**
+	 * Collection of static helper functions for WooCommerce Services.
+	 */
 	class WC_Connect_Functions {
 		/**
 		 * Checks if the potentially expensive Shipping/Tax API requests should be sent
@@ -53,8 +56,8 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 			}
 			$rest_route = $GLOBALS['wp']->query_vars['rest_route'];
 
-			// Use regex to check any route that has "wc/store" with any of these text : "cart", "checkout", or "batch"
-			// Example : wc/store/v3/batch
+			// Use regex to check any route that has "wc/store" with any of these text : "cart", "checkout", or "batch".
+			// Example : wc/store/v3/batch.
 			preg_match( '/wc\/store\/v[0-9]{1,}\/(batch|cart|checkout)/', $rest_route, $route_matches, PREG_OFFSET_CAPTURE );
 
 			return ( ! empty( $route_matches ) );
@@ -134,7 +137,11 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 		 */
 		public static function user_can_manage_labels() {
 			/**
+			 * Filters whether the current user can manage shipping labels.
+			 *
 			 * @since 1.25.14
+			 *
+			 * @param bool $can_manage_labels Whether the current user can manage shipping labels.
 			 */
 			return apply_filters( 'wcship_user_can_manage_labels', current_user_can( 'manage_woocommerce' ) || current_user_can( 'wcship_manage_labels' ) );
 		}
@@ -150,7 +157,7 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 		public static function backup_existing_tax_rates() {
 			global $wpdb;
 
-			// Export Tax Rates
+			// Export Tax Rates.
 			$rates = $wpdb->get_results(
 				$wpdb->prepare(
 					"SELECT * FROM {$wpdb->prefix}woocommerce_tax_rates
@@ -168,16 +175,16 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 
 			ob_start();
 			$header =
-				__( 'Country Code', 'woocommerce' ) . ',' .
-				__( 'State Code', 'woocommerce' ) . ',' .
-				__( 'ZIP/Postcode', 'woocommerce' ) . ',' .
-				__( 'City', 'woocommerce' ) . ',' .
-				__( 'Rate %', 'woocommerce' ) . ',' .
-				__( 'Tax Name', 'woocommerce' ) . ',' .
-				__( 'Priority', 'woocommerce' ) . ',' .
-				__( 'Compound', 'woocommerce' ) . ',' .
-				__( 'Shipping', 'woocommerce' ) . ',' .
-				__( 'Tax Class', 'woocommerce' ) . "\n";
+				__( 'Country Code', 'woocommerce-services' ) . ',' .
+				__( 'State Code', 'woocommerce-services' ) . ',' .
+				__( 'ZIP/Postcode', 'woocommerce-services' ) . ',' .
+				__( 'City', 'woocommerce-services' ) . ',' .
+				__( 'Rate %', 'woocommerce-services' ) . ',' .
+				__( 'Tax Name', 'woocommerce-services' ) . ',' .
+				__( 'Priority', 'woocommerce-services' ) . ',' .
+				__( 'Compound', 'woocommerce-services' ) . ',' .
+				__( 'Shipping', 'woocommerce-services' ) . ',' .
+				__( 'Tax Class', 'woocommerce-services' ) . "\n";
 
 			echo $header; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
@@ -258,7 +265,7 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 				echo ',';
 
 				echo "\n";
-			} // End foreach().
+			}//end foreach
 
 			$csv        = ob_get_clean();
 			$upload_dir = wp_upload_dir();
@@ -367,7 +374,7 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 						}
 					}
 					// If $dir_ready is false, legacy files remain in place and are picked up below.
-				}
+				}//end if
 
 				// Mark migration complete only when no old files remain, so it retries if rename() failed.
 				// Check for false explicitly: glob() returns false on filesystem error (not just an empty
@@ -377,12 +384,12 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 				if ( false !== $remaining_old_files && empty( $remaining_old_files ) ) {
 					update_option( 'wcs_tax_backup_files_migrated', true, false );
 				}
-			}
+			}//end if
 
 			// Collect files from the protected directory and, if migration was not possible, the uploads root.
 			$found_files = array_merge(
-				glob( $backup_dir . '/taxjar-wc_tax_rates-*.csv' ) ?: array(),
-				glob( $upload_dir['basedir'] . '/taxjar-wc_tax_rates-*.csv' ) ?: array()
+				(array) glob( $backup_dir . '/taxjar-wc_tax_rates-*.csv' ),
+				(array) glob( $upload_dir['basedir'] . '/taxjar-wc_tax_rates-*.csv' )
 			);
 
 			if ( empty( $found_files ) ) {
@@ -397,4 +404,4 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 			return $files;
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-functions.php
+++ b/classes/class-wc-connect-functions.php
@@ -174,17 +174,21 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 			}
 
 			ob_start();
+			// These tax-rate CSV column headers intentionally reuse WooCommerce core's
+			// translation catalog so the export matches core's own tax-rate export columns.
+			// phpcs:disable WordPress.WP.I18n.TextDomainMismatch
 			$header =
-				__( 'Country Code', 'woocommerce-services' ) . ',' .
-				__( 'State Code', 'woocommerce-services' ) . ',' .
-				__( 'ZIP/Postcode', 'woocommerce-services' ) . ',' .
-				__( 'City', 'woocommerce-services' ) . ',' .
-				__( 'Rate %', 'woocommerce-services' ) . ',' .
-				__( 'Tax Name', 'woocommerce-services' ) . ',' .
-				__( 'Priority', 'woocommerce-services' ) . ',' .
-				__( 'Compound', 'woocommerce-services' ) . ',' .
-				__( 'Shipping', 'woocommerce-services' ) . ',' .
-				__( 'Tax Class', 'woocommerce-services' ) . "\n";
+				__( 'Country Code', 'woocommerce' ) . ',' .
+				__( 'State Code', 'woocommerce' ) . ',' .
+				__( 'ZIP/Postcode', 'woocommerce' ) . ',' .
+				__( 'City', 'woocommerce' ) . ',' .
+				__( 'Rate %', 'woocommerce' ) . ',' .
+				__( 'Tax Name', 'woocommerce' ) . ',' .
+				__( 'Priority', 'woocommerce' ) . ',' .
+				__( 'Compound', 'woocommerce' ) . ',' .
+				__( 'Shipping', 'woocommerce' ) . ',' .
+				__( 'Tax Class', 'woocommerce' ) . "\n";
+			// phpcs:enable WordPress.WP.I18n.TextDomainMismatch
 
 			echo $header; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -2,33 +2,54 @@
 
 if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 
+	/**
+	 * Renders the WooCommerce Tax help/status admin view.
+	 */
 	class WC_Connect_Help_View {
 
 		/**
+		 * Service schemas store instance.
+		 *
 		 * @var WC_Connect_Service_Schemas_Store
 		 */
 		protected $service_schemas_store;
 
 		/**
+		 * Service settings store instance.
+		 *
 		 * @var WC_Connect_Service_Settings_Store
 		 */
 		protected $service_settings_store;
 
 		/**
+		 * Logger instance.
+		 *
 		 * @var WC_Connect_Logger
 		 */
 		protected $logger;
 
 		/**
+		 * TaxJar integration instance.
+		 *
 		 * @var WC_Connect_TaxJar_Integration
 		 */
 		protected $taxjar_integration;
 
 		/**
-		 * @array
+		 * Form fieldsets.
+		 *
+		 * @var array
 		 */
 		protected $fieldsets;
 
+		/**
+		 * WC_Connect_Help_View constructor.
+		 *
+		 * @param WC_Connect_Service_Schemas_Store  $service_schemas_store  Service schemas store instance.
+		 * @param WC_Connect_TaxJar_Integration     $taxjar_integration     TaxJar integration instance.
+		 * @param WC_Connect_Service_Settings_Store $service_settings_store Service settings store instance.
+		 * @param WC_Connect_Logger                 $logger                 Logger instance.
+		 */
 		public function __construct(
 			WC_Connect_Service_Schemas_Store $service_schemas_store,
 			WC_Connect_TaxJar_Integration $taxjar_integration,
@@ -46,18 +67,24 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			add_action( 'wp_ajax_wcs_download_tax_backup', array( $this, 'handle_tax_backup_download' ) );
 		}
 
+		/**
+		 * Builds the list of system health items shown on the help page.
+		 *
+		 * @return array
+		 */
 		protected function get_health_items() {
 			$health_items = array();
 
-			// WooCommerce
-			// Only one of the following should present
-			// Check that WooCommerce is at least 2.6 or higher (feature-plugin only)
-			// Check that WooCommerce base_country is set
+			// WooCommerce.
+			// Only one of the following should present.
+			// Check that WooCommerce is at least 2.6 or higher (feature-plugin only).
+			// Check that WooCommerce base_country is set.
 			$base_country = WC()->countries->get_base_country();
 			if ( version_compare( WC()->version, WOOCOMMERCE_CONNECT_MINIMUM_WOOCOMMERCE_VERSION, '<' ) ) {
 				$health_item = array(
 					'state'   => 'error',
 					'message' => sprintf(
+						/* translators: %1$s: minimum required WooCommerce version, %2$s: currently running WooCommerce version */
 						__( 'WooCommerce %1$s or higher is required (You are running %2$s)', 'woocommerce-services' ),
 						WOOCOMMERCE_CONNECT_MINIMUM_WOOCOMMERCE_VERSION,
 						WC()->version
@@ -72,11 +99,12 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 				$health_item = array(
 					'state'   => 'success',
 					'message' => sprintf(
+						/* translators: %s: WooCommerce version */
 						__( 'WooCommerce %s is configured correctly', 'woocommerce-services' ),
 						WC()->version
 					),
 				);
-			}
+			}//end if
 			$health_items['woocommerce'] = $health_item;
 
 			if ( WC_Connect_Jetpack::is_offline_mode() ) {
@@ -99,15 +127,15 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 					'state'   => 'success',
 					'message' => __( 'Connected to WordPress.com', 'woocommerce-services' ),
 				);
-			}
+			}//end if
 			$health_items['wpcom_connection'] = $health_item;
 
-			// Automated taxes status
+			// Automated taxes status.
 			$health_items['automated_taxes'] = $this->get_tax_health_item();
 
-			// Lastly, do the WooCommerce Tax health check
-			// Check that we have schema
-			// Check that we are able to talk to the WooCommerce Tax server
+			// Lastly, do the WooCommerce Tax health check.
+			// Check that we have schema.
+			// Check that we are able to talk to the WooCommerce Tax server.
 			$schemas                              = $this->service_schemas_store->get_service_schemas();
 			$last_fetch_timestamp                 = $this->service_schemas_store->get_last_fetch_timestamp();
 			$health_items['woocommerce_services'] = array(
@@ -120,10 +148,20 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			return $health_items;
 		}
 
+		/**
+		 * Determines whether the WooCommerce Shipping plugin is not active.
+		 *
+		 * @return bool
+		 */
 		protected function is_shipping_loaded() {
 			return ! in_array( 'woocommerce-shipping/woocommerce-shipping.php', get_option( 'active_plugins' ) );
 		}
 
+		/**
+		 * Builds the list of enabled shipping service status items.
+		 *
+		 * @return array|false
+		 */
 		protected function get_services_items() {
 			$available_service_method_ids = $this->service_schemas_store->get_all_shipping_method_ids();
 			if ( empty( $available_service_method_ids ) ) {
@@ -148,7 +186,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 					)
 				);
 
-				// Figure out if the service has any settings saved at all
+				// Figure out if the service has any settings saved at all.
 				$service_settings = $this->service_settings_store->get_service_settings( $enabled_service->method_id, $enabled_service->instance_id );
 				if ( empty( $service_settings ) ) {
 					$state   = 'error';
@@ -165,6 +203,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 				}
 
 				$subtitle = sprintf(
+					/* translators: %s: shipping zone name */
 					__( '%s Shipping Zone', 'woocommerce-services' ),
 					$enabled_service->zone_name
 				);
@@ -177,13 +216,16 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 					'timestamp' => $last_failed_request_timestamp,
 					'url'       => $service_settings_url,
 				);
-			}
+			}//end foreach
 
 			return $service_items;
 		}
 
 		/**
-		 * Gets the last 10 lines from the WooCommerce Tax log by feature, if it exists
+		 * Gets the last 10 lines from the WooCommerce Tax log by feature, if it exists.
+		 *
+		 * @param string $feature Optional. Feature slug used to scope the log file lookup.
+		 * @return array
 		 */
 		protected function get_debug_log_data( $feature = '' ) {
 			$data       = new stdClass();
@@ -246,9 +288,9 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 		}
 
 		/**
-		 * Filters the WooCommerce System Status Tabs to add connect
+		 * Filters the WooCommerce System Status Tabs to add connect.
 		 *
-		 * @param array $tabs
+		 * @param array $tabs Existing system status tabs.
 		 * @return array
 		 */
 		public function status_tabs( $tabs ) {
@@ -297,6 +339,14 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 				</h2>
 			<?php
 
+			/**
+			 * Enqueues a WooCommerce Connect admin script with localized data.
+			 *
+			 * @since 3.6.3
+			 *
+			 * @param string $script_handle The handle of the script to enqueue.
+			 * @param array  $data          Data to localize for the script.
+			 */
 			do_action(
 				'enqueue_wc_connect_script',
 				'wc-connect-admin-status',
@@ -307,6 +357,14 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 
 			// Shipping related.
 			if ( WC_Connect_Loader::should_load_shipping_features() ) {
+				/**
+				 * Enqueues a WooCommerce Connect admin script with localized data.
+				 *
+				 * @since 3.6.3
+				 *
+				 * @param string $script_handle The handle of the script to enqueue.
+				 * @param array  $data          Data to localize for the script.
+				 */
 				do_action(
 					'enqueue_wc_connect_script',
 					'wc-connect-admin-test-print',
@@ -320,6 +378,8 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 		}
 
 		/**
+		 * Builds the automated taxes health status item.
+		 *
 		 * @return array
 		 */
 		protected function get_tax_health_item() {
@@ -328,6 +388,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 				return array(
 					'state'              => 'error',
 					'settings_link_type' => '',
+					/* translators: %s: store country code */
 					'message'            => sprintf( __( 'Your store\'s country (%s) is not supported. Automated taxes functionality is disabled', 'woocommerce-services' ), $store_country ),
 				);
 			}
@@ -409,4 +470,4 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 		}
 	}
 
-}
+}//end if

--- a/classes/class-wc-connect-jetpack.php
+++ b/classes/class-wc-connect-jetpack.php
@@ -6,9 +6,17 @@ use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 
 if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
+	/**
+	 * Wraps the Jetpack connection package for use within WooCommerce Shipping & Tax.
+	 */
 	class WC_Connect_Jetpack {
 		const JETPACK_PLUGIN_SLUG = 'woocommerce-services';
 
+		/**
+		 * Returns the Jetpack connection manager instance.
+		 *
+		 * @return Manager
+		 */
 		public static function get_connection_manager() {
 			return new Manager( self::JETPACK_PLUGIN_SLUG );
 		}
@@ -64,6 +72,11 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 			return ( new Host() )->is_woa_site();
 		}
 
+		/**
+		 * Returns the WordPress.com user data for the Jetpack connection owner.
+		 *
+		 * @return array|false
+		 */
 		public static function get_connection_owner_wpcom_data() {
 			$connection_owner = self::get_connection_owner();
 
@@ -90,9 +103,9 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 		/**
 		 * Records a Tracks event
 		 *
-		 * @param $user
-		 * @param $event_type
-		 * @param
+		 * @param WP_User $user       The user the event is recorded for.
+		 * @param string  $event_type The Tracks event name.
+		 * @param array   $data       Optional event properties.
 		 */
 		public static function tracks_record_event( $user, $event_type, $data ) {
 			$tracking = new Automattic\Jetpack\Tracking();
@@ -123,7 +136,7 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 		 * Connects the site to Jetpack.
 		 * This code performs a redirection, so anything executed after it will be ignored.
 		 *
-		 * @param $redirect_url
+		 * @param string $redirect_url URL to redirect to after the connection flow completes.
 		 */
 		public static function connect_site( $redirect_url ) {
 			$connection_manager = self::get_connection_manager();
@@ -167,4 +180,4 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 			return Manager::get_site_id();
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-label-reports.php
+++ b/classes/class-wc-connect-label-reports.php
@@ -5,20 +5,35 @@ use Automattic\WooCommerce\Utilities\OrderUtil;
 if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 	include_once WC()->plugin_path() . '/includes/admin/reports/class-wc-admin-report.php';
 
+	/**
+	 * Renders the shipping label admin report.
+	 */
 	class WC_Connect_Label_Reports extends WC_Admin_Report {
 		const LABELS_TRANSIENT_KEY = 'wcs_label_reports';
 
 		/**
+		 * The service settings store.
+		 *
 		 * @var WC_Connect_Service_Settings_Store
 		 */
 		protected $settings_store;
 
+		/**
+		 * WC_Connect_Label_Reports constructor.
+		 *
+		 * @param WC_Connect_Service_Settings_Store $settings_store The service settings store.
+		 */
 		public function __construct( WC_Connect_Service_Settings_Store $settings_store ) {
 			$this->settings_store = $settings_store;
 		}
 
+		/**
+		 * Output the CSV export button for the report.
+		 *
+		 * @return void
+		 */
 		public function get_export_button() {
-			$current_range = ! empty( $_GET['range'] ) ? sanitize_text_field( $_GET['range'] ) : '7day';
+			$current_range = ! empty( $_GET['range'] ) ? sanitize_text_field( wp_unslash( $_GET['range'] ) ) : '7day';
 			?>
 			<a
 				href="#"
@@ -31,10 +46,22 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 			<?php
 		}
 
+		/**
+		 * Compare two labels by creation date, descending.
+		 *
+		 * @param array $label_a The first label to compare.
+		 * @param array $label_b The second label to compare.
+		 * @return int The comparison result.
+		 */
 		private function compare_label_dates_desc( $label_a, $label_b ) {
 			return $label_b['created'] - $label_a['created'];
 		}
 
+		/**
+		 * Retrieve all labels across orders, sorted by creation date descending.
+		 *
+		 * @return array The list of labels.
+		 */
 		private function get_all_labels() {
 			global $wpdb;
 
@@ -71,11 +98,16 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 			return $results;
 		}
 
+		/**
+		 * Query the labels that fall within the report's date range.
+		 *
+		 * @return array The filtered list of labels.
+		 */
 		private function query_labels() {
 			$all_labels = get_transient( self::LABELS_TRANSIENT_KEY );
 			if ( false === $all_labels ) {
 				$all_labels = $this->get_all_labels();
-				// set transient with ttl of 30 minutes
+				// Set transient with ttl of 30 minutes.
 				set_transient( self::LABELS_TRANSIENT_KEY, $all_labels, 1800 );
 			}
 
@@ -96,17 +128,19 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 					continue;
 				}
 
-				// labels are sorted in descending order, so if we reached the end, break the loop
+				// Labels are sorted in descending order, so if we reached the end, break the loop.
 				if ( $created < $start_date ) {
 					break;
 				}
 
-				if ( isset( $label['error'] ) || // ignore the error labels
-					! isset( $label['rate'] ) ) { // labels where purchase hasn't completed for any reason
+				// Ignore the error labels.
+				if ( isset( $label['error'] ) ||
+					! isset( $label['rate'] ) ) {
+					// Labels where purchase hasn't completed for any reason.
 					continue;
 				}
 
-				// ignore labels with complete refunds
+				// Ignore labels with complete refunds.
 				if ( isset( $label['refund'] ) ) {
 					$refund = (array) $label['refund'];
 					if ( isset( $refund['status'] ) && 'completed' === $refund['status'] ) {
@@ -115,11 +149,16 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 				}
 
 				$results[] = $label;
-			}
+			}//end foreach
 
 			return $results;
 		}
 
+		/**
+		 * Output the labels report.
+		 *
+		 * @return void
+		 */
 		public function output_report() {
 			$ranges = array(
 				'year'       => __( 'Year', 'woocommerce-services' ),
@@ -128,7 +167,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 				'7day'       => __( 'Last 7 days', 'woocommerce-services' ),
 			);
 
-			$current_range = ! empty( $_GET['range'] ) ? sanitize_text_field( $_GET['range'] ) : '7day';
+			$current_range = ! empty( $_GET['range'] ) ? sanitize_text_field( wp_unslash( $_GET['range'] ) ) : '7day';
 
 			if ( ! in_array( $current_range, array( 'custom', 'year', 'last_month', 'month', '7day' ) ) ) {
 				$current_range = '7day';
@@ -142,6 +181,12 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 			include WC()->plugin_path() . '/includes/admin/views/html-report-by-date.php';
 		}
 
+		/**
+		 * Build an edit-order link for the given order.
+		 *
+		 * @param int $post_id The order ID.
+		 * @return string|null The HTML link, or null if the order is invalid.
+		 */
 		private function get_edit_order_link( $post_id ) {
 			$order = wc_get_order( $post_id );
 			if ( ! is_a( $order, 'WC_Order' ) ) {
@@ -150,6 +195,12 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 			return '<a href="' . $order->get_edit_order_url() . '">' . $order->get_order_number() . '</a>';
 		}
 
+		/**
+		 * Determine the refund status text for a label.
+		 *
+		 * @param array $label The label data.
+		 * @return string The refund status text.
+		 */
 		private function get_label_refund_status( $label ) {
 			if ( ! isset( $label['refund'] ) ) {
 				return '';
@@ -197,7 +248,7 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 						<?php foreach ( $labels as $label ) : ?>
 							<tr>
 								<th scope="row">
-									<?php echo esc_html( get_date_from_gmt( date( 'Y-m-d H:i:s', intval( $label['created'] / 1000 ) ) ) ); ?>
+									<?php echo esc_html( get_date_from_gmt( gmdate( 'Y-m-d H:i:s', intval( $label['created'] / 1000 ) ) ) ); ?>
 								</th>
 								<td>
 									<?php
@@ -251,4 +302,4 @@ if ( ! class_exists( 'WC_Connect_Label_Reports' ) ) {
 			<?php
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-logger.php
+++ b/classes/class-wc-connect-logger.php
@@ -2,18 +2,45 @@
 
 if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 
+	/**
+	 * Handles logging and debug output for WooCommerce Services.
+	 */
 	class WC_Connect_Logger {
 
 		/**
+		 * The WooCommerce logger instance.
+		 *
 		 * @var WC_Logger
 		 */
 		private $logger;
 
+		/**
+		 * Whether logging to file is enabled.
+		 *
+		 * @var bool
+		 */
 		private $is_logging_enabled = false;
-		private $is_debug_enabled   = false;
 
+		/**
+		 * Whether debug notices are enabled.
+		 *
+		 * @var bool
+		 */
+		private $is_debug_enabled = false;
+
+		/**
+		 * Optional feature name used to namespace the log file.
+		 *
+		 * @var string
+		 */
 		private $feature;
 
+		/**
+		 * Constructor.
+		 *
+		 * @param WC_Logger $logger  The WooCommerce logger instance.
+		 * @param string    $feature Optional. Feature name used to namespace the log file.
+		 */
 		public function __construct( WC_Logger $logger, $feature = '' ) {
 
 			$this->logger  = $logger;
@@ -45,34 +72,64 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 			return $formatted_message;
 		}
 
+		/**
+		 * Enable logging to file.
+		 *
+		 * @return void
+		 */
 		public function enable_logging() {
 			WC_Connect_Options::update_option( 'debug_logging_enabled', true );
 			$this->is_logging_enabled = true;
 			$this->log( 'Logging enabled' );
 		}
 
+		/**
+		 * Disable logging to file.
+		 *
+		 * @return void
+		 */
 		public function disable_logging() {
 			$this->log( 'Logging disabled' );
 			WC_Connect_Options::update_option( 'debug_logging_enabled', false );
 			$this->is_logging_enabled = false;
 		}
 
+		/**
+		 * Enable debug notices.
+		 *
+		 * @return void
+		 */
 		public function enable_debug() {
 			WC_Connect_Options::update_option( 'debug_display_enabled', true );
 			$this->is_debug_enabled = true;
 			$this->log( 'Debug enabled' );
 		}
 
+		/**
+		 * Disable debug notices.
+		 *
+		 * @return void
+		 */
 		public function disable_debug() {
 			$this->log( 'Debug disabled' );
 			WC_Connect_Options::update_option( 'debug_display_enabled', false );
 			$this->is_debug_enabled = false;
 		}
 
+		/**
+		 * Check whether debug notices are enabled.
+		 *
+		 * @return bool True when debug notices are enabled.
+		 */
 		public function is_debug_enabled() {
 			return $this->is_debug_enabled;
 		}
 
+		/**
+		 * Check whether logging to file is enabled.
+		 *
+		 * @return bool True when logging to file is enabled.
+		 */
 		public function is_logging_enabled() {
 			return $this->is_logging_enabled;
 		}
@@ -90,10 +147,10 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 		}
 
 		/**
-		 * Logs messages even if debugging is disabled
+		 * Logs messages even if debugging is disabled.
 		 *
-		 * @param string $message Message to log
-		 * @param string $context Optional context (e.g. a class or function name)
+		 * @param string $message Message to log.
+		 * @param string $context Optional context (e.g. a class or function name).
 		 */
 		public function error( $message, $context = '' ) {
 			WC_Connect_Error_Notice::instance()->enable_notice( $message );
@@ -101,10 +158,11 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 		}
 
 		/**
-		 * Logs messages to file and error_log if WP_DEBUG
+		 * Logs messages to file and error_log if WP_DEBUG.
 		 *
-		 * @param WP_Error|string $message Message to log
-		 * @param string $context Optional context (e.g. a class or function name)
+		 * @param WP_Error|string $message Message to log.
+		 * @param string          $context Optional context (e.g. a class or function name).
+		 * @param bool            $force   Optional. Whether to log even when logging is disabled.
 		 */
 		public function log( $message, $context = '', $force = false ) {
 			$log_message = $this->format_message( $message, $context );
@@ -128,4 +186,4 @@ if ( ! class_exists( 'WC_Connect_Logger' ) ) {
 		}
 	}
 
-}
+}//end if

--- a/classes/class-wc-connect-migration-survey.php
+++ b/classes/class-wc-connect-migration-survey.php
@@ -3,54 +3,59 @@
  * Migration Survey Class
  *
  * Handles the display and submission of migration survey for users
- * who haven't migrated from WCS&T to WooCommerce Shipping
+ * who haven't migrated from WCS&T to WooCommerce Shipping.
  */
 
 use Automattic\WCServices\Utils;
 
 if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 
+	/**
+	 * Manages the WooCommerce Shipping migration survey lifecycle.
+	 */
 	class WC_Connect_Migration_Survey {
 
 
 		/**
-		 * Maximum number of times to show the survey
+		 * Maximum number of times to show the survey.
 		 */
 		const MAX_DISPLAY_COUNT = 2;
 
 		/**
-		 * Cooldown period between survey displays (in seconds)
+		 * Cooldown period between survey displays (in seconds). Equals 3 days.
 		 */
-		const COOLDOWN_PERIOD = 259200; // 3 days
+		const COOLDOWN_PERIOD = 259200;
 
 		/**
-		 * Initialize the migration survey
+		 * Initialize the migration survey.
 		 */
 		public function __construct() {
-			// Hook into script enqueue action
+			// Hook into script enqueue action.
 			add_action( 'enqueue_wc_connect_script', array( $this, 'add_survey_data_to_script' ), 10, 2 );
 
-			// AJAX handlers
+			// AJAX handlers.
 			add_action( 'wp_ajax_wcs_migration_survey_submit', array( $this, 'handle_survey_submission' ) );
 			add_action( 'wp_ajax_wcs_migration_survey_dismiss', array( $this, 'handle_survey_dismissal' ) );
 			add_action( 'wp_ajax_wcs_migration_survey_track_display', array( $this, 'handle_survey_display_tracking' ) );
 		}
 
 		/**
-		 * Check if survey should be shown to current user
+		 * Check if survey should be shown to current user.
+		 *
+		 * @return bool True when the survey should be displayed, false otherwise.
 		 */
 		public function should_show_survey() {
-			// Force survey to show for testing/debugging
+			// Force survey to show for testing/debugging.
 			if ( isset( $_GET['force_survey'] ) ) {
 				return true;
 			}
 
-			// Don't show if WooCommerce Shipping is already active
+			// Don't show if WooCommerce Shipping is already active.
 			if ( WC_Connect_Loader::is_wc_shipping_activated() ) {
 				return false;
 			}
 
-			// Check if user has already been shown the survey max times
+			// Check if user has already been shown the survey max times.
 			$user_id       = get_current_user_id();
 			$display_count = get_user_meta( $user_id, 'wcs_migration_survey_count', true );
 
@@ -58,13 +63,13 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 				return false;
 			}
 
-			// Check cooldown period
+			// Check cooldown period.
 			$last_shown = get_user_meta( $user_id, 'wcs_migration_survey_last_shown', true );
 			if ( $last_shown && ( time() - $last_shown ) < self::COOLDOWN_PERIOD ) {
 				return false;
 			}
 
-			// Check if user has already completed the survey
+			// Check if user has already completed the survey.
 			if ( get_user_meta( $user_id, 'wcs_migration_survey_completed', true ) ) {
 				return false;
 			}
@@ -74,10 +79,14 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 
 
 		/**
-		 * Add survey data to shipping label script localization
+		 * Add survey data to shipping label script localization.
+		 *
+		 * @param string $root_view The script root view identifier.
+		 * @param array  $payload   The script localization payload. Unused.
+		 * @return void
 		 */
 		public function add_survey_data_to_script( $root_view, $payload ) {
-			// Only add survey data to shipping label context
+			// Only add survey data to shipping label context.
 			if ( 'wc-connect-create-shipping-label' !== $root_view ) {
 				return;
 			}
@@ -88,8 +97,8 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 				return;
 			}
 
-			// Add survey data via separate localize_script call
-			// NOTE: We don't update user meta here - only when survey is actually displayed in frontend
+			// Add survey data via separate localize_script call.
+			// NOTE: We don't update user meta here - only when survey is actually displayed in frontend.
 			$survey_data = array(
 				'shouldShow' => true,
 				'nonce'      => wp_create_nonce( 'wcs_migration_survey' ),
@@ -100,31 +109,34 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 		}
 
 		/**
-		 * Handle survey submission via AJAX
+		 * Handle survey submission via AJAX.
+		 *
+		 * @return void
 		 */
 		public function handle_survey_submission() {
-			// Verify nonce
+			// Verify nonce.
 			if ( ! wp_verify_nonce( Utils::get_sanitized_request_data( 'nonce' ), 'wcs_migration_survey' ) ) {
 				wp_die( 'Security check failed' );
 			}
 
-			// Get survey data
-			$survey_data = json_decode( stripslashes( $_POST['survey_data'] ), true );
+			// Get survey data. This is a JSON payload, so it cannot be pre-sanitized without
+			// corrupting it; it is unslashed here and each decoded value is sanitized below.
+			$survey_data = isset( $_POST['survey_data'] ) ? json_decode( wp_unslash( $_POST['survey_data'] ), true ) : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- JSON payload sanitized per-value below.
 
 			if ( ! $survey_data ) {
 				wp_send_json_error( 'Invalid survey data' );
 			}
 
-			// Mark survey as completed for this user
+			// Mark survey as completed for this user.
 			$user_id = get_current_user_id();
 			update_user_meta( $user_id, 'wcs_migration_survey_completed', true );
 
-			// Track submission event with detailed properties
+			// Track submission event with detailed properties.
 			$track_properties = array(
 				'primary_reason' => sanitize_text_field( $survey_data['primary'] ),
 			);
 
-			// Add followup responses to tracking (flatten the array)
+			// Add followup responses to tracking (flatten the array).
 			if ( ! empty( $survey_data['followup'] ) ) {
 				foreach ( $survey_data['followup'] as $key => $value ) {
 					if ( is_bool( $value ) ) {
@@ -141,43 +153,51 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 		}
 
 		/**
-		 * Handle survey dismissal
+		 * Handle survey dismissal.
+		 *
+		 * @return void
 		 */
 		public function handle_survey_dismissal() {
-			// Verify nonce
+			// Verify nonce.
 			if ( ! wp_verify_nonce( Utils::get_sanitized_request_data( 'nonce' ), 'wcs_migration_survey' ) ) {
 				wp_die( 'Security check failed' );
 			}
 
-			// Track dismissal event
+			// Track dismissal event.
 			$this->track_event( 'dismissed', array() );
 
 			wp_send_json_success();
 		}
 
 		/**
-		 * Handle survey display tracking (update user meta when survey is actually shown)
+		 * Handle survey display tracking (update user meta when survey is actually shown).
+		 *
+		 * @return void
 		 */
 		public function handle_survey_display_tracking() {
-			// Verify nonce
+			// Verify nonce.
 			if ( ! wp_verify_nonce( Utils::get_sanitized_request_data( 'nonce' ), 'wcs_migration_survey' ) ) {
 				wp_die( 'Security check failed' );
 			}
 
-			// Update user meta to track that survey was displayed
+			// Update user meta to track that survey was displayed.
 			$user_id       = get_current_user_id();
 			$display_count = get_user_meta( $user_id, 'wcs_migration_survey_count', true );
 			update_user_meta( $user_id, 'wcs_migration_survey_count', intval( $display_count ) + 1 );
 			update_user_meta( $user_id, 'wcs_migration_survey_last_shown', time() );
 
-			// Track survey display event
+			// Track survey display event.
 			$this->track_event( 'displayed', array() );
 
 			wp_send_json_success();
 		}
 
 		/**
-		 * Track survey events
+		 * Track survey events.
+		 *
+		 * @param string $event_name The survey event name suffix.
+		 * @param array  $properties Optional. Event properties to record. Default empty array.
+		 * @return void
 		 */
 		private function track_event( $event_name, $properties = array() ) {
 			$wc_logger = wc_get_logger();
@@ -186,4 +206,4 @@ if ( ! class_exists( 'WC_Connect_Migration_Survey' ) ) {
 			$tracks->record_user_event( 'migration_survey_' . $event_name, $properties );
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -2,6 +2,9 @@
 
 if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 
+	/**
+	 * Handles the new user experience (NUX) notices, banners, and admin pointers.
+	 */
 	class WC_Connect_Nux {
 		/**
 		 * Jetpack status constants.
@@ -19,22 +22,37 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		const SHOULD_SHOW_AFTER_CXN_BANNER = 'should_display_nux_after_jp_cxn_banner';
 
 		/**
+		 * Tracks instance.
+		 *
 		 * @var WC_Connect_Tracks
 		 */
 		protected $tracks;
 
 		/**
+		 * Shipping label instance.
+		 *
 		 * @var WC_Connect_Shipping_Label
 		 */
 		private $shipping_label;
 
-		function __construct( WC_Connect_Tracks $tracks, WC_Connect_Shipping_Label $shipping_label ) {
+		/**
+		 * Constructor.
+		 *
+		 * @param WC_Connect_Tracks         $tracks         Tracks instance.
+		 * @param WC_Connect_Shipping_Label $shipping_label Shipping label instance.
+		 */
+		public function __construct( WC_Connect_Tracks $tracks, WC_Connect_Shipping_Label $shipping_label ) {
 			$this->tracks         = $tracks;
 			$this->shipping_label = $shipping_label;
 
 			$this->init_pointers();
 		}
 
+		/**
+		 * Get the current user's NUX notice dismissal states.
+		 *
+		 * @return array Array of notice states keyed by notice ID.
+		 */
 		private function get_notice_states() {
 			$states = get_user_meta( get_current_user_id(), 'wc_connect_nux_notices', true );
 
@@ -45,18 +63,35 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			return $states;
 		}
 
+		/**
+		 * Determine whether a given notice has been dismissed by the current user.
+		 *
+		 * @param string $notice Notice ID.
+		 * @return bool True if the notice has been dismissed.
+		 */
 		public function is_notice_dismissed( $notice ) {
 			$notices = $this->get_notice_states();
 
 			return isset( $notices[ $notice ] ) && $notices[ $notice ];
 		}
 
+		/**
+		 * Mark a notice as dismissed for the current user.
+		 *
+		 * @param string $notice Notice ID.
+		 * @return void
+		 */
 		public function dismiss_notice( $notice ) {
 			$notices            = $this->get_notice_states();
 			$notices[ $notice ] = true;
 			update_user_meta( get_current_user_id(), 'wc_connect_nux_notices', $notices );
 		}
 
+		/**
+		 * AJAX handler to dismiss a notice for the current user.
+		 *
+		 * @return void
+		 */
 		public function ajax_dismiss_notice() {
 			if ( empty( $_POST['dismissible_id'] ) ) {
 				return;
@@ -67,14 +102,25 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			wp_die();
 		}
 
+		/**
+		 * Register the admin pointer filters.
+		 *
+		 * @return void
+		 */
 		private function init_pointers() {
 			add_filter( 'wc_services_pointer_post.php', array( $this, 'register_order_page_labels_pointer' ) );
 			add_filter( 'wc_services_pointer_post.php', array( $this, 'register_new_carrier_dhl_pointer' ) );
 		}
 
+		/**
+		 * Enqueue the admin pointers for the current admin page.
+		 *
+		 * @param string $hook Current admin page hook suffix.
+		 * @return void
+		 */
 		public function show_pointers( $hook ) {
-			/*
-			Get admin pointers for the current admin page.
+			/**
+			 * Get admin pointers for the current admin page.
 			 *
 			 * @since 0.9.6
 			 *
@@ -104,6 +150,11 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			wp_enqueue_script( 'wc_services_admin_pointers' );
 		}
 
+		/**
+		 * Get the list of WP pointers the current user has dismissed.
+		 *
+		 * @return array Array of dismissed pointer IDs.
+		 */
 		public function get_dismissed_pointers() {
 			$data = get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true );
 			if ( is_string( $data ) && 0 < strlen( $data ) ) {
@@ -116,7 +167,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		/**
 		 * Dismiss a WP pointer for the current user.
 		 *
-		 * @param string $pointer_to_dismiss Pointer ID to dismiss for the current user
+		 * @param string $pointer_to_dismiss Pointer ID to dismiss for the current user.
 		 */
 		public function dismiss_pointer( $pointer_to_dismiss ) {
 			$dismissed_pointers = $this->get_dismissed_pointers();
@@ -130,6 +181,11 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			update_user_meta( get_current_user_id(), 'dismissed_wp_pointers', $dismissed_data );
 		}
 
+		/**
+		 * Determine whether the current site is new to shipping labels.
+		 *
+		 * @return bool True if no labels have been purchased on the site.
+		 */
 		public function is_new_labels_user() {
 			$is_new_user = get_transient( self::IS_NEW_LABEL_USER );
 			if ( false === $is_new_user ) {
@@ -148,8 +204,14 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			return 'yes' === $is_new_user;
 		}
 
+		/**
+		 * Register the order page shipping labels pointer.
+		 *
+		 * @param array $pointers Array of pointers.
+		 * @return array Filtered array of pointers.
+		 */
 		public function register_order_page_labels_pointer( $pointers ) {
-			// If the user is not new to labels, we should just dismiss this pointer
+			// If the user is not new to labels, we should just dismiss this pointer.
 			if ( ! $this->is_new_labels_user() ) {
 				$this->dismiss_pointer( 'wc_services_labels_metabox' );
 
@@ -174,6 +236,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					'content'  => sprintf(
 						'<h3>%s</h3><p>%s</p>',
 						__( 'Discounted Shipping Labels', 'woocommerce-services' ),
+						/* translators: %s: list of supported shipping carriers */
 						sprintf( __( "When you're ready, purchase and print discounted labels from %s right here.", 'woocommerce-services' ), implode( ' or ', $supported_carriers ) )
 					),
 					'position' => array(
@@ -187,15 +250,21 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			return $pointers;
 		}
 
+		/**
+		 * Register the new DHL carrier pointer for existing label users.
+		 *
+		 * @param array $pointers Array of pointers.
+		 * @return array Filtered array of pointers.
+		 */
 		public function register_new_carrier_dhl_pointer( $pointers ) {
-			// new user? no need to show this alert, `wc_services_labels_metabox` will take care of communicating about DHL
+			// New user? No need to show this alert, `wc_services_labels_metabox` will take care of communicating about DHL.
 			if ( $this->is_new_labels_user() ) {
 				$this->dismiss_pointer( 'wc_services_new_carrier_dhl_express' );
 
 				return $pointers;
 			}
 
-			// existing user? figure out if the order supports DHL, then let them know DHL is a new carrier!
+			// Existing user? Figure out if the order supports DHL, then let them know DHL is a new carrier!
 			if ( ! $this->shipping_label->is_order_dhl_express_eligible() ) {
 				return $pointers;
 			}
@@ -220,6 +289,12 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			return $pointers;
 		}
 
+		/**
+		 * Determine which NUX banner, if any, should be displayed for the given status.
+		 *
+		 * @param array $status Connection and TOS status flags.
+		 * @return string|false Banner type identifier, or false when no banner should display.
+		 */
 		public static function get_banner_type_to_display( $status = array() ) {
 			if ( ! isset( $status['jetpack_connection_status'] ) ) {
 				return false;
@@ -247,7 +322,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					}
 
 					// Has the user already accepted our TOS? Then do nothing.
-					// Note: TOS is accepted during the after_connection banner
+					// Note: TOS is accepted during the after_connection banner.
 					if (
 						isset( $status['tos_accepted'] )
 						&& ! $status['tos_accepted']
@@ -269,16 +344,21 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					return false;
 				default:
 					return false;
-			}
+			}//end switch
 		}
 
+		/**
+		 * Get the current Jetpack installation/connection status.
+		 *
+		 * @return string One of the JETPACK_* status constants.
+		 */
 		public function get_jetpack_install_status() {
 			if ( WC_Connect_Jetpack::is_offline_mode() ) {
-				// activated, and dev mode on
+				// Activated, and dev mode on.
 				return self::JETPACK_OFFLINE_MODE;
 			}
 
-			// dev mode off, check if connected
+			// Dev mode off, check if connected.
 			if ( ! WC_Connect_Jetpack::is_connected() ) {
 				return self::JETPACK_NOT_CONNECTED;
 			}
@@ -286,6 +366,12 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			return self::JETPACK_CONNECTED;
 		}
 
+		/**
+		 * Determine whether a NUX notice should display on the given admin screen.
+		 *
+		 * @param WP_Screen $screen Current admin screen.
+		 * @return bool True if a notice should display on this screen.
+		 */
 		public function should_display_nux_notice_on_screen( $screen ) {
 			if ( // Display if on any of these admin pages.
 				( // Products list.
@@ -302,11 +388,11 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				|| ( // WooCommerce settings.
 					'woocommerce_page_wc-settings' === $screen->base
 					)
-				|| ( // WooCommerce featured extension page
+				|| ( // WooCommerce featured extension page.
 					'woocommerce_page_wc-addons' === $screen->base
 					&& isset( $_GET['section'] ) && 'featured' === $_GET['section']
 					)
-				|| ( // WooCommerce shipping extension page
+				|| ( // WooCommerce shipping extension page.
 					'woocommerce_page_wc-addons' === $screen->base
 					&& isset( $_GET['section'] ) && 'shipping_methods' === $_GET['section']
 					)
@@ -319,7 +405,12 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 		}
 
 		/**
-		 * https://developers.taxjar.com/api/reference/#countries
+		 * Determine whether TaxJar supports the given country.
+		 *
+		 * @see https://developers.taxjar.com/api/reference/#countries
+		 *
+		 * @param string $country_code Two-letter country code.
+		 * @return bool True if the country is supported by TaxJar.
 		 */
 		public function is_taxjar_supported_country( $country_code ) {
 			$taxjar_supported_countries = array_merge(
@@ -334,6 +425,11 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			return in_array( $country_code, $taxjar_supported_countries );
 		}
 
+		/**
+		 * Determine whether a NUX notice should display for the current store locale.
+		 *
+		 * @return bool True if the store's base country supports shipping or taxes.
+		 */
 		public function should_display_nux_notice_for_current_store_locale() {
 			$store_country = WC()->countries->get_base_country();
 
@@ -343,6 +439,12 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			return $supports_shipping || $supports_taxes;
 		}
 
+		/**
+		 * Build the human-readable feature list available for a given country.
+		 *
+		 * @param string $country Two-letter country code.
+		 * @return string|false Translated feature list, or false when no features apply.
+		 */
 		public function get_feature_list_for_country( $country ) {
 			$feature_list   = false;
 			$supports_taxes = $this->is_taxjar_supported_country( $country );
@@ -362,6 +464,11 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			return $feature_list;
 		}
 
+		/**
+		 * Build the admin redirect URL used after the Jetpack connection flow.
+		 *
+		 * @return string Escaped admin URL.
+		 */
 		public function get_jetpack_redirect_url() {
 			$full_path = add_query_arg( array() );
 			// Remove [...]/wp-admin so we can use admin_url().
@@ -371,6 +478,11 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			return esc_url( admin_url( $path ) );
 		}
 
+		/**
+		 * Set up the appropriate NUX notices and banners for the current request.
+		 *
+		 * @return void
+		 */
 		public function set_up_nux_notices() {
 			if ( ! current_user_can( 'manage_woocommerce' ) ) {
 				return;
@@ -378,7 +490,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 
 			// Check for plugin install and activate permissions to handle Jetpack on multisites:
 			// Admins might not be able to install or activate plugins, but Jetpack might already have been installed by a superadmin.
-			// If this is the case, the admin can connect the site on their own, and should be able to use WCS as ususal
+			// If this is the case, the admin can connect the site on their own, and should be able to use WCS as ususal.
 			$jetpack_install_status = $this->get_jetpack_install_status();
 
 			$banner_to_display = self::get_banner_type_to_display(
@@ -412,11 +524,16 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					wp_enqueue_style( 'wc_connect_banner' );
 					add_action( 'admin_notices', array( $this, 'show_tos_informational_banner' ) );
 					break;
-			}
+			}//end switch
 
 			add_action( 'wp_ajax_wc_connect_dismiss_notice', array( $this, 'ajax_dismiss_notice' ) );
 		}
 
+		/**
+		 * Render the NUX banner shown before the Jetpack connection.
+		 *
+		 * @return void
+		 */
 		public function show_banner_before_connection() {
 			if ( ! $this->should_display_nux_notice_for_current_store_locale() ) {
 				return;
@@ -436,7 +553,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 
 			// Make sure that we wait until the button is clicked before displaying
 			// the after_connection banner
-			// so that we don't accept the TOS pre-maturely
+			// so that we don't accept the TOS pre-maturely.
 			WC_Connect_Options::delete_option( self::SHOULD_SHOW_AFTER_CXN_BANNER );
 
 			$country = WC()->countries->get_base_country();
@@ -454,6 +571,11 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			$this->show_nux_banner( $banner_content );
 		}
 
+		/**
+		 * Render the NUX banner shown after the Jetpack connection completes.
+		 *
+		 * @return void
+		 */
 		public function show_banner_after_connection() {
 			if ( ! $this->should_display_nux_notice_for_current_store_locale() ) {
 				return;
@@ -471,7 +593,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				exit;
 			}
 
-			// By going through the connection process, the user has accepted our TOS
+			// By going through the connection process, the user has accepted our TOS.
 			WC_Connect_Options::update_option( 'tos_accepted', true );
 
 			$this->tracks->opted_in( 'connection_banner' );
@@ -500,6 +622,11 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			);
 		}
 
+		/**
+		 * Render the Terms of Service acceptance banner.
+		 *
+		 * @return void
+		 */
 		public function show_tos_banner() {
 			if ( ! $this->should_display_nux_notice_for_current_store_locale() ) {
 				return;
@@ -542,6 +669,11 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			);
 		}
 
+		/**
+		 * Render the informational banner directing users to the Jetpack connection owner.
+		 *
+		 * @return void
+		 */
 		public function show_tos_informational_banner() {
 			if ( ! $this->should_display_nux_notice_for_current_store_locale() ) {
 				return;
@@ -569,6 +701,12 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			);
 		}
 
+		/**
+		 * Render a NUX banner with the given content.
+		 *
+		 * @param array $content Banner content (title, description, button, image, etc.).
+		 * @return void
+		 */
 		public function show_nux_banner( $content ) {
 			if ( isset( $content['dismissible_id'] ) && $this->is_notice_dismissed( sanitize_key( $content['dismissible_id'] ) ) ) {
 				return;
@@ -589,9 +727,9 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					<?php if ( isset( $content['should_show_terms'] ) && $content['should_show_terms'] ) : ?>
 						<p class="wcs-nux__notice-content-tos">
 							<?php
-							/* translators: %1$s example values include "Install Jetpack and CONNECT >", "Activate Jetpack and CONNECT >", "CONNECT >" */
 							printf(
 								wp_kses(
+									/* translators: %1$s: button text (e.g. "Install Jetpack and CONNECT >", "Activate Jetpack and CONNECT >", "CONNECT >"), %2$s: URL to Terms of Service, %3$s: URL to Privacy Policy */
 									__( 'By clicking "%1$s", you agree to our <a href="%2$s">Terms of Service</a> and have read our <a href="%3$s">Privacy Policy</a>.', 'woocommerce-services' ),
 									array(
 										'a' => array(
@@ -633,7 +771,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			</div>
 			<?php
 			if ( isset( $content['dismissible_id'] ) ) :
-				// Add handler for dismissing banner. Only supports a single banner at a time
+				// Add handler for dismissing banner. Only supports a single banner at a time.
 				wp_enqueue_script( 'wp-util' );
 				?>
 				<script>
@@ -665,10 +803,10 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			}
 
 			// Make sure we always display the after-connection banner
-			// after the before_connection button is clicked
+			// after the before_connection button is clicked.
 			WC_Connect_Options::update_option( self::SHOULD_SHOW_AFTER_CXN_BANNER, true );
 
 			WC_Connect_Jetpack::connect_site( $redirect_url );
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-options.php
+++ b/classes/class-wc-connect-options.php
@@ -1,6 +1,10 @@
 <?php
 
 if ( ! class_exists( 'WC_Connect_Options' ) ) {
+	/**
+	 * Manages reading, writing, and deleting WooCommerce Tax plugin options,
+	 * including grouped options and per-shipping-method options.
+	 */
 	class WC_Connect_Options {
 		/**
 		 * An array that maps a grouped option type to an option name.
@@ -65,7 +69,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			}
 
 			foreach ( self::$grouped_options as $group_key => $group ) {
-				// delete legacy options
+				// Delete legacy options.
 				foreach ( self::get_option_names( $group_key ) as $group_option ) {
 					delete_option( "wc_connect_$group_option" );
 				}
@@ -84,8 +88,8 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 		/**
 		 * Returns the requested option.  Looks in wc_connect_options or wc_connect_$name as appropriate.
 		 *
-		 * @param string $name Option name
-		 * @param mixed  $default (optional)
+		 * @param string $name    Option name.
+		 * @param mixed  $default Default value to return if the option is not set (optional).
 		 *
 		 * @return mixed
 		 */
@@ -107,8 +111,8 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 		/**
 		 * Updates the single given option.  Updates wc_connect_options or wc_connect_$name as appropriate.
 		 *
-		 * @param string $name Option name
-		 * @param mixed  $value Option value
+		 * @param string $name  Option name.
+		 * @param mixed  $value Option value.
 		 *
 		 * @return bool Was the option successfully updated?
 		 */
@@ -129,7 +133,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 		 * Deletes the given option.  May be passed multiple option names as an array.
 		 * Updates wc_connect_options and/or deletes wc_connect_$name as appropriate.
 		 *
-		 * @param string|array $names
+		 * @param string|array $names Option name, or an array of option names, to delete.
 		 *
 		 * @return bool Was the option successfully deleted?
 		 */
@@ -156,10 +160,10 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 		/**
 		 * Gets a shipping method option
 		 *
-		 * @param $name
-		 * @param $default
-		 * @param $service_id
-		 * @param $service_instance
+		 * @param string          $name             Shipping method option name.
+		 * @param mixed           $default          Default value to return if the option is not set.
+		 * @param int|string      $service_id       Shipping service identifier.
+		 * @param int|string|bool $service_instance Shipping service instance identifier, or false when not instance-specific.
 		 *
 		 * @return mixed
 		 */
@@ -177,10 +181,10 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 		/**
 		 * Updates a shipping method option
 		 *
-		 * @param $name
-		 * @param $value
-		 * @param $service_id
-		 * @param $service_instance
+		 * @param string          $name             Shipping method option name.
+		 * @param mixed           $value            Option value.
+		 * @param int|string      $service_id       Shipping service identifier.
+		 * @param int|string|bool $service_instance Shipping service instance identifier, or false when not instance-specific.
 		 *
 		 * @return bool
 		 */
@@ -198,9 +202,9 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 		/**
 		 * Deletes a shipping method option
 		 *
-		 * @param $name
-		 * @param $service_id
-		 * @param $service_instance
+		 * @param string          $name             Shipping method option name.
+		 * @param int|string      $service_id       Shipping service identifier.
+		 * @param int|string|bool $service_instance Shipping service instance identifier, or false when not instance-specific.
 		 *
 		 * @return bool
 		 */
@@ -218,8 +222,10 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 		/**
 		 * Deletes all options related to a shipping method
 		 *
-		 * @param $service_id
-		 * @param $service_instance
+		 * @param int|string      $service_id       Shipping service identifier.
+		 * @param int|string|bool $service_instance Shipping service instance identifier, or false when not instance-specific.
+		 *
+		 * @return void
 		 */
 		public static function delete_shipping_method_options( $service_id, $service_instance = false ) {
 			$option_names = self::get_option_names( 'shipping_method' );
@@ -229,13 +235,22 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			}
 		}
 
+		/**
+		 * Returns a single option stored within a grouped option, migrating any legacy value if present.
+		 *
+		 * @param string $group   The grouped option key.
+		 * @param string $name    The option name within the group.
+		 * @param mixed  $default Default value to return if the option is not set.
+		 *
+		 * @return mixed
+		 */
 		private static function get_grouped_option( $group, $name, $default ) {
 			$options = get_option( self::$grouped_options[ $group ] );
 			if ( is_array( $options ) && isset( $options[ $name ] ) ) {
 				return $options[ $name ];
 			}
 
-			// make the grouped options backwards-compatible and migrate the old options
+			// Make the grouped options backwards-compatible and migrate the old options.
 			$legacy_name   = "wc_connect_$name";
 			$legacy_option = get_option( $legacy_name, false );
 			if ( ! $legacy_option ) {
@@ -248,6 +263,15 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			return $legacy_option;
 		}
 
+		/**
+		 * Updates a single option stored within a grouped option.
+		 *
+		 * @param string $group The grouped option key.
+		 * @param string $name  The option name within the group.
+		 * @param mixed  $value Option value.
+		 *
+		 * @return bool Was the grouped option successfully updated?
+		 */
 		private static function update_grouped_option( $group, $name, $value ) {
 			$options = get_option( self::$grouped_options[ $group ] );
 			if ( ! is_array( $options ) ) {
@@ -257,6 +281,14 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			return update_option( self::$grouped_options[ $group ], $options );
 		}
 
+		/**
+		 * Deletes one or more options stored within a grouped option.
+		 *
+		 * @param string $group The grouped option key.
+		 * @param array  $names The option names within the group to delete.
+		 *
+		 * @return bool Was the grouped option successfully updated?
+		 */
 		private static function delete_grouped_option( $group, $names ) {
 			$options   = get_option( self::$grouped_options[ $group ], array() );
 			$to_delete = array_intersect( $names, self::get_option_names( $group ), array_keys( $options ) );
@@ -272,9 +304,9 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 		/**
 		 * Based on the service id and optional instance, generates the option name
 		 *
-		 * @param $name
-		 * @param $service_id
-		 * @param $service_instance
+		 * @param string          $name             Shipping method option name.
+		 * @param int|string      $service_id       Shipping service identifier.
+		 * @param int|string|bool $service_instance Shipping service instance identifier, or false when not instance-specific.
 		 *
 		 * @return string|bool
 		 */
@@ -293,7 +325,7 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 		/**
 		 * Is the option name valid?
 		 *
-		 * @param string $name  The name of the option
+		 * @param string $name  The name of the option.
 		 * @param string $group The name of the group that the option is in. Defaults to compact.
 		 *
 		 * @return bool Is the option name valid?
@@ -338,4 +370,4 @@ if ( ! class_exists( 'WC_Connect_Options' ) ) {
 			}
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-order-presenter.php
+++ b/classes/class-wc-connect-order-presenter.php
@@ -2,13 +2,16 @@
 
 if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
 
+	/**
+	 * Transforms WC_Order objects into the representational form consumed by the React app.
+	 */
 	class WC_Connect_Order_Presenter {
 
 		/**
 		 * This function transform the WC_Order object to a representational JSON form for the react app.
 		 * This is based on WooCommerce v3's get_order API woocommerce/includes/legacy/api/v3/class-wc-api-orders.php
 		 *
-		 * @param WC_Order $order
+		 * @param WC_Order $order The order to transform.
 		 * @return array
 		 */
 		public function get_order_for_api( WC_Order $order ) {
@@ -104,7 +107,7 @@ if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
 				);
 
 				$order_data['line_items'][] = $line_item;
-			}
+			}//end foreach
 
 			// Add shipping.
 			foreach ( $order->get_shipping_methods() as $shipping_item_id => $shipping_item ) {
@@ -160,4 +163,4 @@ if ( ! class_exists( 'WC_Connect_Order_Presenter' ) ) {
 			return $order_data;
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-package-settings.php
+++ b/classes/class-wc-connect-package-settings.php
@@ -4,17 +4,30 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Builds the settings payload for the shipping packages screen.
+ */
 class WC_Connect_Package_Settings {
 	/**
+	 * The settings store instance.
+	 *
 	 * @var WC_Connect_Service_Settings_Store
 	 */
 	protected $settings_store;
 
 	/**
+	 * The service schemas store instance.
+	 *
 	 * @var WC_Connect_Service_Schemas_Store
 	 */
 	protected $service_schemas_store;
 
+	/**
+	 * Constructor.
+	 *
+	 * @param WC_Connect_Service_Settings_Store $settings_store        The settings store instance.
+	 * @param WC_Connect_Service_Schemas_Store  $service_schemas_store The service schemas store instance.
+	 */
 	public function __construct(
 		WC_Connect_Service_Settings_Store $settings_store,
 		WC_Connect_Service_Schemas_Store $service_schemas_store
@@ -22,6 +35,12 @@ class WC_Connect_Package_Settings {
 		$this->settings_store        = $settings_store;
 		$this->service_schemas_store = $service_schemas_store;
 	}
+
+	/**
+	 * Get the package settings payload.
+	 *
+	 * @return array The store options, form schema, and form data for packages.
+	 */
 	public function get() {
 		return array(
 			'storeOptions' => $this->settings_store->get_store_options(),

--- a/classes/class-wc-connect-payment-gateway.php
+++ b/classes/class-wc-connect-payment-gateway.php
@@ -2,8 +2,16 @@
 
 if ( ! class_exists( 'WC_Connect_Payment_Gateway' ) ) {
 
+	/**
+	 * Payment gateway that hydrates itself from a settings array.
+	 */
 	class WC_Connect_Payment_Gateway extends WC_Payment_Gateway {
 
+		/**
+		 * Constructor.
+		 *
+		 * @param array|object $settings Settings used to populate the gateway properties.
+		 */
 		public function __construct( $settings ) {
 
 			foreach ( (array) $settings as $key => $value ) {
@@ -11,10 +19,7 @@ if ( ! class_exists( 'WC_Connect_Payment_Gateway' ) ) {
 			}
 
 			$this->init_settings();
-
 		}
-
 	}
 
-}
-
+}//end if

--- a/classes/class-wc-connect-payment-methods-store.php
+++ b/classes/class-wc-connect-payment-methods-store.php
@@ -2,30 +2,48 @@
 
 if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 
+	/**
+	 * Stores and synchronizes saved payment methods from the Connect server.
+	 */
 	class WC_Connect_Payment_Methods_Store {
 
 		/**
+		 * The service settings store instance.
+		 *
 		 * @var WC_Connect_Service_Settings_Store
 		 */
 		protected $service_settings_store;
 
 		/**
+		 * The Connect API client instance.
+		 *
 		 * @var WC_Connect_API_Client
 		 */
 		protected $api_client;
 
 		/**
+		 * The logger instance.
+		 *
 		 * @var WC_Connect_Logger
 		 */
 		protected $logger;
 
-		public function __construct( WC_Connect_Service_Settings_Store $service_settings_store,
-			WC_Connect_API_Client $api_client, WC_Connect_Logger $logger ) {
+		/**
+		 * Constructor.
+		 *
+		 * @param WC_Connect_Service_Settings_Store $service_settings_store The service settings store instance.
+		 * @param WC_Connect_API_Client             $api_client             The Connect API client instance.
+		 * @param WC_Connect_Logger                 $logger                 The logger instance.
+		 */
+		public function __construct(
+			WC_Connect_Service_Settings_Store $service_settings_store,
+			WC_Connect_API_Client $api_client,
+			WC_Connect_Logger $logger
+		) {
 
 			$this->service_settings_store = $service_settings_store;
 			$this->api_client             = $api_client;
 			$this->logger                 = $logger;
-
 		}
 
 		/**
@@ -60,6 +78,12 @@ if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 			return true;
 		}
 
+		/**
+		 * Update the selected payment method based on the available payment methods.
+		 *
+		 * @param array $payment_methods The available payment methods.
+		 * @return void
+		 */
 		protected function potentially_update_selected_payment_method_from_payment_methods( $payment_methods ) {
 			$payment_method_ids = array();
 
@@ -87,10 +111,21 @@ if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 			}
 		}
 
+		/**
+		 * Get the stored payment methods.
+		 *
+		 * @return array The stored payment methods.
+		 */
 		public function get_payment_methods() {
 			return WC_Connect_Options::get_option( 'payment_methods', array() );
 		}
 
+		/**
+		 * Update the stored payment methods.
+		 *
+		 * @param array $payment_methods The payment methods to store.
+		 * @return void
+		 */
 		protected function update_payment_methods( $payment_methods ) {
 			WC_Connect_Options::update_option( 'payment_methods', $payment_methods );
 		}
@@ -117,6 +152,12 @@ if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 			return true;
 		}
 
+		/**
+		 * Extract and validate payment methods from the response body.
+		 *
+		 * @param object $response_body The response body object.
+		 * @return array|WP_Error The payment methods, or a WP_Error on failure.
+		 */
 		protected function get_payment_methods_from_response_body( $response_body ) {
 			$payment_methods = $response_body->payment_methods;
 			if ( ! is_array( $payment_methods ) ) {
@@ -164,4 +205,4 @@ if ( ! class_exists( 'WC_Connect_Payment_Methods_Store' ) ) {
 			WC_Connect_Options::update_option( 'add_payment_method_url', esc_url_raw( $add_payment_method_url ) );
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-paypal-ec.php
+++ b/classes/class-wc-connect-paypal-ec.php
@@ -14,25 +14,42 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 	class WC_Connect_PayPal_EC {
 
 		/**
+		 * API client used to proxy requests to the WCS server.
+		 *
 		 * @var WC_Connect_API_Client
 		 */
 		private $api_client;
 
 		/**
+		 * NUX helper used to display onboarding banners.
+		 *
 		 * @var WC_Connect_Nux
 		 */
 		private $nux;
 
 		/**
 		 * Express Checkout API methods to proxy.
+		 *
+		 * @var array Array of Express Checkout API method names.
 		 */
 		private $methods_to_proxy = array( 'SetExpressCheckout', 'GetExpressCheckoutDetails', 'DoExpressCheckoutPayment' );
 
+		/**
+		 * Constructor.
+		 *
+		 * @param WC_Connect_API_Client $api_client API client used to proxy requests.
+		 * @param WC_Connect_Nux        $nux        NUX helper used to display banners.
+		 */
 		public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Nux $nux ) {
 			$this->api_client = $api_client;
 			$this->nux        = $nux;
 		}
 
+		/**
+		 * Hook into the PayPal Checkout gateway to enable WCS request proxying.
+		 *
+		 * @return void
+		 */
 		public function init() {
 			if ( ! function_exists( 'wc_gateway_ppec' ) ) {
 				return;
@@ -49,12 +66,12 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 			$this->initialize_settings();
 			$settings = $ppec_plugin->settings;
 
-			// Don't modify any PPEC plugin behavior if WCS request proxying is not enabled
+			// Don't modify any PPEC plugin behavior if WCS request proxying is not enabled.
 			if ( 'yes' !== $settings->reroute_requests ) {
 				return;
 			}
 
-			// If empty, populate Sandbox and Live API Subject values with provided email
+			// If empty, populate Sandbox and Live API Subject values with provided email.
 			if (
 				empty( $settings->sandbox_api_subject ) &&
 				empty( $settings->sandbox_api_username ) &&
@@ -69,7 +86,7 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 			$username = $settings->get_active_api_credentials()->get_username();
 			$subject  = $settings->get_active_api_credentials()->get_subject();
 
-			// Proceed to attach PPEC-related hooks if email address is present but credentials are missing
+			// Proceed to attach PPEC-related hooks if email address is present but credentials are missing.
 			if ( empty( $username ) && ! empty( $subject ) ) {
 				add_filter( 'woocommerce_paypal_express_checkout_request_body', array( $this, 'request_body' ) );
 
@@ -77,21 +94,25 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 				add_filter( 'woocommerce_payment_gateway_supports', array( $this, 'ppec_supports' ), 10, 3 );
 
 				if ( 'live' === $settings->environment ) {
-					// If PPEC order comes in, activate prompt to connect a PayPal account
+					// If PPEC order comes in, activate prompt to connect a PayPal account.
 					add_action( 'woocommerce_order_status_on-hold', array( $this, 'maybe_trigger_banner' ) );
 					add_action( 'woocommerce_payment_complete', array( $this, 'maybe_trigger_banner' ) );
 
-					// Once a payment is received, show prompt to connect a PayPal account on certain screens
+					// Once a payment is received, show prompt to connect a PayPal account on certain screens.
 					add_action( 'admin_enqueue_scripts', array( $this, 'maybe_show_banner' ) );
 
 					add_filter( 'wc_services_pointer_post.php', array( $this, 'register_refund_pointer' ) );
 				}
-				add_filter( 'pre_option_wc_gateway_ppce_prompt_to_connect', '__return_empty_string' ); // Disable default PPEC notice.
+				add_filter( 'pre_option_wc_gateway_ppce_prompt_to_connect', '__return_empty_string' );
+				// Disable default PPEC notice.
 			}
 		}
 
 		/**
-		 * Attach request proxying hook if it's an Express Checkout method
+		 * Attach request proxying hook if it's an Express Checkout method.
+		 *
+		 * @param array $body Request body for the PayPal Checkout request.
+		 * @return array The unmodified request body.
 		 */
 		public function request_body( $body ) {
 			if ( in_array( $body['METHOD'], $this->methods_to_proxy ) ) {
@@ -103,7 +124,12 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 		}
 
 		/**
-		 * Reroute Express Checkout requests from the PPEC extension via WCS server to pick up API credentials
+		 * Reroute Express Checkout requests from the PPEC extension via WCS server to pick up API credentials.
+		 *
+		 * @param mixed  $preempt Whether to preempt an HTTP request's return value.
+		 * @param array  $r       HTTP request arguments.
+		 * @param string $url     The request URL.
+		 * @return mixed The preempt value, or the proxied request result.
 		 */
 		public function proxy_request( $preempt, $r, $url ) {
 			if ( ! preg_match( '/paypal.com\/nvp$/', $url ) ) {
@@ -115,14 +141,22 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 		}
 
 		/**
-		 * Limit supported payment gateway features to payments alone
+		 * Limit supported payment gateway features to payments alone.
+		 *
+		 * @param bool               $supported Whether the feature is supported.
+		 * @param string             $feature   The feature being checked.
+		 * @param WC_Payment_Gateway $gateway   The payment gateway instance.
+		 * @return bool Whether the feature is supported.
 		 */
 		public function ppec_supports( $supported, $feature, $gateway ) {
 			return 'ppec_paypal' === $gateway->id ? 'products' === $feature : $supported;
 		}
 
 		/**
-		 * Add a pointer clarifying the need to link an account before refunding payment
+		 * Add a pointer clarifying the need to link an account before refunding payment.
+		 *
+		 * @param array $pointers Existing admin pointers.
+		 * @return array The pointers with the refund pointer appended.
 		 */
 		public function register_refund_pointer( $pointers ) {
 			$pointers[] = array(
@@ -134,6 +168,7 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 						__( 'Link a PayPal account', 'woocommerce-services' ),
 						sprintf(
 							wp_kses(
+								/* translators: %s: URL to link a PayPal account */
 								__( 'To issue refunds via PayPal Checkout, you will need to <a href="%s">link a PayPal account</a> with the email address that received this payment.', 'woocommerce-services' ),
 								array( 'a' => array( 'href' => array() ) )
 							),
@@ -157,7 +192,10 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 		}
 
 		/**
-		 * Trigger banner to appear based on order paid with PPEC
+		 * Trigger banner to appear based on order paid with PPEC.
+		 *
+		 * @param int $order_id The order ID.
+		 * @return void
 		 */
 		public function maybe_trigger_banner( $order_id ) {
 			$order          = wc_get_order( $order_id );
@@ -232,7 +270,8 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 				$settings['reroute_requests'] = 'no';
 			} elseif ( 'no' === $settings['reroute_requests'] ) {
 				return;
-			} elseif ( ! isset( $settings['button_size'] ) ) { // Check if settings are initialized, represented by button_size as its absence would be first to affect the customer
+			} elseif ( ! isset( $settings['button_size'] ) ) {
+				// Check if settings are initialized, represented by button_size as its absence would be first to affect the customer.
 				$payment_gateways = WC()->payment_gateways->payment_gateways();
 				$gateway          = $payment_gateways['ppec_paypal'];
 
@@ -248,7 +287,10 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 		}
 
 		/**
-		 * Force setting values that will work when proxying requests
+		 * Force setting values that will work when proxying requests.
+		 *
+		 * @param array $settings The PPEC settings array.
+		 * @return array The adjusted settings array.
 		 */
 		public function adjust_settings( $settings ) {
 			$settings['paymentaction'] = 'sale';
@@ -256,20 +298,24 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 		}
 
 		/**
-		 * Modify PPEC settings form to include a toggle (and other accommodations) for WCS request proxying
+		 * Modify PPEC settings form to include a toggle (and other accommodations) for WCS request proxying.
+		 *
+		 * @param array $form_fields The gateway settings form fields.
+		 * @return array The adjusted form fields.
 		 */
 		public function adjust_form_fields( $form_fields ) {
 			$settings = wc_gateway_ppec()->settings;
 
-			// Modify form fields and descriptions depending on whether WCS request proxying is enabled
+			// Modify form fields and descriptions depending on whether WCS request proxying is enabled.
 			if ( 'yes' === $settings->reroute_requests ) {
 				$form_fields = $this->adjust_api_subject_form_field( $form_fields );
 
-				// Prevent user from changing Payment Action away from "Sale", the only option for which payments will work
+				// Prevent user from changing Payment Action away from "Sale", the only option for which payments will work.
 				$form_fields['paymentaction']['disabled']    = true;
+				/* translators: %s: existing payment action field description */
 				$form_fields['paymentaction']['description'] = sprintf( __( '%s (Note that "authorizing payment only" requires linking a PayPal account.)', 'woocommerce-services' ), $form_fields['paymentaction']['description'] );
 
-				// Communicate WCS proxying and provide option to disable
+				// Communicate WCS proxying and provide option to disable.
 				$reset_link         = add_query_arg(
 					array(
 						'reroute_requests' => 'no',
@@ -277,6 +323,7 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 					),
 					wc_gateway_ppec()->get_admin_setting_link()
 				);
+				/* translators: %s: URL to disable request proxying and link a PayPal account */
 				$api_creds_template = __( 'Payments will be authenticated by WooCommerce Tax and directed to the following email address. To disable this feature and link a PayPal account, <a href="%s">click here</a>.', 'woocommerce-services' );
 				if ( empty( $settings->api_username ) ) {
 					$api_creds_text                                = sprintf( $api_creds_template, esc_url( add_query_arg( 'environment', 'live', $reset_link ) ) );
@@ -289,7 +336,7 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 					unset( $form_fields['sandbox_api_username'], $form_fields['sandbox_api_password'], $form_fields['sandbox_api_signature'], $form_fields['sandbox_api_certificate'] );
 				}
 			} else {
-				// Provide option to enable request proxying
+				// Provide option to enable request proxying.
 				$reset_link         = add_query_arg(
 					array(
 						'reroute_requests' => 'yes',
@@ -297,6 +344,7 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 					),
 					wc_gateway_ppec()->get_admin_setting_link()
 				);
+				/* translators: %s: URL to enable request proxying */
 				$api_creds_template = __( 'To authenticate payments with WooCommerce Tax, <a href="%s">click here</a>.', 'woocommerce-services' );
 				if ( empty( $settings->api_username ) ) {
 					$api_creds_text                                 = sprintf( $api_creds_template, esc_url( add_query_arg( 'environment', 'live', $reset_link ) ) );
@@ -306,13 +354,16 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 					$api_creds_text = sprintf( $api_creds_template, esc_url( add_query_arg( 'environment', 'sandbox', $reset_link ) ) );
 					$form_fields['sandbox_api_credentials']['description'] .= '<br /><br />' . $api_creds_text;
 				}
-			}
+			}//end if
 
 			return $form_fields;
 		}
 
 		/**
-		 * Present the "API Subject" setting in a way that's simpler, more comprehensible, and more appropriate to the way it's being used
+		 * Present the "API Subject" setting in a way that's simpler, more comprehensible, and more appropriate to the way it's being used.
+		 *
+		 * @param array $form_fields The gateway settings form fields.
+		 * @return array The adjusted form fields.
 		 */
 		public function adjust_api_subject_form_field( $form_fields ) {
 			$api_subject_title                           = __( 'Payment Email', 'woocommerce-services' );
@@ -338,7 +389,7 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 				! isset( $_GET['page'] ) || 'wc-settings' !== $_GET['page'] ||
 				empty( $_GET['reroute_requests'] ) ||
 				empty( $_GET['nonce'] ) ||
-				! wp_verify_nonce( $_GET['nonce'], 'reroute_requests' ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+				! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['nonce'] ) ), 'reroute_requests' )
 			) {
 				return;
 			}
@@ -354,4 +405,4 @@ if ( ! class_exists( 'WC_Connect_PayPal_EC' ) ) {
 			exit;
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-privacy.php
+++ b/classes/class-wc-connect-privacy.php
@@ -4,17 +4,30 @@ if ( class_exists( 'WC_Connect_Privacy' ) ) {
 	return;
 }
 
+/**
+ * Handles privacy policy content and personal data export/erasure for WooCommerce Services.
+ */
 class WC_Connect_Privacy {
 	/**
+	 * The service settings store.
+	 *
 	 * @var WC_Connect_Service_Settings_Store
 	 */
 	protected $settings_store;
 
 	/**
+	 * The API client.
+	 *
 	 * @var WC_Connect_API_Client
 	 */
 	protected $api_client;
 
+	/**
+	 * Constructor.
+	 *
+	 * @param WC_Connect_Service_Settings_Store $settings_store The service settings store.
+	 * @param WC_Connect_API_Client             $api_client     The API client.
+	 */
 	public function __construct( WC_Connect_Service_Settings_Store $settings_store, WC_Connect_API_Client $api_client ) {
 		$this->settings_store = $settings_store;
 		$this->api_client     = $api_client;
@@ -37,6 +50,7 @@ class WC_Connect_Privacy {
 		$content = wpautop(
 			sprintf(
 				wp_kses(
+					/* translators: %s: URL to documentation about privacy policy */
 					__( 'By using this extension, you may be storing personal data or sharing data with external services. <a href="%s" target="_blank">Learn more about how this works, including what you may want to include in your privacy policy.</a>', 'woocommerce-services' ),
 					array(
 						'a' => array(
@@ -76,9 +90,9 @@ class WC_Connect_Privacy {
 	/**
 	 * Filter for woocommerce_privacy_export_order_personal_data that adds WCS personal data to the exported orders
 	 *
-	 * @param array  $personal_data
-	 * @param object $order
-	 * @return array
+	 * @param array  $personal_data The personal data to export.
+	 * @param object $order         The order being exported.
+	 * @return array The personal data with WCS label data appended.
 	 */
 	public function label_data_exporter( $personal_data, $order ) {
 		$order_id = $order->get_id();

--- a/classes/class-wc-connect-service-schemas-store.php
+++ b/classes/class-wc-connect-service-schemas-store.php
@@ -2,24 +2,42 @@
 
 if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 
+	/**
+	 * Stores and retrieves the service schemas fetched from the Connect server.
+	 */
 	class WC_Connect_Service_Schemas_Store {
 
 		/**
+		 * The API client used to communicate with the Connect server.
+		 *
 		 * @var WC_Connect_API_Client
 		 */
 		protected $api_client;
 
 		/**
+		 * The logger instance.
+		 *
 		 * @var WC_Connect_Logger
 		 */
 		protected $logger;
 
+		/**
+		 * WC_Connect_Service_Schemas_Store constructor.
+		 *
+		 * @param WC_Connect_API_Client $api_client The API client used to communicate with the Connect server.
+		 * @param WC_Connect_Logger     $logger     The logger instance.
+		 */
 		public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Logger $logger ) {
 
 			$this->api_client = $api_client;
 			$this->logger     = $logger;
 		}
 
+		/**
+		 * Fetches the service schemas from the Connect server and stores them.
+		 *
+		 * @return bool True on success, false on failure.
+		 */
 		public function fetch_service_schemas_from_connect_server() {
 
 			$response_body = $this->api_client->get_service_schemas();
@@ -41,41 +59,75 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 
 			$old_schemas = $this->get_service_schemas();
 			if ( $old_schemas == $response_body ) {
-				// schemas weren't changed, but were fetched without problems
+				// Schemas weren't changed, but were fetched without problems.
 				return true;
 			}
 
-			// If we made it this far, it is safe to store the object
+			// If we made it this far, it is safe to store the object.
 			return $this->update_service_schemas( $response_body );
 		}
 
+		/**
+		 * Returns the stored service schemas.
+		 *
+		 * @return object|null The stored service schemas, or null if none are stored.
+		 */
 		public function get_service_schemas() {
 			return WC_Connect_Options::get_option( 'services', null );
 		}
 
+		/**
+		 * Stores the given service schemas.
+		 *
+		 * @param object $service_schemas The service schemas to store.
+		 * @return bool True if the option was updated, false otherwise.
+		 */
 		protected function update_service_schemas( $service_schemas ) {
 			return WC_Connect_Options::update_option( 'services', $service_schemas );
 		}
 
+		/**
+		 * Returns the timestamp of the last successful fetch.
+		 *
+		 * @return int|null The last fetch timestamp, or null if never fetched.
+		 */
 		public function get_last_fetch_timestamp() {
 			return WC_Connect_Options::get_option( 'services_last_update', null );
 		}
 
+		/**
+		 * Stores the current time as the last fetch timestamp.
+		 *
+		 * @return void
+		 */
 		protected function update_last_fetch_timestamp() {
 			WC_Connect_Options::update_option( 'services_last_update', time() );
 		}
 
+		/**
+		 * Returns the result code of the last fetch.
+		 *
+		 * @return mixed The last fetch result code.
+		 */
 		public function get_last_fetch_result_code() {
 			return WC_Connect_Options::get_option( 'services_last_result_code' );
 		}
 
 		/**
-		 * @param int $result_status_code
+		 * Stores the result code of the last fetch.
+		 *
+		 * @param int $result_status_code The result status code to store.
+		 * @return void
 		 */
 		protected function update_last_fetch_result_code( $result_status_code ) {
 			WC_Connect_Options::update_option( 'services_last_result_code', $result_status_code );
 		}
 
+		/**
+		 * Updates the heartbeat timestamp if more than a day has elapsed.
+		 *
+		 * @return void
+		 */
 		protected function maybe_update_heartbeat() {
 			$last_heartbeat = WC_Connect_Options::get_option( 'last_heartbeat' );
 			$now            = time();
@@ -85,7 +137,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 			} else {
 				$last_heartbeat = absint( $last_heartbeat );
 				if ( $last_heartbeat > $now ) {
-					// last heartbeat in the future? wacky
+					// Last heartbeat in the future? Wacky.
 					$should_update = true;
 				} else {
 					$elapsed       = $now - $last_heartbeat;
@@ -98,8 +150,14 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 			}
 		}
 
+		/**
+		 * Marks the site as legacy (tax only) when the schema indicates a first install.
+		 *
+		 * @param object $service_schemas The service schemas to inspect.
+		 * @return void
+		 */
 		protected function maybe_mark_as_legacy_site( $service_schemas ) {
-			if ( isset( $service_schemas->features->first_install ) && $service_schemas->features->first_install === true ) {
+			if ( isset( $service_schemas->features->first_install ) && true === $service_schemas->features->first_install ) {
 				WC_Connect_Options::update_option( 'only_tax', '1' );
 			}
 		}
@@ -107,9 +165,9 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 		/**
 		 * Returns all service ids of a specific type (e.g. shipping)
 		 *
-		 * @param string $type The type of services to return
+		 * @param string $type The type of services to return.
 		 *
-		 * @return array An array of that type's service ids, or an empty array if no such type is known
+		 * @return array An array of that type's service ids, or an empty array if no such type is known.
 		 */
 		public function get_all_service_ids_of_type( $type ) {
 
@@ -156,9 +214,9 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 		/**
 		 * Returns a particular service's schema given its id
 		 *
-		 * @param string $service_id The service id for which to return the schema
+		 * @param string $service_id The service id for which to return the schema.
 		 *
-		 * @return object|null The service schema or null if no such id was found
+		 * @return object|null The service schema or null if no such id was found.
 		 */
 		public function get_service_schema_by_id( $service_id ) {
 			$service_schemas = $this->get_service_schemas();
@@ -179,9 +237,9 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 		/**
 		 * Returns a particular service's schema given its method_id
 		 *
-		 * @param $method_id
+		 * @param string $method_id The method id for which to return the schema.
 		 *
-		 * @return object|null The service schema or null if no such id was found
+		 * @return object|null The service schema or null if no such id was found.
 		 */
 		public function get_service_schema_by_method_id( $method_id ) {
 			$service_schemas = $this->get_service_schemas();
@@ -202,9 +260,9 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 		/**
 		 * Returns a service's schema given its shipping zone instance
 		 *
-		 * @param string $instance_id The shipping zone instance id for which to return the schema
+		 * @param string $instance_id The shipping zone instance id for which to return the schema.
 		 *
-		 * @return object|null The service schema or null if no such instance was found
+		 * @return object|null The service schema or null if no such instance was found.
 		 */
 		public function get_service_schema_by_instance_id( $instance_id ) {
 			global $wpdb;
@@ -251,6 +309,11 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 			return $service_schemas->boxes;
 		}
 
+		/**
+		 * Returns the predefined packages schema keyed by service id.
+		 *
+		 * @return object|array|null An array of predefined packages, or null if no schema is stored.
+		 */
 		public function get_predefined_packages_schema() {
 			$service_schemas = $this->get_service_schemas();
 			if ( ! is_object( $service_schemas ) ) {
@@ -295,4 +358,4 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 			return null;
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-service-schemas-validator.php
+++ b/classes/class-wc-connect-service-schemas-validator.php
@@ -2,12 +2,15 @@
 
 if ( ! class_exists( 'WC_Connect_Service_Schemas_Validator' ) ) {
 
+	/**
+	 * Validates service schemas returned by the WooCommerce Shipping & Tax service.
+	 */
 	class WC_Connect_Service_Schemas_Validator {
 
 		/**
 		 * Validates the overall passed services object (all service types and all services therein)
 		 *
-		 * @param object $services
+		 * @param object $service_schemas The service schemas object to validate.
 		 *
 		 * @return WP_Error|true
 		 */
@@ -44,7 +47,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Validator' ) ) {
 					return $result;
 				}
 
-				$service_counter ++;
+				++$service_counter;
 			}
 
 			if ( ! isset( $service_schemas->boxes ) || ! is_object( $service_schemas->boxes ) ) {
@@ -61,9 +64,9 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Validator' ) ) {
 		 * Validates a particular service schema, especially the parts of the service that WC relies
 		 * on like id, method_title, method_description, etc
 		 *
-		 * @param string  $service_type
-		 * @param integer $service_counter
-		 * @param object  $service
+		 * @param string  $service_type    The service type (e.g. 'shipping').
+		 * @param integer $service_counter The index of the service within its type.
+		 * @param object  $service_schema  The service schema object to validate.
 		 *
 		 * @return WP_Error|true
 		 */
@@ -103,7 +106,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Validator' ) ) {
 						)
 					);
 				}
-			}
+			}//end foreach
 
 			return $this->validate_service_schema_settings( $service_schema->id, $service_schema->service_settings );
 		}
@@ -112,8 +115,8 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Validator' ) ) {
 		 * Validates a particular service's service settings schema, especially the parts of the
 		 * service settings that WC relies on like type, required and properties
 		 *
-		 * @param string $service_id
-		 * @param object $service_settings
+		 * @param string $service_id       The service ID being validated.
+		 * @param object $service_settings The service settings object to validate.
 		 *
 		 * @return WP_Error|true
 		 */
@@ -149,7 +152,7 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Validator' ) ) {
 						)
 					);
 				}
-			}
+			}//end foreach
 
 			$result = $this->validate_service_settings_required_properties( $service_id, $service_settings->properties );
 			if ( is_wp_error( $result ) ) {
@@ -164,8 +167,8 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Validator' ) ) {
 		 * Validates a particular service's schema's required properties, especially the parts of the
 		 * properties that WC relies on and title
 		 *
-		 * @param string $service_id
-		 * @param object $service_settings_properties
+		 * @param string $service_id                  The service ID being validated.
+		 * @param object $service_settings_properties The service settings properties object to validate.
 		 *
 		 * @return WP_Error|true
 		 */
@@ -189,7 +192,6 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Validator' ) ) {
 
 			return true;
 		}
-
 	}
 
-}
+}//end if

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -2,23 +2,39 @@
 
 if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 
+	/**
+	 * Stores and retrieves WooCommerce Connect service settings.
+	 */
 	class WC_Connect_Service_Settings_Store {
 
 		/**
+		 * Service schemas store instance.
+		 *
 		 * @var WC_Connect_Service_Schemas_Store
 		 */
 		protected $service_schemas_store;
 
 		/**
+		 * API client instance.
+		 *
 		 * @var WC_Connect_API_Client
 		 */
 		protected $api_client;
 
 		/**
+		 * Logger instance.
+		 *
 		 * @var WC_Connect_Logger
 		 */
 		protected $logger;
 
+		/**
+		 * Constructor.
+		 *
+		 * @param WC_Connect_Service_Schemas_Store $service_schemas_store Service schemas store instance.
+		 * @param WC_Connect_API_Client            $api_client            API client instance.
+		 * @param WC_Connect_Logger                $logger                Logger instance.
+		 */
 		public function __construct( WC_Connect_Service_Schemas_Store $service_schemas_store, WC_Connect_API_Client $api_client, WC_Connect_Logger $logger ) {
 			$this->service_schemas_store = $service_schemas_store;
 			$this->api_client            = $api_client;
@@ -78,12 +94,12 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		/**
 		 * Updates connect account settings (e.g. payment method)
 		 *
-		 * @param array $settings
+		 * @param array $settings Account settings to update.
 		 *
 		 * @return true
 		 */
 		public function update_account_settings( $settings ) {
-			// simple validation for now.
+			// Simple validation for now.
 			if ( ! is_array( $settings ) ) {
 				$this->logger->log( 'Array expected but not received', __FUNCTION__ );
 				return false;
@@ -96,11 +112,22 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			return WC_Connect_Options::update_option( 'account_settings', $settings );
 		}
 
+		/**
+		 * Returns the selected payment method ID.
+		 *
+		 * @return int The selected payment method ID.
+		 */
 		public function get_selected_payment_method_id() {
 			$account_settings = $this->get_account_settings();
 			return intval( $account_settings['selected_payment_method_id'] );
 		}
 
+		/**
+		 * Sets the selected payment method ID.
+		 *
+		 * @param int $new_payment_method_id The payment method ID to select.
+		 * @return void
+		 */
 		public function set_selected_payment_method_id( $new_payment_method_id ) {
 			$new_payment_method_id = intval( $new_payment_method_id );
 			$account_settings      = $this->get_account_settings();
@@ -112,19 +139,30 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			$this->update_account_settings( $account_settings );
 		}
 
+		/**
+		 * Determines whether the current user can manage payment methods.
+		 *
+		 * @return bool True if the user can manage payment methods.
+		 */
 		public function can_user_manage_payment_methods() {
 			return WC_Connect_Jetpack::is_offline_mode() || WC_Connect_Jetpack::is_current_user_connection_owner();
 		}
 
+		/**
+		 * Returns the store origin address.
+		 *
+		 * @return array The origin address fields.
+		 */
 		public function get_origin_address() {
 			$wc_address_fields            = array();
-			$wc_address_fields['company'] = html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES ); // HTML entities may be saved in the option.
-			$wc_address_fields['name']    = wp_get_current_user()->display_name;
-			$wc_address_fields['phone']   = '';
+			$wc_address_fields['company'] = html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES );
+			// HTML entities may be saved in the option.
+			$wc_address_fields['name']  = wp_get_current_user()->display_name;
+			$wc_address_fields['phone'] = '';
 
 			$wc_countries = WC()->countries;
-			// WC 3.2 introduces ability to configure a full address in the settings
-			// Use it for address defaults if available
+			// WC 3.2 introduces ability to configure a full address in the settings.
+			// Use it for address defaults if available.
 			if ( method_exists( $wc_countries, 'get_base_address' ) ) {
 				$wc_address_fields['country']   = $wc_countries->get_base_country();
 				$wc_address_fields['state']     = $wc_countries->get_base_state();
@@ -144,10 +182,16 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 
 			$stored_address_fields    = WC_Connect_Options::get_option( 'origin_address', array() );
 			$merged_fields            = is_array( $stored_address_fields ) ? array_merge( $wc_address_fields, $stored_address_fields ) : $wc_address_fields;
-			$merged_fields['company'] = html_entity_decode( $merged_fields['company'], ENT_QUOTES ); // Decode again for any existing stores that had some html entities saved in the option.
+			$merged_fields['company'] = html_entity_decode( $merged_fields['company'], ENT_QUOTES );
+			// Decode again for any existing stores that had some html entities saved in the option.
 			return $merged_fields;
 		}
 
+		/**
+		 * Returns the preferred paper size, falling back to a sensible default by country.
+		 *
+		 * @return string The preferred paper size.
+		 */
 		public function get_preferred_paper_size() {
 			$paper_size = WC_Connect_Options::get_option( 'paper_size', '' );
 			if ( $paper_size ) {
@@ -162,6 +206,12 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			return 'a4';
 		}
 
+		/**
+		 * Sets the preferred paper size.
+		 *
+		 * @param string $size The paper size to store.
+		 * @return bool Whether the option was updated.
+		 */
 		public function set_preferred_paper_size( $size ) {
 			return WC_Connect_Options::update_option( 'paper_size', $size );
 		}
@@ -169,8 +219,8 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		/**
 		 * Attempts to recover faulty json string fields that might contain strings with unescaped quotes
 		 *
-		 * @param string $field_name
-		 * @param string $json
+		 * @param string $field_name The JSON field name to recover.
+		 * @param string $json       The JSON string to process.
 		 *
 		 * @return string
 		 */
@@ -190,8 +240,8 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		/**
 		 * Attempts to recover faulty json string array fields that might contain strings with unescaped quotes
 		 *
-		 * @param string $field_name
-		 * @param string $json
+		 * @param string $field_name The JSON field name to recover.
+		 * @param string $json       The JSON string to process.
 		 *
 		 * @return string
 		 */
@@ -208,8 +258,14 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			return $json;
 		}
 
+		/**
+		 * Attempts to deserialize label data stored as a JSON string.
+		 *
+		 * @param string $label_data The raw label data to deserialize.
+		 * @return array The deserialized labels, or an empty array on failure.
+		 */
 		public function try_deserialize_labels_json( $label_data ) {
-			// attempt to decode the JSON (legacy way of storing the labels data).
+			// Attempt to decode the JSON (legacy way of storing the labels data).
 			$decoded_labels = json_decode( $label_data, true );
 			if ( $decoded_labels ) {
 				return $decoded_labels;
@@ -233,7 +289,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		/**
 		 * Returns labels for the specific order ID
 		 *
-		 * @param $order_id
+		 * @param int $order_id The order ID.
 		 *
 		 * @return array
 		 */
@@ -261,8 +317,8 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		/**
 		 * Updates the existing label data
 		 *
-		 * @param $order_id
-		 * @param $new_label_data
+		 * @param int    $order_id       The order ID.
+		 * @param object $new_label_data The new label data to merge in.
 		 *
 		 * @return array updated label info
 		 */
@@ -289,8 +345,8 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		/**
 		 * Adds new labels to the order
 		 *
-		 * @param $order_id
-		 * @param array    $new_labels - labels to be added
+		 * @param int   $order_id   The order ID.
+		 * @param array $new_labels Labels to be added.
 		 */
 		public function add_labels_to_order( $order_id, $new_labels ) {
 			$labels_data = $this->get_label_order_meta_data( $order_id );
@@ -300,10 +356,23 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			$order->save();
 		}
 
+		/**
+		 * Updates the stored store origin address.
+		 *
+		 * @param array $address The origin address to store.
+		 * @return bool Whether the option was updated.
+		 */
 		public function update_origin_address( $address ) {
 			return WC_Connect_Options::update_option( 'origin_address', $address );
 		}
 
+		/**
+		 * Updates the destination address on an order from a normalized API address.
+		 *
+		 * @param int   $order_id    The order ID.
+		 * @param array $api_address The normalized address returned from the API.
+		 * @return void
+		 */
 		public function update_destination_address( $order_id, $api_address ) {
 			$order      = wc_get_order( $order_id );
 			$wc_address = $order->get_address( 'shipping' );
@@ -324,6 +393,13 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			$order->save();
 		}
 
+		/**
+		 * Comparison callback that sorts services by zone order and instance ID.
+		 *
+		 * @param object $a The first service to compare.
+		 * @param object $b The second service to compare.
+		 * @return int Negative, zero, or positive ordering value.
+		 */
 		protected function sort_services( $a, $b ) {
 
 			if ( $a->zone_order === $b->zone_order ) {
@@ -359,6 +435,12 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			return $this->get_enabled_services_by_ids( $shipping_services );
 		}
 
+		/**
+		 * Returns enabled services for the given shipping method IDs.
+		 *
+		 * @param array $service_ids The shipping method IDs to look up.
+		 * @return array The enabled services.
+		 */
 		public function get_enabled_services_by_ids( $service_ids ) {
 			if ( empty( $service_ids ) ) {
 				return array();
@@ -416,11 +498,13 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * Checks if the shipping method ids have been migrated to the "wc_services_*" format and migrates them
 		 */
 		public function migrate_legacy_services() {
-			if ( WC_Connect_Options::get_option( 'shipping_methods_migrated', false ) ) { // check if the method have already been migrated.
+			if ( WC_Connect_Options::get_option( 'shipping_methods_migrated', false ) ) {
+				// check if the method have already been migrated.
 				return;
 			}
 
-			if ( ! $this->service_schemas_store->fetch_service_schemas_from_connect_server() ) { // ensure the latest schemas are fetched.
+			if ( ! $this->service_schemas_store->fetch_service_schemas_from_connect_server() ) {
+				// ensure the latest schemas are fetched.
 				// No schemes exist this is a site that has nothing to migrate.
 				WC_Connect_Options::update_option( 'shipping_methods_migrated', true );
 				return;
@@ -438,7 +522,8 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				$service_schema   = $this->service_schemas_store->get_service_schema_by_id( $service_id );
 				$service_settings = $this->get_service_settings( $service_id, $instance_id );
 				if ( ( is_array( $service_settings ) && ! $service_settings ) // check for an empty array.
-					|| ( ! is_array( $service_settings ) && ! is_object( $service_settings ) ) ) { // settings are neither an array nor an object.
+					|| ( ! is_array( $service_settings ) && ! is_object( $service_settings ) ) ) {
+					// settings are neither an array nor an object.
 					continue;
 				}
 
@@ -459,7 +544,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				WC_Connect_Options::update_shipping_method_option( 'form_settings', $service_settings, $new_method_id, $instance_id );
 				// delete the old service settings.
 				WC_Connect_Options::delete_shipping_method_options( $service_id, $instance_id );
-			}
+			}//end foreach
 
 			WC_Connect_Options::update_option( 'shipping_methods_migrated', true );
 		}
@@ -468,8 +553,8 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * Given a service's id and optional instance, returns the settings for that
 		 * service or an empty array
 		 *
-		 * @param string  $service_id
-		 * @param integer $service_instance
+		 * @param string  $service_id       The service ID.
+		 * @param integer $service_instance Optional. The service instance ID.
 		 *
 		 * @return object|array
 		 */
@@ -479,6 +564,10 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 
 		/**
 		 * Given id and possibly instance, validates the settings and, if they validate, saves them to options
+		 *
+		 * @param array   $settings The settings to validate and save.
+		 * @param string  $id       The service ID.
+		 * @param integer $instance Optional. The service instance ID.
 		 *
 		 * @return bool|WP_Error
 		 */
@@ -501,7 +590,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			$response_body = $this->api_client->validate_service_settings( $service_schema->id, $settings );
 
 			if ( is_wp_error( $response_body ) ) {
-				// TODO - handle multiple error messages when the validation endpoint can return them
+				// TODO - handle multiple error messages when the validation endpoint can return them.
 				return $response_body;
 			}
 
@@ -509,6 +598,15 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			WC_Connect_Options::update_shipping_method_option( 'form_settings', $settings, $id, $instance );
 			// Invalidate shipping rates session cache.
 			WC_Cache_Helper::get_transient_version( 'shipping', /* $refresh = */ true );
+			/**
+			 * Fires after service settings have been validated and saved.
+			 *
+			 * @since 3.6.3
+			 *
+			 * @param string  $id       The service ID.
+			 * @param integer $instance The service instance ID.
+			 * @param array   $settings The saved service settings.
+			 */
 			do_action( 'wc_connect_saved_service_settings', $id, $instance, $settings );
 
 			return true;
@@ -526,7 +624,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		/**
 		 * Extends the global list of packages with a list of new packages
 		 *
-		 * @param array new_packages - packages to extend
+		 * @param array $new_packages Packages to extend the list with.
 		 */
 		public function create_packages( $new_packages ) {
 			if ( is_null( $new_packages ) ) {
@@ -540,7 +638,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		/**
 		 * Updates the global list of packages
 		 *
-		 * @param array packages
+		 * @param array $packages The packages to store.
 		 */
 		public function update_packages( $packages ) {
 			WC_Connect_Options::update_option( 'packages', $packages );
@@ -558,7 +656,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		/**
 		 * Returns a list of enabled predefined packages for the specified service
 		 *
-		 * @param $service_id
+		 * @param string $service_id The service ID.
 		 * @return array
 		 */
 		public function get_predefined_packages_for_service( $service_id ) {
@@ -573,7 +671,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		/**
 		 * Extends the global list of enabled predefined packages with a list of new packages
 		 *
-		 * @param array new_packages - packages to extend
+		 * @param array $new_packages Packages to extend the list with.
 		 */
 		public function create_predefined_packages( $new_packages ) {
 			if ( is_null( $new_packages ) ) {
@@ -587,12 +685,17 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		/**
 		 * Updates the global list of enabled predefined packages for all services
 		 *
-		 * @param array packages
+		 * @param array $packages The packages to store.
 		 */
 		public function update_predefined_packages( $packages ) {
 			WC_Connect_Options::update_option( 'predefined_packages', $packages );
 		}
 
+		/**
+		 * Builds a lookup table of custom and predefined packages keyed by package identifier.
+		 *
+		 * @return array The package lookup table.
+		 */
 		public function get_package_lookup() {
 			$lookup = array();
 
@@ -617,6 +720,11 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			return $lookup;
 		}
 
+		/**
+		 * Determines whether the site is eligible for migration to WooCommerce Shipping.
+		 *
+		 * @return bool True if the site is eligible for migration.
+		 */
 		public function is_eligible_for_migration() {
 			$migration_state = intval( get_option( 'wcshipping_migration_state', 0 ) );
 
@@ -632,7 +740,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			}
 
 			$migration_dismissed = false;
-			if ( isset( $_COOKIE[ WC_Connect_Loader::MIGRATION_DISMISSAL_COOKIE_KEY ] ) && (int) $_COOKIE[ WC_Connect_Loader::MIGRATION_DISMISSAL_COOKIE_KEY ] === 1 ) {
+			if ( isset( $_COOKIE[ WC_Connect_Loader::MIGRATION_DISMISSAL_COOKIE_KEY ] ) && 1 === (int) $_COOKIE[ WC_Connect_Loader::MIGRATION_DISMISSAL_COOKIE_KEY ] ) {
 				$migration_dismissed = true;
 			}
 
@@ -642,6 +750,12 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			return $migration_pending && $migration_enabled && ! $migration_dismissed;
 		}
 
+		/**
+		 * Translates a measurement unit slug into its localized label.
+		 *
+		 * @param string $value The measurement unit slug.
+		 * @return string The localized unit label, or the original value if unrecognized.
+		 */
 		private function translate_unit( $value ) {
 			switch ( $value ) {
 				case 'kg':
@@ -665,7 +779,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				default:
 					$this->logger->log( 'Unexpected measurement unit: ' . $value, __FUNCTION__ );
 					return $value;
-			}
+			}//end switch
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -76,9 +76,11 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 		 * Localizes the bootstrap, enqueues the script and styles for the settings page
 		 */
 		public function output_shipping_settings_screen() {
-			// hiding the save button because the react container has its own.
+			// Hiding the save button because the React container has its own.
 			global $hide_save_button;
-			$hide_save_button = true;
+			// $hide_save_button is a WooCommerce core global (WC_Admin_Settings reads it to
+			// suppress the native Save button); it is not a plugin-owned global to prefix.
+			$hide_save_button = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- WC core global.
 
 			if ( WC_Connect_Jetpack::is_offline_mode() ) {
 				if ( WC_Connect_Jetpack::is_connected() ) {
@@ -115,13 +117,13 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 			}
 
 			if ( isset( $_GET['from_order'] ) ) {
-				$from_order               = sanitize_text_field( $_GET['from_order'] );
+				$from_order               = sanitize_text_field( wp_unslash( $_GET['from_order'] ) );
 				$extra_args['order_id']   = $from_order;
 				$extra_args['order_href'] = get_edit_post_link( $from_order );
 			}
 
 			if ( ! empty( $_GET['carrier'] ) ) {
-				$carrier                  = sanitize_text_field( $_GET['carrier'] );
+				$carrier                  = sanitize_text_field( wp_unslash( $_GET['carrier'] ) );
 				$extra_args['carrier']    = $carrier;
 				$extra_args['continents'] = $this->continents->get();
 

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -2,50 +2,82 @@
 
 if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
+	/**
+	 * Handles shipping label data preparation and the order shipping label meta box.
+	 */
 	class WC_Connect_Shipping_Label {
 
 		/**
+		 * API client instance.
+		 *
 		 * @var WC_Connect_API_Client
 		 */
 		protected $api_client;
 
 		/**
+		 * Service settings store instance.
+		 *
 		 * @var WC_Connect_Service_Settings_Store
 		 */
 		protected $settings_store;
 
 		/**
+		 * Service schemas store instance.
+		 *
 		 * @var WC_Connect_Service_Schemas_Store
 		 */
 		protected $service_schemas_store;
 
 		/**
+		 * Account settings instance.
+		 *
 		 * @var WC_Connect_Account_Settings
 		 */
 		protected $account_settings;
 
 		/**
+		 * Package settings instance.
+		 *
 		 * @var WC_Connect_Package_Settings
 		 */
 		protected $package_settings;
 
 		/**
+		 * Continents instance.
+		 *
 		 * @var WC_Connect_Continents
 		 */
 		protected $continents;
 
 		/**
-		 * @var array Supported countries by USPS, see: https://webpmt.usps.gov/pmt010.cfm
+		 * Supported countries by USPS, see: https://webpmt.usps.gov/pmt010.cfm.
+		 *
+		 * @var array
 		 */
 		private $supported_countries = array( 'US', 'AS', 'PR', 'VI', 'GU', 'MP', 'UM', 'FM', 'MH' );
 
 		/**
-		 * @var array Supported currencies
+		 * Supported currencies.
+		 *
+		 * @var array
 		 */
 		private $supported_currencies = array( 'USD' );
 
+		/**
+		 * Whether the meta box should be shown. Null until calculated.
+		 *
+		 * @var bool|null
+		 */
 		private $show_metabox = null;
 
+		/**
+		 * Constructor.
+		 *
+		 * @param WC_Connect_API_Client             $api_client            API client instance.
+		 * @param WC_Connect_Service_Settings_Store $settings_store        Service settings store instance.
+		 * @param WC_Connect_Service_Schemas_Store  $service_schemas_store Service schemas store instance.
+		 * @param WC_Connect_Payment_Methods_Store  $payment_methods_store Payment methods store instance.
+		 */
 		public function __construct(
 			WC_Connect_API_Client $api_client,
 			WC_Connect_Service_Settings_Store $settings_store,
@@ -66,6 +98,13 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			$this->continents            = new WC_Connect_Continents();
 		}
 
+		/**
+		 * Build the shipping item data for a single order item.
+		 *
+		 * @param WC_Order $order The order the item belongs to.
+		 * @param mixed    $item  The order item to build data for.
+		 * @return array|null The item shipping data, or null when the item does not need shipping.
+		 */
 		public function get_item_data( WC_Order $order, $item ) {
 			$product = WC_Connect_Utils::get_item_product( $order, $item );
 			if ( ! $product || ! $product->needs_shipping() ) {
@@ -100,6 +139,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return $product_data;
 		}
 
+		/**
+		 * Extract the WC Connect packages from a shipping method's metadata.
+		 *
+		 * @param mixed $shipping_method The order shipping method.
+		 * @return array The packages stored on the shipping method, or an empty array.
+		 */
 		protected function get_packaging_from_shipping_method( $shipping_method ) {
 			if ( ! $shipping_method || ! isset( $shipping_method['wc_connect_packages'] ) ) {
 				return array();
@@ -136,6 +181,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return array();
 		}
 
+		/**
+		 * Get the packaging metadata for an order.
+		 *
+		 * @param WC_Order $order The order to read packaging metadata from.
+		 * @return array The packaging metadata, or an empty array.
+		 */
 		protected function get_packaging_metadata( WC_Order $order ) {
 			$shipping_methods = $order->get_shipping_methods();
 			$shipping_method  = reset( $shipping_methods );
@@ -148,6 +199,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return array();
 		}
 
+		/**
+		 * Build a display name for a product using its SKU or ID.
+		 *
+		 * @param WC_Product $product The product to build the name for.
+		 * @return string The formatted product name.
+		 */
 		protected function get_name( WC_Product $product ) {
 			if ( $product->get_sku() ) {
 				$identifier = $product->get_sku();
@@ -157,6 +214,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return sprintf( '%s - %s', $identifier, $product->get_title() );
 		}
 
+		/**
+		 * Get the selected packages for an order, formatted for the label UI.
+		 *
+		 * @param WC_Order $order The order to get the selected packages for.
+		 * @return array The formatted packages keyed by package ID.
+		 */
 		public function get_selected_packages( WC_Order $order ) {
 			$packages = $this->get_packaging_metadata( $order );
 			if ( ! $packages ) {
@@ -206,12 +269,18 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 					}
 
 					$formatted_packages[ $package_id ]['items'][ $item_index ] = $product_data;
-				}
-			}
+				}//end foreach
+			}//end foreach
 
 			return $formatted_packages;
 		}
 
+		/**
+		 * Get all shippable items for an order when no packaging metadata is present.
+		 *
+		 * @param WC_Order $order The order to get the items for.
+		 * @return array The list of shippable item data.
+		 */
 		public function get_all_items( WC_Order $order ) {
 			if ( $this->get_packaging_metadata( $order ) ) {
 				return array();
@@ -230,11 +299,19 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				 * The threshold at which we will start batching items together.
 				 * As an example, if a single order item has a quantity 60, which is more than the default threshold
 				 * value of 20 we will start batching together.
+				 *
+				 * @since 3.6.3
+				 *
+				 * @param int $threshold The item quantity threshold for batching. Default 20.
 				 */
 				$threshold = apply_filters( 'wc_connect_shipment_item_quantity_threshold', 20 );
 				/**
 				 * Max number of shipments allowed to be created for this item should quantity of this order items
-				 * exceeds `wc_connect_shipment_item_quantity_threshold`
+				 * exceeds `wc_connect_shipment_item_quantity_threshold`.
+				 *
+				 * @since 3.6.3
+				 *
+				 * @param int $max_shipments The maximum number of shipments to create. Default 5.
 				 */
 				$max_shipments = apply_filters( 'wc_connect_max_shipments_if_quantity_exceeds_threshold', 5 );
 
@@ -260,11 +337,17 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 						$items[] = $item_data;
 					}
 				}
-			}
+			}//end foreach
 
 			return $items;
 		}
 
+		/**
+		 * Get the selected shipping rates for an order, keyed by package ID.
+		 *
+		 * @param WC_Order $order The order to get the selected rates for.
+		 * @return array The selected service IDs keyed by package ID.
+		 */
 		public function get_selected_rates( WC_Order $order ) {
 			$shipping_methods = $order->get_shipping_methods();
 			$shipping_method  = reset( $shipping_methods );
@@ -273,7 +356,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 			foreach ( $packages as $idx => $package_obj ) {
 				$package = (array) $package_obj;
-				// Abort if the package data is malformed
+				// Abort if the package data is malformed.
 				if ( ! isset( $package['id'] ) || ! isset( $package['service_id'] ) ) {
 					return array();
 				}
@@ -284,6 +367,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return $rates;
 		}
 
+		/**
+		 * Normalize an address array into the shape expected by the API.
+		 *
+		 * @param array $address The address to format.
+		 * @return array The formatted address.
+		 */
 		protected function format_address_for_api( $address ) {
 			// Combine first and last name.
 			if ( ! isset( $address['name'] ) ) {
@@ -304,12 +393,23 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return $address;
 		}
 
+		/**
+		 * Get the store origin address formatted for the API.
+		 *
+		 * @return array The formatted origin address.
+		 */
 		protected function get_origin_address() {
 			$origin = $this->format_address_for_api( $this->settings_store->get_origin_address() );
 
 			return $origin;
 		}
 
+		/**
+		 * Get the order destination (shipping) address formatted for the API.
+		 *
+		 * @param WC_Order $order The order to get the destination address from.
+		 * @return array The formatted destination address.
+		 */
 		protected function get_destination_address( WC_Order $order ) {
 			$order_address = $order->get_address( 'shipping' );
 			$destination   = $this->format_address_for_api( $order_address );
@@ -317,6 +417,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return $destination;
 		}
 
+		/**
+		 * Build the label form data for an order.
+		 *
+		 * @param WC_Order $order The order to build the form data for.
+		 * @return array The label form data.
+		 */
 		protected function get_form_data( WC_Order $order ) {
 			$order_id          = $order->get_id();
 			$selected_packages = $this->get_selected_packages( $order );
@@ -435,12 +541,22 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return in_array( $currency_code, $this->supported_currencies, true );
 		}
 
+		/**
+		 * Check whether the DHL Express service schema is available.
+		 *
+		 * @return bool True when DHL Express is available.
+		 */
 		public function is_dhl_express_available() {
 			$dhl_express = $this->service_schemas_store->get_service_schema_by_id( 'dhlexpress' );
 
 			return (bool) $dhl_express;
 		}
 
+		/**
+		 * Check whether the current order is eligible for DHL Express.
+		 *
+		 * @return bool True when the order is eligible for DHL Express.
+		 */
 		public function is_order_dhl_express_eligible() {
 			if ( ! $this->is_dhl_express_available() ) {
 				return false;
@@ -538,6 +654,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return true;
 		}
 
+		/**
+		 * Build the shipping label payload for an order.
+		 *
+		 * @param mixed $post_order_or_id A post, order, or order ID.
+		 * @return array|false The label payload, or false when the order cannot be resolved.
+		 */
 		public function get_label_payload( $post_order_or_id ) {
 			$order = wc_get_order( $post_order_or_id );
 			if ( ! is_a( $order, 'WC_Order' ) ) {
@@ -581,12 +703,29 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return $sum + $item->get_quantity();
 		}
 
+		/**
+		 * Render the shipping label meta box for an order.
+		 *
+		 * @param WP_Post $post The post object for the order.
+		 * @param array   $args The meta box arguments.
+		 * @return void
+		 */
 		public function meta_box( $post, $args ) {
 
 			$connect_order_presenter = new WC_Connect_Order_Presenter();
 			$order                   = WC_Connect_Compatibility::instance()->init_theorder_object( $post );
 			$items                   = array_filter( $order->get_items(), array( $this, 'filter_items_needing_shipping' ) );
 			$items_count             = array_reduce( $items, array( $this, 'reducer_items_quantity' ), 0 ) - absint( $order->get_item_count_refunded() );
+			/**
+			 * Filter the payload passed to the shipping label meta box.
+			 *
+			 * @since 3.6.3
+			 *
+			 * @param array    $payload The meta box payload data.
+			 * @param array    $args    The meta box arguments.
+			 * @param WC_Order $order   The order being rendered.
+			 * @param WC_Connect_Shipping_Label $shipping_label The shipping label instance.
+			 */
 			$payload                 = apply_filters(
 				'wc_connect_meta_box_payload',
 				array(
@@ -604,7 +743,15 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				$this
 			);
 
+			/**
+			 * Enqueue the WC Connect script for the shipping label meta box.
+			 *
+			 * @since 3.6.3
+			 *
+			 * @param string $script_id The script identifier to enqueue.
+			 * @param array  $payload   The payload data for the script.
+			 */
 			do_action( 'enqueue_wc_connect_script', 'wc-connect-create-shipping-label', $payload );
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -2,24 +2,35 @@
 
 if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
+	/**
+	 * Shipping method that fetches live rates from the WooCommerce Shipping & Tax service.
+	 */
 	class WC_Connect_Shipping_Method extends WC_Shipping_Method {
 
 		/**
-		 * @var object A reference to a the fetched properties of the service
+		 * A reference to the fetched properties of the service.
+		 *
+		 * @var object
 		 */
 		protected $service_schema = null;
 
 		/**
+		 * The service settings store.
+		 *
 		 * @var WC_Connect_Service_Settings_Store
 		 */
 		protected $service_settings_store;
 
 		/**
+		 * The logger instance.
+		 *
 		 * @var WC_Connect_Logger
 		 */
 		protected $logger;
 
 		/**
+		 * The API client instance.
+		 *
 		 * @var WC_Connect_API_Client
 		 */
 		protected $api_client;
@@ -38,6 +49,11 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		 */
 		protected $validated_package_destinations = array();
 
+		/**
+		 * Constructor.
+		 *
+		 * @param int|string|null $id_or_instance_id The method id or numeric instance id.
+		 */
 		public function __construct( $id_or_instance_id = null ) {
 			parent::__construct( $id_or_instance_id );
 
@@ -57,8 +73,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			 * to provide a hook for our plugin to inject dependencies into each
 			 * shipping method instance.
 			 *
-			 * @param WC_Connect_Shipping_Method $this
-			 * @param int|string                 $id_or_instance_id
+			 * @since 3.6.3
+			 *
+			 * @param WC_Connect_Shipping_Method $this              The shipping method instance.
+			 * @param int|string                 $id_or_instance_id The method id or numeric instance id.
 			 */
 			do_action( 'wc_connect_service_init', $this, $id_or_instance_id );
 
@@ -91,45 +109,89 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				// and this constructor is not called with an instance id until after
 				// admin_enqueue_scripts has already fired.  This is why WC_Connect_Loader
 				// does it instead.
-			}
+			}//end if
 			$this->package_validation_errors = new WP_Error();
 		}
 
+		/**
+		 * Get the service schema.
+		 *
+		 * @return object The service schema.
+		 */
 		public function get_service_schema() {
 
 			return $this->service_schema;
 		}
 
+		/**
+		 * Set the service schema.
+		 *
+		 * @param object $service_schema The service schema.
+		 * @return void
+		 */
 		public function set_service_schema( $service_schema ) {
 
 			$this->service_schema = $service_schema;
 		}
 
+		/**
+		 * Get the service settings store.
+		 *
+		 * @return WC_Connect_Service_Settings_Store The service settings store.
+		 */
 		public function get_service_settings_store() {
 
 			return $this->service_settings_store;
 		}
 
+		/**
+		 * Set the service settings store.
+		 *
+		 * @param WC_Connect_Service_Settings_Store $service_settings_store The service settings store.
+		 * @return void
+		 */
 		public function set_service_settings_store( $service_settings_store ) {
 
 			$this->service_settings_store = $service_settings_store;
 		}
 
+		/**
+		 * Get the logger.
+		 *
+		 * @return WC_Connect_Logger The logger instance.
+		 */
 		public function get_logger() {
 
 			return $this->logger;
 		}
 
+		/**
+		 * Set the logger.
+		 *
+		 * @param WC_Connect_Logger $logger The logger instance.
+		 * @return void
+		 */
 		public function set_logger( WC_Connect_Logger $logger ) {
 
 			$this->logger = $logger;
 		}
 
+		/**
+		 * Get the API client.
+		 *
+		 * @return WC_Connect_API_Client The API client instance.
+		 */
 		public function get_api_client() {
 
 			return $this->api_client;
 		}
 
+		/**
+		 * Set the API client.
+		 *
+		 * @param WC_Connect_API_Client $api_client The API client instance.
+		 * @return void
+		 */
 		public function set_api_client( WC_Connect_API_Client $api_client ) {
 
 			$this->api_client = $api_client;
@@ -142,8 +204,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		 * injected during the init action in the constructor.
 		 *
 		 * @see WC_Connect_Logger::debug()
-		 * @param string|WP_Error $message
-		 * @param string          $context
+		 * @param string|WP_Error $message Either a string message, or WP_Error object.
+		 * @param string          $context Optional. Context for the logged message.
 		 */
 		protected function log( $message, $context = '' ) {
 
@@ -156,6 +218,13 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			}
 		}
 
+		/**
+		 * Logging helper for errors.
+		 *
+		 * @param string|WP_Error $message Either a string message, or WP_Error object.
+		 * @param string          $context Optional. Context for the logged message.
+		 * @return void
+		 */
 		protected function log_error( $message, $context = '' ) {
 			$logger = $this->get_logger();
 			if ( is_a( $logger, 'WC_Connect_Logger' ) ) {
@@ -259,8 +328,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 						),
 						array( 'id' => 'postcode' )
 					);
-				}
-			}
+				}//end if
+			}//end if
 
 			// Validate State.
 			$valid_states = WC()->countries->get_states( $country );
@@ -295,8 +364,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 						),
 						array( 'id' => 'state' )
 					);
-				}
-			}
+				}//end if
+			}//end if
 			$is_valid = ! $this->package_validation_errors->has_errors();
 			$this->validated_package_destinations[ $destination_key ] = $is_valid;
 			return $is_valid;
@@ -311,6 +380,13 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			return $this->package_validation_errors;
 		}
 
+		/**
+		 * Look up a product within a package by its product or variation id.
+		 *
+		 * @param array $package    The shipping package.
+		 * @param int   $product_id The product or variation id to look up.
+		 * @return WC_Product|false The product data, or false if not found.
+		 */
 		private function lookup_product( $package, $product_id ) {
 			foreach ( $package['contents'] as $item ) {
 				if ( $item['product_id'] === $product_id || $item['variation_id'] === $product_id ) {
@@ -321,10 +397,23 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			return false;
 		}
 
+		/**
+		 * Filter callback to keep only string preset box ids.
+		 *
+		 * @param mixed $preset_id The preset box id to test.
+		 * @return bool Whether the preset id is a string.
+		 */
 		private function filter_preset_boxes( $preset_id ) {
 			return is_string( $preset_id );
 		}
 
+		/**
+		 * Check the rate response for errors and handle them by adding a fallback rate.
+		 *
+		 * @param object|WP_Error $response_body    The rate response body.
+		 * @param object          $service_settings The service settings.
+		 * @return bool True if an error was found and handled, false otherwise.
+		 */
 		private function check_and_handle_response_error( $response_body, $service_settings ) {
 			if ( is_wp_error( $response_body ) ) {
 				$this->debug(
@@ -348,7 +437,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				$this->log_error( $response_body, __FUNCTION__ );
 				$this->add_fallback_rate( $service_settings );
 				return true;
-			}
+			}//end if
 
 			if ( ! property_exists( $response_body, 'rates' ) ) {
 				$this->debug( 'Response is missing `rates` property', 'error' );
@@ -360,6 +449,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			return false;
 		}
 
+		/**
+		 * Add a fallback rate when no rates are returned and a fallback is configured.
+		 *
+		 * @param object $service_settings The service settings.
+		 * @return void
+		 */
 		private function add_fallback_rate( $service_settings ) {
 			if ( ! property_exists( $service_settings, 'fallback_rate' ) || 0 >= $service_settings->fallback_rate ) {
 				return;
@@ -376,6 +471,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			$this->add_rate( $rate_to_add );
 		}
 
+		/**
+		 * Calculate shipping rates for the given package and register them with WooCommerce.
+		 *
+		 * @param array $package Optional. The shipping package to rate.
+		 * @return void
+		 */
 		public function calculate_shipping( $package = array() ) {
 			if ( ! WC_Connect_Functions::should_send_cart_api_request() ) {
 				return;
@@ -519,7 +620,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 						$package_summaries[] = sprintf( '<strong>%s</strong> %s', $package_name, $package_measurements )
 							. '<ul><li>' . implode( '</li><li>', $product_summaries ) . '</li></ul>';
-					}
+					}//end foreach
 
 					$packaging_info  = implode( ', ', $package_summaries );
 					$services_list   = implode( '-', array_unique( $service_ids ) );
@@ -559,11 +660,11 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 							$this->debug( $rate_debug, 'success' );
 						}
-					}
+					}//end if
 
 					$this->add_rate( $rate_to_add );
-				}
-			}
+				}//end foreach
+			}//end foreach
 
 			if ( 0 === count( $this->rates ) ) {
 				$this->add_fallback_rate( $service_settings );
@@ -574,6 +675,11 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			$this->update_last_rate_request_timestamp();
 		}
 
+		/**
+		 * Update the stored timestamp of the last rate request.
+		 *
+		 * @return void
+		 */
 		public function update_last_rate_request_timestamp() {
 			$previous_timestamp = WC_Connect_Options::get_option( 'last_rate_request' );
 			if ( false === $previous_timestamp ||
@@ -582,6 +688,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			}
 		}
 
+		/**
+		 * Record the timestamp of the last failed rate request.
+		 *
+		 * @param int|null $timestamp Optional. The timestamp to record. Defaults to the current time.
+		 * @return void
+		 */
 		public function set_last_request_failed( $timestamp = null ) {
 			if ( is_null( $timestamp ) ) {
 				$timestamp = time();
@@ -590,28 +702,52 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			WC_Connect_Options::update_shipping_method_option( 'failure_timestamp', $timestamp, $this->id, $this->instance_id );
 		}
 
+		/**
+		 * Render the admin options for this shipping method.
+		 *
+		 * @return void
+		 */
 		public function admin_options() {
-			// hide WP native save button on settings page.
+			// Hide WP native save button on settings page.
 			global $hide_save_button;
-			$hide_save_button = true;
+			// $hide_save_button is a WooCommerce core global (WC_Admin_Settings reads it to
+			// suppress the native Save button); it is not a plugin-owned global to prefix.
+			$hide_save_button = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- WC core global.
 
+			/**
+			 * Render the admin options for a WooCommerce Shipping & Tax service.
+			 *
+			 * @since 3.6.3
+			 *
+			 * @param string   $id          The shipping method id.
+			 * @param int|null $instance_id The shipping method instance id.
+			 */
 			do_action( 'wc_connect_service_admin_options', $this->id, $this->instance_id );
 		}
 
 		/**
-		 * @param string $method_id
-		 * @param int    $instance_id
-		 * @param string $service_ids
+		 * Format a rate id from its component parts.
 		 *
-		 * @return string
+		 * @param string $method_id   The shipping method id.
+		 * @param int    $instance_id The shipping method instance id.
+		 * @param string $service_ids The service ids.
+		 *
+		 * @return string The formatted rate id.
 		 */
 		public static function format_rate_id( $method_id, $instance_id, $service_ids ) {
 			return sprintf( '%s:%d:%s', $method_id, $instance_id, $service_ids );
 		}
 
+		/**
+		 * Sanitize and format a rate title for display.
+		 *
+		 * @param string $rate_title The raw rate title.
+		 * @return string The sanitized rate title.
+		 */
 		public static function format_rate_title( $rate_title ) {
 			$formatted_title = wp_kses(
-				html_entity_decode( $rate_title, ENT_COMPAT ), // ENT_COMPAT is explicitly set for cross-version compatibility as it was the default prior to PHP v8.1.
+				html_entity_decode( $rate_title, ENT_COMPAT ),
+				// ENT_COMPAT is explicitly set for cross-version compatibility as it was the default prior to PHP v8.1.
 				array(
 					'sup'    => array(),
 					'del'    => array(),
@@ -725,9 +861,9 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				$this->debug( $message );
 
 				return false;
-			}
+			}//end foreach
 
 			return true;
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -2,35 +2,54 @@
 
 use Automattic\WCServices\StoreNotices\StoreNoticesNotifier;
 
+/**
+ * Integrates WooCommerce with the TaxJar SmartCalcs API for automated tax calculation.
+ */
 class WC_Connect_TaxJar_Integration {
 
 	/**
+	 * TaxJar API client.
+	 *
 	 * @var WC_Connect_API_Client
 	 */
 	public $api_client;
 
 	/**
+	 * Logger instance.
+	 *
 	 * @var WC_Connect_Logger
 	 */
 	public $logger;
 
 	/**
+	 * Store notices notifier.
+	 *
 	 * @var StoreNoticesNotifier
 	 */
 	private $notifier;
 
+	/**
+	 * WC Connect base URL.
+	 *
+	 * @var string
+	 */
 	public $wc_connect_base_url;
 
+	/**
+	 * WooCommerce options that are forced to specific values when automated taxes are enabled.
+	 *
+	 * @var array
+	 */
 	private $expected_options = array(
-		// Users can set either billing or shipping address for tax rates but not shop
+		// Users can set either billing or shipping address for tax rates but not shop.
 		'woocommerce_tax_based_on'       => 'shipping',
-		// Rate calculations assume tax not included
+		// Rate calculations assume tax not included.
 		'woocommerce_prices_include_tax' => 'no',
-		// Use no special handling on shipping taxes, our API handles that
+		// Use no special handling on shipping taxes, our API handles that.
 		'woocommerce_shipping_tax_class' => '',
-		// Rates are calculated in the cart assuming tax not included
+		// Rates are calculated in the cart assuming tax not included.
 		'woocommerce_tax_display_shop'   => 'excl',
-		// TaxJar returns one total amount, not line item amounts
+		// TaxJar returns one total amount, not line item amounts.
 		'woocommerce_tax_display_cart'   => 'excl',
 	);
 
@@ -56,16 +75,22 @@ class WC_Connect_TaxJar_Integration {
 	private $error_cache_time;
 
 	/**
+	 * Tax rate IDs keyed by line item, from the last TaxJar response.
+	 *
 	 * @var array
 	 */
 	private $response_rate_ids;
 
 	/**
+	 * Line item tax data from the last TaxJar response.
+	 *
 	 * @var array
 	 */
 	private $response_line_items;
 
 	/**
+	 * Whether the store displays taxes itemized.
+	 *
 	 * @var bool
 	 */
 	private $is_itemized_tax_display;
@@ -161,6 +186,11 @@ class WC_Connect_TaxJar_Integration {
 		return ( '' !== $jurisdiction ? $jurisdiction . ' : ' : '' ) . $rate_name;
 	}
 
+	/**
+	 * Initialize the integration by registering hooks and filters.
+	 *
+	 * @return void
+	 */
 	public function init() {
 		// Only enable WCS TaxJar integration if the official TaxJar plugin isn't active.
 		if ( class_exists( 'WC_Taxjar' ) ) {
@@ -170,12 +200,12 @@ class WC_Connect_TaxJar_Integration {
 		$store_settings = $this->get_store_settings();
 		$store_country  = $store_settings['country'];
 
-		// TaxJar supports USA, Canada, Australia, and the European Union
+		// TaxJar supports USA, Canada, Australia, and the European Union.
 		if ( ! $this->is_supported_country( $store_country ) ) {
 			return;
 		}
 
-		// Add toggle for automated taxes to the core settings page
+		// Add toggle for automated taxes to the core settings page.
 		add_filter( 'woocommerce_tax_settings', array( $this, 'add_tax_settings' ) );
 
 		// Fix tooltip with link on older WC.
@@ -183,10 +213,10 @@ class WC_Connect_TaxJar_Integration {
 			add_action( 'admin_enqueue_scripts', array( $this, 'fix_tooltip_keepalive' ), 11 );
 		}
 
-		// Settings values filter to handle the hardcoded settings
+		// Settings values filter to handle the hardcoded settings.
 		add_filter( 'woocommerce_admin_settings_sanitize_option', array( $this, 'sanitize_tax_option' ), 10, 2 );
 
-		// Bow out if we're not wanted
+		// Bow out if we're not wanted.
 		if ( ! $this->is_enabled() ) {
 			return;
 		}
@@ -200,22 +230,23 @@ class WC_Connect_TaxJar_Integration {
 			);
 		}
 
-		// Scripts / Stylesheets
+		// Scripts / Stylesheets.
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_taxjar_admin_new_order_assets' ) );
 
 		$this->configure_tax_settings();
 
-		// Calculate Taxes at Cart / Checkout
-		if ( class_exists( 'WC_Cart_Totals' ) ) { // Woo 3.2+
+		// Calculate Taxes at Cart / Checkout.
+		if ( class_exists( 'WC_Cart_Totals' ) ) {
+			// Woo 3.2+.
 			add_action( 'woocommerce_after_calculate_totals', array( $this, 'maybe_calculate_totals' ), 20 );
 		} else {
 			add_action( 'woocommerce_calculate_totals', array( $this, 'maybe_calculate_totals' ), 20 );
 		}
 
-		// Calculate Taxes for Backend Orders (Woo 2.6+)
+		// Calculate Taxes for Backend Orders (Woo 2.6+).
 		add_action( 'woocommerce_before_save_order_items', array( $this, 'calculate_backend_totals' ), 20 );
 
-		// Set customer taxable location for local pickup
+		// Set customer taxable location for local pickup.
 		add_filter( 'woocommerce_customer_taxable_address', array( $this, 'append_base_address_to_customer_taxable_address' ), 10, 1 );
 
 		add_filter( 'woocommerce_calc_tax', array( $this, 'override_woocommerce_tax_rates' ), 10, 3 );
@@ -236,7 +267,7 @@ class WC_Connect_TaxJar_Integration {
 	 * @return bool
 	 */
 	public function is_enabled() {
-		// Migrate automated taxes selection from the setup wizard
+		// Migrate automated taxes selection from the setup wizard.
 		if ( get_option( self::SETUP_WIZARD_OPTION_NAME ) ) {
 			update_option( self::OPTION_NAME, 'yes' );
 			delete_option( self::SETUP_WIZARD_OPTION_NAME );
@@ -250,7 +281,7 @@ class WC_Connect_TaxJar_Integration {
 	/**
 	 * Add our "automated taxes" setting to the core group.
 	 *
-	 * @param array $tax_settings WooCommerce Tax Settings
+	 * @param array $tax_settings WooCommerce Tax Settings.
 	 *
 	 * @return array
 	 */
@@ -258,11 +289,14 @@ class WC_Connect_TaxJar_Integration {
 		$enabled                = $this->is_enabled();
 		$backedup_tax_rates_url = admin_url( '/admin.php?page=wc-status&tab=connect#tax-rate-backups' );
 
+		/* translators: %1$s: opening anchor tag, %2$s: closing anchor tag */
 		$powered_by_wct_notice = '<p>' . sprintf( __( 'Automated taxes take over from the WooCommerce core tax settings. This means that "Display prices" will be set to Excluding tax and tax will be Calculated using Customer shipping address. %1$sLearn more about Automated taxes here.%2$s', 'woocommerce-services' ), '<a href="https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-tax/#setup-and-configuration">', '</a>' ) . '</p>';
 
+		/* translators: %1$s: opening anchor tag, %2$s: closing anchor tag */
 		$backup_notice = ( ! empty( WC_Connect_Functions::get_backed_up_tax_rate_files() ) ) ? '<p>' . sprintf( __( 'Your previous tax rates were backed up and can be downloaded %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . esc_url( $backedup_tax_rates_url ) . '">', '</a>' ) . '</p>' : '';
 
 		$desctructive_action_notice = '<p>' . __( 'Enabling this option overrides any tax rates you have manually added.', 'woocommerce-services' ) . '</p>';
+		/* translators: %1$s: opening anchor tag, %2$s: closing anchor tag */
 		$desctructive_backup_notice = '<p>' . sprintf( __( 'Your existing tax rates will be backed-up to a CSV that you can download %1$shere%2$s.', 'woocommerce-services' ), '<a href="' . esc_url( $backedup_tax_rates_url ) . '">', '</a>' ) . '</p>';
 
 		$tax_nexus_notice = '<p>' . $this->get_tax_tooltip() . '</p>';
@@ -276,24 +310,25 @@ class WC_Connect_TaxJar_Integration {
 			) : array( $desctructive_action_notice, $desctructive_backup_notice, $tax_nexus_notice )
 		);
 		$automated_taxes             = array(
-			'title'    => __( 'Automated taxes', 'woocommerce-services' ),
-			'id'       => self::OPTION_NAME, // TODO: save in `wc_connect_options`?
-			'desc_tip' => $this->get_tax_tooltip(),
-			'desc'     => $automated_taxes_description,
-			'default'  => 'no',
-			'type'     => 'select',
-			'class'    => 'wc-enhanced-select',
-			'options'  => array(
+			'title'                    => __( 'Automated taxes', 'woocommerce-services' ),
+			'id'                       => self::OPTION_NAME,
+			// TODO: save in `wc_connect_options`?
+							'desc_tip' => $this->get_tax_tooltip(),
+			'desc'                     => $automated_taxes_description,
+			'default'                  => 'no',
+			'type'                     => 'select',
+			'class'                    => 'wc-enhanced-select',
+			'options'                  => array(
 				'no'  => __( 'Disable automated taxes', 'woocommerce-services' ),
 				'yes' => __( 'Enable automated taxes', 'woocommerce-services' ),
 			),
 		);
 
-		// Insert the "automated taxes" setting at the top (under the section title)
+		// Insert the "automated taxes" setting at the top (under the section title).
 		array_splice( $tax_settings, 1, 0, array( $automated_taxes ) );
 
 		if ( $enabled ) {
-			// If the automated taxes are enabled, disable the settings that would be reverted in the original plugin
+			// If the automated taxes are enabled, disable the settings that would be reverted in the original plugin.
 			foreach ( $tax_settings as $index => $tax_setting ) {
 				if ( empty( $tax_setting['id'] ) || ! array_key_exists( $tax_setting['id'], $this->expected_options ) ) {
 					continue;
@@ -358,29 +393,29 @@ class WC_Connect_TaxJar_Integration {
 	 * This is similar to the original plugin functionality where these options were reverted on page load
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/82bf7c58/includes/class-wc-taxjar-integration.php#L66-L91
 	 *
-	 * @param mixed $value - option value
-	 * @param array $option - option metadata
+	 * @param mixed $value - option value.
+	 * @param array $option - option metadata.
 	 * @return string new option value, based on the automated taxes state or $value
 	 */
 	public function sanitize_tax_option( $value, $option ) {
     // phpcs:disable WordPress.Security.NonceVerification.Missing --- Security is taken care of by WooCommerce
 		if (
-			// skip unrecognized option format
+			// skip unrecognized option format.
 			! is_array( $option )
-			// skip if unexpected option format
+			// skip if unexpected option format.
 			|| ! isset( $option['id'] )
-			// skip if not enabled or not being enabled in the current request
-			|| ! $this->is_enabled() && ( ! isset( $_POST[ self::OPTION_NAME ] ) || 'yes' != $_POST[ self::OPTION_NAME ] ) ) {
+			// skip if not enabled or not being enabled in the current request.
+			|| ( ! $this->is_enabled() && ( ! isset( $_POST[ self::OPTION_NAME ] ) || 'yes' != $_POST[ self::OPTION_NAME ] ) ) ) {
 			return $value;
 		}
 
-		// the option is currently being enabled - backup the rates and flush the rates table
+		// the option is currently being enabled - backup the rates and flush the rates table.
 		if ( ! $this->is_enabled() && self::OPTION_NAME === $option['id'] && 'yes' === $value ) {
 			$this->backup_existing_tax_rates();
 			return $value;
 		}
 
-		// skip if unexpected option
+		// skip if unexpected option.
 		if ( ! array_key_exists( $option['id'], $this->expected_options ) ) {
 			return $value;
 		}
@@ -397,7 +432,7 @@ class WC_Connect_TaxJar_Integration {
 	 */
 	public function configure_tax_settings() {
 		foreach ( $this->expected_options as $option => $value ) {
-			// first check the option value - with default memory caching this should help to avoid unnecessary DB operations
+			// first check the option value - with default memory caching this should help to avoid unnecessary DB operations.
 			if ( get_option( $option ) !== $value ) {
 				update_option( $option, $value );
 			}
@@ -443,11 +478,23 @@ class WC_Connect_TaxJar_Integration {
 			'postcode' => WC()->countries->get_base_postcode(),
 		);
 
+		/**
+		 * Filter the store location settings used for tax calculation.
+		 *
+		 * @since 3.6.3
+		 *
+		 * @param array $store_settings Store address settings (street, city, state, country, postcode).
+		 * @param array $args           Additional arguments (unused).
+		 */
 		return apply_filters( 'taxjar_store_settings', $store_settings, array() );
 	}
 
 	/**
-	 * @param $message
+	 * Log a message via the WCS Tax logger.
+	 *
+	 * @param mixed $message Message to log; non-scalar values are JSON-encoded.
+	 *
+	 * @return void
 	 */
 	public function _log( $message ) {
 		if ( ! $this->logger->is_logging_enabled() ) {
@@ -460,12 +507,16 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	/**
-	 * @param $message
+	 * Log an error, surfacing customer-facing notices for address input errors.
+	 *
+	 * @param mixed $message Error message; non-scalar values are JSON-encoded.
+	 *
+	 * @return void
 	 */
 	public function _error( $message ) {
 		$formatted_message = is_scalar( $message ) ? $message : json_encode( $message );
 
-		// ignore error messages caused by customer input
+		// ignore error messages caused by customer input.
 		$state_zip_mismatch = false !== strpos( $formatted_message, 'to_zip' ) && false !== strpos( $formatted_message, 'is not used within to_state' );
 		$invalid_postcode   = false !== strpos( $formatted_message, 'isn\'t a valid postal code for' );
 		$malformed_postcode = false !== strpos( $formatted_message, 'zip code has incorrect format' );
@@ -477,17 +528,20 @@ class WC_Connect_TaxJar_Integration {
 			}
 
 			if ( $state_zip_mismatch ) {
+				/* translators: %s: ZIP/Postal code checkout field label */
 				$message = sprintf( _x( '%s does not match the selected state.', '%s - ZIP/Postal code checkout field label', 'woocommerce-services' ), $postcode_field_name );
 			} elseif ( $malformed_postcode ) {
+				/* translators: %s: ZIP/Postal code checkout field label */
 				$message = sprintf( _x( '%s is not formatted correctly.', '%s - ZIP/Postal code checkout field label', 'woocommerce-services' ), $postcode_field_name );
 			} else {
+				/* translators: %s: ZIP/Postal code checkout field label */
 				$message = sprintf( _x( 'Invalid %s entered.', '%s - ZIP/Postal code checkout field label', 'woocommerce-services' ), $postcode_field_name );
 			}
 
 			$this->notifier->error( $message, array(), 'taxjar' );
 
 			return;
-		}
+		}//end if
 
 		$this->logger->error( $formatted_message, 'WCS Tax' );
 	}
@@ -495,7 +549,9 @@ class WC_Connect_TaxJar_Integration {
 	/**
 	 * Wrapper to avoid calling calculate_totals() for admin carts.
 	 *
-	 * @param $wc_cart_object
+	 * @param WC_Cart $wc_cart_object The cart object.
+	 *
+	 * @return void
 	 */
 	public function maybe_calculate_totals( $wc_cart_object ) {
 		if ( ! WC_Connect_Functions::should_send_cart_api_request() ) {
@@ -510,7 +566,7 @@ class WC_Connect_TaxJar_Integration {
 	 * Unchanged from the TaxJar plugin.
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L471
 	 *
-	 * @param WC_Cart $wc_cart_object
+	 * @param WC_Cart $wc_cart_object The cart object.
 	 * @return void
 	 */
 	public function calculate_totals( $wc_cart_object ) {
@@ -539,7 +595,8 @@ class WC_Connect_TaxJar_Integration {
 		 * @var WC_Coupon $coupon
 		*/
 		foreach ( $wc_cart_object->coupons as $coupon ) {
-			if ( method_exists( $coupon, 'get_limit_usage_to_x_items' ) ) { // Woo 3.0+.
+			if ( method_exists( $coupon, 'get_limit_usage_to_x_items' ) ) {
+				// Woo 3.0+.
 				$limit_usage_qty = $coupon->get_limit_usage_to_x_items();
 
 				if ( $limit_usage_qty ) {
@@ -578,30 +635,48 @@ class WC_Connect_TaxJar_Integration {
 			$line_item_key = $product->get_id() . '-' . $cart_item_key;
 			if ( isset( $taxes['line_items'][ $line_item_key ] ) && ! $taxes['line_items'][ $line_item_key ]->combined_tax_rate ) {
 				if ( method_exists( $product, 'set_tax_status' ) ) {
-					$product->set_tax_status( 'none' ); // Woo 3.0+
+					$product->set_tax_status( 'none' );
+					// Woo 3.0+.
 				} else {
-					$product->tax_status = 'none'; // Woo 2.6
+					$product->tax_status = 'none';
+					// Woo 2.6.
 				}
 			}
 		}
 
-		// Recalculate shipping package rates
+		// Recalculate shipping package rates.
 		foreach ( $wc_cart_object->get_shipping_packages() as $package_key => $package ) {
 			WC()->session->set( 'shipping_for_package_' . $package_key, null );
 		}
 
-		if ( class_exists( 'WC_Cart_Totals' ) ) { // Woo 3.2+
+		if ( class_exists( 'WC_Cart_Totals' ) ) {
+			// Woo 3.2+.
+			/**
+			 * This action is documented in WooCommerce core.
+			 *
+			 * @since 3.6.3
+			 */
 			do_action( 'woocommerce_cart_reset', $wc_cart_object, false );
+			/**
+			 * This action is documented in WooCommerce core.
+			 *
+			 * @since 3.6.3
+			 */
 			do_action( 'woocommerce_before_calculate_totals', $wc_cart_object );
 			new WC_Cart_Totals( $wc_cart_object );
 			remove_action( 'woocommerce_after_calculate_totals', array( $this, 'maybe_calculate_totals' ), 20 );
+			/**
+			 * This action is documented in WooCommerce core.
+			 *
+			 * @since 3.6.3
+			 */
 			do_action( 'woocommerce_after_calculate_totals', $wc_cart_object );
 			add_action( 'woocommerce_after_calculate_totals', array( $this, 'maybe_calculate_totals' ), 20 );
 		} else {
 			remove_action( 'woocommerce_calculate_totals', array( $this, 'maybe_calculate_totals' ), 20 );
 			$wc_cart_object->calculate_totals();
 			add_action( 'woocommerce_calculate_totals', array( $this, 'maybe_calculate_totals' ), 20 );
-		}
+		}//end if
 	}
 
 	/**
@@ -610,6 +685,8 @@ class WC_Connect_TaxJar_Integration {
 	 * Unchanged from the TaxJar plugin.
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L557
 	 *
+	 * @param int $order_id The order ID.
+	 *
 	 * @return void
 	 */
 	public function calculate_backend_totals( $order_id ) {
@@ -617,9 +694,11 @@ class WC_Connect_TaxJar_Integration {
 		$address    = $this->get_backend_address();
 		$line_items = $this->get_backend_line_items( $order );
 		if ( method_exists( $order, 'get_shipping_total' ) ) {
-			$shipping = $order->get_shipping_total(); // Woo 3.0+
+			$shipping = $order->get_shipping_total();
+			// Woo 3.0+.
 		} else {
-			$shipping = $order->get_total_shipping(); // Woo 2.6
+			$shipping = $order->get_total_shipping();
+			// Woo 2.6.
 		}
 		$taxes = $this->calculate_tax(
 			array(
@@ -632,8 +711,11 @@ class WC_Connect_TaxJar_Integration {
 				'line_items'      => $line_items,
 			)
 		);
-		if ( class_exists( 'WC_Order_Item_Tax' ) ) { // Add tax rates manually for Woo 3.0+
+		if ( class_exists( 'WC_Order_Item_Tax' ) ) {
+			// Add tax rates manually for Woo 3.0+.
 			/**
+			 * Product order item.
+			 *
 			 * @var WC_Order_Item_Product $item Product Order Item.
 			 */
 			foreach ( $order->get_items() as $item_key => $item ) {
@@ -647,13 +729,14 @@ class WC_Connect_TaxJar_Integration {
 					$item_tax->save();
 				}
 			}
-		} elseif ( class_exists( 'WC_AJAX' ) ) { // Recalculate tax for Woo 2.6 to apply new tax rates
+		} elseif ( class_exists( 'WC_AJAX' ) ) {
+			// Recalculate tax for Woo 2.6 to apply new tax rates.
 				remove_action( 'woocommerce_before_save_order_items', array( $this, 'calculate_backend_totals' ), 20 );
 			if ( check_ajax_referer( 'calc-totals', 'security', false ) ) {
 				WC_AJAX::calc_line_taxes();
 			}
 				add_action( 'woocommerce_before_save_order_items', array( $this, 'calculate_backend_totals' ), 20 );
-		}
+		}//end if
 	}
 
 	/**
@@ -685,15 +768,15 @@ class WC_Connect_TaxJar_Integration {
 	/**
 	 * Allow street address to be passed when finding rates
 	 *
-	 * @param array  $matched_tax_rates
-	 * @param string $tax_class
+	 * @param array  $matched_tax_rates Tax rates matched by WooCommerce.
+	 * @param string $tax_class         Tax class to find rates for.
 	 * @return array
 	 */
 	public function allow_street_address_for_matched_rates( $matched_tax_rates, $tax_class = '' ) {
 		$tax_class         = sanitize_title( $tax_class );
 		$location          = WC_Tax::get_tax_location( $tax_class );
 		$matched_tax_rates = array();
-		if ( sizeof( $location ) >= 4 ) {
+		if ( count( $location ) >= 4 ) {
 			list( $country, $state, $postcode, $city, $street ) = array_pad( $location, 5, '' );
 			$matched_tax_rates                                  = WC_Tax::find_rates(
 				array(
@@ -708,6 +791,13 @@ class WC_Connect_TaxJar_Integration {
 		return $matched_tax_rates;
 	}
 
+	/**
+	 * Strip the jurisdiction prefix from a tax rate label when taxes are displayed itemized.
+	 *
+	 * @param string $rate_name The tax rate label.
+	 *
+	 * @return string The cleaned-up tax rate label.
+	 */
 	public function cleanup_tax_label( $rate_name ) {
 
 		if ( ! $this->is_itemized_tax_display ) {
@@ -762,10 +852,24 @@ class WC_Connect_TaxJar_Integration {
 	 * @return bool
 	 */
 	protected function is_local_pickup() {
+		/**
+		 * Filter whether the store base address should be used for tax on local pickup.
+		 *
+		 * @since 3.6.3
+		 *
+		 * @param bool $apply Whether to apply base address tax for local pickup.
+		 */
 		if ( ! apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) ) {
 			return false;
 		}
 
+		/**
+		 * Filter the list of shipping method IDs treated as local pickup.
+		 *
+		 * @since 3.6.3
+		 *
+		 * @param array $methods Local pickup shipping method IDs.
+		 */
 		$local_pickup_methods = apply_filters(
 			'woocommerce_local_pickup_methods',
 			array( 'legacy_local_pickup', 'local_pickup' )
@@ -844,7 +948,7 @@ class WC_Connect_TaxJar_Integration {
 			// array_merge() would be incorrect as it re-indexes numeric keys.
 			$merged_taxes['rate_ids']   += $taxes['rate_ids'];
 			$merged_taxes['line_items'] += $taxes['line_items'];
-		}
+		}//end foreach
 
 		// If no group produced any taxes (e.g. all groups were cross-state), return false
 		// to preserve backward compatibility with callers that check for false.
@@ -899,8 +1003,15 @@ class WC_Connect_TaxJar_Integration {
 			$postcode = WC()->customer->get_shipping_postcode();
 			$city     = WC()->customer->get_shipping_city();
 			$street   = WC()->customer->get_shipping_address();
-		}
+		}//end if
 
+		/**
+		 * Filter the customer's taxable address.
+		 *
+		 * @since 3.6.3
+		 *
+		 * @param array $address Taxable address as [ country, state, postcode, city, street ].
+		 */
 		return apply_filters( 'woocommerce_customer_taxable_address', array( $country, $state, $postcode, $city, $street ) );
 	}
 
@@ -914,11 +1025,11 @@ class WC_Connect_TaxJar_Integration {
 	 */
 	protected function get_backend_address() {
     // phpcs:disable WordPress.Security.NonceVerification.Missing --- Security handled by WooCommerce
-		$to_country = isset( $_POST['country'] ) ? strtoupper( wc_clean( $_POST['country'] ) ) : false;
-		$to_state   = isset( $_POST['state'] ) ? strtoupper( wc_clean( $_POST['state'] ) ) : false;
-		$to_zip     = isset( $_POST['postcode'] ) ? strtoupper( wc_clean( $_POST['postcode'] ) ) : false;
-		$to_city    = isset( $_POST['city'] ) ? strtoupper( wc_clean( $_POST['city'] ) ) : false;
-		$to_street  = isset( $_POST['street'] ) ? strtoupper( wc_clean( $_POST['street'] ) ) : false;
+		$to_country = isset( $_POST['country'] ) ? strtoupper( wc_clean( wp_unslash( $_POST['country'] ) ) ) : false;
+		$to_state   = isset( $_POST['state'] ) ? strtoupper( wc_clean( wp_unslash( $_POST['state'] ) ) ) : false;
+		$to_zip     = isset( $_POST['postcode'] ) ? strtoupper( wc_clean( wp_unslash( $_POST['postcode'] ) ) ) : false;
+		$to_city    = isset( $_POST['city'] ) ? strtoupper( wc_clean( wp_unslash( $_POST['city'] ) ) ) : false;
+		$to_street  = isset( $_POST['street'] ) ? strtoupper( wc_clean( wp_unslash( $_POST['street'] ) ) ) : false;
     // phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		return array(
@@ -935,6 +1046,8 @@ class WC_Connect_TaxJar_Integration {
 	 *
 	 * Unchanged from the TaxJar plugin.
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L645
+	 *
+	 * @param WC_Cart $wc_cart_object The cart object.
 	 *
 	 * @return array
 	 */
@@ -960,7 +1073,7 @@ class WC_Connect_TaxJar_Integration {
 				$tax_code = '99999';
 			}
 
-			// Get WC Subscription sign-up fees for calculations
+			// Get WC Subscription sign-up fees for calculations.
 			if ( class_exists( 'WC_Subscriptions_Cart' ) ) {
 				if ( 'none' == WC_Subscriptions_Cart::get_calculation_type() ) {
 					if ( class_exists( 'WC_Subscriptions_Synchroniser' ) ) {
@@ -1002,7 +1115,7 @@ class WC_Connect_TaxJar_Integration {
 					'tax_location'     => $tax_location,
 				)
 			);
-		}
+		}//end foreach
 
 		return $line_items;
 	}
@@ -1013,6 +1126,8 @@ class WC_Connect_TaxJar_Integration {
 	 * Unchanged from the TaxJar plugin.
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L695
 	 *
+	 * @param WC_Order $order The order object.
+	 *
 	 * @return array
 	 */
 	protected function get_backend_line_items( $order ) {
@@ -1021,7 +1136,8 @@ class WC_Connect_TaxJar_Integration {
 		$default_location          = get_option( 'woocommerce_tax_based_on', 'shipping' );
 
 		foreach ( $order->get_items() as $item_key => $item ) {
-			if ( is_object( $item ) ) { // Woo 3.0+
+			if ( is_object( $item ) ) {
+				// Woo 3.0+.
 				$id             = $item->get_product_id();
 				$quantity       = $item->get_quantity();
 				$unit_price     = empty( $quantity ) ? $item->get_subtotal() : wc_format_decimal( $item->get_subtotal() / $quantity );
@@ -1029,7 +1145,8 @@ class WC_Connect_TaxJar_Integration {
 				$tax_class_name = $item->get_tax_class();
 				$tax_status     = $item->get_tax_status();
 				$product        = $item->get_product();
-			} else { // Woo 2.6
+			} else {
+				// Woo 2.6.
 				$id             = $item['product_id'];
 				$quantity       = $item['qty'];
 				$unit_price     = empty( $quantity ) ? $item['line_subtotal'] : wc_format_decimal( $item['line_subtotal'] / $quantity );
@@ -1048,7 +1165,11 @@ class WC_Connect_TaxJar_Integration {
 				$tax_code = '99999';
 			}
 
-			/** This filter is documented in get_line_items() */
+			/**
+			 * This filter is documented in get_line_items()
+			 *
+			 * @since 3.4.0
+			 */
 			$tax_location = apply_filters( 'woocommerce_tax_line_item_location', $default_location, $product );
 
 			if ( $tax_location !== $default_location ) {
@@ -1068,10 +1189,18 @@ class WC_Connect_TaxJar_Integration {
 					)
 				);
 			}
-		}
+		}//end foreach
 		return $line_items;
 	}
 
+	/**
+	 * Find a line item by its ID.
+	 *
+	 * @param string $id         The line item ID to find.
+	 * @param array  $line_items Line items to search.
+	 *
+	 * @return array|null The matching line item, or null if not found.
+	 */
 	protected function get_line_item( $id, $line_items ) {
 		foreach ( $line_items as $line_item ) {
 			if ( $line_item['id'] === $id ) {
@@ -1234,6 +1363,10 @@ class WC_Connect_TaxJar_Integration {
 	 * Unchanged from the TaxJar plugin.
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L729
 	 *
+	 * @param array $taxes Taxes keyed by tax rate ID.
+	 * @param float $price The item price being taxed.
+	 * @param array $rates Tax rates applicable to the item.
+	 *
 	 * @return array
 	 */
 	public function override_woocommerce_tax_rates( $taxes, $price, $rates ) {
@@ -1246,25 +1379,25 @@ class WC_Connect_TaxJar_Integration {
 			return $taxes;
 		}
 
-		// Get tax rate ID for current item
+		// Get tax rate ID for current item.
 		$keys        = array_keys( $taxes );
 		$tax_rate_id = $keys[0];
 		$line_items  = array();
 
-		// Map line items using rate ID
+		// Map line items using rate ID.
 		foreach ( $this->response_rate_ids as $line_item_key => $rate_id ) {
 			if ( $rate_id == $tax_rate_id ) {
 				$line_items[] = $line_item_key;
 			}
 		}
 
-		// Remove number precision if Woo 3.2+
+		// Remove number precision if Woo 3.2+.
 		if ( function_exists( 'wc_remove_number_precision' ) ) {
 			$price = wc_remove_number_precision( $price );
 		}
 
 		foreach ( $this->response_line_items as $line_item_key => $line_item ) {
-			// If line item belongs to rate and matches the price, manually set the tax
+			// If line item belongs to rate and matches the price, manually set the tax.
 			if ( in_array( $line_item_key, $line_items ) && $price == $line_item->line_total ) {
 				if ( function_exists( 'wc_add_number_precision' ) ) {
 					$taxes[ $tax_rate_id ] = wc_add_number_precision( $line_item->tax_collectable );
@@ -1283,6 +1416,8 @@ class WC_Connect_TaxJar_Integration {
 	 * Unchanged from the TaxJar plugin.
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/82bf7c587/includes/class-wc-taxjar-integration.php#L653
 	 *
+	 * @param array $address Customer taxable address as [ country, state, postcode, city, street ].
+	 *
 	 * @return array
 	 */
 	public function append_base_address_to_customer_taxable_address( $address ) {
@@ -1290,13 +1425,23 @@ class WC_Connect_TaxJar_Integration {
 
 		list( $country, $state, $postcode, $city, $street ) = array_pad( $address, 5, '' );
 
-		// See WC_Customer get_taxable_address()
-		// wc_get_chosen_shipping_method_ids() available since Woo 2.6.2+
+		// See WC_Customer get_taxable_address().
+		// wc_get_chosen_shipping_method_ids() available since Woo 2.6.2+.
 		if ( function_exists( 'wc_get_chosen_shipping_method_ids' ) ) {
-			if ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
+			/**
+			 * This filter is documented in is_local_pickup()
+			 *
+			 * @since 3.6.3
+			 */
+			if ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && count( array_intersect( wc_get_chosen_shipping_method_ids(), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
 				$tax_based_on = 'base';
 			}
-		} elseif ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && sizeof( array_intersect( WC()->session->get( 'chosen_shipping_methods', array() ), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
+			/**
+			 * This filter is documented in is_local_pickup()
+			 *
+			 * @since 3.6.3
+			 */
+		} elseif ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && count( array_intersect( WC()->session->get( 'chosen_shipping_methods', array() ), apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) ) ) ) > 0 ) {
 				$tax_based_on = 'base';
 		}
 
@@ -1327,9 +1472,18 @@ class WC_Connect_TaxJar_Integration {
 			return;
 		}
 
+		/**
+		 * Filter the tax rate returned by TaxJar before it is applied.
+		 *
+		 * @since 3.6.3
+		 *
+		 * @param float  $rate            The tax rate from the TaxJar response.
+		 * @param object $taxjar_resp_tax The TaxJar response tax object.
+		 * @param array  $body            The TaxJar API request body.
+		 */
 		$new_tax_rate = floatval( apply_filters( 'woocommerce_services_override_tax_rate', $taxjar_resp_tax->rate, $taxjar_resp_tax, $body ) );
 
-		if ( $new_tax_rate === floatval( $taxjar_resp_tax->rate ) ) {
+		if ( floatval( $taxjar_resp_tax->rate ) === $new_tax_rate ) {
 			return $taxjar_resp_tax;
 		}
 
@@ -1360,7 +1514,7 @@ class WC_Connect_TaxJar_Integration {
 	/**
 	 * Validates TaxJar nexus address.
 	 *
-	 * @param  array $address
+	 * @param  array $address The nexus address to validate.
 	 *
 	 * @return bool
 	 */
@@ -1374,11 +1528,12 @@ class WC_Connect_TaxJar_Integration {
 				'max_length'  => 255,
 			),
 			'country' => array(
-				'type'        => 'string',
-				'required'    => true,
-				'pattern'     => '/^[A-Z]{2}$/', // two-letter ISO alpha-2 (upper-case)
-				'description' => 'Two-letter ISO country code (e.g. "US").',
-				'max_length'  => 2,
+				'type'                                => 'string',
+				'required'                            => true,
+				'pattern'                             => '/^[A-Z]{2}$/',
+				// two-letter ISO alpha-2 (upper-case).
+										'description' => 'Two-letter ISO country code (e.g. "US").',
+				'max_length'                          => 2,
 			),
 			'zip'     => array(
 				'type'        => 'string',
@@ -1387,11 +1542,12 @@ class WC_Connect_TaxJar_Integration {
 				'max_length'  => 20,
 			),
 			'state'   => array(
-				'type'        => 'string',
-				'required'    => true,
-				'pattern'     => '/^[A-Z0-9\-]{1,100}$/', // typical short code like "NY", "CA", "NSW"
-				'description' => 'Two-letter (or short) ISO state/province code where applicable.',
-				'max_length'  => 100,
+				'type'                                => 'string',
+				'required'                            => true,
+				'pattern'                             => '/^[A-Z0-9\-]{1,100}$/',
+				// typical short code like "NY", "CA", "NSW".
+										'description' => 'Two-letter (or short) ISO state/province code where applicable.',
+				'max_length'                          => 100,
 			),
 			'city'    => array(
 				'type'        => 'string',
@@ -1430,12 +1586,12 @@ class WC_Connect_TaxJar_Integration {
 				continue;
 			}
 
-			if ( ! $exists || $value === '' || $value === null ) {
+			if ( ! $exists || '' === $value || null === $value ) {
 				continue;
 			}
 
 			if ( isset( $rules['type'] ) ) {
-				if ( $rules['type'] === 'string' && ! is_string( $value ) ) {
+				if ( 'string' === $rules['type'] && ! is_string( $value ) ) {
 					$errors[] = "[$field] field must be a string";
 					continue;
 				}
@@ -1452,7 +1608,7 @@ class WC_Connect_TaxJar_Integration {
 					$errors[] = "[$field] field format is invalid";
 				}
 			}
-		}
+		}//end foreach
 
 		if ( ! empty( $errors ) ) {
 			$this->logger->error( 'Nexus Address ERRORS: ' . implode( ', ', $errors ) . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . print_r( $address, true ), 'WCS Tax' );
@@ -1468,6 +1624,8 @@ class WC_Connect_TaxJar_Integration {
 	 *
 	 * Direct from the TaxJar plugin, without Nexus check.
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L247
+	 *
+	 * @param array $options Tax calculation options (to_country, to_state, to_zip, to_city, to_street, shipping_amount, line_items).
 	 *
 	 * @return array|boolean
 	 */
@@ -1739,7 +1897,7 @@ class WC_Connect_TaxJar_Integration {
 
 					++$priority;
 				}
-			}
+			}//end foreach
 
 			// Add shipping tax rate.
 			$_tax_rates = isset( $taxjar_taxes->breakdown->shipping ) ? (array) $taxjar_taxes->breakdown->shipping : array();
@@ -1759,7 +1917,7 @@ class WC_Connect_TaxJar_Integration {
 
 				++$priority;
 			}
-		}
+		}//end if
 
 		return $taxes;
 	}
@@ -1767,12 +1925,12 @@ class WC_Connect_TaxJar_Integration {
 	/**
 	 * Add or update WooCommerce tax rate.
 	 *
-	 * @param  array     $location
-	 * @param  int|float $rate
-	 * @param  string    $tax_class
-	 * @param  int       $freight_taxable
-	 * @param  int       $rate_priority
-	 * @param  string    $tax_rate_name
+	 * @param  array     $location        Location data (to_country, to_state, to_zip, to_city).
+	 * @param  int|float $rate            Tax rate percentage.
+	 * @param  string    $tax_class       Tax class slug.
+	 * @param  int       $freight_taxable Whether shipping is taxable (1 or 0).
+	 * @param  int       $rate_priority   Tax rate priority.
+	 * @param  string    $tax_rate_name   Tax rate label.
 	 *
 	 * @return int
 	 */
@@ -1783,6 +1941,8 @@ class WC_Connect_TaxJar_Integration {
 		$rate_priority = absint( $rate_priority );
 
 		/**
+		 * Enable shipping tax by default for Florida-to-Florida shipping.
+		 *
 		 * @see https://github.com/Automattic/woocommerce-services/issues/2531
 		 * @see https://floridarevenue.com/faq/Pages/FAQDetails.aspx?FAQID=1277&IsDlg=1
 		 *
@@ -1809,7 +1969,7 @@ class WC_Connect_TaxJar_Integration {
 			'tax_rate_state'    => $to_state,
 			// For the US, we're going to modify the name of the tax rate to simplify the reporting and distinguish between the tax rates at the counties level.
 			// I would love to do this for other locations, but it looks like that would create issues.
-			// For example, for the UK it would continuously rename the rate name with an updated `state` "piece", each time a request is made
+			// For example, for the UK it would continuously rename the rate name with an updated `state` "piece", each time a request is made.
 			'tax_rate_name'     => $tax_rate_name,
 			'tax_rate_priority' => $rate_priority,
 			'tax_rate_compound' => false,
@@ -1839,10 +1999,10 @@ class WC_Connect_TaxJar_Integration {
 			$this->_log( ':: Tax Rate Found ::' );
 			$this->_log( $wc_rate );
 
-			// Get the existing ID
+			// Get the existing ID.
 			$rate_id = key( $wc_rate );
 
-			// Update Tax Rates with TaxJar rates ( rates might be coming from a cached taxjar rate )
+			// Update Tax Rates with TaxJar rates ( rates might be coming from a cached taxjar rate ).
 			$this->_log( ':: Updating Tax Rate To ::' );
 			$this->_log( $tax_rate );
 			if ( $wc_rate[ $rate_id ]['label'] !== $tax_rate_name || (float) $wc_rate[ $rate_id ]['rate'] !== (float) $rate ) {
@@ -1851,7 +2011,7 @@ class WC_Connect_TaxJar_Integration {
 				WC_Tax::_update_tax_rate( $rate_id, $tax_rate );
 			}
 		} else {
-			// Insert a rate if we did not find one
+			// Insert a rate if we did not find one.
 			$this->_log( ':: Adding New Tax Rate ::' );
 			$this->_log( $tax_rate );
 			$rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
@@ -1860,7 +2020,7 @@ class WC_Connect_TaxJar_Integration {
 				WC_Tax::_update_tax_rate_postcodes( $rate_id, wc_normalize_postcode( wc_clean( $location['to_zip'] ) ) );
 				WC_Tax::_update_tax_rate_cities( $rate_id, wc_clean( $location['to_city'] ) );
 			}
-		}
+		}//end if
 
 		$this->_log( 'Tax Rate ID Set for ' . $rate_id );
 
@@ -1870,7 +2030,7 @@ class WC_Connect_TaxJar_Integration {
 	/**
 	 * Validate TaxJar API request json value and add the error to log.
 	 *
-	 * @param $json
+	 * @param string $json The JSON-encoded request body.
 	 *
 	 * @return bool
 	 */
@@ -1937,8 +2097,8 @@ class WC_Connect_TaxJar_Integration {
 	 * Unchanged from the TaxJar plugin.
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L451
 	 *
-	 * @param $json
-	 * @param $from_state
+	 * @param string $json       The JSON-encoded request body.
+	 * @param string $from_state The origin state code.
 	 *
 	 * @return mixed|WP_Error
 	 */
@@ -2003,7 +2163,7 @@ class WC_Connect_TaxJar_Integration {
 					set_transient( $cache_key, $response, $this->error_cache_time );
 				}
 			}
-		}
+		}//end if
 
 		if ( in_array( $response_code, $save_error_codes ) ) {
 			$this->_log( 'Retrieved the error from the cache. Received (' . $response['response']['code'] . '): ' . $response['body'] );
@@ -2020,7 +2180,7 @@ class WC_Connect_TaxJar_Integration {
 	 * Modified from TaxJar's plugin.
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/82bf7c58/includes/class-wc-taxjar-integration.php#L440
 	 *
-	 * @param $json
+	 * @param string $json The JSON-encoded request body.
 	 *
 	 * @return array|WP_Error
 	 */
@@ -2066,7 +2226,7 @@ class WC_Connect_TaxJar_Integration {
 	 */
 	public function backup_existing_tax_rates() {
 
-		// Back up all tax rates to a csv file
+		// Back up all tax rates to a csv file.
 		$backed_up = WC_Connect_Functions::backup_existing_tax_rates();
 
 		if ( ! $backed_up ) {
@@ -2075,7 +2235,7 @@ class WC_Connect_TaxJar_Integration {
 
 		global $wpdb;
 
-		// Delete all tax rates
+		// Delete all tax rates.
 		$wpdb->query( 'TRUNCATE ' . $wpdb->prefix . 'woocommerce_tax_rates' );
 		$wpdb->query( 'TRUNCATE ' . $wpdb->prefix . 'woocommerce_tax_rate_locations' );
 	}
@@ -2119,17 +2279,20 @@ class WC_Connect_TaxJar_Integration {
 		if ( ! $this->on_order_page() ) {
 			return;
 		}
-		// Load Javascript for WooCommerce new order page
+		// Load Javascript for WooCommerce new order page.
 		wp_enqueue_script( 'wc-taxjar-order', $this->wc_connect_base_url . 'woocommerce-services-new-order-taxjar-' . WC_Connect_Loader::get_wcs_version() . '.js', array( 'jquery' ), null, true );
 	}
 
 	/**
 	 * Check for incorrect California tax nexus in the TaxJar API response or cached response.
 	 *
-	 * @param $response_body
-	 * @param $cached
+	 * @param string|object $response_body The TaxJar response body (JSON string when cached, object otherwise).
+	 * @param bool          $cached        Whether the response body comes from the cache.
+	 * @param string        $from_state    The origin state code.
 	 *
 	 * @return void
+	 *
+	 * @throws Exception When the to_state, to_country, or has_nexus values are not set.
 	 */
 	private function check_for_incorrect_california_tax_nexus( $response_body, $cached, $from_state ): void {
 		$log_suffix = 'in TaxJar API response.';
@@ -2148,7 +2311,7 @@ class WC_Connect_TaxJar_Integration {
 				sprintf(
 					'Incorrect California tax nexus detected %1$s (from_state: %2$s, to_state: %3$s, to_country: %4$s, has_nexus: %5$s).',
 					$log_suffix,
-					$from_state ?: 'unknown',
+					$from_state ? $from_state : 'unknown',
 					$to_state,
 					$to_country,
 					json_encode( $has_nexus ),
@@ -2157,7 +2320,7 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		if ( 'not set' === $to_state || 'not set' === $to_country || null === $has_nexus ) {
-			throw new Exception( sprintf( 'One or more values are not set : to_state=>%1$s, to_country=>%2$s, has_nexus=>%3$s', $to_state, $to_country, json_encode( $has_nexus ) ) );
+			throw new Exception( esc_html( sprintf( 'One or more values are not set : to_state=>%1$s, to_country=>%2$s, has_nexus=>%3$s', $to_state, $to_country, wp_json_encode( $has_nexus ) ) ) );
 		}
 	}
 }

--- a/classes/class-wc-connect-tracks.php
+++ b/classes/class-wc-connect-tracks.php
@@ -1,16 +1,31 @@
 <?php
+/**
+ * Tracks analytics integration for WooCommerce Services.
+ *
+ * @package WooCommerce_Services
+ */
 
-// No direct access please
+// No direct access please.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 
+	/**
+	 * Records Tracks analytics events for WooCommerce Services.
+	 */
 	class WC_Connect_Tracks {
-		static $product_name = 'woocommerceconnect';
+		/**
+		 * The product name prefix used for event names.
+		 *
+		 * @var string
+		 */
+		public static $product_name = 'woocommerceconnect';
 
 		/**
+		 * The logger instance.
+		 *
 		 * @var WC_Connect_Logger
 		 */
 		protected $logger;
@@ -22,11 +37,22 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 		 */
 		public $plugin_file;
 
+		/**
+		 * Constructor.
+		 *
+		 * @param WC_Connect_Logger $logger      The logger instance.
+		 * @param string            $plugin_file Plugin file path.
+		 */
 		public function __construct( WC_Connect_Logger $logger, $plugin_file ) {
 			$this->logger      = $logger;
 			$this->plugin_file = $plugin_file;
 		}
 
+		/**
+		 * Register hooks for tracking events.
+		 *
+		 * @return void
+		 */
 		public function init() {
 			add_action( 'wc_connect_shipping_zone_method_added', array( $this, 'shipping_zone_method_added' ), 10, 3 );
 			add_action( 'wc_connect_shipping_zone_method_deleted', array( $this, 'shipping_zone_method_deleted' ), 10, 3 );
@@ -35,6 +61,12 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 			register_deactivation_hook( $this->plugin_file, array( $this, 'opted_out' ) );
 		}
 
+		/**
+		 * Record an opt-in event.
+		 *
+		 * @param string|null $source Optional. The source of the opt-in.
+		 * @return void
+		 */
 		public function opted_in( $source = null ) {
 			if ( is_null( $source ) ) {
 				$this->record_user_event( 'opted_in' );
@@ -43,23 +75,51 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 			}
 		}
 
+		/**
+		 * Record an opt-out event when the plugin is deactivated.
+		 *
+		 * @return void
+		 */
 		public function opted_out() {
-			// Only send opted_out if user has previously opted in
+			// Only send opted_out if user has previously opted in.
 			if ( WC_Connect_Options::get_option( 'tos_accepted' ) ) {
 				$this->record_user_event( 'opted_out' );
 			}
 		}
 
+		/**
+		 * Record a shipping zone method added event.
+		 *
+		 * @param int    $instance_id The shipping method instance ID.
+		 * @param string $service_id  The service ID.
+		 * @return void
+		 */
 		public function shipping_zone_method_added( $instance_id, $service_id ) {
 			$this->record_user_event( 'shipping_zone_method_added' );
 			$this->record_user_event( 'shipping_zone_' . $service_id . '_added' );
 		}
 
+		/**
+		 * Record a shipping zone method deleted event.
+		 *
+		 * @param int    $instance_id The shipping method instance ID.
+		 * @param string $service_id  The service ID.
+		 * @return void
+		 */
 		public function shipping_zone_method_deleted( $instance_id, $service_id ) {
 			$this->record_user_event( 'shipping_zone_method_deleted' );
 			$this->record_user_event( 'shipping_zone_' . $service_id . '_deleted' );
 		}
 
+		/**
+		 * Record a shipping zone method status toggled event.
+		 *
+		 * @param int    $instance_id The shipping method instance ID.
+		 * @param string $service_id  The service ID.
+		 * @param int    $zone_id     The shipping zone ID.
+		 * @param bool   $enabled     Whether the method was enabled.
+		 * @return void
+		 */
 		public function shipping_zone_method_status_toggled( $instance_id, $service_id, $zone_id, $enabled ) {
 			if ( $enabled ) {
 				$this->record_user_event( 'shipping_zone_method_enabled' );
@@ -70,15 +130,28 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 			}
 		}
 
+		/**
+		 * Record a saved service settings event.
+		 *
+		 * @param string $service_id The service ID.
+		 * @return void
+		 */
 		public function saved_service_settings( $service_id ) {
 			$this->record_user_event( 'saved_service_settings' );
 			$this->record_user_event( 'saved_' . $service_id . '_settings' );
 		}
 
+		/**
+		 * Record a user event in Tracks.
+		 *
+		 * @param string $event_type The event type name.
+		 * @param array  $data       Optional. Additional event properties.
+		 * @return void
+		 */
 		public function record_user_event( $event_type, $data = array() ) {
 			$user = wp_get_current_user();
 
-			// Check for WooCommerce
+			// Check for WooCommerce.
 			$wc_version = 'unavailable';
 			if ( function_exists( 'WC' ) ) {
 				$wc_version = WC()->version;
@@ -110,12 +183,17 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 			WC_Connect_Jetpack::tracks_record_event( $user, $event_type, $data );
 		}
 
+		/**
+		 * Log a debug message via the logger.
+		 *
+		 * @param string $message The message to log.
+		 * @return void
+		 */
 		protected function debug( $message ) {
 			if ( ! is_null( $this->logger ) ) {
 				$this->logger->log( $message );
 			}
 		}
-
 	}
 
-}
+}//end if

--- a/classes/class-wc-connect-utils.php
+++ b/classes/class-wc-connect-utils.php
@@ -105,4 +105,4 @@ if ( ! class_exists( 'WC_Connect_Utils' ) ) {
 			return false;
 		}
 	}
-}
+}//end if

--- a/classes/class-wc-connect-wcst-to-wcshipping-migration-state-enum.php
+++ b/classes/class-wc-connect-wcst-to-wcshipping-migration-state-enum.php
@@ -17,6 +17,12 @@ class WC_Connect_WCST_To_WCShipping_Migration_State_Enum {
 	public const ERROR_DEACTIVATING = 11;
 	public const COMPLETED          = 12;
 
+	/**
+	 * Determines whether the given value is a valid migration state.
+	 *
+	 * @param mixed $state The value to validate against the known migration states.
+	 * @return bool True if the value is a valid migration state, false otherwise.
+	 */
 	public static function is_valid_value( $state ) {
 		$valid_states = array(
 			self::NOT_STARTED,

--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -8,20 +8,40 @@ if ( class_exists( 'WC_REST_Connect_Account_Settings_Controller' ) ) {
 	return;
 }
 
+/**
+ * Handles the connect account settings REST endpoint.
+ */
 class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_Controller {
 
+	/**
+	 * The REST base for this controller.
+	 *
+	 * @var string
+	 */
 	protected $rest_base = 'connect/account/settings';
 
-	/*
+	/**
+	 * The payment methods store instance.
+	 *
 	 * @var WC_Connect_Payment_Methods_Store
 	 */
 	protected $payment_methods_store;
 
 	/**
+	 * The account settings instance.
+	 *
 	 * @var WC_Connect_Account_Settings
 	 */
 	protected $account_settings;
 
+	/**
+	 * Constructor.
+	 *
+	 * @param WC_Connect_API_Client             $api_client            The API client instance.
+	 * @param WC_Connect_Service_Settings_Store $settings_store        The service settings store instance.
+	 * @param WC_Connect_Logger                 $logger                The logger instance.
+	 * @param WC_Connect_Payment_Methods_Store  $payment_methods_store The payment methods store instance.
+	 */
 	public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Service_Settings_Store $settings_store, WC_Connect_Logger $logger, WC_Connect_Payment_Methods_Store $payment_methods_store ) {
 		parent::__construct( $api_client, $settings_store, $logger );
 		$this->payment_methods_store = $payment_methods_store;
@@ -32,6 +52,11 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 		);
 	}
 
+	/**
+	 * Get the account settings.
+	 *
+	 * @return WP_REST_Response The account settings response.
+	 */
 	public function get() {
 		return new WP_REST_Response(
 			array_merge(
@@ -42,11 +67,17 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 		);
 	}
 
+	/**
+	 * Update the account settings.
+	 *
+	 * @param WP_REST_Request $request The REST request object.
+	 * @return WP_Error|WP_REST_Response The response on success, or a WP_Error on failure.
+	 */
 	public function post( $request ) {
 		$settings = $request->get_json_params();
 
 		if ( ! $this->settings_store->can_user_manage_payment_methods() ) {
-			// Ignore the user-provided payment method ID if they don't have permission to change it
+			// Ignore the user-provided payment method ID if they don't have permission to change it.
 			$old_settings                           = $this->settings_store->get_account_settings();
 			$settings['selected_payment_method_id'] = $old_settings['selected_payment_method_id'];
 		}
@@ -57,6 +88,7 @@ class WC_REST_Connect_Account_Settings_Controller extends WC_REST_Connect_Base_C
 			$error = new WP_Error(
 				'save_failed',
 				sprintf(
+					/* translators: %s: error message */
 					__( 'Unable to update settings. %s', 'woocommerce-services' ),
 					$result->get_error_message()
 				),

--- a/classes/class-wc-rest-connect-base-controller.php
+++ b/classes/class-wc-rest-connect-base-controller.php
@@ -8,6 +8,9 @@ if ( class_exists( 'WC_REST_Connect_Base_Controller' ) ) {
 	return;
 }
 
+/**
+ * Base controller for Connect REST API endpoints.
+ */
 abstract class WC_REST_Connect_Base_Controller extends WP_REST_Controller {
 
 	/**
@@ -18,26 +21,44 @@ abstract class WC_REST_Connect_Base_Controller extends WP_REST_Controller {
 	protected $namespace = 'wc/v1';
 
 	/**
+	 * The Connect API client.
+	 *
 	 * @var WC_Connect_API_Client
 	 */
 	protected $api_client;
 
 	/**
+	 * The service settings store.
+	 *
 	 * @var WC_Connect_Service_Settings_Store
 	 */
 	protected $settings_store;
 
 	/**
+	 * The Connect logger.
+	 *
 	 * @var WC_Connect_Logger
 	 */
 	protected $logger;
 
+	/**
+	 * WC_REST_Connect_Base_Controller constructor.
+	 *
+	 * @param WC_Connect_API_Client             $api_client     The Connect API client.
+	 * @param WC_Connect_Service_Settings_Store $settings_store The service settings store.
+	 * @param WC_Connect_Logger                 $logger         The Connect logger.
+	 */
 	public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Service_Settings_Store $settings_store, WC_Connect_Logger $logger ) {
 		$this->api_client     = $api_client;
 		$this->settings_store = $settings_store;
 		$this->logger         = $logger;
 	}
 
+	/**
+	 * Register the REST API routes for this controller.
+	 *
+	 * @return void
+	 */
 	public function register_routes() {
 		if ( method_exists( $this, 'get' ) ) {
 			register_rest_route(
@@ -98,10 +119,12 @@ abstract class WC_REST_Connect_Base_Controller extends WP_REST_Controller {
 	 */
 	public function prevent_route_caching() {
 		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
-			define( 'DONOTCACHEPAGE', true ); // Play nice with WP-Super-Cache
+			// Play nice with WP-Super-Cache. DONOTCACHEPAGE is a well-known caching constant
+			// shared across caching plugins, not a plugin-owned constant to prefix.
+			define( 'DONOTCACHEPAGE', true ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- standard caching constant.
 		}
 
-		// Prevent our REST API endpoint responses from being added to browser cache
+		// Prevent our REST API endpoint responses from being added to browser cache.
 		add_filter( 'rest_post_dispatch', array( $this, 'send_nocache_header' ), PHP_INT_MAX, 2 );
 	}
 
@@ -111,8 +134,8 @@ abstract class WC_REST_Connect_Base_Controller extends WP_REST_Controller {
 	 *
 	 * See: https://pantheon.io/docs/cache-control/
 	 *
-	 * @param WP_REST_Response $response
-	 * @param WP_REST_Server   $server
+	 * @param WP_REST_Response $response The REST response object.
+	 * @param WP_REST_Server   $server   The REST server instance.
 	 *
 	 * @return WP_REST_Response passthrough $response parameter
 	 */
@@ -122,34 +145,61 @@ abstract class WC_REST_Connect_Base_Controller extends WP_REST_Controller {
 		return $response;
 	}
 
+	/**
+	 * Handle an internal GET request.
+	 *
+	 * @param WP_REST_Request $request The REST request object.
+	 * @return mixed The response from the GET handler.
+	 */
 	public function get_internal( $request ) {
 		$this->prevent_route_caching();
 
 		return $this->get( $request );
 	}
 
+	/**
+	 * Handle an internal POST request.
+	 *
+	 * @param WP_REST_Request $request The REST request object.
+	 * @return mixed The response from the POST handler.
+	 */
 	public function post_internal( $request ) {
 		$this->prevent_route_caching();
 
 		return $this->post( $request );
 	}
 
+	/**
+	 * Handle an internal PUT request.
+	 *
+	 * @param WP_REST_Request $request The REST request object.
+	 * @return mixed The response from the PUT handler.
+	 */
 	public function put_internal( $request ) {
 		$this->prevent_route_caching();
 
 		return $this->put( $request );
 	}
 
+	/**
+	 * Handle an internal DELETE request.
+	 *
+	 * @param WP_REST_Request $request The REST request object.
+	 * @return mixed The response from the DELETE handler.
+	 */
 	public function delete_internal( $request ) {
 		$this->prevent_route_caching();
 
 		return $this->delete( $request );
 	}
+
 	/**
-	 * Validate the requester's permissions
+	 * Validate the requester's permissions.
+	 *
+	 * @param WP_REST_Request $request The REST request object.
+	 * @return bool Whether the requester can manage labels.
 	 */
 	public function check_permission( $request ) {
 		return WC_Connect_Functions::user_can_manage_labels();
 	}
-
 }

--- a/classes/class-wc-rest-connect-migration-flag-controller.php
+++ b/classes/class-wc-rest-connect-migration-flag-controller.php
@@ -8,7 +8,15 @@ if ( class_exists( 'WC_REST_Connect_Migration_Flag_Controller' ) ) {
 	return;
 }
 
+/**
+ * REST controller for updating the WCS&T to WooCommerce Shipping migration flag.
+ */
 class WC_REST_Connect_Migration_Flag_Controller extends WC_REST_Connect_Base_Controller {
+	/**
+	 * The REST base for this controller's endpoint.
+	 *
+	 * @var string
+	 */
 	protected $rest_base = 'connect/migration-flag';
 
 	/**
@@ -18,6 +26,14 @@ class WC_REST_Connect_Migration_Flag_Controller extends WC_REST_Connect_Base_Con
 	 */
 	protected $tracks;
 
+	/**
+	 * Constructor.
+	 *
+	 * @param WC_Connect_API_Client             $api_client     The API client instance.
+	 * @param WC_Connect_Service_Settings_Store $settings_store The settings store instance.
+	 * @param WC_Connect_Logger                 $logger         The logger instance.
+	 * @param WC_Connect_Tracks                 $tracks         The tracks instance.
+	 */
 	public function __construct( $api_client, $settings_store, $logger, $tracks ) {
 		parent::__construct( $api_client, $settings_store, $logger );
 
@@ -33,6 +49,12 @@ class WC_REST_Connect_Migration_Flag_Controller extends WC_REST_Connect_Base_Con
 		$this->tracks = $tracks;
 	}
 
+	/**
+	 * Handle the request to update the migration flag.
+	 *
+	 * @param WP_REST_Request $request The REST request object.
+	 * @return WP_REST_Response|WP_Error The REST response on success, or a WP_Error on failure.
+	 */
 	public function post( $request ) {
 		$params          = $request->get_json_params();
 		$migration_state = intval( $params['migration_state'] );

--- a/classes/class-wc-rest-connect-packages-controller.php
+++ b/classes/class-wc-rest-connect-packages-controller.php
@@ -64,7 +64,7 @@ class WC_REST_Connect_Packages_Controller extends WC_REST_Connect_Base_Controlle
 		// Handle new custom packages. The custom packages are structured as an array of packages as dictionaries.
 		if ( ! empty( $custom_packages ) ) {
 			// Validate that the new custom packages have unique names.
-			$map_package_name            = function( $package ) {
+			$map_package_name            = function ( $package ) {
 				return $package['name'];
 			};
 			$custom_package_names        = array_map( $map_package_name, $custom_packages );
@@ -74,7 +74,7 @@ class WC_REST_Connect_Packages_Controller extends WC_REST_Connect_Base_Controlle
 				$duplicate_package_names = array_diff_assoc( $custom_package_names, $unique_custom_package_names );
 				$error                   = array(
 					'code'    => 'duplicate_custom_package_names',
-					'message' => __( 'The new custom package names are not unique.' ),
+					'message' => __( 'The new custom package names are not unique.', 'woocommerce-services' ),
 					'data'    => array( 'package_names' => array_values( $duplicate_package_names ) ),
 				);
 				return new WP_REST_Response( $error, 400 );
@@ -88,7 +88,7 @@ class WC_REST_Connect_Packages_Controller extends WC_REST_Connect_Base_Controlle
 			if ( ! empty( $duplicate_package_names ) ) {
 				$error = array(
 					'code'    => 'duplicate_custom_package_names_of_existing_packages',
-					'message' => __( 'At least one of the new custom packages has the same name as existing packages.' ),
+					'message' => __( 'At least one of the new custom packages has the same name as existing packages.', 'woocommerce-services' ),
 					'data'    => array( 'package_names' => array_values( $duplicate_package_names ) ),
 				);
 				return new WP_REST_Response( $error, 400 );
@@ -115,7 +115,7 @@ class WC_REST_Connect_Packages_Controller extends WC_REST_Connect_Base_Controlle
 			if ( ! empty( $duplicate_package_names_by_carrier ) ) {
 				$error = array(
 					'code'    => 'duplicate_predefined_package_names',
-					'message' => __( 'The new predefined package names are not unique.' ),
+					'message' => __( 'The new predefined package names are not unique.', 'woocommerce-services' ),
 					'data'    => array( 'package_names_by_carrier' => $duplicate_package_names_by_carrier ),
 				);
 				return new WP_REST_Response( $error, 400 );
@@ -136,7 +136,7 @@ class WC_REST_Connect_Packages_Controller extends WC_REST_Connect_Base_Controlle
 			if ( ! empty( $duplicate_package_names_by_carrier ) ) {
 				$error = array(
 					'code'    => 'duplicate_predefined_package_names_of_existing_packages',
-					'message' => __( 'At least one of the new predefined packages has the same name as existing packages.' ),
+					'message' => __( 'At least one of the new predefined packages has the same name as existing packages.', 'woocommerce-services' ),
 					'data'    => array( 'package_names_by_carrier' => $duplicate_package_names_by_carrier ),
 				);
 				return new WP_REST_Response( $error, 400 );

--- a/classes/class-wc-rest-connect-self-help-controller.php
+++ b/classes/class-wc-rest-connect-self-help-controller.php
@@ -8,9 +8,23 @@ if ( class_exists( 'WC_REST_Connect_Self_Help_Controller' ) ) {
 	return;
 }
 
+/**
+ * REST controller for updating the self-help logging and debug settings.
+ */
 class WC_REST_Connect_Self_Help_Controller extends WC_REST_Connect_Base_Controller {
+	/**
+	 * The REST base for this controller.
+	 *
+	 * @var string
+	 */
 	protected $rest_base = 'connect/self-help';
 
+	/**
+	 * Update the logging and debug settings from the submitted form data.
+	 *
+	 * @param WP_REST_Request $request The REST request containing the settings.
+	 * @return WP_REST_Response|WP_Error The response on success, or a WP_Error on failure.
+	 */
 	public function post( $request ) {
 		$settings = $request->get_json_params();
 
@@ -42,5 +56,4 @@ class WC_REST_Connect_Self_Help_Controller extends WC_REST_Connect_Base_Controll
 
 		return new WP_REST_Response( array( 'success' => true ), 200 );
 	}
-
 }

--- a/classes/class-wc-rest-connect-service-data-refresh-controller.php
+++ b/classes/class-wc-rest-connect-service-data-refresh-controller.php
@@ -8,25 +8,45 @@ if ( class_exists( 'WC_REST_Connect_Service_Data_Refresh_Controller' ) ) {
 	return;
 }
 
+/**
+ * REST controller that refreshes the cached service schemas from the Connect server.
+ */
 class WC_REST_Connect_Service_Data_Refresh_Controller extends WC_REST_Connect_Base_Controller {
+	/**
+	 * The REST base for this controller.
+	 *
+	 * @var string
+	 */
 	protected $rest_base = 'connect/service-data-refresh';
 
 	/**
+	 * The service schemas store.
+	 *
 	 * @var WC_Connect_Service_Schemas_Store
 	 */
 	protected $services_schemas_store;
 
+	/**
+	 * Set the service schemas store.
+	 *
+	 * @param WC_Connect_Service_Schemas_Store $services_schemas_store The service schemas store.
+	 */
 	public function set_service_schemas_store( $services_schemas_store ) {
 		$this->services_schemas_store = $services_schemas_store;
 	}
 
+	/**
+	 * Refresh the service schemas from the Connect server.
+	 *
+	 * @return WP_REST_Response The response indicating success and schema availability.
+	 */
 	public function post() {
 		$result = $this->services_schemas_store->fetch_service_schemas_from_connect_server();
-		if ( $result === false ) {
+		if ( false === $result ) {
 			return new WP_REST_Response(
-				[
+				array(
 					'success' => false,
-				],
+				),
 				500
 			);
 		}
@@ -34,13 +54,12 @@ class WC_REST_Connect_Service_Data_Refresh_Controller extends WC_REST_Connect_Ba
 		$schemas = $this->services_schemas_store->get_service_schemas();
 
 		return new WP_REST_Response(
-			[
+			array(
 				'success'             => true,
 				'timestamp'           => $this->services_schemas_store->get_last_fetch_timestamp(),
 				'has_service_schemas' => ! is_null( $schemas ),
-			],
+			),
 			200
 		);
 	}
-
 }

--- a/classes/class-wc-rest-connect-services-controller.php
+++ b/classes/class-wc-rest-connect-services-controller.php
@@ -8,14 +8,32 @@ if ( class_exists( 'WC_REST_Connect_Services_Controller' ) ) {
 	return;
 }
 
+/**
+ * Handles the connect service settings REST endpoint.
+ */
 class WC_REST_Connect_Services_Controller extends WC_REST_Connect_Base_Controller {
+	/**
+	 * The REST base for this controller.
+	 *
+	 * @var string
+	 */
 	protected $rest_base = 'connect/services/(?P<id>[a-z_]+)\/(?P<instance>[\d]+)';
 
 	/**
+	 * The service schemas store instance.
+	 *
 	 * @var WC_Connect_Service_Schemas_Store
 	 */
 	protected $service_schemas_store;
 
+	/**
+	 * Constructor.
+	 *
+	 * @param WC_Connect_API_Client             $api_client     The API client instance.
+	 * @param WC_Connect_Service_Settings_Store $settings_store The service settings store instance.
+	 * @param WC_Connect_Logger                 $logger         The logger instance.
+	 * @param WC_Connect_Service_Schemas_Store  $schemas_store  The service schemas store instance.
+	 */
 	public function __construct(
 		WC_Connect_API_Client $api_client,
 		WC_Connect_Service_Settings_Store $settings_store,
@@ -26,6 +44,12 @@ class WC_REST_Connect_Services_Controller extends WC_REST_Connect_Base_Controlle
 		$this->service_schemas_store = $schemas_store;
 	}
 
+	/**
+	 * Get the settings for a particular service and instance.
+	 *
+	 * @param WP_REST_Request $request The REST request object.
+	 * @return WP_Error|WP_REST_Response The response on success, or a WP_Error on failure.
+	 */
 	public function get( $request ) {
 		$method_id   = $request['id'];
 		$instance_id = isset( $request['instance'] ) ? $request['instance'] : false;
@@ -40,6 +64,15 @@ class WC_REST_Connect_Services_Controller extends WC_REST_Connect_Base_Controlle
 			return new WP_Error( 'schemas_not_found', __( 'Service schemas were not loaded', 'woocommerce-services' ), array( 'status' => 500 ) );
 		}
 
+		/**
+		 * Filters the shipping service settings payload returned for a service instance.
+		 *
+		 * @since 3.6.3
+		 *
+		 * @param array  $payload     The service settings payload.
+		 * @param string $method_id   The shipping method ID.
+		 * @param int    $instance_id The shipping method instance ID.
+		 */
 		$payload = apply_filters(
 			'wc_connect_shipping_service_settings',
 			array(
@@ -53,7 +86,10 @@ class WC_REST_Connect_Services_Controller extends WC_REST_Connect_Base_Controlle
 	}
 
 	/**
-	 * Attempts to update the settings on a particular service and instance
+	 * Attempts to update the settings on a particular service and instance.
+	 *
+	 * @param WP_REST_Request $request The REST request object.
+	 * @return WP_Error|WP_REST_Response The response on success, or a WP_Error on failure.
 	 */
 	public function post( $request ) {
 		$request_params = $request->get_params();
@@ -89,6 +125,7 @@ class WC_REST_Connect_Services_Controller extends WC_REST_Connect_Base_Controlle
 			$error = new WP_Error(
 				'validation_failed',
 				sprintf(
+					/* translators: %s: validation error message */
 					__( 'Unable to update service settings. Validation failed. %s', 'woocommerce-services' ),
 					$validation_result->get_error_message()
 				),
@@ -100,5 +137,4 @@ class WC_REST_Connect_Services_Controller extends WC_REST_Connect_Base_Controlle
 
 		return new WP_REST_Response( array( 'success' => true ), 200 );
 	}
-
 }

--- a/classes/class-wc-rest-connect-shipping-carrier-controller.php
+++ b/classes/class-wc-rest-connect-shipping-carrier-controller.php
@@ -29,5 +29,4 @@ class WC_REST_Connect_Shipping_Carrier_Controller extends WC_REST_Connect_Base_C
 		do_action( 'wc_connect_fetch_service_schemas' );
 		return $response;
 	}
-
 }

--- a/classes/class-wc-rest-connect-shipping-carriers-controller.php
+++ b/classes/class-wc-rest-connect-shipping-carriers-controller.php
@@ -8,9 +8,22 @@ if ( class_exists( 'WC_REST_Connect_Shipping_Carriers_Controller' ) ) {
 	return;
 }
 
+/**
+ * REST controller for retrieving the available shipping carriers.
+ */
 class WC_REST_Connect_Shipping_Carriers_Controller extends WC_REST_Connect_Base_Controller {
+	/**
+	 * The REST base for this controller.
+	 *
+	 * @var string
+	 */
 	protected $rest_base = 'connect/shipping/carriers';
 
+	/**
+	 * Retrieve all available shipping carriers.
+	 *
+	 * @return array|WP_Error The shipping carriers response, or a WP_Error on failure.
+	 */
 	public function get() {
 		$response = $this->api_client->get_all_shipping_carriers();
 		if ( is_wp_error( $response ) ) {

--- a/classes/class-wc-rest-connect-shipping-label-eligibility-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-eligibility-controller.php
@@ -8,6 +8,9 @@ if ( class_exists( 'WC_REST_Connect_Shipping_Label_Eligibility_Controller' ) ) {
 	return;
 }
 
+/**
+ * Handles the shipping label creation eligibility REST endpoint.
+ */
 class WC_REST_Connect_Shipping_Label_Eligibility_Controller extends WC_REST_Connect_Base_Controller {
 
 	/**
@@ -26,18 +29,36 @@ class WC_REST_Connect_Shipping_Label_Eligibility_Controller extends WC_REST_Conn
 
 
 	/**
+	 * The shipping label instance.
+	 *
 	 * @var WC_Connect_Shipping_Label
 	 */
 	protected $shipping_label;
 
 	/**
+	 * The payment methods store instance.
+	 *
 	 * @var WC_Connect_Payment_Methods_Store
 	 */
 	protected $payment_methods_store;
 
-
+	/**
+	 * Whether the plugin only provides tax functionality.
+	 *
+	 * @var bool
+	 */
 	protected $has_only_tax_functionality;
 
+	/**
+	 * Constructor.
+	 *
+	 * @param WC_Connect_API_Client             $api_client                 The API client instance.
+	 * @param WC_Connect_Service_Settings_Store $settings_store             The service settings store instance.
+	 * @param WC_Connect_Logger                 $logger                     The logger instance.
+	 * @param WC_Connect_Shipping_Label         $shipping_label             The shipping label instance.
+	 * @param WC_Connect_Payment_Methods_Store  $payment_methods_store      The payment methods store instance.
+	 * @param bool                              $has_only_tax_functionality Whether the plugin only provides tax functionality.
+	 */
 	public function __construct(
 		WC_Connect_API_Client $api_client,
 		WC_Connect_Service_Settings_Store $settings_store,
@@ -56,7 +77,7 @@ class WC_REST_Connect_Shipping_Label_Eligibility_Controller extends WC_REST_Conn
 	 * Register the routes for the shipping label eligibility.
 	 */
 	public function register_routes() {
-		// Accept request without order_id
+		// Accept request without order_id.
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base . '/creation_eligibility',
@@ -75,7 +96,7 @@ class WC_REST_Connect_Shipping_Label_Eligibility_Controller extends WC_REST_Conn
 			)
 		);
 
-		// Accept request with order_id
+		// Accept request with order_id.
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base . '/(?P<order_id>\d+)/creation_eligibility',
@@ -183,7 +204,7 @@ class WC_REST_Connect_Shipping_Label_Eligibility_Controller extends WC_REST_Conn
 					200
 				);
 			}
-		}
+		}//end if
 
 		// If the client cannot create a package (`can_create_package` param is set to `false`), a pre-existing package
 		// is required.

--- a/classes/class-wc-rest-connect-shipping-label-preview-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-preview-controller.php
@@ -36,5 +36,4 @@ class WC_REST_Connect_Shipping_Label_Preview_Controller extends WC_REST_Connect_
 		echo $raw_response['body']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		die();
 	}
-
 }

--- a/classes/class-wc-rest-connect-shipping-label-print-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-print-controller.php
@@ -65,5 +65,4 @@ class WC_REST_Connect_Shipping_Label_Print_Controller extends WC_REST_Connect_Ba
 			die();
 		}
 	}
-
 }

--- a/classes/class-wc-rest-connect-shipping-label-refund-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-refund-controller.php
@@ -44,5 +44,4 @@ class WC_REST_Connect_Shipping_Label_Refund_Controller extends WC_REST_Connect_B
 			'refund'  => $response->refund,
 		);
 	}
-
 }

--- a/classes/class-wc-rest-connect-shipping-rates-controller.php
+++ b/classes/class-wc-rest-connect-shipping-rates-controller.php
@@ -14,7 +14,7 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WC_REST_Connect_Base_Con
 	/**
 	 * Prefix to add in package name for making requests with multiple rates.
 	 */
-	public $SPECIAL_RATE_PREFIX = '_wcs_rate_type_';
+	public $special_rate_prefix = '_wcs_rate_type_';
 
 	/**
 	 * Array of extra options to collect rates for.
@@ -88,8 +88,8 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WC_REST_Connect_Base_Con
 	 * @return WPError|stdClass
 	 */
 	public function get_all_rates( $payload ) {
-		$signature_packages     = [];
-		$original_package_names = [];
+		$signature_packages     = array();
+		$original_package_names = array();
 
 		// Add extra package requests with special options set.
 		foreach ( $this->extra_rates as $rate_name => $rate_option ) {
@@ -99,7 +99,7 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WC_REST_Connect_Base_Con
 					$new_package                 = $package;
 					$new_package[ $option_name ] = $option_value;
 
-					$new_package['id']   .= $this->SPECIAL_RATE_PREFIX . $rate_name;
+					$new_package['id']   .= $this->special_rate_prefix . $rate_name;
 					$signature_packages[] = $new_package;
 				}
 			}
@@ -130,7 +130,7 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WC_REST_Connect_Base_Con
 	 * @return array Rates
 	 */
 	public function merge_all_rates( $rates, $original_package_names ) {
-		$parsed_rates = [];
+		$parsed_rates = array();
 
 		foreach ( $original_package_names as $name ) {
 			// Add a 'default' entry for the rate with no special options.
@@ -140,7 +140,7 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WC_REST_Connect_Base_Con
 
 			// Get package for each extra rate to group them under the original package name.
 			foreach ( $this->extra_rates as $extra_rate_name => $option ) {
-				$extra_rate_package_name = $name . $this->SPECIAL_RATE_PREFIX . $extra_rate_name;
+				$extra_rate_package_name = $name . $this->special_rate_prefix . $extra_rate_name;
 				if ( isset( $rates->{ $extra_rate_package_name } ) ) {
 					$parsed_rates[ $name ][ $extra_rate_name ] = $rates->{ $extra_rate_package_name };
 				}

--- a/classes/class-wc-rest-connect-subscriptions-controller.php
+++ b/classes/class-wc-rest-connect-subscriptions-controller.php
@@ -8,9 +8,22 @@ if ( class_exists( 'WC_REST_Connect_Subscriptions_Controller' ) ) {
 	return;
 }
 
+/**
+ * REST controller for retrieving the WooCommerce.com subscriptions.
+ */
 class WC_REST_Connect_Subscriptions_Controller extends WC_REST_Connect_Base_Controller {
+	/**
+	 * The REST base for this controller.
+	 *
+	 * @var string
+	 */
 	protected $rest_base = 'connect/subscriptions';
 
+	/**
+	 * Retrieve the WooCommerce.com subscriptions for the connected account.
+	 *
+	 * @return WP_REST_Response|WP_Error The subscriptions response, or a WP_Error on failure.
+	 */
 	public function post() {
 		$response = $this->api_client->get_wccom_subscriptions();
 		if ( is_wp_error( $response ) ) {

--- a/classes/class-wc-rest-connect-tos-controller.php
+++ b/classes/class-wc-rest-connect-tos-controller.php
@@ -8,10 +8,23 @@ if ( class_exists( 'WC_REST_Connect_Tos_Controller' ) ) {
 	return;
 }
 
+/**
+ * REST controller for reading and accepting the Terms of Service.
+ */
 class WC_REST_Connect_Tos_Controller extends WC_REST_Connect_Base_Controller {
 
+	/**
+	 * The REST base for this controller.
+	 *
+	 * @var string
+	 */
 	protected $rest_base = 'connect/tos';
 
+	/**
+	 * Get the current Terms of Service acceptance status.
+	 *
+	 * @return WP_REST_Response The response containing the acceptance status.
+	 */
 	public function get() {
 		return new WP_REST_Response(
 			array(
@@ -22,6 +35,12 @@ class WC_REST_Connect_Tos_Controller extends WC_REST_Connect_Base_Controller {
 		);
 	}
 
+	/**
+	 * Record acceptance of the Terms of Service.
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return WP_REST_Response|WP_Error The response containing the acceptance status, or an error.
+	 */
 	public function post( $request ) {
 		$settings = $request->get_json_params();
 
@@ -41,7 +60,10 @@ class WC_REST_Connect_Tos_Controller extends WC_REST_Connect_Base_Controller {
 	}
 
 	/**
-	 * Validate the requester's permissions
+	 * Validate the requester's permissions.
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return bool Whether the requester has permission.
 	 */
 	public function check_permission( $request ) {
 		return current_user_can( 'manage_woocommerce' ) &&

--- a/classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php
+++ b/classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php
@@ -75,7 +75,7 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 					'permission_callback' => array( $this, 'get_items_permissions_check' ),
 					'args'                => array(
 						'continent' => array(
-							'description' => __( '2 character continent code.', 'woocommerce-services' ),
+							'description' => __( '2 character continent code.', 'woocommerce' ),
 							'type'        => 'string',
 						),
 					),
@@ -115,7 +115,7 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 	public function get_item( $request ) {
 		$data = $this->continents->get_continent( strtoupper( $request['location'] ), $request );
 		if ( empty( $data ) ) {
-			return new WP_Error( 'woocommerce_rest_data_invalid_location', __( 'There are no locations matching these parameters.', 'woocommerce-services' ), array( 'status' => 404 ) );
+			return new WP_Error( 'woocommerce_rest_data_invalid_location', __( 'There are no locations matching these parameters.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 		return $this->prepare_item_for_response( $data, $request );
 	}
@@ -180,19 +180,19 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 			'properties' => array(
 				'code'      => array(
 					'type'        => 'string',
-					'description' => __( '2 character continent code.', 'woocommerce-services' ),
+					'description' => __( '2 character continent code.', 'woocommerce' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
 				'name'      => array(
 					'type'        => 'string',
-					'description' => __( 'Full name of continent.', 'woocommerce-services' ),
+					'description' => __( 'Full name of continent.', 'woocommerce' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
 				'countries' => array(
 					'type'        => 'array',
-					'description' => __( 'List of countries on this continent.', 'woocommerce-services' ),
+					'description' => __( 'List of countries on this continent.', 'woocommerce' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 					'items'       => array(
@@ -202,49 +202,49 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 						'properties' => array(
 							'code'           => array(
 								'type'        => 'string',
-								'description' => __( 'ISO3166 alpha-2 country code.', 'woocommerce-services' ),
+								'description' => __( 'ISO3166 alpha-2 country code.', 'woocommerce' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
 							'currency_code'  => array(
 								'type'        => 'string',
-								'description' => __( 'Default ISO4127 alpha-3 currency code for the country.', 'woocommerce-services' ),
+								'description' => __( 'Default ISO4127 alpha-3 currency code for the country.', 'woocommerce' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
 							'currency_pos'   => array(
 								'type'        => 'string',
-								'description' => __( 'Currency symbol position for this country.', 'woocommerce-services' ),
+								'description' => __( 'Currency symbol position for this country.', 'woocommerce' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
 							'decimal_sep'    => array(
 								'type'        => 'string',
-								'description' => __( 'Decimal separator for displayed prices for this country.', 'woocommerce-services' ),
+								'description' => __( 'Decimal separator for displayed prices for this country.', 'woocommerce' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
 							'dimension_unit' => array(
 								'type'        => 'string',
-								'description' => __( 'The unit lengths are defined in for this country.', 'woocommerce-services' ),
+								'description' => __( 'The unit lengths are defined in for this country.', 'woocommerce' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
 							'name'           => array(
 								'type'        => 'string',
-								'description' => __( 'Full name of country.', 'woocommerce-services' ),
+								'description' => __( 'Full name of country.', 'woocommerce' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
 							'num_decimals'   => array(
 								'type'        => 'integer',
-								'description' => __( 'Number of decimal points shown in displayed prices for this country.', 'woocommerce-services' ),
+								'description' => __( 'Number of decimal points shown in displayed prices for this country.', 'woocommerce' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
 							'states'         => array(
 								'type'        => 'array',
-								'description' => __( 'List of states in this country.', 'woocommerce-services' ),
+								'description' => __( 'List of states in this country.', 'woocommerce' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 								'items'       => array(
@@ -254,13 +254,13 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 									'properties' => array(
 										'code' => array(
 											'type'        => 'string',
-											'description' => __( 'State code.', 'woocommerce-services' ),
+											'description' => __( 'State code.', 'woocommerce' ),
 											'context'     => array( 'view' ),
 											'readonly'    => true,
 										),
 										'name' => array(
 											'type'        => 'string',
-											'description' => __( 'Full name of state.', 'woocommerce-services' ),
+											'description' => __( 'Full name of state.', 'woocommerce' ),
 											'context'     => array( 'view' ),
 											'readonly'    => true,
 										),
@@ -269,13 +269,13 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 							),
 							'thousand_sep'   => array(
 								'type'        => 'string',
-								'description' => __( 'Thousands separator for displayed prices in this country.', 'woocommerce-services' ),
+								'description' => __( 'Thousands separator for displayed prices in this country.', 'woocommerce' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
 							'weight_unit'    => array(
 								'type'        => 'string',
-								'description' => __( 'The unit weights are defined in for this country.', 'woocommerce-services' ),
+								'description' => __( 'The unit weights are defined in for this country.', 'woocommerce' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),

--- a/classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php
+++ b/classes/wc-api-dev/class-wc-rest-dev-data-continents-controller.php
@@ -75,7 +75,7 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 					'permission_callback' => array( $this, 'get_items_permissions_check' ),
 					'args'                => array(
 						'continent' => array(
-							'description' => __( '2 character continent code.', 'woocommerce' ),
+							'description' => __( '2 character continent code.', 'woocommerce-services' ),
 							'type'        => 'string',
 						),
 					),
@@ -115,7 +115,7 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 	public function get_item( $request ) {
 		$data = $this->continents->get_continent( strtoupper( $request['location'] ), $request );
 		if ( empty( $data ) ) {
-			return new WP_Error( 'woocommerce_rest_data_invalid_location', __( 'There are no locations matching these parameters.', 'woocommerce' ), array( 'status' => 404 ) );
+			return new WP_Error( 'woocommerce_rest_data_invalid_location', __( 'There are no locations matching these parameters.', 'woocommerce-services' ), array( 'status' => 404 ) );
 		}
 		return $this->prepare_item_for_response( $data, $request );
 	}
@@ -180,19 +180,19 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 			'properties' => array(
 				'code'      => array(
 					'type'        => 'string',
-					'description' => __( '2 character continent code.', 'woocommerce' ),
+					'description' => __( '2 character continent code.', 'woocommerce-services' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
 				'name'      => array(
 					'type'        => 'string',
-					'description' => __( 'Full name of continent.', 'woocommerce' ),
+					'description' => __( 'Full name of continent.', 'woocommerce-services' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
 				'countries' => array(
 					'type'        => 'array',
-					'description' => __( 'List of countries on this continent.', 'woocommerce' ),
+					'description' => __( 'List of countries on this continent.', 'woocommerce-services' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 					'items'       => array(
@@ -202,49 +202,49 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 						'properties' => array(
 							'code'           => array(
 								'type'        => 'string',
-								'description' => __( 'ISO3166 alpha-2 country code.', 'woocommerce' ),
+								'description' => __( 'ISO3166 alpha-2 country code.', 'woocommerce-services' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
 							'currency_code'  => array(
 								'type'        => 'string',
-								'description' => __( 'Default ISO4127 alpha-3 currency code for the country.', 'woocommerce' ),
+								'description' => __( 'Default ISO4127 alpha-3 currency code for the country.', 'woocommerce-services' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
 							'currency_pos'   => array(
 								'type'        => 'string',
-								'description' => __( 'Currency symbol position for this country.', 'woocommerce' ),
+								'description' => __( 'Currency symbol position for this country.', 'woocommerce-services' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
 							'decimal_sep'    => array(
 								'type'        => 'string',
-								'description' => __( 'Decimal separator for displayed prices for this country.', 'woocommerce' ),
+								'description' => __( 'Decimal separator for displayed prices for this country.', 'woocommerce-services' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
 							'dimension_unit' => array(
 								'type'        => 'string',
-								'description' => __( 'The unit lengths are defined in for this country.', 'woocommerce' ),
+								'description' => __( 'The unit lengths are defined in for this country.', 'woocommerce-services' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
 							'name'           => array(
 								'type'        => 'string',
-								'description' => __( 'Full name of country.', 'woocommerce' ),
+								'description' => __( 'Full name of country.', 'woocommerce-services' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
 							'num_decimals'   => array(
 								'type'        => 'integer',
-								'description' => __( 'Number of decimal points shown in displayed prices for this country.', 'woocommerce' ),
+								'description' => __( 'Number of decimal points shown in displayed prices for this country.', 'woocommerce-services' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
 							'states'         => array(
 								'type'        => 'array',
-								'description' => __( 'List of states in this country.', 'woocommerce' ),
+								'description' => __( 'List of states in this country.', 'woocommerce-services' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 								'items'       => array(
@@ -254,13 +254,13 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 									'properties' => array(
 										'code' => array(
 											'type'        => 'string',
-											'description' => __( 'State code.', 'woocommerce' ),
+											'description' => __( 'State code.', 'woocommerce-services' ),
 											'context'     => array( 'view' ),
 											'readonly'    => true,
 										),
 										'name' => array(
 											'type'        => 'string',
-											'description' => __( 'Full name of state.', 'woocommerce' ),
+											'description' => __( 'Full name of state.', 'woocommerce-services' ),
 											'context'     => array( 'view' ),
 											'readonly'    => true,
 										),
@@ -269,13 +269,13 @@ class WC_REST_Dev_Data_Continents_Controller extends WC_REST_Dev_Data_Controller
 							),
 							'thousand_sep'   => array(
 								'type'        => 'string',
-								'description' => __( 'Thousands separator for displayed prices in this country.', 'woocommerce' ),
+								'description' => __( 'Thousands separator for displayed prices in this country.', 'woocommerce-services' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),
 							'weight_unit'    => array(
 								'type'        => 'string',
-								'description' => __( 'The unit weights are defined in for this country.', 'woocommerce' ),
+								'description' => __( 'The unit weights are defined in for this country.', 'woocommerce-services' ),
 								'context'     => array( 'view' ),
 								'readonly'    => true,
 							),

--- a/classes/wc-api-dev/class-wc-rest-dev-data-controller.php
+++ b/classes/wc-api-dev/class-wc-rest-dev-data-controller.php
@@ -66,7 +66,7 @@ class WC_REST_Dev_Data_Controller extends WC_REST_Controller {
 	 */
 	public function get_items_permissions_check( $request ) {
 		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
-			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce-services' ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -80,7 +80,7 @@ class WC_REST_Dev_Data_Controller extends WC_REST_Controller {
 	 */
 	public function get_item_permissions_check( $request ) {
 		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
-			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce-services' ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -98,15 +98,15 @@ class WC_REST_Dev_Data_Controller extends WC_REST_Controller {
 		$resources = array(
 			array(
 				'slug'        => 'continents',
-				'description' => __( 'List of supported continents, countries, and states.', 'woocommerce-services' ),
+				'description' => __( 'List of supported continents, countries, and states.', 'woocommerce' ),
 			),
 			array(
 				'slug'        => 'countries',
-				'description' => __( 'List of supported states in a given country.', 'woocommerce-services' ),
+				'description' => __( 'List of supported states in a given country.', 'woocommerce' ),
 			),
 			array(
 				'slug'        => 'currencies',
-				'description' => __( 'List of supported currencies.', 'woocommerce-services' ),
+				'description' => __( 'List of supported currencies.', 'woocommerce' ),
 			),
 		);
 
@@ -173,13 +173,13 @@ class WC_REST_Dev_Data_Controller extends WC_REST_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'slug'        => array(
-					'description' => __( 'Data resource ID.', 'woocommerce-services' ),
+					'description' => __( 'Data resource ID.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
 				'description' => array(
-					'description' => __( 'Data resource description.', 'woocommerce-services' ),
+					'description' => __( 'Data resource description.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view' ),
 					'readonly'    => true,

--- a/classes/wc-api-dev/class-wc-rest-dev-data-controller.php
+++ b/classes/wc-api-dev/class-wc-rest-dev-data-controller.php
@@ -66,7 +66,7 @@ class WC_REST_Dev_Data_Controller extends WC_REST_Controller {
 	 */
 	public function get_items_permissions_check( $request ) {
 		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
-			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce-services' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -80,7 +80,7 @@ class WC_REST_Dev_Data_Controller extends WC_REST_Controller {
 	 */
 	public function get_item_permissions_check( $request ) {
 		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
-			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce-services' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -98,15 +98,15 @@ class WC_REST_Dev_Data_Controller extends WC_REST_Controller {
 		$resources = array(
 			array(
 				'slug'        => 'continents',
-				'description' => __( 'List of supported continents, countries, and states.', 'woocommerce' ),
+				'description' => __( 'List of supported continents, countries, and states.', 'woocommerce-services' ),
 			),
 			array(
 				'slug'        => 'countries',
-				'description' => __( 'List of supported states in a given country.', 'woocommerce' ),
+				'description' => __( 'List of supported states in a given country.', 'woocommerce-services' ),
 			),
 			array(
 				'slug'        => 'currencies',
-				'description' => __( 'List of supported currencies.', 'woocommerce' ),
+				'description' => __( 'List of supported currencies.', 'woocommerce-services' ),
 			),
 		);
 
@@ -173,13 +173,13 @@ class WC_REST_Dev_Data_Controller extends WC_REST_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'slug'        => array(
-					'description' => __( 'Data resource ID.', 'woocommerce' ),
+					'description' => __( 'Data resource ID.', 'woocommerce-services' ),
 					'type'        => 'string',
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
 				'description' => array(
-					'description' => __( 'Data resource description.', 'woocommerce' ),
+					'description' => __( 'Data resource description.', 'woocommerce-services' ),
 					'type'        => 'string',
 					'context'     => array( 'view' ),
 					'readonly'    => true,

--- a/composer.json
+++ b/composer.json
@@ -37,20 +37,23 @@
 		}
 	},
 	"scripts": {
-		"check-all": [
-			"./vendor/bin/phpcs . --ignore=vendor,.git,assets,node_modules,dist,docker,release,bin,wp-calypso --standard=WooCommerce-Core,WordPress-Core,WordPress-Extra,WordPress-Docs  --report-full --report-summary --colors"
+		"check-security": [
+			"./vendor/bin/phpcs --standard=./.phpcs.security.xml --report-full --report-summary -s"
 		],
-		"check-all:fix": [
-			"./vendor/bin/phpcbf . --ignore=vendor,.git,assets,node_modules,dist,docker,release,bin,wp-calypso --standard=WooCommerce-Core,WordPress-Core,WordPress-Extra,WordPress-Docs  --report-full --report-summary --colors"
+		"check-l18n": [
+			"./vendor/bin/phpcs --standard=./.phpcs.l18n.xml --report-full --report-summary -s"
 		],
 		"check-php": [
-			"./vendor/bin/phpcs . --ignore=vendor,.git,assets,node_modules,dist,docker,release,bin,wp-calypso --standard=WooCommerce-Core,WordPress-Core,WordPress-Extra  --report-full --report-summary --colors"
+			"./vendor/bin/phpcs --standard=./.phpcs.php.xml --report-full --report-summary -s"
 		],
 		"check-php:fix": [
-			"./vendor/bin/phpcbf . --ignore=vendor,.git,assets,node_modules,dist,docker,release,bin,wp-calypso --standard=WooCommerce-Core,WordPress-Core,WordPress-Extra  --report-full --report-summary --colors"
+			"./vendor/bin/phpcbf --standard=./.phpcs.php.xml --report-full --report-summary"
 		],
-		"check-security": [
-			"./vendor/bin/phpcs . --ignore=vendor,.git,assets,node_modules,dist,docker,release,bin,wp-calypso --standard=./.phpcs.security.xml  --report-full --report-summary"
+		"check-all": [
+			"./vendor/bin/phpcs --standard=./phpcs.xml.dist --report-full --report-summary -s"
+		],
+		"check-all:fix": [
+			"./vendor/bin/phpcbf --standard=./phpcs.xml.dist --report-full --report-summary"
 		],
 		"phpcbf": [
 			"./vendor/bin/phpcbf . -p --ignore=vendor,.git,assets,node_modules,dist,docker,release,bin,wp-calypso --standard=WooCommerce-Core,WordPress-Core,WordPress-Extra "

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,50 +1,8 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress Coding Standards">
-	<!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress-Core/ruleset.xml -->
+<ruleset name="WooCommerce Shipping &amp; Tax">
+	<description>WooCommerce Shipping &amp; Tax dev PHP_CodeSniffer ruleset. Aggregator: imports the three concern-specific rulesets so `composer run check-all` runs them together.</description>
 
-	<description>WooCommerce dev PHP_CodeSniffer ruleset.</description>
-
-	<!-- Exclude paths -->
-	<exclude-pattern>*/node_modules/*</exclude-pattern>
-	<exclude-pattern>*/vendor/*</exclude-pattern>
-	<exclude-pattern>bin/*</exclude-pattern>
-	<exclude-pattern>docker/*</exclude-pattern>
-	<exclude-pattern>wp-calypso/*</exclude-pattern>
-
-	<!-- Configs -->
-	<config name="minimum_supported_wp_version" value="6.7" />
-	<config name="testVersion" value="7.4-"/>
-
-	<!-- Rules -->
-	<rule ref="WooCommerce-Core" />
-
-	<rule ref="WordPress.WP.I18n">
-		<properties>
-			<property name="text_domain" type="array">
-				<element value="woocommerce-services" />
-			</property>
-		</properties>
-	</rule>
-
-	<rule ref="PHPCompatibility">
-		<exclude-pattern>tests/</exclude-pattern>
-	</rule>
-
-	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
-		<exclude-pattern>tests/*</exclude-pattern>
-		<exclude-pattern>woocommerce-services.php</exclude-pattern>
-	</rule>
-
-	<rule ref="Generic.Commenting">
-		<exclude-pattern>tests/</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.FileComment.MissingPackageTag">
-		<exclude-pattern>classes/</exclude-pattern>
-		<exclude-pattern>tests/</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.FileComment.Missing">
-		<exclude-pattern>classes/</exclude-pattern>
-		<exclude-pattern>tests/</exclude-pattern>
-	</rule>
+	<rule ref="./.phpcs.php.xml"/>
+	<rule ref="./.phpcs.l18n.xml"/>
+	<rule ref="./.phpcs.security.xml"/>
 </ruleset>

--- a/src/Integrations/WooCommerceBlocksIntegration.php
+++ b/src/Integrations/WooCommerceBlocksIntegration.php
@@ -25,6 +25,11 @@ class WooCommerceBlocksIntegration implements IntegrationInterface {
 	 */
 	private string $base_url;
 
+	/**
+	 * Constructor.
+	 *
+	 * @param string $wc_connect_base_url The base URL to use for loading assets.
+	 */
 	public function __construct( string $wc_connect_base_url ) {
 		$this->base_url = $wc_connect_base_url;
 	}
@@ -91,13 +96,14 @@ class WooCommerceBlocksIntegration implements IntegrationInterface {
 	 * @param string $handle Script handle.
 	 */
 	protected function register_script( string $handle ) {
-		$plugin_version      = Utils::get_wcservices_version();
-		$script_name         = "$handle-$plugin_version.js";
-		$script_path         = $this->base_url . $script_name;
-		$script_url          = Utils::get_enqueue_base_url() . $script_name;
-		$script_asset_path   = $this->base_url . $handle . '.asset.php';
-		$script_asset        = file_exists( $script_asset_path )
-			? require $script_asset_path : array();  // nosemgrep: audit.php.lang.security.file.inclusion-arg --- This is a safe file inclusion.
+		$plugin_version    = Utils::get_wcservices_version();
+		$script_name       = "$handle-$plugin_version.js";
+		$script_path       = $this->base_url . $script_name;
+		$script_url        = Utils::get_enqueue_base_url() . $script_name;
+		$script_asset_path = $this->base_url . $handle . '.asset.php';
+		$script_asset      = file_exists( $script_asset_path )
+			? require $script_asset_path : array();
+		// nosemgrep: audit.php.lang.security.file.inclusion-arg --- This is a safe file inclusion.
 		$script_dependencies = $script_asset['dependencies'] ?? array();
 
 		wp_register_script(

--- a/src/StoreApi/Extensions/StoreNoticesExtension.php
+++ b/src/StoreApi/Extensions/StoreNoticesExtension.php
@@ -76,7 +76,7 @@ class StoreNoticesExtension extends AbstractStoreApiExtension {
 
 				$data['notices'][] = $notice->to_array();
 			}
-		}
+		}//end foreach
 
 		return $data;
 	}

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -40,7 +40,7 @@ require_once $wp_tests_dir . '/includes/functions.php';
  * @return void
  */
 function _manually_load_plugin() {
-	require dirname( __FILE__ ) . '/../../woocommerce-services.php';
+	require __DIR__ . '/../../woocommerce-services.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/php/class-wc-connect-api-client-local-test-mock.php
+++ b/tests/php/class-wc-connect-api-client-local-test-mock.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! class_exists( 'WC_Connect_API_Client_Local_Test_Mock' ) ) {
-	require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client.php';
+	require_once __DIR__ . '/../../classes/class-wc-connect-api-client.php';
 
 	class WC_Connect_API_Client_Local_Test_Mock extends WC_Connect_API_Client {
 

--- a/tests/php/classes/test-class-wc-rest-connect-packages-controller.php
+++ b/tests/php/classes/test-class-wc-rest-connect-packages-controller.php
@@ -21,13 +21,13 @@ class WP_Test_WC_REST_Connect_Packages_Controller extends WC_REST_Unit_Test_Case
 	 * @inherit
 	 */
 	public static function set_up_before_class() {
-		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-api-client-live.php';
-		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-service-settings-store.php';
-		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-logger.php';
-		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-service-schemas-store.php';
-		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-package-settings.php';
-		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-rest-connect-base-controller.php';
-		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-rest-connect-packages-controller.php';
+		require_once __DIR__ . '/../../../classes/class-wc-connect-api-client-live.php';
+		require_once __DIR__ . '/../../../classes/class-wc-connect-service-settings-store.php';
+		require_once __DIR__ . '/../../../classes/class-wc-connect-logger.php';
+		require_once __DIR__ . '/../../../classes/class-wc-connect-service-schemas-store.php';
+		require_once __DIR__ . '/../../../classes/class-wc-connect-package-settings.php';
+		require_once __DIR__ . '/../../../classes/class-wc-rest-connect-base-controller.php';
+		require_once __DIR__ . '/../../../classes/class-wc-rest-connect-packages-controller.php';
 	}
 
 	/**

--- a/tests/php/classes/test-class-wc-rest-connect-shipping-carrier-types-controller.php
+++ b/tests/php/classes/test-class-wc-rest-connect-shipping-carrier-types-controller.php
@@ -20,11 +20,11 @@ class WP_Test_WC_REST_Connect_Shipping_Carrier_Types_Controller extends WC_Unit_
 	 * @inherit
 	 */
 	public static function set_up_before_class() {
-		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-api-client-live.php';
-		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-service-settings-store.php';
-		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-logger.php';
-		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-rest-connect-base-controller.php';
-		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-rest-connect-shipping-carrier-types-controller.php';
+		require_once __DIR__ . '/../../../classes/class-wc-connect-api-client-live.php';
+		require_once __DIR__ . '/../../../classes/class-wc-connect-service-settings-store.php';
+		require_once __DIR__ . '/../../../classes/class-wc-connect-logger.php';
+		require_once __DIR__ . '/../../../classes/class-wc-rest-connect-base-controller.php';
+		require_once __DIR__ . '/../../../classes/class-wc-rest-connect-shipping-carrier-types-controller.php';
 	}
 
 	/**
@@ -36,7 +36,7 @@ class WP_Test_WC_REST_Connect_Shipping_Carrier_Types_Controller extends WC_Unit_
 		// Creating a mock class and overide protected request method so that we can mock the API response.
 		$this->api_client_mock = $this->getMockBuilder( WC_Connect_API_Client_Live::class )
 			->disableOriginalConstructor()
-			->setMethods( [ 'request' ] )
+			->setMethods( array( 'request' ) )
 			->getMock();
 
 		$this->setting_store_mock  = $this->createMock( WC_Connect_Service_Settings_Store::class );
@@ -57,10 +57,10 @@ class WP_Test_WC_REST_Connect_Shipping_Carrier_Types_Controller extends WC_Unit_
 
 		$wc_connect_shipping_carrier_types_controller = new WC_REST_Connect_Shipping_Carrier_Types_Controller( $this->api_client_mock, $this->setting_store_mock, $this->connect_logger_mock );
 		$actual                                       = $wc_connect_shipping_carrier_types_controller->get();
-		$expected                                     = [
+		$expected                                     = array(
 			'success'  => true,
 			'carriers' => $api_client_response->carriers,
-		];
+		);
 
 		$this->assertEquals( 200, $actual->status );
 		$this->assertEquals( $expected, $actual->data );

--- a/tests/php/classes/test-class-wc-rest-connect-subscriptions-controller.php
+++ b/tests/php/classes/test-class-wc-rest-connect-subscriptions-controller.php
@@ -20,11 +20,11 @@ class WP_Test_WC_REST_Connect_Subscriptions_Controller extends WC_Unit_Test_Case
 	 * @inherit
 	 */
 	public static function set_up_before_class() {
-		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-api-client-live.php';
-		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-service-settings-store.php';
-		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-connect-logger.php';
-		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-rest-connect-base-controller.php';
-		require_once dirname( __FILE__ ) . '/../../../classes/class-wc-rest-connect-subscriptions-controller.php';
+		require_once __DIR__ . '/../../../classes/class-wc-connect-api-client-live.php';
+		require_once __DIR__ . '/../../../classes/class-wc-connect-service-settings-store.php';
+		require_once __DIR__ . '/../../../classes/class-wc-connect-logger.php';
+		require_once __DIR__ . '/../../../classes/class-wc-rest-connect-base-controller.php';
+		require_once __DIR__ . '/../../../classes/class-wc-rest-connect-subscriptions-controller.php';
 	}
 
 	/**
@@ -36,7 +36,7 @@ class WP_Test_WC_REST_Connect_Subscriptions_Controller extends WC_Unit_Test_Case
 		// Creating a mock class and overide protected request method so that we can mock the API response.
 		$this->api_client_mock = $this->getMockBuilder( WC_Connect_API_Client_Live::class )
 			->disableOriginalConstructor()
-			->setMethods( [ 'request' ] )
+			->setMethods( array( 'request' ) )
 			->getMock();
 
 		$this->setting_store_mock  = $this->createMock( WC_Connect_Service_Settings_Store::class );
@@ -118,10 +118,10 @@ class WP_Test_WC_REST_Connect_Subscriptions_Controller extends WC_Unit_Test_Case
 		$actual                              = $wc_connect_subscriptions_controller->post();
 		$expected                            = $api_client_response->subscriptions;
 
-		$expected = [
+		$expected = array(
 			'success'       => true,
 			'subscriptions' => $api_client_response->subscriptions,
-		];
+		);
 
 		$this->assertEquals( 200, $actual->status );
 		$this->assertEquals( $expected, $actual->data );

--- a/tests/php/test-class-wc-connect-service-settings-store.php
+++ b/tests/php/test-class-wc-connect-service-settings-store.php
@@ -41,11 +41,11 @@ class WP_Test_WC_Connect_Service_Settings_Store extends WC_Unit_Test_Case {
 	protected $order_id;
 
 	public static function set_up_before_class() {
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-service-settings-store.php';
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client.php';
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client-live.php';
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-service-schemas-store.php';
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-logger.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-service-settings-store.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-api-client.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-api-client-live.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-service-schemas-store.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-logger.php';
 	}
 
 	private function get_settings_store( $service_schemas_store = false, $api_client = false, $logger = false ) {

--- a/tests/php/test-class-wc-connect-shipping-label.php
+++ b/tests/php/test-class-wc-connect-shipping-label.php
@@ -153,16 +153,16 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 	);
 
 	public static function set_up_before_class() {
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-compatibility.php';
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-shipping-label.php';
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-service-settings-store.php';
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client.php';
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-api-client-live.php';
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-service-schemas-store.php';
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-payment-methods-store.php';
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-account-settings.php';
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-package-settings.php';
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-continents.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-compatibility.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-shipping-label.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-service-settings-store.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-api-client.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-api-client-live.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-service-schemas-store.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-payment-methods-store.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-account-settings.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-package-settings.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-continents.php';
 
 		WC_Connect_Compatibility::set_version( '3.0.0' );
 	}
@@ -170,9 +170,9 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 	private function get_shipping_label( $api_client = false, $settings_store = false, $service_schemas_store = false, $payment_methods_store = false ) {
 		if ( ! $settings_store ) {
 			$settings_store = $this->getMockBuilder( 'WC_Connect_Service_Settings_Store' )
-				 ->disableOriginalConstructor()
-				 ->setMethods( null )
-				 ->getMock();
+				->disableOriginalConstructor()
+				->setMethods( null )
+				->getMock();
 		}
 
 		if ( ! $api_client ) {
@@ -668,12 +668,18 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 
 	public function test_shipment_for_items_with_big_quantity_is_capped() {
 
-		add_filter( 'wc_connect_shipment_item_quantity_threshold', function (){
-			return 20;
-		} );
-		add_filter( 'wc_connect_max_shipments_if_quantity_exceeds_threshold', function (){
-			return 5;
-		} );
+		add_filter(
+			'wc_connect_shipment_item_quantity_threshold',
+			function () {
+				return 20;
+			}
+		);
+		add_filter(
+			'wc_connect_max_shipments_if_quantity_exceeds_threshold',
+			function () {
+				return 5;
+			}
+		);
 
 		$product_A = $this->create_simple_product();
 		$product_A->save();
@@ -691,15 +697,17 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		$order->add_product( $product_B, 19 );
 		$order->save();
 
-		$shipping_label  = $this->get_shipping_label();
-		$all_items       = $shipping_label->get_all_items( $order );
+		$shipping_label = $this->get_shipping_label();
+		$all_items      = $shipping_label->get_all_items( $order );
 
 		$all_items_of_product_A_type = array_values(
-				array_filter( $all_items, function ($item) use($product_A) {
+			array_filter(
+				$all_items,
+				function ( $item ) use ( $product_A ) {
 					return $item['product_id'] === $product_A->get_id();
-				})
+				}
+			)
 		);
-
 
 		/**
 		 * An item with quantity = 32 would yield 5 shipments all having 6 quantity and  the last shipment having 8.
@@ -712,16 +720,19 @@ class WP_Test_WC_Connect_Shipping_Label extends WC_Unit_Test_Case {
 		$this->assertEquals( 8, $all_items_of_product_A_type[4]['quantity'] );
 
 		$all_items_of_product_B_type = array_values(
-			array_filter( $all_items, function ($item) use( $product_B ) {
-				return $item['product_id'] === $product_B->get_id();
-			})
+			array_filter(
+				$all_items,
+				function ( $item ) use ( $product_B ) {
+					return $item['product_id'] === $product_B->get_id();
+				}
+			)
 		);
 
 		/**
 		 * Everything remains like before for the order item with quantity NOT exceeding the threshold
 		 * e.g. each split will have quantity = 1, and we'll 19 splits.
 		 */
-		$this->assertEquals(19, count( $all_items_of_product_B_type ) );
+		$this->assertEquals( 19, count( $all_items_of_product_B_type ) );
 		foreach ( $all_items_of_product_B_type as $item ) {
 			$this->assertEquals( 1, $item['quantity'] );
 		}

--- a/tests/php/test-class-wc-connect-shipping-method.php
+++ b/tests/php/test-class-wc-connect-shipping-method.php
@@ -2,7 +2,7 @@
 
 class WP_Test_WC_Connect_Shipping_Method extends WP_UnitTestCase {
 
-	static function set_up_before_class() {
+	public static function set_up_before_class() {
 		require_once __DIR__ . '/../../classes/class-wc-connect-shipping-method.php';
 		require_once __DIR__ . '/../../classes/class-wc-connect-cart-validation.php';
 	}
@@ -110,7 +110,6 @@ class WP_Test_WC_Connect_Shipping_Method extends WP_UnitTestCase {
 				true,
 			),
 		);
-
 	}
 
 	/**
@@ -122,7 +121,6 @@ class WP_Test_WC_Connect_Shipping_Method extends WP_UnitTestCase {
 		$shipping_method = new WC_Connect_Shipping_Method();
 
 		$this->assertEquals( $expected, $shipping_method->is_valid_package_destination( $package ) );
-
 	}
 
 	/**
@@ -151,7 +149,6 @@ class WP_Test_WC_Connect_Shipping_Method extends WP_UnitTestCase {
 			);
 
 		$shipping_method->calculate_shipping();
-
 	}
 
 	/**
@@ -245,7 +242,5 @@ class WP_Test_WC_Connect_Shipping_Method extends WP_UnitTestCase {
 		$this->assertTrue( $empty_method->is_available( $fully_valid ) );
 		$this->assertTrue( $empty_method->is_available( $partially_valid ) );
 		$this->assertTrue( $empty_method->is_available( $fully_invalid ) );
-
 	}
-
 }

--- a/tests/php/test-class_wc-connect-nux.php
+++ b/tests/php/test-class_wc-connect-nux.php
@@ -3,7 +3,7 @@
 class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 
 	public static function set_up_before_class() {
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-nux.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-nux.php';
 	}
 
 	public function test_get_banner_type_to_display_dev_jp() {

--- a/tests/php/test-wc-connect-services-validator.php
+++ b/tests/php/test-wc-connect-services-validator.php
@@ -37,7 +37,6 @@ class WP_Test_WC_Connect_Service_Schemas_Validator extends WC_Unit_Test_Case {
 			),
 			'boxes'    => new stdClass(),
 		);
-
 	}
 
 	public function set_up() {
@@ -52,13 +51,11 @@ class WP_Test_WC_Connect_Service_Schemas_Validator extends WC_Unit_Test_Case {
 		if ( ! is_a( $this->validator, 'WC_Connect_Service_Schemas_Validator' ) ) {
 			$this->validator = new WC_Connect_Service_Schemas_Validator();
 		}
-
 	}
 
 	public function test_class_exists() {
 
 		$this->assertTrue( class_exists( 'WC_Connect_Service_Schemas_Validator' ) );
-
 	}
 
 	public function validate_services_errors_provider() {
@@ -156,7 +153,6 @@ class WP_Test_WC_Connect_Service_Schemas_Validator extends WC_Unit_Test_Case {
 			'service settings properties should have title' => array( $service_settings_title_required, 'service_properties_missing_required_property' ),
 			'boxes should be an object'                    => array( $service_settings_boxes_required, 'boxes_not_object' ),
 		);
-
 	}
 
 	/**
@@ -169,7 +165,6 @@ class WP_Test_WC_Connect_Service_Schemas_Validator extends WC_Unit_Test_Case {
 
 		$this->assertWPError( $result );
 		$this->assertEquals( $expected, $result->get_error_code() );
-
 	}
 
 	/**
@@ -182,7 +177,5 @@ class WP_Test_WC_Connect_Service_Schemas_Validator extends WC_Unit_Test_Case {
 
 		$this->assertNotWPError( $result );
 		$this->assertTrue( $result );
-
 	}
-
 }

--- a/tests/php/test-woocommerce-connect-client.php
+++ b/tests/php/test-woocommerce-connect-client.php
@@ -86,7 +86,6 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 	public function test_class_exists() {
 
 		$this->assertTrue( class_exists( 'WC_Connect_Loader' ) );
-
 	}
 
 	/**
@@ -104,7 +103,6 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 
 		$attached = has_action( 'before_woocommerce_init', array( $loader, 'pre_wc_init' ) );
 		$this->assertNotFalse( $attached, 'WC_Connect_Loader::pre_wc_init() not attached to `before_woocommerce_init`.' );
-
 	}
 
 	/**
@@ -121,7 +119,6 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 		$loader->set_logger( $logger );
 
 		$this->assertEquals( $logger, $loader->get_logger() );
-
 	}
 
 	/**
@@ -138,7 +135,6 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 		$loader->set_api_client( $client );
 
 		$this->assertEquals( $client, $loader->get_api_client() );
-
 	}
 
 	/**
@@ -156,7 +152,6 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 		$loader->set_service_schemas_store( $store );
 
 		$this->assertEquals( $store, $loader->get_service_schemas_store() );
-
 	}
 
 	/**
@@ -173,7 +168,6 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 		$loader->set_service_schemas_validator( $validator );
 
 		$this->assertEquals( $validator, $loader->get_service_schemas_validator() );
-
 	}
 
 	/**
@@ -218,7 +212,6 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 		$this->assertEquals( $loader->get_logger(), $method->get_logger() );
 		$this->assertEquals( $loader->get_api_client(), $method->get_api_client() );
 		$this->assertEquals( $service_data, $method->get_service_schema() );
-
 	}
 
 	/**
@@ -229,7 +222,6 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 
 		$this->assertTrue( $loader->is_wc_connect_shipping_service( 'test_method_that_is_from_wc_connect' ) );
 		$this->assertFalse( $loader->is_wc_connect_shipping_service( 'test_method_that_is_not_from_wc_connect' ) );
-
 	}
 
 	/**
@@ -246,5 +238,4 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 		$loader->shipping_zone_method_added( 3, 'test_method_that_is_from_wc_connect', 2 );
 		$this->assertEquals( 2, did_action( 'wc_connect_shipping_zone_method_added' ) );
 	}
-
 }

--- a/tests/php/test-woocommerce-connect-tracks.php
+++ b/tests/php/test-woocommerce-connect-tracks.php
@@ -7,16 +7,16 @@ class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 	protected $jetpack_tracker;
 
 	public static function set_up_before_class() {
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-options.php';
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-tracks.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-options.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-tracks.php';
 	}
 
 	public function set_up() {
 		$this->jetpack_tracker = $this->createMock( Automattic\Jetpack\Tracking::class );
 		$this->logger          = $this->getMockBuilder( 'WC_Connect_Logger' )
-									  ->disableOriginalConstructor()
-									  ->setMethods( array( 'log' ) )
-									  ->getMock();
+										->disableOriginalConstructor()
+										->setMethods( array( 'log' ) )
+										->getMock();
 
 		$this->tracks = new WC_Connect_Tracks( $this->logger, __FILE__ );
 		$this->tracks->init();
@@ -24,7 +24,7 @@ class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 
 	public function test_record_user_event() {
 		$this->logger->expects( $this->once() )
-					 ->method( 'log' )
+					->method( 'log' )
 					->with(
 						$this->stringContains( 'woocommerceconnect_test' )
 					);
@@ -37,20 +37,20 @@ class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 			),
 			$this->callback(
 				function ( $argument ) {
-					return $argument === 'woocommerceconnect_test';
+					return 'woocommerceconnect_test' === $argument;
 				}
 			),
 			$this->callback(
 				function ( $argument ) {
 					return is_array( $argument ) &&
-					  isset( $argument['_via_ua'] ) &&
-					  isset( $argument['_via_ip'] ) &&
-					  isset( $argument['_lg'] ) &&
-					  isset( $argument['blog_url'] ) &&
-					  isset( $argument['blog_id'] ) &&
-					  isset( $argument['jetpack_version'] ) &&
-					  isset( $argument['wc_version'] ) &&
-					  isset( $argument['wp_version'] );
+						isset( $argument['_via_ua'] ) &&
+						isset( $argument['_via_ip'] ) &&
+						isset( $argument['_lg'] ) &&
+						isset( $argument['blog_url'] ) &&
+						isset( $argument['blog_id'] ) &&
+						isset( $argument['jetpack_version'] ) &&
+						isset( $argument['wc_version'] ) &&
+						isset( $argument['wp_version'] );
 				}
 			)
 		);
@@ -60,7 +60,7 @@ class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 
 	public function test_opted_in() {
 		$this->logger->expects( $this->once() )
-					 ->method( 'log' )
+					->method( 'log' )
 					->with(
 						$this->stringContains( 'woocommerceconnect_opted_in' )
 					);
@@ -73,20 +73,20 @@ class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 			),
 			$this->callback(
 				function ( $argument ) {
-					return $argument === 'woocommerceconnect_opted_in';
+					return 'woocommerceconnect_opted_in' === $argument;
 				}
 			),
 			$this->callback(
 				function ( $argument ) {
 					return is_array( $argument ) &&
-					  isset( $argument['_via_ua'] ) &&
-					  isset( $argument['_via_ip'] ) &&
-					  isset( $argument['_lg'] ) &&
-					  isset( $argument['blog_url'] ) &&
-					  isset( $argument['blog_id'] ) &&
-					  isset( $argument['jetpack_version'] ) &&
-					  isset( $argument['wc_version'] ) &&
-					  isset( $argument['wp_version'] );
+						isset( $argument['_via_ua'] ) &&
+						isset( $argument['_via_ip'] ) &&
+						isset( $argument['_lg'] ) &&
+						isset( $argument['blog_url'] ) &&
+						isset( $argument['blog_id'] ) &&
+						isset( $argument['jetpack_version'] ) &&
+						isset( $argument['wc_version'] ) &&
+						isset( $argument['wp_version'] );
 				}
 			)
 		);
@@ -99,7 +99,7 @@ class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 		WC_Connect_Options::update_option( 'tos_accepted', true );
 
 		$this->logger->expects( $this->once() )
-					 ->method( 'log' )
+					->method( 'log' )
 					->with(
 						$this->stringContains( 'woocommerceconnect_opted_out' )
 					);
@@ -112,20 +112,20 @@ class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 			),
 			$this->callback(
 				function ( $argument ) {
-					return $argument === 'woocommerceconnect_opted_out';
+					return 'woocommerceconnect_opted_out' === $argument;
 				}
 			),
 			$this->callback(
 				function ( $argument ) {
 					return is_array( $argument ) &&
-					  isset( $argument['_via_ua'] ) &&
-					  isset( $argument['_via_ip'] ) &&
-					  isset( $argument['_lg'] ) &&
-					  isset( $argument['blog_url'] ) &&
-					  isset( $argument['blog_id'] ) &&
-					  isset( $argument['jetpack_version'] ) &&
-					  isset( $argument['wc_version'] ) &&
-					  isset( $argument['wp_version'] );
+						isset( $argument['_via_ua'] ) &&
+						isset( $argument['_via_ip'] ) &&
+						isset( $argument['_lg'] ) &&
+						isset( $argument['blog_url'] ) &&
+						isset( $argument['blog_id'] ) &&
+						isset( $argument['jetpack_version'] ) &&
+						isset( $argument['wc_version'] ) &&
+						isset( $argument['wp_version'] );
 				}
 			)
 		);
@@ -143,11 +143,11 @@ class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 
 		// Logger should NOT be called since user never opted in
 		$this->logger->expects( $this->never() )
-					 ->method( 'log' );
+					->method( 'log' );
 
 		// Jetpack tracker should NOT be called
 		$this->jetpack_tracker->expects( $this->never() )
-							   ->method( 'tracks_record_event' );
+								->method( 'tracks_record_event' );
 
 		// Call opted_out - should not send any event
 		$this->tracks->opted_out();
@@ -227,5 +227,4 @@ class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 
 		do_action( 'wc_connect_shipping_zone_method_status_toggled', 2, 'usps', 3, false );
 	}
-
 }

--- a/tests/php/test-woocommerce-services-compatibility.php
+++ b/tests/php/test-woocommerce-services-compatibility.php
@@ -1,8 +1,8 @@
 <?php
 
 if ( ! class_exists( 'WC_Connect_Compatibility' ) ) {
-	require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-compatibility.php';
-	require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-utils.php';
+	require_once __DIR__ . '/../../classes/class-wc-connect-compatibility.php';
+	require_once __DIR__ . '/../../classes/class-wc-connect-utils.php';
 }
 
 class WP_Test_WC_Services_Compatibility extends WC_Unit_Test_Case {

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -33,6 +33,8 @@
  *
  * WooCommerce Tax incorporates code from WooCommerce Sales Tax Plugin by TaxJar, Copyright 2014-2017 TaxJar.
  * WooCommerce Sales Tax Plugin by TaxJar is distributed under the terms of the GNU GPL, Version 2 (or later).
+ *
+ * @package WooCommerce Services
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -72,89 +74,129 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 	define( 'WCSERVICES_ASSETS_DIR', WCSERVICES_PLUGIN_DIR . '/assets/' );
 	define( 'WCSERVICES_STYLESHEETS_DIR', WCSERVICES_ASSETS_DIR . 'stylesheets/' );
 
+	/**
+	 * Main plugin bootstrap class.
+	 *
+	 * Wires up loggers, API client, REST controllers, settings stores and the
+	 * shipping/tax integrations that make up WooCommerce Tax.
+	 */
 	class WC_Connect_Loader {
 
 		/**
+		 * Logger instance.
+		 *
 		 * @var WC_Connect_Logger
 		 */
 		protected $logger;
 
 		/**
+		 * Logger instance used for shipping-specific logging.
+		 *
 		 * @var WC_Connect_Logger
 		 */
 		protected $shipping_logger;
 
 		/**
+		 * API client for communicating with the Connect server.
+		 *
 		 * @var WC_Connect_API_Client
 		 */
 		protected $api_client;
 
 		/**
+		 * Store for cached service schemas.
+		 *
 		 * @var WC_Connect_Service_Schemas_Store
 		 */
 		protected $service_schemas_store;
 
 		/**
+		 * Store for service settings.
+		 *
 		 * @var WC_Connect_Service_Settings_Store
 		 */
 		protected $service_settings_store;
 
 		/**
+		 * Store for saved payment methods.
+		 *
 		 * @var WC_Connect_Payment_Methods_Store
 		 */
 		protected $payment_methods_store;
 
 		/**
+		 * REST controller for account settings.
+		 *
 		 * @var WC_REST_Connect_Account_Settings_Controller
 		 */
 		protected $rest_account_settings_controller;
 
 		/**
+		 * REST controller for packages.
+		 *
 		 * @var WC_REST_Connect_Packages_Controller
 		 */
 		protected $rest_packages_controller;
 
 		/**
+		 * REST controller for services.
+		 *
 		 * @var WC_REST_Connect_Services_Controller
 		 */
 		protected $rest_services_controller;
 
 		/**
+		 * REST controller for the self-help page.
+		 *
 		 * @var WC_REST_Connect_Self_Help_Controller
 		 */
 		protected $rest_self_help_controller;
 
 		/**
+		 * REST controller for shipping labels.
+		 *
 		 * @var WC_REST_Connect_Shipping_Label_Controller
 		 */
 		protected $rest_shipping_label_controller;
 
 		/**
+		 * REST controller for shipping label status.
+		 *
 		 * @var WC_REST_Connect_Shipping_Label_Status_Controller
 		 */
 		protected $rest_shipping_label_status_controller;
 
 		/**
+		 * REST controller for shipping label refunds.
+		 *
 		 * @var WC_REST_Connect_Shipping_Label_Refund_Controller
 		 */
 		protected $rest_shipping_label_refund_controller;
 
 		/**
+		 * REST controller for shipping label previews.
+		 *
 		 * @var WC_REST_Connect_Shipping_Label_Preview_Controller
 		 */
 		protected $rest_shipping_label_preview_controller;
 
 		/**
+		 * REST controller for printing shipping labels.
+		 *
 		 * @var WC_REST_Connect_Shipping_Label_Print_Controller
 		 */
 		protected $rest_shipping_label_print_controller;
 
 		/**
+		 * REST controller for shipping rates.
+		 *
 		 * @var WC_REST_Connect_Shipping_Rates_Controller
 		 */
 		protected $rest_shipping_rates_controller;
 
 		/**
+		 * REST controller for address normalization.
+		 *
 		 * @var WC_REST_Connect_Address_Normalization_Controller
 		 */
 		protected $rest_address_normalization_controller;
@@ -182,6 +224,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		protected $rest_carrier_controller;
 
 		/**
+		 * Notifier for store notices.
+		 *
 		 * @var StoreNoticesNotifier
 		 */
 		protected $store_notices_notifier;
@@ -222,66 +266,111 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		protected $rest_migration_flag_controller;
 
 		/**
+		 * Validator for service schemas.
+		 *
 		 * @var WC_Connect_Service_Schemas_Validator
 		 */
 		protected $service_schemas_validator;
 
 		/**
+		 * Settings pages handler.
+		 *
 		 * @var WC_Connect_Settings_Pages
 		 */
 		protected $settings_pages;
 
 		/**
+		 * Help view handler.
+		 *
 		 * @var WC_Connect_Help_View
 		 */
 		protected $help_view;
 
 		/**
+		 * Shipping label handler.
+		 *
 		 * @var WC_Connect_Shipping_Label
 		 */
 		protected $shipping_label;
 
 		/**
+		 * New user experience (NUX) handler.
+		 *
 		 * @var WC_Connect_Nux
 		 */
 		protected $nux;
 
 		/**
+		 * TaxJar integration handler.
+		 *
 		 * @var WC_Connect_TaxJar_Integration
 		 */
 		protected $taxjar;
 
 		/**
+		 * PayPal Express Checkout integration handler.
+		 *
 		 * @var WC_Connect_PayPal_EC
 		 */
 		protected $paypal_ec;
 
 		/**
+		 * Tracks event recorder.
+		 *
 		 * @var WC_Connect_Tracks
 		 */
 		protected $tracks;
 
 		/**
+		 * Label reports handler.
+		 *
 		 * @var WC_Connect_Label_Reports
 		 */
 		protected $label_reports;
 
 		/**
+		 * REST controller for the Terms of Service.
+		 *
 		 * @var WC_REST_Connect_Tos_Controller
 		 */
 		protected $rest_tos_controller;
 
+		/**
+		 * Registered service instances.
+		 *
+		 * @var array
+		 */
 		protected $services = array();
 
+		/**
+		 * Runtime cache of instantiated service objects.
+		 *
+		 * @var array
+		 */
 		protected $service_object_cache = array();
 
+		/**
+		 * Base URL of the WooCommerce Connect server.
+		 *
+		 * @var string
+		 */
 		protected $wc_connect_base_url;
 
+		/**
+		 * Cached plugin version string.
+		 *
+		 * @var string
+		 */
 		protected static $wcs_version;
 
 		public const MIGRATION_DISMISSAL_COOKIE_KEY        = 'wcst-wcshipping-migration-dismissed';
 		private const SIFT_FETCH_IN_PROGRESS_TRANSIENT_KEY = 'wc_connect_sift_fetch_in_progress';
 
+		/**
+		 * Handles plugin deactivation cleanup.
+		 *
+		 * @return void
+		 */
 		public static function plugin_deactivation() {
 			wp_clear_scheduled_hook( 'wc_connect_fetch_service_schemas' );
 
@@ -294,7 +383,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			require_once __DIR__ . '/classes/class-wc-connect-wcst-to-wcshipping-migration-state-enum.php';
 
 			$migration_state = intval( get_option( 'wcshipping_migration_state' ) );
-			if ( $migration_state === WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED ) {
+			if ( WC_Connect_WCST_To_WCShipping_Migration_State_Enum::COMPLETED === $migration_state ) {
 				$core_logger = new WC_Logger();
 				$logger      = new WC_Connect_Logger( $core_logger );
 				$tracks      = new WC_Connect_Tracks( $logger, __FILE__ );
@@ -308,6 +397,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 		}
 
+		/**
+		 * Handles plugin uninstall cleanup.
+		 *
+		 * @return void
+		 */
 		public static function plugin_uninstall() {
 			WC_Connect_Options::delete_all_options();
 			self::delete_notices();
@@ -385,6 +479,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 		}
 
+		/**
+		 * Constructor. Registers core hooks and feature-coexistence filters.
+		 */
 		public function __construct() {
 			$this->wc_connect_base_url = self::get_wc_connect_base_url();
 			add_action(
@@ -419,223 +516,565 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_filter( 'wc_services_will_disable_shipping_logic', '__return_true' );
 		}
 
+		/**
+		 * Gets the logger instance.
+		 *
+		 * @return WC_Connect_Logger
+		 */
 		public function get_logger() {
 			return $this->logger;
 		}
 
+		/**
+		 * Sets the logger instance.
+		 *
+		 * @param WC_Connect_Logger $logger Logger instance.
+		 *
+		 * @return void
+		 */
 		public function set_logger( WC_Connect_Logger $logger ) {
 			$this->logger = $logger;
 		}
 
+		/**
+		 * Gets the shipping logger instance.
+		 *
+		 * @return WC_Connect_Logger
+		 */
 		public function get_shipping_logger() {
 			return $this->shipping_logger;
 		}
 
+		/**
+		 * Sets the shipping logger instance.
+		 *
+		 * @param WC_Connect_Logger $logger Logger instance.
+		 *
+		 * @return void
+		 */
 		public function set_shipping_logger( WC_Connect_Logger $logger ) {
 			$this->shipping_logger = $logger;
 		}
 
+		/**
+		 * Gets the API client instance.
+		 *
+		 * @return WC_Connect_API_Client
+		 */
 		public function get_api_client() {
 			return $this->api_client;
 		}
 
+		/**
+		 * Sets the API client instance.
+		 *
+		 * @param WC_Connect_API_Client $api_client API client instance.
+		 *
+		 * @return void
+		 */
 		public function set_api_client( WC_Connect_API_Client $api_client ) {
 			$this->api_client = $api_client;
 		}
 
+		/**
+		 * Gets the service schemas store.
+		 *
+		 * @return WC_Connect_Service_Schemas_Store
+		 */
 		public function get_service_schemas_store() {
 			return $this->service_schemas_store;
 		}
 
+		/**
+		 * Sets the service schemas store.
+		 *
+		 * @param WC_Connect_Service_Schemas_Store $schemas_store Service schemas store.
+		 *
+		 * @return void
+		 */
 		public function set_service_schemas_store( WC_Connect_Service_Schemas_Store $schemas_store ) {
 			$this->service_schemas_store = $schemas_store;
 		}
 
+		/**
+		 * Gets the service settings store.
+		 *
+		 * @return WC_Connect_Service_Settings_Store
+		 */
 		public function get_service_settings_store() {
 			return $this->service_settings_store;
 		}
 
+		/**
+		 * Sets the service settings store.
+		 *
+		 * @param WC_Connect_Service_Settings_Store $settings_store Service settings store.
+		 *
+		 * @return void
+		 */
 		public function set_service_settings_store( WC_Connect_Service_Settings_Store $settings_store ) {
 			$this->service_settings_store = $settings_store;
 		}
 
+		/**
+		 * Gets the payment methods store.
+		 *
+		 * @return WC_Connect_Payment_Methods_Store
+		 */
 		public function get_payment_methods_store() {
 			return $this->payment_methods_store;
 		}
 
+		/**
+		 * Sets the payment methods store.
+		 *
+		 * @param WC_Connect_Payment_Methods_Store $payment_methods_store Payment methods store.
+		 *
+		 * @return void
+		 */
 		public function set_payment_methods_store( WC_Connect_Payment_Methods_Store $payment_methods_store ) {
 			$this->payment_methods_store = $payment_methods_store;
 		}
 
+		/**
+		 * Gets the Tracks event recorder.
+		 *
+		 * @return WC_Connect_Tracks
+		 */
 		public function get_tracks() {
 			return $this->tracks;
 		}
 
+		/**
+		 * Sets the Tracks event recorder.
+		 *
+		 * @param WC_Connect_Tracks $tracks Tracks event recorder.
+		 *
+		 * @return void
+		 */
 		public function set_tracks( WC_Connect_Tracks $tracks ) {
 			$this->tracks = $tracks;
 		}
 
+		/**
+		 * Gets the REST account settings controller.
+		 *
+		 * @return WC_REST_Connect_Account_Settings_Controller
+		 */
 		public function get_rest_account_settings_controller() {
 			return $this->rest_account_settings_controller;
 		}
 
+		/**
+		 * Sets the REST Terms of Service controller.
+		 *
+		 * @param WC_REST_Connect_Tos_Controller $rest_tos_controller REST ToS controller.
+		 *
+		 * @return void
+		 */
 		public function set_rest_tos_controller( WC_REST_Connect_Tos_Controller $rest_tos_controller ) {
 			$this->rest_tos_controller = $rest_tos_controller;
 		}
 
+		/**
+		 * Sets the REST assets controller.
+		 *
+		 * @param WC_REST_Connect_Assets_Controller $rest_assets_controller REST assets controller.
+		 *
+		 * @return void
+		 */
 		public function set_rest_assets_controller( WC_REST_Connect_Assets_Controller $rest_assets_controller ) {
 			$this->rest_assets_controller = $rest_assets_controller;
 		}
 
+		/**
+		 * Sets the REST carriers controller.
+		 *
+		 * @param WC_REST_Connect_Shipping_Carriers_Controller $rest_carriers_controller REST carriers controller.
+		 *
+		 * @return void
+		 */
 		public function set_rest_carriers_controller( WC_REST_Connect_Shipping_Carriers_Controller $rest_carriers_controller ) {
 			$this->rest_carriers_controller = $rest_carriers_controller;
 		}
 
+		/**
+		 * Sets the REST subscriptions controller.
+		 *
+		 * @param WC_REST_Connect_Subscriptions_Controller $rest_subscriptions_controller REST subscriptions controller.
+		 *
+		 * @return void
+		 */
 		public function set_rest_subscriptions_controller( WC_REST_Connect_Subscriptions_Controller $rest_subscriptions_controller ) {
 			$this->rest_subscriptions_controller = $rest_subscriptions_controller;
 		}
 
+		/**
+		 * Sets the REST subscription activate controller.
+		 *
+		 * @param WC_REST_Connect_Subscription_Activate_Controller $rest_subscription_activate_controller REST subscription activate controller.
+		 *
+		 * @return void
+		 */
 		public function set_rest_subscription_activate_controller( WC_REST_Connect_Subscription_Activate_Controller $rest_subscription_activate_controller ) {
 			$this->rest_subscription_activate_controller = $rest_subscription_activate_controller;
 		}
 
+		/**
+		 * Sets the REST shipping carrier controller.
+		 *
+		 * @param WC_REST_Connect_Shipping_Carrier_Controller $rest_carrier_controller REST carrier controller.
+		 *
+		 * @return void
+		 */
 		public function set_rest_carrier_controller( WC_REST_Connect_Shipping_Carrier_Controller $rest_carrier_controller ) {
 			$this->rest_carrier_controller = $rest_carrier_controller;
 		}
 
+		/**
+		 * Sets the REST shipping carrier delete controller.
+		 *
+		 * @param WC_REST_Connect_Shipping_Carrier_Delete_Controller $rest_carrier_delete_controller REST carrier delete controller.
+		 *
+		 * @return void
+		 */
 		public function set_rest_carrier_delete_controller( WC_REST_Connect_Shipping_Carrier_Delete_Controller $rest_carrier_delete_controller ) {
 			$this->rest_carrier_delete_controller = $rest_carrier_delete_controller;
 		}
 
+		/**
+		 * Sets the REST packages controller.
+		 *
+		 * @param WC_REST_Connect_Packages_Controller $rest_packages_controller REST packages controller.
+		 *
+		 * @return void
+		 */
 		public function set_rest_packages_controller( WC_REST_Connect_Packages_Controller $rest_packages_controller ) {
 			$this->rest_packages_controller = $rest_packages_controller;
 		}
 
+		/**
+		 * Sets the REST account settings controller.
+		 *
+		 * @param WC_REST_Connect_Account_Settings_Controller $rest_account_settings_controller REST account settings controller.
+		 *
+		 * @return void
+		 */
 		public function set_rest_account_settings_controller( WC_REST_Connect_Account_Settings_Controller $rest_account_settings_controller ) {
 			$this->rest_account_settings_controller = $rest_account_settings_controller;
 		}
 
+		/**
+		 * Gets the REST services controller.
+		 *
+		 * @return WC_REST_Connect_Services_Controller
+		 */
 		public function get_rest_services_controller() {
 			return $this->rest_services_controller;
 		}
 
+		/**
+		 * Sets the REST services controller.
+		 *
+		 * @param WC_REST_Connect_Services_Controller $rest_services_controller REST services controller.
+		 *
+		 * @return void
+		 */
 		public function set_rest_services_controller( WC_REST_Connect_Services_Controller $rest_services_controller ) {
 			$this->rest_services_controller = $rest_services_controller;
 		}
 
+		/**
+		 * Gets the REST self-help controller.
+		 *
+		 * @return WC_REST_Connect_Self_Help_Controller
+		 */
 		public function get_rest_self_help_controller() {
 			return $this->rest_self_help_controller;
 		}
 
+		/**
+		 * Sets the REST self-help controller.
+		 *
+		 * @param WC_REST_Connect_Self_Help_Controller $rest_self_help_controller REST self-help controller.
+		 *
+		 * @return void
+		 */
 		public function set_rest_self_help_controller( WC_REST_Connect_Self_Help_Controller $rest_self_help_controller ) {
 			$this->rest_self_help_controller = $rest_self_help_controller;
 		}
 
+		/**
+		 * Gets the REST shipping label controller.
+		 *
+		 * @return WC_REST_Connect_Shipping_Label_Controller
+		 */
 		public function get_rest_shipping_label_controller() {
 			return $this->rest_shipping_label_controller;
 		}
 
+		/**
+		 * Sets the REST shipping label controller.
+		 *
+		 * @param WC_REST_Connect_Shipping_Label_Controller $rest_shipping_label_controller REST shipping label controller.
+		 *
+		 * @return void
+		 */
 		public function set_rest_shipping_label_controller( WC_REST_Connect_Shipping_Label_Controller $rest_shipping_label_controller ) {
 			$this->rest_shipping_label_controller = $rest_shipping_label_controller;
 		}
 
+		/**
+		 * Gets the REST shipping label status controller.
+		 *
+		 * @return WC_REST_Connect_Shipping_Label_Status_Controller
+		 */
 		public function get_rest_shipping_label_status_controller() {
 			return $this->rest_shipping_label_status_controller;
 		}
 
+		/**
+		 * Sets the REST shipping label status controller.
+		 *
+		 * @param WC_REST_Connect_Shipping_Label_Status_Controller $rest_shipping_label_status_controller REST shipping label status controller.
+		 *
+		 * @return void
+		 */
 		public function set_rest_shipping_label_status_controller( WC_REST_Connect_Shipping_Label_Status_Controller $rest_shipping_label_status_controller ) {
 			$this->rest_shipping_label_status_controller = $rest_shipping_label_status_controller;
 		}
 
+		/**
+		 * Gets the REST shipping label refund controller.
+		 *
+		 * @return WC_REST_Connect_Shipping_Label_Refund_Controller
+		 */
 		public function get_rest_shipping_label_refund_controller() {
 			return $this->rest_shipping_label_refund_controller;
 		}
 
+		/**
+		 * Sets the REST shipping label refund controller.
+		 *
+		 * @param WC_REST_Connect_Shipping_Label_Refund_Controller $rest_shipping_label_refund_controller REST shipping label refund controller.
+		 *
+		 * @return void
+		 */
 		public function set_rest_shipping_label_refund_controller( WC_REST_Connect_Shipping_Label_Refund_Controller $rest_shipping_label_refund_controller ) {
 			$this->rest_shipping_label_refund_controller = $rest_shipping_label_refund_controller;
 		}
 
+		/**
+		 * Gets the REST shipping label preview controller.
+		 *
+		 * @return WC_REST_Connect_Shipping_Label_Preview_Controller
+		 */
 		public function get_rest_shipping_label_preview_controller() {
 			return $this->rest_shipping_label_preview_controller;
 		}
 
+		/**
+		 * Sets the REST shipping label preview controller.
+		 *
+		 * @param WC_REST_Connect_Shipping_Label_Preview_Controller $rest_shipping_label_preview_controller REST shipping label preview controller.
+		 *
+		 * @return void
+		 */
 		public function set_rest_shipping_label_preview_controller( WC_REST_Connect_Shipping_Label_Preview_Controller $rest_shipping_label_preview_controller ) {
 			$this->rest_shipping_label_preview_controller = $rest_shipping_label_preview_controller;
 		}
 
+		/**
+		 * Gets the REST shipping label print controller.
+		 *
+		 * @return WC_REST_Connect_Shipping_Label_Print_Controller
+		 */
 		public function get_rest_shipping_label_print_controller() {
 			return $this->rest_shipping_label_print_controller;
 		}
 
+		/**
+		 * Sets the REST shipping label print controller.
+		 *
+		 * @param WC_REST_Connect_Shipping_Label_Print_Controller $rest_shipping_label_print_controller REST shipping label print controller.
+		 *
+		 * @return void
+		 */
 		public function set_rest_shipping_label_print_controller( WC_REST_Connect_Shipping_Label_Print_Controller $rest_shipping_label_print_controller ) {
 			$this->rest_shipping_label_print_controller = $rest_shipping_label_print_controller;
 		}
 
+		/**
+		 * Sets the REST shipping rates controller.
+		 *
+		 * @param WC_REST_Connect_Shipping_Rates_Controller $rest_shipping_rates_controller REST shipping rates controller.
+		 *
+		 * @return void
+		 */
 		public function set_rest_shipping_rates_controller( WC_REST_Connect_Shipping_Rates_Controller $rest_shipping_rates_controller ) {
 			$this->rest_shipping_rates_controller = $rest_shipping_rates_controller;
 		}
 
+		/**
+		 * Sets the REST address normalization controller.
+		 *
+		 * @param WC_REST_Connect_Address_Normalization_Controller $rest_address_normalization_controller REST address normalization controller.
+		 *
+		 * @return void
+		 */
 		public function set_rest_address_normalization_controller( WC_REST_Connect_Address_Normalization_Controller $rest_address_normalization_controller ) {
 			$this->rest_address_normalization_controller = $rest_address_normalization_controller;
 		}
 
+		/**
+		 * Sets the REST shipping carrier types controller.
+		 *
+		 * @param WC_REST_Connect_Shipping_Carrier_Types_Controller $rest_carrier_types_controller REST carrier types controller.
+		 *
+		 * @return void
+		 */
 		public function set_carrier_types_controller( WC_REST_Connect_Shipping_Carrier_Types_Controller $rest_carrier_types_controller ) {
 			$this->rest_carrier_types_controller = $rest_carrier_types_controller;
 		}
 
+		/**
+		 * Sets the REST migration flag controller.
+		 *
+		 * @param WC_REST_Connect_Migration_Flag_Controller $rest_migration_flag_controller REST migration flag controller.
+		 *
+		 * @return void
+		 */
 		public function set_rest_migration_flag_controller( WC_REST_Connect_Migration_Flag_Controller $rest_migration_flag_controller ) {
 			$this->rest_migration_flag_controller = $rest_migration_flag_controller;
 		}
 
+		/**
+		 * Gets the REST shipping carrier types controller.
+		 *
+		 * @return WC_REST_Connect_Shipping_Carrier_Types_Controller
+		 */
 		public function get_carrier_types_controller() {
 			return $this->rest_carrier_types_controller;
 		}
 
+		/**
+		 * Gets the service schemas validator.
+		 *
+		 * @return WC_Connect_Service_Schemas_Validator
+		 */
 		public function get_service_schemas_validator() {
 			return $this->service_schemas_validator;
 		}
 
+		/**
+		 * Sets the service schemas validator.
+		 *
+		 * @param WC_Connect_Service_Schemas_Validator $validator Service schemas validator.
+		 *
+		 * @return void
+		 */
 		public function set_service_schemas_validator( WC_Connect_Service_Schemas_Validator $validator ) {
 			$this->service_schemas_validator = $validator;
 		}
 
+		/**
+		 * Gets the settings pages handler.
+		 *
+		 * @return WC_Connect_Settings_Pages
+		 */
 		public function get_settings_pages() {
 			return $this->settings_pages;
 		}
 
+		/**
+		 * Sets the settings pages handler.
+		 *
+		 * @param WC_Connect_Settings_Pages $settings_pages Settings pages handler.
+		 *
+		 * @return void
+		 */
 		public function set_settings_pages( WC_Connect_Settings_Pages $settings_pages ) {
 			$this->settings_pages = $settings_pages;
 		}
 
+		/**
+		 * Gets the help view handler.
+		 *
+		 * @return WC_Connect_Help_View
+		 */
 		public function get_help_view() {
 			return $this->help_view;
 		}
 
+		/**
+		 * Sets the help view handler.
+		 *
+		 * @param WC_Connect_Help_View $help_view Help view handler.
+		 *
+		 * @return void
+		 */
 		public function set_help_view( WC_Connect_Help_View $help_view ) {
 			$this->help_view = $help_view;
 		}
 
+		/**
+		 * Sets the shipping label handler.
+		 *
+		 * @param WC_Connect_Shipping_Label $shipping_label Shipping label handler.
+		 *
+		 * @return void
+		 */
 		public function set_shipping_label( WC_Connect_Shipping_Label $shipping_label ) {
 			$this->shipping_label = $shipping_label;
 		}
 
+		/**
+		 * Sets the NUX handler.
+		 *
+		 * @param WC_Connect_Nux $nux NUX handler.
+		 *
+		 * @return void
+		 */
 		public function set_nux( WC_Connect_Nux $nux ) {
 			$this->nux = $nux;
 		}
 
+		/**
+		 * Sets the TaxJar integration handler.
+		 *
+		 * @param WC_Connect_TaxJar_Integration $taxjar TaxJar integration handler.
+		 *
+		 * @return void
+		 */
 		public function set_taxjar( WC_Connect_TaxJar_Integration $taxjar ) {
 			$this->taxjar = $taxjar;
 		}
 
+		/**
+		 * Sets the PayPal Express Checkout integration handler.
+		 *
+		 * @param WC_Connect_PayPal_EC $paypal_ec PayPal Express Checkout handler.
+		 *
+		 * @return void
+		 */
 		public function set_paypal_ec( WC_Connect_PayPal_EC $paypal_ec ) {
 			$this->paypal_ec = $paypal_ec;
 		}
 
+		/**
+		 * Sets the label reports handler.
+		 *
+		 * @param WC_Connect_Label_Reports $label_reports Label reports handler.
+		 *
+		 * @return void
+		 */
 		public function set_label_reports( WC_Connect_Label_Reports $label_reports ) {
 			$this->label_reports = $label_reports;
 		}
 
 		/**
+		 * Gets the store notices notifier.
+		 *
 		 * @return StoreNoticesNotifier
 		 */
 		public function get_store_notices_notifier() {
@@ -643,7 +1082,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		/**
-		 * @param StoreNoticesNotifier $store_notices_notifier
+		 * Sets the store notices notifier.
+		 *
+		 * @param StoreNoticesNotifier $store_notices_notifier Store notices notifier.
+		 *
+		 * @return void
 		 */
 		public function set_store_notices_notifier( StoreNoticesNotifier $store_notices_notifier ) {
 			$this->store_notices_notifier = $store_notices_notifier;
@@ -658,6 +1101,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			load_plugin_textdomain( 'woocommerce-services', false, dirname( plugin_basename( __FILE__ ) ) . '/i18n/languages' );
 		}
 
+		/**
+		 * Ensures the Jetpack connection package is configured.
+		 *
+		 * @return void
+		 */
 		public function ensure_jetpack_connection() {
 			$jetpack_config = new Automattic\Jetpack\Config();
 			$jetpack_config->ensure(
@@ -669,6 +1117,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			);
 		}
 
+		/**
+		 * Initializes the plugin once all plugins are loaded.
+		 *
+		 * @return void
+		 */
 		public function on_plugins_loaded() {
 
 			/**
@@ -678,7 +1131,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			 * and WooCommerce Tax (this plugin), by letting them take over all responsibilities if all three
 			 * plugins are activated at the same time.
 			 *
-			 * @since {{next-release}}
+			 * @since 3.6.3
 			 *
 			 * @param bool $status The value will determine if we should initiate the plugins logic or not.
 			 */
@@ -763,6 +1216,13 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'woocommerce_init', array( $this, 'after_wc_init' ) );
 		}
 
+		/**
+		 * Extracts default values from a service schema.
+		 *
+		 * @param object $schema Service schema object.
+		 *
+		 * @return array Map of property IDs to their default values.
+		 */
 		public function get_service_schema_defaults( $schema ) {
 			$defaults = array();
 
@@ -786,6 +1246,15 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			return $defaults;
 		}
 
+		/**
+		 * Saves schema default settings to a shipping method instance.
+		 *
+		 * @param int    $instance_id Shipping method instance ID.
+		 * @param string $service_id  Service ID.
+		 * @param int    $zone_id     Shipping zone ID.
+		 *
+		 * @return void
+		 */
 		public function save_defaults_to_shipping_method( $instance_id, $service_id, $zone_id ) {
 			$shipping_method = WC_Shipping_Zones::get_shipping_method( $instance_id );
 			$schema          = $shipping_method->get_service_schema();
@@ -793,6 +1262,14 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			WC_Connect_Options::update_shipping_method_option( 'form_settings', $defaults, $service_id, $instance_id );
 		}
 
+		/**
+		 * Adds a shipping method to a shipping zone.
+		 *
+		 * @param int    $zone_id   Shipping zone ID.
+		 * @param string $method_id Service/method ID to add.
+		 *
+		 * @return void
+		 */
 		protected function add_method_to_shipping_zone( $zone_id, $method_id ) {
 			$method = $this->get_service_schemas_store()->get_service_schema_by_id( $method_id );
 			if ( empty( $method ) ) {
@@ -997,7 +1474,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function init_shipping_labels() {
 			add_filter( 'woocommerce_admin_reports', array( $this, 'reports_tabs' ) );
 
-			// Initialize migration survey
+			// Initialize migration survey.
 			require_once __DIR__ . '/classes/class-wc-connect-migration-survey.php';
 			new WC_Connect_Migration_Survey();
 
@@ -1058,6 +1535,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'shutdown', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
 		}
 
+		/**
+		 * Registers the Terms of Service REST controller.
+		 *
+		 * @return void
+		 */
 		public function tos_rest_init() {
 			$settings_store = $this->get_service_settings_store();
 			$logger         = $this->get_logger();
@@ -1175,7 +1657,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				$rest_carrier_types_controller = new WC_REST_Connect_Shipping_Carrier_Types_Controller( $this->api_client, $settings_store, $logger );
 				$this->set_carrier_types_controller( $rest_carrier_types_controller );
 				$rest_carrier_types_controller->register_routes();
-			}
+			}//end if
 			require_once __DIR__ . '/classes/class-wc-rest-connect-migration-flag-controller.php';
 			$rest_migration_flag_controller = new WC_REST_Connect_Migration_Flag_Controller( $this->api_client, $settings_store, $logger, $this->tracks );
 			$this->set_rest_migration_flag_controller( $rest_migration_flag_controller );
@@ -1212,6 +1694,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			 * passing the `WC_Connect_Loader` as an argument.
 			 *
 			 * @see WC_Connect_Compatibility_WCShipping_Packages::register_rest_controller_hooks
+			 *
+			 * @since 3.6.3
+			 *
+			 * @param WC_Connect_Loader $this The plugin loader instance.
 			 */
 			do_action( 'wcservices_rest_api_init', $this );
 
@@ -1260,13 +1746,13 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		/**
-		 * Added to the wc_connect_shipping_service_settings filter, returns service settings
+		 * Added to the wc_connect_shipping_service_settings filter, returns service settings.
 		 *
-		 * @param $settings
-		 * @param $method_id
-		 * @param $instance_id
+		 * @param array     $settings    Existing service settings.
+		 * @param string    $method_id   Shipping method ID.
+		 * @param int|false $instance_id Shipping method instance ID, or false.
 		 *
-		 * @return array
+		 * @return array Augmented service settings.
 		 */
 		public function shipping_service_settings( $settings, $method_id, $instance_id ) {
 			$settings_store = $this->get_service_settings_store();
@@ -1304,12 +1790,25 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * (see attach_hooks) and then that action is fired by WC_Connect_Shipping_Method::admin_options
 		 * to get the service instance form layout and settings bundled inside wcConnectData
 		 * as the form container is emitted into the body's HTML
+		 *
+		 * @param string    $method_id   Shipping method ID.
+		 * @param int|false $instance_id Shipping method instance ID, or false.
+		 *
+		 * @return void
 		 */
 		public function localize_and_enqueue_service_script( $method_id, $instance_id = false ) {
 			if ( ! function_exists( 'get_rest_url' ) ) {
 				return;
 			}
 
+			/**
+			 * Enqueues the WC Connect admin script with the given root view and arguments.
+			 *
+			 * @since 3.6.3
+			 *
+			 * @param string $root_view  The root view identifier to render.
+			 * @param array  $extra_args Extra arguments passed to the script.
+			 */
 			do_action(
 				'enqueue_wc_connect_script',
 				'wc-connect-service-settings',
@@ -1391,7 +1890,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 						);
 					}
 				}
-			}
+			}//end foreach
 
 			if ( empty( $services ) ) {
 				return;
@@ -1413,11 +1912,13 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		/**
-		 * Add tracking info (if available) to completed emails using the woocommerce_email_after_order_table hook
+		 * Add tracking info (if available) to completed emails using the woocommerce_email_after_order_table hook.
 		 *
-		 * @param bool|\WC_Order|\WC_Order_Refund $order
-		 * @param $sent_to_admin
-		 * @param $plain_text
+		 * @param bool|\WC_Order|\WC_Order_Refund $order         Order object the email is for.
+		 * @param bool                            $sent_to_admin Whether the email is sent to the admin.
+		 * @param bool                            $plain_text    Whether the email is plain text.
+		 *
+		 * @return void
 		 */
 		public function add_tracking_info_to_emails( $order, $sent_to_admin, $plain_text ) {
 
@@ -1480,7 +1981,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				$markup .= '<a href="' . esc_url( $tracking_url ) . '" style="color: ' . esc_attr( $link_color ) . '">' . esc_html( $tracking ) . '</a>';
 				$markup .= '</td>';
 				$markup .= '</tr>';
-			}
+			}//end foreach
 
 			// Abort if all labels are refunded.
 			if ( empty( $markup ) ) {
@@ -1520,7 +2021,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$schemas           = $schemas_store->get_service_schemas();
 			$last_fetch_result = $schemas_store->get_last_fetch_result_code();
 
-			if ( ! $schemas && '401' !== $last_fetch_result ) { // Don't retry auth failures wait for next scheduled time.
+			if ( ! $schemas && '401' !== $last_fetch_result ) {
+				// Don't retry auth failures wait for next scheduled time.
 				$schemas_store->fetch_service_schemas_from_connect_server();
 			} elseif ( defined( 'WOOCOMMERCE_CONNECT_FREQUENT_FETCH' ) && WOOCOMMERCE_CONNECT_FREQUENT_FETCH ) {
 				$schemas_store->fetch_service_schemas_from_connect_server();
@@ -1532,12 +2034,14 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		/**
 		 * Inject API Client and Logger into WC Connect shipping method instances.
 		 *
-		 * @param WC_Connect_Shipping_Method $method
-		 * @param int|string                 $id_or_instance_id
+		 * @param WC_Connect_Shipping_Method $method            Shipping method instance to initialize.
+		 * @param int|string                 $id_or_instance_id Service ID or shipping method instance ID.
+		 *
+		 * @return void
 		 */
 		public function init_service( WC_Connect_Shipping_Method $method, $id_or_instance_id ) {
 
-			// TODO - make more generic - allow things other than WC_Connect_Shipping_Method to work here
+			// TODO - make more generic - allow things other than WC_Connect_Shipping_Method to work here.
 
 			$method->set_api_client( $this->get_api_client() );
 			$method->set_logger( $this->get_shipping_logger() );
@@ -1554,8 +2058,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * Returns a reference to a service (e.g. WC_Connect_Shipping_Method) of
 		 * a particular id so we can avoid instantiating them multiple times
 		 *
-		 * @param string $class_name Class name of service to create (e.g. WC_Connect_Shipping_Method)
-		 * @param string $service_id Service id of service to create (e.g. usps)
+		 * @param string $class_name Class name of service to create (e.g. WC_Connect_Shipping_Method).
+		 * @param string $service_id Service id of service to create (e.g. usps).
 		 * @return mixed
 		 */
 		protected function get_service_object_by_id( $class_name, $service_id ) {
@@ -1569,8 +2073,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		/**
 		 * Filters in shipping methods for things like WC_Shipping::get_shipping_method_class_names
 		 *
-		 * @param $shipping_methods
-		 * @return mixed
+		 * @param array $shipping_methods Registered shipping methods keyed by ID.
+		 * @return mixed Shipping methods including WC Connect services.
 		 */
 		public function woocommerce_shipping_methods( $shipping_methods ) {
 			$shipping_service_ids = $this->get_service_schemas_store()->get_all_shipping_method_ids();
@@ -1595,10 +2099,22 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 		}
 
+		/**
+		 * Filters the registered WooCommerce payment gateways.
+		 *
+		 * @param array $payment_gateways Registered payment gateways.
+		 *
+		 * @return array Payment gateways.
+		 */
 		public function woocommerce_payment_gateways( $payment_gateways ) {
 			return $payment_gateways;
 		}
 
+		/**
+		 * Reads the localized i18n JSON file for the current locale.
+		 *
+		 * @return string Locale JSON data, or '{}' when unavailable.
+		 */
 		private function get_i18n_json() {
 			$i18n_json = plugin_dir_path( __FILE__ ) . 'i18n/languages/woocommerce-services-' . get_locale() . '.json';
 			if ( is_file( $i18n_json ) && is_readable( $i18n_json ) ) {
@@ -1640,8 +2156,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				return false;
 			}
 
-			// All WC settings pages
-			if ( $screen->id === 'woocommerce_page_wc-settings' ) {
+			// All WC settings pages.
+			if ( 'woocommerce_page_wc-settings' === $screen->id ) {
 				return true;
 			}
 
@@ -1654,13 +2170,18 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			*   $screen->id = "woocommerce_page_wc-orders"
 			*   $$wc_order_screen_id = "woocommerce_page_wc-orders"
 			*/
-			if ( $screen->id !== 'edit-shop_order' && $screen->id !== 'woocommerce_page_wc-orders' ) {
+			if ( 'edit-shop_order' !== $screen->id && 'woocommerce_page_wc-orders' !== $screen->id ) {
 				return false;
 			}
 
 			return true;
 		}
 
+		/**
+		 * Conditionally registers the WCShipping migration upgrade banner.
+		 *
+		 * @return void
+		 */
 		public function maybe_render_upgrade_banner() {
 			if ( ! $this->should_render_upgrade_banner() ) {
 				// If this is not on the order list page, then don't add any action.
@@ -1716,6 +2237,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			);
 		}
 
+		/**
+		 * Returns the IDs of shipping services that are active in any zone.
+		 *
+		 * @return array List of active shipping service IDs.
+		 */
 		public function get_active_shipping_services() {
 			global $wpdb;
 			$active_shipping_services = array();
@@ -1737,34 +2263,109 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			return $active_shipping_services;
 		}
 
+		/**
+		 * Returns the IDs of active shipping services.
+		 *
+		 * @return array List of active shipping service IDs.
+		 */
 		public function get_active_services() {
 			return $this->get_active_shipping_services();
 		}
 
+		/**
+		 * Determines whether a service ID belongs to a WC Connect shipping service.
+		 *
+		 * @param string $service_id Service ID to check.
+		 *
+		 * @return bool True when the service is a WC Connect shipping service.
+		 */
 		public function is_wc_connect_shipping_service( $service_id ) {
 			$shipping_service_ids = $this->get_service_schemas_store()->get_all_shipping_method_ids();
 			return in_array( $service_id, $shipping_service_ids );
 		}
 
+		/**
+		 * Fires when a WC Connect shipping method is added to a zone.
+		 *
+		 * @param int    $instance_id Shipping method instance ID.
+		 * @param string $service_id  Service/method ID.
+		 * @param int    $zone_id     Shipping zone ID.
+		 *
+		 * @return void
+		 */
 		public function shipping_zone_method_added( $instance_id, $service_id, $zone_id ) {
 			if ( $this->is_wc_connect_shipping_service( $service_id ) ) {
+				/**
+				 * Fires after a WC Connect shipping method is added to a zone.
+				 *
+				 * @since 3.6.3
+				 *
+				 * @param int    $instance_id Shipping method instance ID.
+				 * @param string $service_id  Service/method ID.
+				 * @param int    $zone_id     Shipping zone ID.
+				 */
 				do_action( 'wc_connect_shipping_zone_method_added', $instance_id, $service_id, $zone_id );
 			}
 		}
 
+		/**
+		 * Fires when a WC Connect shipping method is deleted from a zone.
+		 *
+		 * @param int    $instance_id Shipping method instance ID.
+		 * @param string $service_id  Service/method ID.
+		 * @param int    $zone_id     Shipping zone ID.
+		 *
+		 * @return void
+		 */
 		public function shipping_zone_method_deleted( $instance_id, $service_id, $zone_id ) {
 			if ( $this->is_wc_connect_shipping_service( $service_id ) ) {
 				WC_Connect_Options::delete_shipping_method_options( $service_id, $instance_id );
+				/**
+				 * Fires after a WC Connect shipping method is deleted from a zone.
+				 *
+				 * @since 3.6.3
+				 *
+				 * @param int    $instance_id Shipping method instance ID.
+				 * @param string $service_id  Service/method ID.
+				 * @param int    $zone_id     Shipping zone ID.
+				 */
 				do_action( 'wc_connect_shipping_zone_method_deleted', $instance_id, $service_id, $zone_id );
 			}
 		}
 
+		/**
+		 * Fires when a WC Connect shipping method's enabled status is toggled.
+		 *
+		 * @param int    $instance_id Shipping method instance ID.
+		 * @param string $service_id  Service/method ID.
+		 * @param int    $zone_id     Shipping zone ID.
+		 * @param bool   $enabled     Whether the method is now enabled.
+		 *
+		 * @return void
+		 */
 		public function shipping_zone_method_status_toggled( $instance_id, $service_id, $zone_id, $enabled ) {
 			if ( $this->is_wc_connect_shipping_service( $service_id ) ) {
+				/**
+				 * Fires after a WC Connect shipping method's status is toggled.
+				 *
+				 * @since 3.6.3
+				 *
+				 * @param int    $instance_id Shipping method instance ID.
+				 * @param string $service_id  Service/method ID.
+				 * @param int    $zone_id     Shipping zone ID.
+				 * @param bool   $enabled     Whether the method is now enabled.
+				 */
 				do_action( 'wc_connect_shipping_zone_method_status_toggled', $instance_id, $service_id, $zone_id, $enabled );
 			}
 		}
 
+		/**
+		 * Determines whether the shipping debug meta box should be shown for a post.
+		 *
+		 * @param int|WP_Post $post Post ID or post object for the order.
+		 *
+		 * @return bool True when packing log data is present.
+		 */
 		public function should_show_shipping_debug_meta_box( $post ) {
 			$order = WC_Connect_Compatibility::instance()->init_theorder_object( $post );
 
@@ -1783,6 +2384,14 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			return false;
 		}
 
+		/**
+		 * Registers WC Connect order meta boxes.
+		 *
+		 * @param string      $screen_id Current admin screen ID.
+		 * @param int|WP_Post $post      Post ID or post object for the order.
+		 *
+		 * @return void
+		 */
 		public function add_meta_boxes( $screen_id, $post ) {
 
 			if ( $this->shipping_label->should_show_meta_box( $post ) ) {
@@ -1797,6 +2406,13 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 		}
 
+		/**
+		 * Renders the shipping rate packaging debug log meta box.
+		 *
+		 * @param int|WP_Post $post Post ID or post object for the order.
+		 *
+		 * @return void
+		 */
 		public function shipping_rate_packaging_debug_log_meta_box( $post ) {
 			$order            = wc_get_order( $post );
 			$shipping_methods = $order->get_shipping_methods();
@@ -1834,15 +2450,31 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				</p>
 				<pre class="packing-log"><?php echo esc_html( implode( "\n", $method['wc_connect_packing_log'] ) ); ?></pre>
 				<?php
-			}
+			}//end foreach
 		}
 
+		/**
+		 * Hides WC Connect package meta data keys from the order item meta display.
+		 *
+		 * @param array $hidden_keys Existing hidden meta keys.
+		 *
+		 * @return array Hidden meta keys including WC Connect keys.
+		 */
 		public function hide_wc_connect_package_meta_data( $hidden_keys ) {
 			$hidden_keys[] = 'wc_connect_packages';
 			$hidden_keys[] = 'wc_connect_packing_log';
 			return $hidden_keys;
 		}
 
+		/**
+		 * Marks WC Connect order meta data as protected.
+		 *
+		 * @param bool   $protected Whether the meta key is protected.
+		 * @param string $meta_key  Meta key being checked.
+		 * @param string $meta_type Type of object meta is for.
+		 *
+		 * @return bool Whether the meta key is protected.
+		 */
 		public function hide_wc_connect_order_meta_data( $protected, $meta_key, $meta_type ) {
 			if ( in_array( $meta_key, array( 'wc_connect_labels', 'wc_connect_destination_normalized' ), true ) ) {
 				$protected = true;
@@ -1851,6 +2483,13 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			return $protected;
 		}
 
+		/**
+		 * Adds a shipping phone field to the checkout shipping fields.
+		 *
+		 * @param array $fields Existing checkout shipping fields.
+		 *
+		 * @return array Shipping fields including the phone field.
+		 */
 		public function add_shipping_phone_to_checkout( $fields ) {
 			$defaults = array(
 				'label'        => __( 'Phone', 'woocommerce-services' ),
@@ -1879,6 +2518,13 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			return $fields;
 		}
 
+		/**
+		 * Adds a phone field to the order shipping address fields.
+		 *
+		 * @param array $fields Existing order address fields.
+		 *
+		 * @return array Address fields including the phone field.
+		 */
 		public function add_shipping_phone_to_order_fields( $fields ) {
 			$fields['phone'] = array(
 				'label' => __( 'Phone', 'woocommerce-services' ),
@@ -1886,6 +2532,15 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			return $fields;
 		}
 
+		/**
+		 * Returns the shipping phone, falling back to the billing phone, for an order.
+		 *
+		 * @param array    $fields       Existing formatted address fields.
+		 * @param string   $address_type Address type being formatted (e.g. 'shipping').
+		 * @param WC_Order $order        Order the address belongs to.
+		 *
+		 * @return array Address fields, including the phone for shipping addresses.
+		 */
 		public function get_shipping_or_billing_phone_from_order( $fields, $address_type, WC_Order $order ) {
 			if ( 'shipping' !== $address_type ) {
 				return $fields;
@@ -1896,6 +2551,13 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			return $fields;
 		}
 
+		/**
+		 * Adds plugin action links shown on the Plugins screen.
+		 *
+		 * @param array $links Existing plugin action links.
+		 *
+		 * @return array Action links including the Support link.
+		 */
 		public function add_plugin_action_links( $links ) {
 			$links[] = sprintf(
 				wp_kses(
@@ -1951,7 +2613,15 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$result = ( WC_Connect_Jetpack::is_connected() && '1' === WC_Connect_Options::get_option( 'only_tax' ) ) ||
 						( ! WC_Connect_Jetpack::is_connected() && ! self::_has_any_labels_db_check() );
 
-			// Allow tests to override this functionality.
+			/**
+			 * Filters whether the store is configured for tax-only functionality.
+			 *
+			 * Allows tests to override this functionality.
+			 *
+			 * @since 3.6.3
+			 *
+			 * @param bool $result Whether the store is tax-only.
+			 */
 			return apply_filters( 'wc_connect_has_only_tax_functionality', $result );
 		}
 
@@ -1967,6 +2637,13 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			return ! self::is_wc_shipping_activated() && ! self::has_only_tax_functionality();
 		}
 
+		/**
+		 * Renames the plugin entry shown on the Plugins screen based on functionality.
+		 *
+		 * @param array $plugins Installed plugins data keyed by basename.
+		 *
+		 * @return array Plugins data with updated name and description.
+		 */
 		public function maybe_rename_plugin( $plugins ) {
 			$plugin_basename = 'woocommerce-services/woocommerce-services.php';
 
@@ -1982,18 +2659,38 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			return $plugins;
 		}
 
+		/**
+		 * Returns the plugin name used on legacy (shipping-enabled) sites.
+		 *
+		 * @return string Translated plugin name.
+		 */
 		private function get_plugin_name_for_legacy_sites() {
 			return __( 'WooCommerce Tax (previously WooCommerce Shipping & Tax)', 'woocommerce-services' );
 		}
 
+		/**
+		 * Returns the plugin description used on legacy (shipping-enabled) sites.
+		 *
+		 * @return string Translated plugin description.
+		 */
 		private function get_plugin_description_for_legacy_sites() {
 			return __( 'Hosted services for WooCommerce: automated tax calculation, shipping label printing, and smoother payment setup.', 'woocommerce-services' );
 		}
 
+		/**
+		 * Returns the plugin name used on new (tax-only) sites.
+		 *
+		 * @return string Translated plugin name.
+		 */
 		private function get_plugin_name_for_new_sites() {
 			return __( 'WooCommerce Tax', 'woocommerce-services' );
 		}
 
+		/**
+		 * Returns the plugin description used on new (tax-only) sites.
+		 *
+		 * @return string Translated plugin description.
+		 */
 		private function get_plugin_description_for_new_sites() {
 			return __( 'Automated tax calculation for WooCommerce.', 'woocommerce-services' );
 		}
@@ -2072,6 +2769,14 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 		}
 
+		/**
+		 * Enqueues the WC Connect admin React bundle and bootstrap data.
+		 *
+		 * @param string $root_view  Root view identifier to render in the bundle.
+		 * @param array  $extra_args Extra arguments merged into the bootstrap data.
+		 *
+		 * @return void
+		 */
 		public function enqueue_wc_connect_script( $root_view, $extra_args = array() ) {
 			$is_alive = $this->api_client->is_alive_cached();
 
@@ -2107,12 +2812,18 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			?>
 				<div class="wcc-root woocommerce <?php echo esc_attr( $root_view ); ?>" data-args="<?php echo wc_esc_json( $encoded_arguments ); ?>">
 					<span class="form-troubles" style="opacity: 0">
+						<?php /* translators: %s: URL to the status page */ ?>
 						<?php printf( esc_html__( 'Section not loading? Visit the <a href="%s">status page</a> for troubleshooting steps.', 'woocommerce-services' ), esc_url( $debug_page_uri ) ); ?>
 					</span>
 				</div>
 			<?php
 		}
 
+		/**
+		 * Renders admin notices supplied by the service schemas.
+		 *
+		 * @return void
+		 */
 		public function render_schema_notices() {
 			$schemas = $this->get_service_schemas_store()->get_service_schemas();
 			if ( empty( $schemas ) || ! property_exists( $schemas, 'notices' ) || empty( $schemas->notices ) ) {
@@ -2148,7 +2859,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					<p><?php echo wp_kses( $notice->message, $allowed_html ); ?></p>
 				</div>
 				<?php
-			}
+			}//end foreach
 		}
 
 		/**
@@ -2188,7 +2899,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * @return bool
 		 */
 		public function display_wcst_to_wcshipping_migration_notice() {
-			if ( isset( $_COOKIE[ self::MIGRATION_DISMISSAL_COOKIE_KEY ] ) && (int) $_COOKIE[ self::MIGRATION_DISMISSAL_COOKIE_KEY ] === 1 ) {
+			if ( isset( $_COOKIE[ self::MIGRATION_DISMISSAL_COOKIE_KEY ] ) && 1 === (int) $_COOKIE[ self::MIGRATION_DISMISSAL_COOKIE_KEY ] ) {
 				return;
 			}
 			$schema = $this->get_service_schemas_store();
@@ -2224,8 +2935,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 					wc_esc_json( $encoded_arguments )
 				) .
 				sprintf(
-					/* translators: %s: documentation URL */
-					__( $banner->message, 'woocommerce-services' ),
+					// $banner->message is a remote-provided format string (already localised
+					// server-side); it is dynamic, so it cannot be wrapped in __().
+					$banner->message,
 					'https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#how-do-i-migrate-from-wcst'
 				) .
 				sprintf(
@@ -2240,6 +2952,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			);
 		}
 
+		/**
+		 * Registers assets and data for the WCShipping migration modal.
+		 *
+		 * @return void
+		 */
 		public function register_wcshipping_migration_modal() {
 			$plugin_version = self::get_wcs_version();
 			wp_register_style( 'wcst_wcshipping_migration_admin_notice', $this->wc_connect_base_url . 'woocommerce-services-wcshipping-migration-admin-notice-' . $plugin_version . '.css', array(), null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
@@ -2257,7 +2974,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			wp_enqueue_style( 'wcst_wcshipping_migration_admin_notice' );
 		}
 	}
-}
+}//end if
 
 register_deactivation_hook( __FILE__, array( 'WC_Connect_Loader', 'plugin_deactivation' ) );
 register_uninstall_hook( __FILE__, array( 'WC_Connect_Loader', 'plugin_uninstall' ) );


### PR DESCRIPTION
## Description

Milestone 2 of the PHPCS work for this plugin — the cleanup counterpart to the M1 ruleset restructure in #2956. Resolves the PHPCS violations the M1 ruleset deliberately deferred, so that `composer run check-all` exits with **no errors** (warnings are allowed per the ticket's definition of done).

The change is overwhelmingly PHPCBF auto-fixes (docblocks, Yoda conditions, `count()` vs `sizeof()`, long-array syntax, alignment) plus a small set of narrowly-scoped ruleset exclusions. Two behavior-preserving points worth calling out for review:

- **Reused WooCommerce core strings keep the `woocommerce` text domain.** The dev-data REST controllers in `classes/wc-api-dev/` (forks of core's `/wc/v3/data` controllers) and the tax-rate CSV export reuse strings verbatim from WooCommerce core and rely on core's translation catalog. They intentionally stay on the `woocommerce` domain, with `WordPress.WP.I18n.TextDomainMismatch` suppressed narrowly for just those strings, so translations aren't lost on non-English locales.
- No runtime behavior changes; the existing PHPUnit suite stays green.

> ⚠️ **Stacked on #2956 — do not merge first.** This PR is based on the M1 ruleset branch because the split ruleset it lints against only exists there. Once #2956 lands on trunk, this PR will be retargeted to trunk.

### Related issue(s)

Closes https://linear.app/a8c/issue/WOOTAX-288

### Steps to reproduce & screenshots/GIFs

PHPCS (the definition of done) — exits with no errors:

```
composer run check-all       # exit 0 — 0 errors, 168 warnings
composer run check-php
composer run check-security
composer run check-l18n
```

PHPUnit (no behavior change) — existing suite stays green:

```
composer test
```

### Checklist

- [ ] unit tests — N/A: standards/config cleanup with no behavior change; no new tests. Existing suite stays green.
- [ ] `changelog.txt` entry added — N/A: PHPCS cleanup, no user-facing change.
- [ ] `readme.txt` entry added — N/A: PHPCS cleanup, no user-facing change.
