### PR TITLE
Fix WOOTAX-49 - Report unfiltered store currency for service fetch

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.6.6 - 2026-xx-xx =
+* Fix   - Prevent currency-switcher plugins from limiting the available shipping services.
+
 = 3.6.5 - 2026-06-08 =
 * Fix   - Prevent PHP "undefined variable" warning when WooCommerce Helper authentication data is unavailable.
 

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -482,7 +482,11 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				'base_country'         => WC()->countries->get_base_country(),
 				'base_state'           => WC()->countries->get_base_state(),
 				'base_postcode'        => WC()->countries->get_base_postcode(),
-				'currency'             => get_woocommerce_currency(),
+				// Report the store's configured base currency, not get_woocommerce_currency(), which applies the
+				// `woocommerce_currency` filter. Currency-switcher plugins filter that value per customer session,
+				// so a scheduled service-schema fetch running in such a session would otherwise report a display
+				// currency to the server and receive a currency-limited service list (WOOTAX-49).
+				'currency'             => get_option( 'woocommerce_currency' ),
 				'dimension_unit'       => strtolower( get_option( 'woocommerce_dimension_unit' ) ),
 				'weight_unit'          => strtolower( get_option( 'woocommerce_weight_unit' ) ),
 				'wcs_version'          => WC_Connect_Loader::get_wcs_version(),

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.6.6 - 2026-xx-xx =
+* Fix   - Prevent currency-switcher plugins from limiting the available shipping services.
+
 = 3.6.5 - 2026-06-08 =
 * Fix   - Prevent PHP "undefined variable" warning when WooCommerce Helper authentication data is unavailable.
 

--- a/tests/php/test-class-wc-connect-api-client.php
+++ b/tests/php/test-class-wc-connect-api-client.php
@@ -159,4 +159,49 @@ class WP_Test_WC_Connect_API_Client extends WC_Unit_Test_Case {
 		$this->assertWPError( $actual );
 		$this->assertEquals( 'sift_not_cached', $actual->get_error_code() );
 	}
+
+	/**
+	 * The currency reported to the WooCommerce Tax / Connect server must be the store's
+	 * configured base currency, never a per-session display currency injected by a
+	 * currency-switcher plugin through the `woocommerce_currency` filter.
+	 *
+	 * Regression test for WOOTAX-49: a scheduled service-schema fetch that ran inside a
+	 * customer session (where the currency had been filtered, e.g. to USD) reported the
+	 * filtered currency to the server, which then returned a currency-limited service
+	 * list and hid the store's configured shipping methods until settings were re-saved.
+	 */
+	public function test_get_settings_values_currency_ignores_woocommerce_currency_filter() {
+		$original_currency = get_option( 'woocommerce_currency' );
+		update_option( 'woocommerce_currency', 'CAD' );
+
+		$force_usd = static function () {
+			return 'USD';
+		};
+		add_filter( 'woocommerce_currency', $force_usd );
+
+		try {
+			// Precondition: a currency switcher really is filtering the display currency.
+			$this->assertSame( 'USD', get_woocommerce_currency(), 'Expected the woocommerce_currency filter to be active.' );
+
+			// Stub the loader collaborator so get_settings_values() can run in isolation.
+			$loader = $this->getMockBuilder( 'WC_Connect_Loader' )
+				->disableOriginalConstructor()
+				->setMethods( array( 'get_active_services' ) )
+				->getMock();
+			$loader->method( 'get_active_services' )->willReturn( array() );
+
+			$loader_prop = new ReflectionProperty( 'WC_Connect_API_Client', 'wc_connect_loader' );
+			$loader_prop->setAccessible( true );
+			$loader_prop->setValue( $this->api_client, $loader );
+
+			$get_settings_values = new ReflectionMethod( 'WC_Connect_API_Client', 'get_settings_values' );
+			$get_settings_values->setAccessible( true );
+			$values = $get_settings_values->invoke( $this->api_client );
+
+			$this->assertSame( 'CAD', $values['currency'], 'Settings currency must be the unfiltered store base currency.' );
+		} finally {
+			remove_filter( 'woocommerce_currency', $force_usd );
+			update_option( 'woocommerce_currency', $original_currency );
+		}
+	}
 }


### PR DESCRIPTION
## Description
<!-- Explain the motivation for making this change -->

`get_settings_values()` in the Connect API client reported the store currency to the WooCommerce Tax / Connect server using `get_woocommerce_currency()`, which applies the `woocommerce_currency` filter. Currency-switcher plugins (e.g. Currency Switcher for WooCommerce) filter that value **per customer session**.

The daily service-schema fetch (and the immediate fetch performed when no schemas are cached) can run inside a front-end customer session, so the filtered display currency (e.g. USD) was reported to the server instead of the store's configured base currency (e.g. CAD). The server then returned a currency-limited service list, and the store's configured shipping method disappeared until the settings were re-saved (which forces a fresh fetch in an admin context with the correct currency).

This reports the unfiltered store base currency via `get_option( 'woocommerce_currency' )`. The store's configured base currency — not a per-session display currency — is the correct value to send to the server for all requests; carrier rates are priced in the store base currency regardless of the shopper's selected display currency. `get_settings_values()` is the single source feeding the request body and the `X-Woo-Settings` proxy header, so this one change corrects the currency for the schema fetch and every other settings/rate request.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
Fixes #1312
Linear: WOOTAX-49

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
1. Install and configure a currency-switcher plugin (e.g. Currency Switcher for WooCommerce) with a display currency (e.g. USD) that differs from the store base currency (e.g. CAD).
2. Enable frequent fetch: `define( 'WOOCOMMERCE_CONNECT_FREQUENT_FETCH', true );`
3. Load a front-end page as a customer (so the `woocommerce_currency` filter is applied), triggering a service-schema fetch.
4. Disable frequent fetch.
5. On a shipping zone screen, open **Add shipping method** and confirm the available services match the store base currency/country (the configured method is present), not the filtered currency.

Before this fix, the service list reflected the filtered currency and the configured method was missing until the settings were re-saved.

N/A - logic fix, no visual changes.

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added
