### PR TITLE
[WOOTAX-295] Tweak - WooCommerce 10.9 Compatibility.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.6.6 - 2026-xx-xx =
+* Tweak - WooCommerce 10.9 Compatibility.
+
 = 3.6.5 - 2026-06-08 =
 * Fix   - Prevent PHP "undefined variable" warning when WooCommerce Helper authentication data is unavailable.
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Requires PHP: 7.4
 Requires at least: 6.9
 Requires Plugins: woocommerce
 Tested up to: 7.0
-WC requires at least: 10.6
-WC tested up to: 10.8
+WC requires at least: 10.7
+WC tested up to: 10.9
 Stable tag: 3.6.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -69,6 +69,9 @@ This plugin relies on the following external services:
 2. Checking on the health of WooCommerce Tax
 
 == Changelog ==
+
+= 3.6.6 - 2026-xx-xx =
+* Tweak - WooCommerce 10.9 Compatibility.
 
 = 3.6.5 - 2026-06-08 =
 * Fix   - Prevent PHP "undefined variable" warning when WooCommerce Helper authentication data is unavailable.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -13,8 +13,8 @@
  * Requires PHP: 7.4
  * Requires at least: 6.9
  * Tested up to: 7.0
- * WC requires at least: 10.6
- * WC tested up to: 10.8
+ * WC requires at least: 10.7
+ * WC tested up to: 10.9
  *
  * Copyright (c) 2017-2023 Automattic
  *


### PR DESCRIPTION
Bumps WooCommerce compatibility headers for the WooCommerce 10.9 release.

- `WC requires at least`: 10.6 → 10.7 (plugin header and readme.txt)
- `WC tested up to`: 10.8 → 10.9 (plugin header and readme.txt)
- Added changelog entry for version 3.6.6 (changelog.txt and readme.txt).

Part of WOOTAX-295.
https://linear.app/a8c/issue/WOOTAX-295/ensure-woocommerce-109-compatibility-woocommerce-services-woo-tax