### PR TITLE
WOOTAX-25 - Add regression test for zero-amount tax calculations

### DIFF
--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -1146,4 +1146,84 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$this->assertEmpty( $result['line_items'] );
 		$this->assertEquals( 0, $result['has_nexus'] );
 	}
+
+	/**
+	 * A tax calculation whose taxable amount is zero must not zero out the tax rate.
+	 *
+	 * When a subscription is switched, or when a free-trial subscription's initial
+	 * cart total is $0, TaxJar returns a response whose top-level `rate` (and
+	 * `amount_to_collect`) is 0 because `taxable_amount` is 0 — yet the real
+	 * per-jurisdiction rates are still present inside `breakdown.line_items`. The
+	 * itemized rate builder must persist those real rates and must never write the
+	 * zeroed top-level rate, which previously clobbered an existing tax rate to
+	 * 0.0000%.
+	 *
+	 * Regression test for WOOTAX-25 (free-trial renewal charged no tax) and
+	 * WOOTAX-18 (subscription switch zeroed an existing rate). The fixture mirrors
+	 * the exact response captured in WOOTAX-18.
+	 */
+	public function test_zero_amount_response_persists_real_itemized_rates() {
+		$options = array(
+			'to_country' => 'US',
+			'to_state'   => 'MO',
+			'to_zip'     => '64150',
+			'to_city'    => 'RIVERSIDE',
+		);
+
+		// taxable_amount and the top-level rate are 0, but the line item still
+		// carries the real jurisdiction rates (city 1.5%, county 1.25%, state 4.225%).
+		$line_item = (object) array(
+			'id'                   => '351-regressionkey',
+			'city_tax_rate'        => 0.015,
+			'county_tax_rate'      => 0.0125,
+			'state_sales_tax_rate' => 0.04225,
+			'special_tax_rate'     => 0.0,
+			'combined_tax_rate'    => 0.06975,
+			'taxable_amount'       => 0.0,
+		);
+		$taxjar_taxes = (object) array(
+			'freight_taxable' => 0,
+			'has_nexus'       => 1,
+			'rate'            => 0.0,
+			'jurisdictions'   => (object) array(
+				'country' => 'US',
+				'state'   => 'MO',
+				'county'  => 'PLATTE COUNTY',
+				'city'    => 'RIVERSIDE',
+			),
+			'breakdown'       => (object) array(
+				'line_items' => array( $line_item ),
+			),
+		);
+
+		$taxes = array(
+			'freight_taxable' => 1,
+			'has_nexus'       => 0,
+			'line_items'      => array(),
+			'rate_ids'        => array(),
+			'tax_rate'        => 0,
+		);
+
+		$result = $this->invoke_protected_method( 'get_itemized_tax_rates', array( $taxes, $taxjar_taxes, $options ) );
+
+		$this->assertArrayHasKey( '351-regressionkey', $result['rate_ids'] );
+
+		$persisted = array();
+		foreach ( $result['rate_ids']['351-regressionkey'] as $rate_id ) {
+			$rate        = WC_Tax::_get_tax_rate( $rate_id );
+			$persisted[] = (float) $rate['tax_rate'];
+		}
+		sort( $persisted );
+
+		// One row per jurisdiction component (city, county, state, special district).
+		$this->assertCount( 4, $persisted );
+		$this->assertEqualsWithDelta( 0.0, $persisted[0], 0.0001, 'Special district rate.' );
+		$this->assertEqualsWithDelta( 1.25, $persisted[1], 0.0001, 'County rate.' );
+		$this->assertEqualsWithDelta( 1.5, $persisted[2], 0.0001, 'City rate.' );
+		$this->assertEqualsWithDelta( 4.225, $persisted[3], 0.0001, 'State rate.' );
+
+		// The combined persisted rate must equal the real 6.975%, never the zeroed
+		// top-level rate. This is the core guard against the zeroing-out regression.
+		$this->assertEqualsWithDelta( 6.975, array_sum( $persisted ), 0.0001, 'Existing tax rate must not be zeroed out by a $0 calculation.' );
+	}
 }


### PR DESCRIPTION
## Description
<!-- Explain the motivation for making this change -->

When a subscription is switched, or when a free-trial subscription's initial cart total is `$0`, TaxJar returns a response whose top-level `rate` (and `amount_to_collect`) is `0` because `taxable_amount` is `0` — while the real per-jurisdiction rates are still present inside `breakdown.line_items`. Historically the rate builder wrote the zeroed top-level rate into the shared WooCommerce tax-rate row, which set an existing rate to `0.0000%` (WOOTAX-18) and left subscription renewals with no tax (WOOTAX-25).

The current `get_itemized_tax_rates()` already persists the real per-jurisdiction rates from `breakdown.line_items` and never writes the zeroed top-level rate (fixed by the itemized-tax-rate refactor). This PR is a **test-only** change that locks that behaviour in with a regression test, so the zeroing-out cannot silently come back.

The test feeds the exact zero-amount response captured in WOOTAX-18 into `get_itemized_tax_rates()` and asserts the real per-jurisdiction rates (city 1.5%, county 1.25%, state 4.225%) are persisted and the combined rate is 6.975%, never 0. It was verified to fail if the builder is reverted to writing the top-level rate.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->
Linear: WOOTAX-25 (same root cause as WOOTAX-18 / #2826).

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->
Original bug (no longer reproducible on trunk):
1. Enable automated tax rates (WooCommerce Tax).
2. Create a subscription product with a free trial and no sign-up fee.
3. Add it to the cart; observe the "recurring total" tax line shows $0.00 because the $0 initial calculation zeroed the shared tax rate.

Verifying the guard:
1. Run the suite: `./vendor/bin/phpunit --filter test_zero_amount_response_persists_real_itemized_rates` — passes on trunk.
2. Temporarily change the line-item rate in `get_itemized_tax_rates()` to write the top-level rate — the test fails, confirming it catches the regression.

N/A - test-only change, no visual changes.

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added — N/A: test-only change, no user-facing impact.
- [ ] `readme.txt` entry added — N/A: test-only change, no user-facing impact.
