### PR TITLE
Fix undefined $helper_auth_data warning in get_wc_helper_auth_info()

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.6.5 - 2026-xx-xx =
+* Fix   - Prevent PHP "undefined variable" warning when WooCommerce Helper authentication data is unavailable.
+
 = 3.6.4 - 2026-06-01 =
 * Dev   - Update JS dependencies.
 

--- a/classes/class-wc-connect-functions.php
+++ b/classes/class-wc-connect-functions.php
@@ -28,6 +28,7 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 		 * @return array|WP_Error
 		 */
 		public static function get_wc_helper_auth_info() {
+			$helper_auth_data = false;
 			if ( class_exists( 'WC_Helper_Options' ) && is_callable( 'WC_Helper_Options::get' ) ) {
 				$helper_auth_data = WC_Helper_Options::get( 'auth' );
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.6.5 - 2026-xx-xx =
+* Fix   - Prevent PHP "undefined variable" warning when WooCommerce Helper authentication data is unavailable.
+
 = 3.6.4 - 2026-06-01 =
 * Dev   - Update JS dependencies.
 


### PR DESCRIPTION
## Description

`WC_Connect_Functions::get_wc_helper_auth_info()` only assigns `$helper_auth_data` inside the `class_exists( 'WC_Helper_Options' ) && is_callable( 'WC_Helper_Options::get' )` guard. When that guard is false (e.g. during a cron run where the helper isn't loaded), the falsy check on the next line reads an undeclared variable and PHP 8+ emits:

```
Undefined variable $helper_auth_data in .../classes/class-wc-connect-functions.php on line 36
```

Initializing `$helper_auth_data = false;` before the guard silences the warning. Functionally a no-op — the existing falsy check already returns `WP_Error( 'missing_wccom_auth' )` in both branches.

Reported on wp.org: https://wordpress.org/support/topic/minor-php-bug-undeclared-variable/ — confirmed by woo-hc against 3.6.2 and 3.6.3.

### Related issue(s)

WOOTAX-293

### Steps to reproduce & screenshots/GIFs

1. On a site where `WC_Helper_Options` is not available (e.g. WooCommerce not active, or a cron context that doesn't load it), call `WC_Connect_Functions::get_wc_helper_auth_info()`.
2. Before this fix: a PHP "Undefined variable $helper_auth_data" warning is emitted.
3. After this fix: no warning; the function still returns `WP_Error( 'missing_wccom_auth' )` as before.

### Checklist

- [ ] unit tests (no logic change — existing behavior preserved; not adding a test for a pure declaration fix)
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added