### PR TITLE
Fix/issue WOOSHIP-2256 - Fixes for TaxJar tax lines wiped when REST API order update includes address change

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.6.7 - 2026-xx-xx =
+* Fix   - TaxJar tax lines wiped when REST API order update includes address change.
+
 = 3.6.6 - 2026-06-22 =
 * Tweak - WooCommerce 10.9 Compatibility.
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -78,6 +78,22 @@ class WC_Connect_TaxJar_Integration {
 	private $backend_tax_classes;
 
 	/**
+	 * Whether TaxJar API recalculation failed on the current order update.
+	 *
+	 * @since x.x.x
+	 * @var bool
+	 */
+	private $taxjar_recalculation_failed = false;
+
+	/**
+	 * Snapshotted tax state saved before a non-cart recalculation, for fallback restore.
+	 *
+	 * @since x.x.x
+	 * @var array
+	 */
+	private $pre_recalculation_tax_snapshot = array();
+
+	/**
 	 * Tracks instance.
 	 *
 	 * @var WC_Connect_Tracks
@@ -214,6 +230,9 @@ class WC_Connect_TaxJar_Integration {
 
 		// Calculate Taxes for Backend Orders (Woo 2.6+)
 		add_action( 'woocommerce_before_save_order_items', array( $this, 'calculate_backend_totals' ), 20 );
+
+		// Calculate taxes via TaxJar API for REST API / programmatic order updates.
+		add_action( 'woocommerce_order_before_calculate_taxes', array( $this, 'calculate_order_taxes_via_taxjar' ), 10, 2 );
 
 		// Set customer taxable location for local pickup
 		add_filter( 'woocommerce_customer_taxable_address', array( $this, 'append_base_address_to_customer_taxable_address' ), 10, 1 );
@@ -2159,5 +2178,19 @@ class WC_Connect_TaxJar_Integration {
 		if ( 'not set' === $to_state || 'not set' === $to_country || null === $has_nexus ) {
 			throw new Exception( sprintf( 'One or more values are not set : to_state=>%1$s, to_country=>%2$s, has_nexus=>%3$s', $to_state, $to_country, json_encode( $has_nexus ) ) );
 		}
+	}
+
+	/**
+	 * Calculate order taxes via TaxJar API for non-cart, non-admin contexts.
+	 *
+	 * Fires on woocommerce_order_before_calculate_taxes to intercept tax
+	 * recalculation triggered by REST API or direct programmatic calls to
+	 * $order->calculate_totals(), before WC's native find_rates() runs.
+	 *
+	 * @since x.x.x
+	 * @param array    $args  Args passed to calculate_taxes().
+	 * @param WC_Order $order The order being recalculated.
+	 */
+	public function calculate_order_taxes_via_taxjar( $args, $order ) {
 	}
 }

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -2192,6 +2192,9 @@ class WC_Connect_TaxJar_Integration {
 	 * @param WC_Order $order The order being recalculated.
 	 */
 	public function calculate_order_taxes_via_taxjar( $args, $order ) {
+		// Reset failure flag from any previous call.
+		$this->taxjar_recalculation_failed = false;
+
 		// Skip if TaxJar already ran for this request (cart/checkout path populated response_rate_ids).
 		if ( ! empty( $this->response_rate_ids ) ) {
 			return;
@@ -2205,6 +2208,69 @@ class WC_Connect_TaxJar_Integration {
 		// Skip if new order being created from scratch (no existing taxes to recalculate).
 		if ( ! $order->get_id() ) {
 			return;
+		}
+
+		// Snapshot existing tax state in case we need to restore on API failure.
+		$this->pre_recalculation_tax_snapshot = $this->snapshot_order_taxes( $order );
+
+		// Ensure WC customer object is available (may be null in REST/CLI context).
+		if ( is_null( WC()->customer ) ) {
+			WC()->customer = new WC_Customer( $order->get_customer_id() );
+		}
+
+		// Build address from order (reflects any address update already applied by REST request).
+		$to_country = strtoupper( $order->get_shipping_country() ?: $order->get_billing_country() );
+		$to_state   = strtoupper( $order->get_shipping_state() ?: $order->get_billing_state() );
+		$to_zip     = $order->get_shipping_postcode() ?: $order->get_billing_postcode();
+		$to_city    = $order->get_shipping_city() ?: $order->get_billing_city();
+		$to_street  = $order->get_shipping_address_1() ?: $order->get_billing_address_1();
+
+		// Get line items and shipping using the existing backend helper.
+		$line_items = $this->get_backend_line_items( $order );
+		$shipping   = $order->get_shipping_total();
+
+		// Call TaxJar API.
+		$taxes = $this->calculate_tax(
+			array(
+				'to_country'      => $to_country,
+				'to_state'        => $to_state,
+				'to_zip'          => $to_zip,
+				'to_city'         => $to_city,
+				'to_street'       => $to_street,
+				'shipping_amount' => $shipping,
+				'line_items'      => $line_items,
+			)
+		);
+
+		if ( false === $taxes ) {
+			$this->_log( 'TaxJar API failed for order ' . $order->get_id() . '. Preserving existing taxes as fallback.' );
+			$this->taxjar_recalculation_failed = true;
+			$snapshot                          = $this->pre_recalculation_tax_snapshot;
+			add_action(
+				'woocommerce_order_after_calculate_totals',
+				function ( $and_taxes, $updated_order ) use ( $order, $snapshot ) {
+					if ( $updated_order->get_id() === $order->get_id() ) {
+						$this->restore_order_taxes( $updated_order, $snapshot );
+					}
+				},
+				10,
+				2
+			);
+			return;
+		}
+
+		$this->response_rate_ids   = $taxes['rate_ids'];
+		$this->response_line_items = $taxes['line_items'];
+
+		// Adjust line_total on response_line_items to match what override_woocommerce_tax_rates expects.
+		if ( isset( $this->response_line_items ) ) {
+			foreach ( $this->response_line_items as $response_line_item_key => $response_line_item ) {
+				$line_item = $this->get_line_item( $response_line_item_key, $line_items );
+				if ( isset( $line_item ) ) {
+					$this->response_line_items[ $response_line_item_key ]->line_total =
+						( $line_item['unit_price'] * $line_item['quantity'] ) - $line_item['discount'];
+				}
+			}
 		}
 	}
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -66,6 +66,14 @@ class WC_Connect_TaxJar_Integration {
 	private $response_line_items;
 
 	/**
+	 * Tax snapshots captured before an out-of-cart recalculation, keyed by order id,
+	 * so they can be restored after WC recalculates the order totals.
+	 *
+	 * @var array
+	 */
+	private $pre_recalculation_tax_snapshots = array();
+
+	/**
 	 * @var bool
 	 */
 	private $is_itemized_tax_display;
@@ -2181,10 +2189,21 @@ class WC_Connect_TaxJar_Integration {
 	 * untouched, and an order with no existing tax lines is left to calculate for the
 	 * first time normally.
 	 *
+	 * Restoration happens on woocommerce_order_after_calculate_totals, the only post-
+	 * recalculation hook WC fires on this path. A caller that invokes
+	 * WC_Abstract_Order::calculate_taxes() directly (without a following
+	 * calculate_totals()) is therefore not restored, because WC exposes no hook after
+	 * calculate_taxes(); the REST API and programmatic order-update paths this targets
+	 * all go through calculate_totals(). The snapshot is stashed by order id (not in a
+	 * per-call closure) so a batch can recalculate many orders without stacking one-shot
+	 * callbacks, and so a snapshot whose restore never fires cannot leak onto the hook.
+	 *
 	 * @internal Hooked to woocommerce_order_before_calculate_taxes.
-	 * @since 3.6.7
+	 *
 	 * @param array    $args  Args passed to calculate_taxes(). Unused.
 	 * @param WC_Order $order The order being recalculated.
+	 *
+	 * @since 3.6.7
 	 */
 	public function preserve_order_taxes_on_recalculation( $args, $order ) {
 		// The cart/checkout flow populates response_rate_ids and manages its own taxes.
@@ -2210,19 +2229,38 @@ class WC_Connect_TaxJar_Integration {
 			return;
 		}
 
-		$order_id         = $order->get_id();
-		$restore_callback = null;
-		$restore_callback = function ( $and_taxes, $recalculated_order ) use ( $order_id, $snapshot, &$restore_callback ) {
-			if ( (int) $recalculated_order->get_id() !== (int) $order_id ) {
-				return;
-			}
+		// Stash the snapshot keyed by order id and register a single restore handler.
+		$this->pre_recalculation_tax_snapshots[ (int) $order->get_id() ] = $snapshot;
 
-			// Remove the callback first so it only runs once, then restore the taxes.
-			remove_action( 'woocommerce_order_after_calculate_totals', $restore_callback, 10 );
-			$this->restore_order_taxes( $recalculated_order, $snapshot );
-		};
+		// remove_action() first so repeated recalculations register the handler once.
+		remove_action( 'woocommerce_order_after_calculate_totals', array( $this, 'restore_order_taxes_after_recalculation' ), 10 );
+		add_action( 'woocommerce_order_after_calculate_totals', array( $this, 'restore_order_taxes_after_recalculation' ), 10, 2 );
+	}
 
-		add_action( 'woocommerce_order_after_calculate_totals', $restore_callback, 10, 2 );
+	/**
+	 * Restore a preserved tax snapshot after WC has recalculated an order's totals.
+	 *
+	 * Looks up the snapshot captured in preserve_order_taxes_on_recalculation() for the
+	 * recalculated order and, if one is present, restores it and drops it from the
+	 * pending set. Keyed by order id so a batch that recalculates several orders
+	 * restores each from its own snapshot.
+	 *
+	 * @internal Hooked to woocommerce_order_after_calculate_totals.
+	 *
+	 * @param bool     $and_taxes Whether taxes were recalculated. Unused.
+	 * @param WC_Order $order     The order whose totals were recalculated.
+	 */
+	public function restore_order_taxes_after_recalculation( $and_taxes, $order ) {
+		$order_id = (int) $order->get_id();
+
+		if ( ! isset( $this->pre_recalculation_tax_snapshots[ $order_id ] ) ) {
+			return;
+		}
+
+		$snapshot = $this->pre_recalculation_tax_snapshots[ $order_id ];
+		unset( $this->pre_recalculation_tax_snapshots[ $order_id ] );
+
+		$this->restore_order_taxes( $order, $snapshot );
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -2207,4 +2207,93 @@ class WC_Connect_TaxJar_Integration {
 			return;
 		}
 	}
+
+	/**
+	 * Snapshot the current tax state of an order before recalculation.
+	 *
+	 * Captures tax line items and per-item tax arrays so they can be restored
+	 * if a subsequent TaxJar API call fails.
+	 *
+	 * @since x.x.x
+	 * @param WC_Order $order The order to snapshot.
+	 * @return array {
+	 *   @type array $tax_lines  Keyed by item_id; each has 'rate_id', 'tax_total', 'shipping_tax_total'.
+	 *   @type array $item_taxes Keyed by item_id (prefix 'shipping_' for shipping items); each is a taxes array.
+	 * }
+	 */
+	private function snapshot_order_taxes( $order ) {
+		$snapshot = array(
+			'tax_lines'  => array(),
+			'item_taxes' => array(),
+		);
+
+		foreach ( $order->get_taxes() as $item_id => $tax_item ) {
+			$snapshot['tax_lines'][ $item_id ] = array(
+				'rate_id'            => $tax_item->get_rate_id(),
+				'tax_total'          => $tax_item->get_tax_total(),
+				'shipping_tax_total' => $tax_item->get_shipping_tax_total(),
+			);
+		}
+
+		foreach ( $order->get_items( array( 'line_item', 'fee' ) ) as $item_id => $item ) {
+			$snapshot['item_taxes'][ $item_id ] = $item->get_taxes();
+		}
+
+		foreach ( $order->get_shipping_methods() as $item_id => $item ) {
+			$snapshot['item_taxes'][ 'shipping_' . $item_id ] = $item->get_taxes();
+		}
+
+		return $snapshot;
+	}
+
+	/**
+	 * Restore order taxes from a previously taken snapshot.
+	 *
+	 * Called when TaxJar API fails during a non-cart recalculation, to undo
+	 * whatever WC's update_taxes() did and put the original tax data back.
+	 *
+	 * @since x.x.x
+	 * @param WC_Order $order    The order to restore into.
+	 * @param array    $snapshot Snapshot returned by snapshot_order_taxes().
+	 */
+	private function restore_order_taxes( $order, $snapshot ) {
+		if ( empty( $snapshot ) ) {
+			return;
+		}
+
+		// Restore per-item tax arrays on line items and fees.
+		foreach ( $order->get_items( array( 'line_item', 'fee' ) ) as $item_id => $item ) {
+			if ( isset( $snapshot['item_taxes'][ $item_id ] ) ) {
+				$item->set_taxes( $snapshot['item_taxes'][ $item_id ] );
+				$item->save();
+			}
+		}
+
+		// Restore per-item tax arrays on shipping items.
+		foreach ( $order->get_shipping_methods() as $item_id => $item ) {
+			if ( isset( $snapshot['item_taxes'][ 'shipping_' . $item_id ] ) ) {
+				$item->set_taxes( $snapshot['item_taxes'][ 'shipping_' . $item_id ] );
+				$item->save();
+			}
+		}
+
+		// Remove all current tax line items (update_taxes() may have wiped and re-added wrong ones).
+		foreach ( $order->get_taxes() as $tax_item ) {
+			$order->remove_item( $tax_item->get_id() );
+		}
+
+		// Re-add tax lines from snapshot.
+		foreach ( $snapshot['tax_lines'] as $tax_data ) {
+			$tax_item = new WC_Order_Item_Tax();
+			$tax_item->set_rate( $tax_data['rate_id'] );
+			$tax_item->set_tax_total( $tax_data['tax_total'] );
+			$tax_item->set_shipping_tax_total( $tax_data['shipping_tax_total'] );
+			$order->add_item( $tax_item );
+		}
+
+		// Recalculate order-level totals from restored snapshot data.
+		$order->set_cart_tax( array_sum( array_column( $snapshot['tax_lines'], 'tax_total' ) ) );
+		$order->set_shipping_tax( array_sum( array_column( $snapshot['tax_lines'], 'shipping_tax_total' ) ) );
+		$order->save();
+	}
 }

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -2203,7 +2203,7 @@ class WC_Connect_TaxJar_Integration {
 	 * @param array    $args  Args passed to calculate_taxes(). Unused.
 	 * @param WC_Order $order The order being recalculated.
 	 *
-	 * @since 3.6.7
+	 * @since 3.6.8
 	 */
 	public function preserve_order_taxes_on_recalculation( $args, $order ) {
 		// The cart/checkout flow populates response_rate_ids and manages its own taxes.
@@ -2270,7 +2270,7 @@ class WC_Connect_TaxJar_Integration {
 	 * arrays, and the order-level tax totals so they can be restored verbatim after
 	 * WC recalculates the order for a changed address.
 	 *
-	 * @since 3.6.7
+	 * @since 3.6.8
 	 * @param WC_Order $order The order to snapshot.
 	 * @return array {
 	 *   @type array  $tax_lines    Keyed by item_id; each holds the full WC_Order_Item_Tax field set.
@@ -2320,7 +2320,7 @@ class WC_Connect_TaxJar_Integration {
 	 * instead of whatever WC computed for the new address, while keeping any updated
 	 * non-tax amounts (such as a changed shipping total).
 	 *
-	 * @since 3.6.7
+	 * @since 3.6.8
 	 * @param WC_Order $order    The order to restore into.
 	 * @param array    $snapshot Snapshot returned by snapshot_order_taxes().
 	 */

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -2361,5 +2361,11 @@ class WC_Connect_TaxJar_Integration {
 		$order->set_cart_tax( array_sum( array_column( $snapshot['tax_lines'], 'tax_total' ) ) );
 		$order->set_shipping_tax( array_sum( array_column( $snapshot['tax_lines'], 'shipping_tax_total' ) ) );
 		$order->save();
+
+		// Update the order total to include the restored taxes.
+		$cart_tax     = $order->get_cart_tax();
+		$shipping_tax = $order->get_shipping_tax();
+		$order->set_total( $order->get_subtotal() - $order->get_discount_total() + $order->get_shipping_total() + $order->get_total_fees() + $cart_tax + $shipping_tax );
+		$order->save();
 	}
 }

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -86,6 +86,15 @@ class WC_Connect_TaxJar_Integration {
 	private $taxjar_recalculation_failed = false;
 
 	/**
+	 * Whether response_rate_ids was populated by calculate_order_taxes_via_taxjar()
+	 * (as opposed to the cart/checkout path). Used to detect stale state in batch requests.
+	 *
+	 * @since x.x.x
+	 * @var bool
+	 */
+	private $response_rate_ids_from_order = false;
+
+	/**
 	 * Snapshotted tax state saved before a non-cart recalculation, for fallback restore.
 	 *
 	 * @since x.x.x
@@ -2195,7 +2204,16 @@ class WC_Connect_TaxJar_Integration {
 		// Reset failure flag from any previous call.
 		$this->taxjar_recalculation_failed = false;
 
-		// Skip if TaxJar already ran for this request (cart/checkout path populated response_rate_ids).
+		// If response_rate_ids was set by a previous order in this process (e.g. batch REST
+		// request or programmatic loop), clear it so each order gets its own TaxJar call.
+		// We do NOT clear when the cart/checkout path set response_rate_ids (that flag stays false).
+		if ( $this->response_rate_ids_from_order ) {
+			$this->response_rate_ids          = null;
+			$this->response_line_items        = null;
+			$this->response_rate_ids_from_order = false;
+		}
+
+		// Skip if TaxJar already ran for this request via the cart/checkout path.
 		if ( ! empty( $this->response_rate_ids ) ) {
 			return;
 		}
@@ -2214,6 +2232,8 @@ class WC_Connect_TaxJar_Integration {
 		$this->pre_recalculation_tax_snapshot = $this->snapshot_order_taxes( $order );
 
 		// Ensure WC customer object is available (may be null in REST/CLI context).
+		// Save and restore the previous value to avoid polluting global state across orders.
+		$previous_customer = WC()->customer;
 		if ( is_null( WC()->customer ) ) {
 			WC()->customer = new WC_Customer( $order->get_customer_id() );
 		}
@@ -2242,25 +2262,29 @@ class WC_Connect_TaxJar_Integration {
 			)
 		);
 
+		// Restore customer regardless of outcome to avoid cross-order contamination.
+		WC()->customer = $previous_customer;
+
 		if ( false === $taxes ) {
 			$this->_log( 'TaxJar API failed for order ' . $order->get_id() . '. Preserving existing taxes as fallback.' );
 			$this->taxjar_recalculation_failed = true;
 			$snapshot                          = $this->pre_recalculation_tax_snapshot;
-			add_action(
-				'woocommerce_order_after_calculate_totals',
-				function ( $and_taxes, $updated_order ) use ( $order, $snapshot ) {
-					if ( $updated_order->get_id() === $order->get_id() ) {
-						$this->restore_order_taxes( $updated_order, $snapshot );
-					}
-				},
-				10,
-				2
-			);
+			// Use a named variable so the closure can remove itself after firing once
+			// for the matching order, preventing it from persisting on the hook indefinitely.
+			$restore_callback = null;
+			$restore_callback = function ( $and_taxes, $updated_order ) use ( $order, $snapshot, &$restore_callback ) {
+				if ( $updated_order->get_id() === $order->get_id() ) {
+					remove_action( 'woocommerce_order_after_calculate_totals', $restore_callback, 10 );
+					$this->restore_order_taxes( $updated_order, $snapshot );
+				}
+			};
+			add_action( 'woocommerce_order_after_calculate_totals', $restore_callback, 10, 2 );
 			return;
 		}
 
-		$this->response_rate_ids   = $taxes['rate_ids'];
-		$this->response_line_items = $taxes['line_items'];
+		$this->response_rate_ids            = $taxes['rate_ids'];
+		$this->response_line_items          = $taxes['line_items'];
+		$this->response_rate_ids_from_order = true;
 
 		// Adjust line_total on response_line_items to match what override_woocommerce_tax_rates expects.
 		if ( isset( $this->response_line_items ) ) {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -2206,6 +2206,13 @@ class WC_Connect_TaxJar_Integration {
 	 * @since 3.6.8
 	 */
 	public function preserve_order_taxes_on_recalculation( $args, $order ) {
+		// The gates below are exclusionary: preservation runs for ANY out-of-cart
+		// recalculation of an existing, already-taxed order — the REST/address-change
+		// path this fix targets, but also WP-CLI, cron, and Action Scheduler runs.
+		// That breadth is intentional: once an order is placed its tax is a record of
+		// what was charged, so we preserve it on every programmatic recalculation, not
+		// only the REST path that prompted this fix.
+
 		// The cart/checkout flow populates response_rate_ids and manages its own taxes.
 		if ( ! empty( $this->response_rate_ids ) ) {
 			return;

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -2351,7 +2351,7 @@ class WC_Connect_TaxJar_Integration {
 		// Re-add tax lines from snapshot.
 		foreach ( $snapshot['tax_lines'] as $tax_data ) {
 			$tax_item = new WC_Order_Item_Tax();
-			$tax_item->set_rate( $tax_data['rate_id'] );
+			$tax_item->set_rate_id( $tax_data['rate_id'] );
 			$tax_item->set_tax_total( $tax_data['tax_total'] );
 			$tax_item->set_shipping_tax_total( $tax_data['shipping_tax_total'] );
 			$order->add_item( $tax_item );

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -2192,5 +2192,19 @@ class WC_Connect_TaxJar_Integration {
 	 * @param WC_Order $order The order being recalculated.
 	 */
 	public function calculate_order_taxes_via_taxjar( $args, $order ) {
+		// Skip if TaxJar already ran for this request (cart/checkout path populated response_rate_ids).
+		if ( ! empty( $this->response_rate_ids ) ) {
+			return;
+		}
+
+		// Skip if admin AJAX — handled by calculate_backend_totals().
+		if ( wp_doing_ajax() ) {
+			return;
+		}
+
+		// Skip if new order being created from scratch (no existing taxes to recalculate).
+		if ( ! $order->get_id() ) {
+			return;
+		}
 	}
 }

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -78,31 +78,6 @@ class WC_Connect_TaxJar_Integration {
 	private $backend_tax_classes;
 
 	/**
-	 * Whether TaxJar API recalculation failed on the current order update.
-	 *
-	 * @since x.x.x
-	 * @var bool
-	 */
-	private $taxjar_recalculation_failed = false;
-
-	/**
-	 * Whether response_rate_ids was populated by calculate_order_taxes_via_taxjar()
-	 * (as opposed to the cart/checkout path). Used to detect stale state in batch requests.
-	 *
-	 * @since x.x.x
-	 * @var bool
-	 */
-	private $response_rate_ids_from_order = false;
-
-	/**
-	 * Snapshotted tax state saved before a non-cart recalculation, for fallback restore.
-	 *
-	 * @since x.x.x
-	 * @var array
-	 */
-	private $pre_recalculation_tax_snapshot = array();
-
-	/**
 	 * Tracks instance.
 	 *
 	 * @var WC_Connect_Tracks
@@ -240,8 +215,10 @@ class WC_Connect_TaxJar_Integration {
 		// Calculate Taxes for Backend Orders (Woo 2.6+)
 		add_action( 'woocommerce_before_save_order_items', array( $this, 'calculate_backend_totals' ), 20 );
 
-		// Calculate taxes via TaxJar API for REST API / programmatic order updates.
-		add_action( 'woocommerce_order_before_calculate_taxes', array( $this, 'calculate_order_taxes_via_taxjar' ), 10, 2 );
+		// Preserve recorded taxes when an existing order is recalculated outside the
+		// cart/checkout and admin flows (e.g. a REST API or programmatic order update),
+		// so a changed address does not wipe the stored tax lines to zero.
+		add_action( 'woocommerce_order_before_calculate_taxes', array( $this, 'preserve_order_taxes_on_recalculation' ), 10, 2 );
 
 		// Set customer taxable location for local pickup
 		add_filter( 'woocommerce_customer_taxable_address', array( $this, 'append_base_address_to_customer_taxable_address' ), 10, 1 );
@@ -2190,136 +2167,97 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	/**
-	 * Calculate order taxes via TaxJar API for non-cart, non-admin contexts.
+	 * Preserve an order's recorded taxes when it is recalculated outside the cart.
 	 *
-	 * Fires on woocommerce_order_before_calculate_taxes to intercept tax
-	 * recalculation triggered by REST API or direct programmatic calls to
-	 * $order->calculate_totals(), before WC's native find_rates() runs.
+	 * WC_Abstract_Order::calculate_taxes() recomputes item taxes against the order's
+	 * current address using WC_Tax::find_rates(). TaxJar stores its rates scoped to
+	 * the checkout address, so when a REST API or programmatic update changes the
+	 * address the lookup returns nothing and update_taxes() wipes every tax line to
+	 * zero. Once an order is placed its tax is a record of what was charged, so we
+	 * preserve it rather than recompute it: snapshot the existing taxes here (before
+	 * WC recalculates) and restore them once the totals have been recalculated.
 	 *
-	 * @since x.x.x
-	 * @param array    $args  Args passed to calculate_taxes().
+	 * The cart/checkout and admin-AJAX flows have their own handling and are left
+	 * untouched, and an order with no existing tax lines is left to calculate for the
+	 * first time normally.
+	 *
+	 * @internal Hooked to woocommerce_order_before_calculate_taxes.
+	 * @since 3.6.7
+	 * @param array    $args  Args passed to calculate_taxes(). Unused.
 	 * @param WC_Order $order The order being recalculated.
 	 */
-	public function calculate_order_taxes_via_taxjar( $args, $order ) {
-		// Reset failure flag from any previous call.
-		$this->taxjar_recalculation_failed = false;
-
-		// If response_rate_ids was set by a previous order in this process (e.g. batch REST
-		// request or programmatic loop), clear it so each order gets its own TaxJar call.
-		// We do NOT clear when the cart/checkout path set response_rate_ids (that flag stays false).
-		if ( $this->response_rate_ids_from_order ) {
-			$this->response_rate_ids          = null;
-			$this->response_line_items        = null;
-			$this->response_rate_ids_from_order = false;
-		}
-
-		// Skip if TaxJar already ran for this request via the cart/checkout path.
+	public function preserve_order_taxes_on_recalculation( $args, $order ) {
+		// The cart/checkout flow populates response_rate_ids and manages its own taxes.
 		if ( ! empty( $this->response_rate_ids ) ) {
 			return;
 		}
 
-		// Skip if admin AJAX — handled by calculate_backend_totals().
+		// Admin order edits recalculate over AJAX and are handled by calculate_backend_totals().
 		if ( wp_doing_ajax() ) {
 			return;
 		}
 
-		// Skip if new order being created from scratch (no existing taxes to recalculate).
+		// A new order that does not exist yet has no recorded taxes to preserve.
 		if ( ! $order->get_id() ) {
 			return;
 		}
 
-		// Snapshot existing tax state in case we need to restore on API failure.
-		$this->pre_recalculation_tax_snapshot = $this->snapshot_order_taxes( $order );
+		$snapshot = $this->snapshot_order_taxes( $order );
 
-		// Ensure WC customer object is available (may be null in REST/CLI context).
-		// Save and restore the previous value to avoid polluting global state across orders.
-		$previous_customer = WC()->customer;
-		if ( is_null( WC()->customer ) ) {
-			WC()->customer = new WC_Customer( $order->get_customer_id() );
-		}
-
-		// Build address from order (reflects any address update already applied by REST request).
-		$to_country = strtoupper( $order->get_shipping_country() ?: $order->get_billing_country() );
-		$to_state   = strtoupper( $order->get_shipping_state() ?: $order->get_billing_state() );
-		$to_zip     = $order->get_shipping_postcode() ?: $order->get_billing_postcode();
-		$to_city    = $order->get_shipping_city() ?: $order->get_billing_city();
-		$to_street  = $order->get_shipping_address_1() ?: $order->get_billing_address_1();
-
-		// Get line items and shipping using the existing backend helper.
-		$line_items = $this->get_backend_line_items( $order );
-		$shipping   = $order->get_shipping_total();
-
-		// Call TaxJar API.
-		$taxes = $this->calculate_tax(
-			array(
-				'to_country'      => $to_country,
-				'to_state'        => $to_state,
-				'to_zip'          => $to_zip,
-				'to_city'         => $to_city,
-				'to_street'       => $to_street,
-				'shipping_amount' => $shipping,
-				'line_items'      => $line_items,
-			)
-		);
-
-		// Restore customer regardless of outcome to avoid cross-order contamination.
-		WC()->customer = $previous_customer;
-
-		if ( false === $taxes ) {
-			$this->_log( 'TaxJar API failed for order ' . $order->get_id() . '. Preserving existing taxes as fallback.' );
-			$this->taxjar_recalculation_failed = true;
-			$snapshot                          = $this->pre_recalculation_tax_snapshot;
-			// Use a named variable so the closure can remove itself after firing once
-			// for the matching order, preventing it from persisting on the hook indefinitely.
-			$restore_callback = null;
-			$restore_callback = function ( $and_taxes, $updated_order ) use ( $order, $snapshot, &$restore_callback ) {
-				if ( $updated_order->get_id() === $order->get_id() ) {
-					remove_action( 'woocommerce_order_after_calculate_totals', $restore_callback, 10 );
-					$this->restore_order_taxes( $updated_order, $snapshot );
-				}
-			};
-			add_action( 'woocommerce_order_after_calculate_totals', $restore_callback, 10, 2 );
+		// Only preserve when the order already had tax lines; never turn a first-time
+		// tax calculation into a zeroed one.
+		if ( empty( $snapshot['tax_lines'] ) ) {
 			return;
 		}
 
-		$this->response_rate_ids            = $taxes['rate_ids'];
-		$this->response_line_items          = $taxes['line_items'];
-		$this->response_rate_ids_from_order = true;
-
-		// Adjust line_total on response_line_items to match what override_woocommerce_tax_rates expects.
-		if ( isset( $this->response_line_items ) ) {
-			foreach ( $this->response_line_items as $response_line_item_key => $response_line_item ) {
-				$line_item = $this->get_line_item( $response_line_item_key, $line_items );
-				if ( isset( $line_item ) ) {
-					$this->response_line_items[ $response_line_item_key ]->line_total =
-						( $line_item['unit_price'] * $line_item['quantity'] ) - $line_item['discount'];
-				}
+		$order_id         = $order->get_id();
+		$restore_callback = null;
+		$restore_callback = function ( $and_taxes, $recalculated_order ) use ( $order_id, $snapshot, &$restore_callback ) {
+			if ( (int) $recalculated_order->get_id() !== (int) $order_id ) {
+				return;
 			}
-		}
+
+			// Remove the callback first so it only runs once, then restore the taxes.
+			remove_action( 'woocommerce_order_after_calculate_totals', $restore_callback, 10 );
+			$this->restore_order_taxes( $recalculated_order, $snapshot );
+		};
+
+		add_action( 'woocommerce_order_after_calculate_totals', $restore_callback, 10, 2 );
 	}
 
 	/**
 	 * Snapshot the current tax state of an order before recalculation.
 	 *
-	 * Captures tax line items and per-item tax arrays so they can be restored
-	 * if a subsequent TaxJar API call fails.
+	 * Captures the tax line items (with their full metadata), the per-item tax
+	 * arrays, and the order-level tax totals so they can be restored verbatim after
+	 * WC recalculates the order for a changed address.
 	 *
-	 * @since x.x.x
+	 * @since 3.6.7
 	 * @param WC_Order $order The order to snapshot.
 	 * @return array {
-	 *   @type array $tax_lines  Keyed by item_id; each has 'rate_id', 'tax_total', 'shipping_tax_total'.
-	 *   @type array $item_taxes Keyed by item_id (prefix 'shipping_' for shipping items); each is a taxes array.
+	 *   @type array  $tax_lines    Keyed by item_id; each holds the full WC_Order_Item_Tax field set.
+	 *   @type array  $item_taxes   Keyed by item_id (prefix 'shipping_' for shipping items); each is a taxes array.
+	 *   @type string $cart_tax     Order cart tax total.
+	 *   @type string $shipping_tax Order shipping tax total.
+	 *   @type string $discount_tax Order discount tax total.
 	 * }
 	 */
 	private function snapshot_order_taxes( $order ) {
 		$snapshot = array(
-			'tax_lines'  => array(),
-			'item_taxes' => array(),
+			'tax_lines'    => array(),
+			'item_taxes'   => array(),
+			'cart_tax'     => $order->get_cart_tax(),
+			'shipping_tax' => $order->get_shipping_tax(),
+			'discount_tax' => $order->get_discount_tax(),
 		);
 
 		foreach ( $order->get_taxes() as $item_id => $tax_item ) {
 			$snapshot['tax_lines'][ $item_id ] = array(
 				'rate_id'            => $tax_item->get_rate_id(),
+				'rate_code'          => $tax_item->get_rate_code(),
+				'label'              => $tax_item->get_label(),
+				'rate_percent'       => $tax_item->get_rate_percent(),
+				'compound'           => $tax_item->get_compound(),
 				'tax_total'          => $tax_item->get_tax_total(),
 				'shipping_tax_total' => $tax_item->get_shipping_tax_total(),
 			);
@@ -2337,59 +2275,64 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	/**
-	 * Restore order taxes from a previously taken snapshot.
+	 * Restore an order's taxes from a snapshot after WC recalculated it.
 	 *
-	 * Called when TaxJar API fails during a non-cart recalculation, to undo
-	 * whatever WC's update_taxes() did and put the original tax data back.
+	 * Puts back the per-item taxes and tax line items (with their metadata) that
+	 * update_taxes() removed, and rebases the order total on the preserved tax
+	 * instead of whatever WC computed for the new address, while keeping any updated
+	 * non-tax amounts (such as a changed shipping total).
 	 *
-	 * @since x.x.x
+	 * @since 3.6.7
 	 * @param WC_Order $order    The order to restore into.
 	 * @param array    $snapshot Snapshot returned by snapshot_order_taxes().
 	 */
 	private function restore_order_taxes( $order, $snapshot ) {
-		if ( empty( $snapshot ) ) {
+		if ( empty( $snapshot['tax_lines'] ) ) {
 			return;
 		}
 
-		// Restore per-item tax arrays on line items and fees.
+		// Restore the per-item tax arrays on line items and fees.
 		foreach ( $order->get_items( array( 'line_item', 'fee' ) ) as $item_id => $item ) {
 			if ( isset( $snapshot['item_taxes'][ $item_id ] ) ) {
 				$item->set_taxes( $snapshot['item_taxes'][ $item_id ] );
-				$item->save();
 			}
 		}
 
-		// Restore per-item tax arrays on shipping items.
+		// Restore the per-item tax arrays on shipping items.
 		foreach ( $order->get_shipping_methods() as $item_id => $item ) {
 			if ( isset( $snapshot['item_taxes'][ 'shipping_' . $item_id ] ) ) {
 				$item->set_taxes( $snapshot['item_taxes'][ 'shipping_' . $item_id ] );
-				$item->save();
 			}
 		}
 
-		// Remove all current tax line items (update_taxes() may have wiped and re-added wrong ones).
+		// Remove the tax lines WC rebuilt for the new address.
 		foreach ( $order->get_taxes() as $tax_item ) {
 			$order->remove_item( $tax_item->get_id() );
 		}
 
-		// Re-add tax lines from snapshot.
+		// Re-add the original tax lines, preserving their full metadata.
 		foreach ( $snapshot['tax_lines'] as $tax_data ) {
 			$tax_item = new WC_Order_Item_Tax();
 			$tax_item->set_rate_id( $tax_data['rate_id'] );
+			$tax_item->set_rate_code( $tax_data['rate_code'] );
+			$tax_item->set_label( $tax_data['label'] );
+			$tax_item->set_rate_percent( $tax_data['rate_percent'] );
+			$tax_item->set_compound( $tax_data['compound'] );
 			$tax_item->set_tax_total( $tax_data['tax_total'] );
 			$tax_item->set_shipping_tax_total( $tax_data['shipping_tax_total'] );
 			$order->add_item( $tax_item );
 		}
 
-		// Recalculate order-level totals from restored snapshot data.
-		$order->set_cart_tax( array_sum( array_column( $snapshot['tax_lines'], 'tax_total' ) ) );
-		$order->set_shipping_tax( array_sum( array_column( $snapshot['tax_lines'], 'shipping_tax_total' ) ) );
-		$order->save();
+		// Rebase the order total on the preserved tax. WC has already recomputed the
+		// non-tax amounts (subtotal, discounts, shipping, fees), so strip whatever tax
+		// it calculated for the new address and add the preserved tax back.
+		$non_tax_total = (float) $order->get_total() - (float) $order->get_cart_tax() - (float) $order->get_shipping_tax();
 
-		// Update the order total to include the restored taxes.
-		$cart_tax     = $order->get_cart_tax();
-		$shipping_tax = $order->get_shipping_tax();
-		$order->set_total( $order->get_subtotal() - $order->get_discount_total() + $order->get_shipping_total() + $order->get_total_fees() + $cart_tax + $shipping_tax );
+		$order->set_cart_tax( $snapshot['cart_tax'] );
+		$order->set_shipping_tax( $snapshot['shipping_tax'] );
+		$order->set_discount_tax( $snapshot['discount_tax'] );
+		$order->set_total( round( $non_tax_total + (float) $snapshot['cart_tax'] + (float) $snapshot['shipping_tax'], wc_get_price_decimals() ) );
+
 		$order->save();
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.6.7 - 2026-xx-xx =
+* Fix   - TaxJar tax lines wiped when REST API order update includes address change.
+
 = 3.6.6 - 2026-06-22 =
 * Tweak - WooCommerce 10.9 Compatibility.
 

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -1190,6 +1190,67 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that stale response_rate_ids from a previous order (batch context) are cleared
+	 * so each order in a batch gets its own TaxJar call.
+	 */
+	public function test_calculate_order_taxes_clears_stale_order_state_in_batch() {
+		// Arrange: simulate state left over from a previous order in the same batch.
+		$this->set_private_property( 'response_rate_ids', array( 'old-product-key' => array( 99 ) ) );
+		$this->set_private_property( 'response_rate_ids_from_order', true );
+
+		// Use an order with ID 0 to short-circuit after the clear, keeping the test simple.
+		$order = $this->getMockBuilder( 'WC_Order' )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_id' ) )
+			->getMock();
+		$order->method( 'get_id' )->willReturn( 0 );
+
+		// Act.
+		$this->integration->calculate_order_taxes_via_taxjar( array(), $order );
+
+		// Assert: stale state was cleared before the new order was evaluated.
+		$prop = new ReflectionProperty( 'WC_Connect_TaxJar_Integration', 'response_rate_ids' );
+		$prop->setAccessible( true );
+		$this->assertEmpty( $prop->getValue( $this->integration ) );
+
+		$flag_prop = new ReflectionProperty( 'WC_Connect_TaxJar_Integration', 'response_rate_ids_from_order' );
+		$flag_prop->setAccessible( true );
+		$this->assertFalse( $flag_prop->getValue( $this->integration ) );
+	}
+
+	/**
+	 * Test that calculate_order_taxes_via_taxjar restores WC()->customer to its
+	 * previous value after the API call, preventing cross-order contamination.
+	 */
+	public function test_calculate_order_taxes_restores_wc_customer_after_call() {
+		$previous_customer = WC()->customer;
+
+		// Ensure WC()->customer is null so our code creates a temporary one.
+		WC()->customer = null;
+
+		$order = wc_create_order();
+
+		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'calculate_tax', 'get_backend_line_items', '_log' ) )
+			->getMock();
+		$integration->method( 'calculate_tax' )->willReturn( false );
+		$integration->method( 'get_backend_line_items' )->willReturn( array() );
+		$integration->method( '_log' )->willReturn( null );
+
+		// Act.
+		$integration->calculate_order_taxes_via_taxjar( array(), $order );
+
+		// Assert: WC()->customer is restored to null (its value before the call).
+		$this->assertNull( WC()->customer );
+
+		// Clean up.
+		WC()->customer = $previous_customer;
+		remove_all_actions( 'woocommerce_order_after_calculate_totals' );
+		$order->delete( true );
+	}
+
+	/**
 	 * Test that calculate_order_taxes_via_taxjar skips when order ID is 0 (new order).
 	 */
 	public function test_calculate_order_taxes_skips_when_order_id_is_zero() {

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -87,9 +87,9 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that calculate_order_taxes_via_taxjar hook is registered after init().
+	 * Test that the preserve_order_taxes_on_recalculation hook is registered after init().
 	 */
-	public function test_calculate_order_taxes_hook_registered_after_init() {
+	public function test_preserve_order_taxes_hook_registered_after_init() {
 		// Arrange: enable automated taxes option so init() does not bail early.
 		update_option( WC_Connect_TaxJar_Integration::OPTION_NAME, 'yes' );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
@@ -99,7 +99,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 
 		// Assert.
 		$this->assertNotFalse(
-			has_action( 'woocommerce_order_before_calculate_taxes', array( $this->integration, 'calculate_order_taxes_via_taxjar' ) ),
+			has_action( 'woocommerce_order_before_calculate_taxes', array( $this->integration, 'preserve_order_taxes_on_recalculation' ) ),
 			'Hook woocommerce_order_before_calculate_taxes should be registered'
 		);
 
@@ -1172,126 +1172,108 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that calculate_order_taxes_via_taxjar skips when response_rate_ids already set (cart path ran).
+	 * Test that preserve_order_taxes_on_recalculation skips when the cart/checkout
+	 * flow already populated response_rate_ids.
 	 */
-	public function test_calculate_order_taxes_skips_when_response_rate_ids_populated() {
-		// Arrange: pre-populate response_rate_ids as the cart path would.
+	public function test_preserve_order_taxes_skips_when_response_rate_ids_populated() {
 		$this->set_private_property( 'response_rate_ids', array( 'product-key' => array( 1, 2 ) ) );
 
 		$order = $this->getMockBuilder( 'WC_Order' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		// Assert: get_id() should never be called if gate triggers.
+		// The first gate returns before the order is inspected.
 		$order->expects( $this->never() )->method( 'get_id' );
 
-		// Act.
-		$this->integration->calculate_order_taxes_via_taxjar( array(), $order );
+		$this->integration->preserve_order_taxes_on_recalculation( array(), $order );
 	}
 
 	/**
-	 * Test that stale response_rate_ids from a previous order (batch context) are cleared
-	 * so each order in a batch gets its own TaxJar call.
+	 * Test that preserve_order_taxes_on_recalculation skips admin AJAX recalculations,
+	 * which are handled by calculate_backend_totals().
 	 */
-	public function test_calculate_order_taxes_clears_stale_order_state_in_batch() {
-		// Arrange: simulate state left over from a previous order in the same batch.
-		$this->set_private_property( 'response_rate_ids', array( 'old-product-key' => array( 99 ) ) );
-		$this->set_private_property( 'response_rate_ids_from_order', true );
+	public function test_preserve_order_taxes_skips_when_doing_ajax() {
+		// Use a filter instead of define() so the constant does not leak into other tests.
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		$this->set_private_property( 'response_rate_ids', array() );
 
-		// Use an order with ID 0 to short-circuit after the clear, keeping the test simple.
+		$order = $this->getMockBuilder( 'WC_Order' )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_id' ) )
+			->getMock();
+
+		// The AJAX gate returns before the order id is inspected.
+		$order->expects( $this->never() )->method( 'get_id' );
+
+		$this->integration->preserve_order_taxes_on_recalculation( array(), $order );
+
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+	}
+
+	/**
+	 * Test that preserve_order_taxes_on_recalculation skips a new order (id 0) and
+	 * does not register a restore callback.
+	 */
+	public function test_preserve_order_taxes_skips_when_order_id_is_zero() {
+		remove_all_actions( 'woocommerce_order_after_calculate_totals' );
+		$this->set_private_property( 'response_rate_ids', array() );
+
 		$order = $this->getMockBuilder( 'WC_Order' )
 			->disableOriginalConstructor()
 			->onlyMethods( array( 'get_id' ) )
 			->getMock();
 		$order->method( 'get_id' )->willReturn( 0 );
 
-		// Act.
-		$this->integration->calculate_order_taxes_via_taxjar( array(), $order );
+		$this->integration->preserve_order_taxes_on_recalculation( array(), $order );
 
-		// Assert: stale state was cleared before the new order was evaluated.
-		$prop = new ReflectionProperty( 'WC_Connect_TaxJar_Integration', 'response_rate_ids' );
-		$prop->setAccessible( true );
-		$this->assertEmpty( $prop->getValue( $this->integration ) );
-
-		$flag_prop = new ReflectionProperty( 'WC_Connect_TaxJar_Integration', 'response_rate_ids_from_order' );
-		$flag_prop->setAccessible( true );
-		$this->assertFalse( $flag_prop->getValue( $this->integration ) );
+		$this->assertFalse( has_action( 'woocommerce_order_after_calculate_totals' ) );
 	}
 
 	/**
-	 * Test that calculate_order_taxes_via_taxjar restores WC()->customer to its
-	 * previous value after the API call, preventing cross-order contamination.
+	 * Test that preserve_order_taxes_on_recalculation does not register a restore when
+	 * the order has no existing tax lines, so a first-time calculation runs normally.
 	 */
-	public function test_calculate_order_taxes_restores_wc_customer_after_call() {
-		$previous_customer = WC()->customer;
-
-		// Ensure WC()->customer is null so our code creates a temporary one.
-		WC()->customer = null;
+	public function test_preserve_order_taxes_skips_when_no_existing_tax_lines() {
+		remove_all_actions( 'woocommerce_order_after_calculate_totals' );
+		$this->set_private_property( 'response_rate_ids', array() );
 
 		$order = wc_create_order();
 
-		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
-			->disableOriginalConstructor()
-			->onlyMethods( array( 'calculate_tax', 'get_backend_line_items', '_log' ) )
-			->getMock();
-		$integration->method( 'calculate_tax' )->willReturn( false );
-		$integration->method( 'get_backend_line_items' )->willReturn( array() );
-		$integration->method( '_log' )->willReturn( null );
+		$this->integration->preserve_order_taxes_on_recalculation( array(), $order );
 
-		// Act.
-		$integration->calculate_order_taxes_via_taxjar( array(), $order );
+		$this->assertFalse(
+			has_action( 'woocommerce_order_after_calculate_totals' ),
+			'No restore should be registered for an order without existing tax lines.'
+		);
 
-		// Assert: WC()->customer is restored to null (its value before the call).
-		$this->assertNull( WC()->customer );
-
-		// Clean up.
-		WC()->customer = $previous_customer;
-		remove_all_actions( 'woocommerce_order_after_calculate_totals' );
 		$order->delete( true );
 	}
 
 	/**
-	 * Test that calculate_order_taxes_via_taxjar skips when order ID is 0 (new order).
+	 * Test that preserve_order_taxes_on_recalculation registers a restore callback when
+	 * the order already has tax lines.
 	 */
-	public function test_calculate_order_taxes_skips_when_order_id_is_zero() {
-		// Arrange: response_rate_ids is empty (REST context).
+	public function test_preserve_order_taxes_registers_restore_when_order_has_taxes() {
+		remove_all_actions( 'woocommerce_order_after_calculate_totals' );
 		$this->set_private_property( 'response_rate_ids', array() );
 
-		$order = $this->getMockBuilder( 'WC_Order' )
-			->disableOriginalConstructor()
-			->getMock();
-		$order->method( 'get_id' )->willReturn( 0 );
+		$order    = wc_create_order();
+		$tax_item = new WC_Order_Item_Tax();
+		$tax_item->set_rate_id( 6 );
+		$tax_item->set_tax_total( '1.76' );
+		$order->add_item( $tax_item );
+		$order->save();
 
-		// Assert: get_shipping_country() should never be called if gate triggers.
-		$order->expects( $this->never() )->method( 'get_shipping_country' );
+		$this->integration->preserve_order_taxes_on_recalculation( array(), $order );
 
-		// Act.
-		$this->integration->calculate_order_taxes_via_taxjar( array(), $order );
-	}
+		$this->assertGreaterThan(
+			0,
+			has_action( 'woocommerce_order_after_calculate_totals' ),
+			'A restore should be registered for an order that already has tax lines.'
+		);
 
-	/**
-	 * Test that calculate_order_taxes_via_taxjar skips when wp_doing_ajax() is true.
-	 */
-	public function test_calculate_order_taxes_skips_when_doing_ajax() {
-		// Use a filter instead of define() — constants pollute the entire test run.
-		add_filter( 'wp_doing_ajax', '__return_true' );
-
-		// Arrange: response_rate_ids is empty so the first gate does not trigger.
-		$this->set_private_property( 'response_rate_ids', array() );
-
-		$order = $this->getMockBuilder( 'WC_Order' )
-			->disableOriginalConstructor()
-			->onlyMethods( array( 'get_id' ) )
-			->getMock();
-
-		// Assert: get_id() is never reached because the AJAX gate fires first.
-		$order->expects( $this->never() )->method( 'get_id' );
-
-		// Act.
-		$this->integration->calculate_order_taxes_via_taxjar( array(), $order );
-
-		// Clean up.
-		remove_filter( 'wp_doing_ajax', '__return_true' );
+		remove_all_actions( 'woocommerce_order_after_calculate_totals' );
+		$order->delete( true );
 	}
 
 	// -------------------------------------------------------------------------
@@ -1299,270 +1281,221 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Test that snapshot_order_taxes captures existing tax lines and item taxes.
+	 * Test that snapshot_order_taxes captures the full tax-line metadata, per-item
+	 * taxes, and order-level tax totals.
 	 */
-	public function test_snapshot_order_taxes_captures_tax_state() {
-		// Create a real order with a tax line item.
+	public function test_snapshot_order_taxes_captures_full_tax_state() {
 		$order = wc_create_order();
 
-		// Add a tax line.
 		$tax_item = new WC_Order_Item_Tax();
 		$tax_item->set_rate_code( 'US-CA-TAX-1' );
 		$tax_item->set_rate_id( 6 );
 		$tax_item->set_label( 'CA Tax' );
+		$tax_item->set_rate_percent( 8.25 );
+		$tax_item->set_compound( false );
 		$tax_item->set_tax_total( '1.76' );
 		$tax_item->set_shipping_tax_total( '0.00' );
 		$order->add_item( $tax_item );
+		$order->set_cart_tax( '1.76' );
 		$order->save();
 
-		// Act.
 		$snapshot = $this->invoke_protected_method( 'snapshot_order_taxes', array( $order ) );
 
-		// Assert structure.
 		$this->assertArrayHasKey( 'tax_lines', $snapshot );
 		$this->assertArrayHasKey( 'item_taxes', $snapshot );
+		$this->assertEquals( '1.76', $snapshot['cart_tax'] );
 		$this->assertCount( 1, $snapshot['tax_lines'] );
 
-		$saved_tax = reset( $snapshot['tax_lines'] );
-		$this->assertEquals( 6, $saved_tax['rate_id'] );
-		$this->assertEquals( '1.76', $saved_tax['tax_total'] );
-		$this->assertEquals( '0.00', $saved_tax['shipping_tax_total'] );
+		$saved = reset( $snapshot['tax_lines'] );
+		$this->assertEquals( 6, $saved['rate_id'] );
+		$this->assertEquals( 'US-CA-TAX-1', $saved['rate_code'] );
+		$this->assertEquals( 'CA Tax', $saved['label'] );
+		$this->assertEquals( 8.25, $saved['rate_percent'] );
+		$this->assertEquals( '1.76', $saved['tax_total'] );
 
-		// Clean up.
 		$order->delete( true );
 	}
 
 	/**
-	 * Test that restore_order_taxes re-adds tax lines removed from an order.
+	 * Test that restore_order_taxes re-adds tax lines with their full metadata and
+	 * keeps the order tax totals in sync.
 	 */
-	public function test_restore_order_taxes_restores_tax_lines() {
-		// Create a real order.
+	public function test_restore_order_taxes_restores_tax_lines_with_metadata() {
 		$order = wc_create_order();
 
-		// Add a tax line and save snapshot before wiping.
 		$tax_item = new WC_Order_Item_Tax();
+		$tax_item->set_rate_code( 'US-CA-TAX-1' );
 		$tax_item->set_rate_id( 6 );
+		$tax_item->set_label( 'CA Tax' );
+		$tax_item->set_rate_percent( 8.25 );
 		$tax_item->set_tax_total( '1.76' );
 		$tax_item->set_shipping_tax_total( '0.00' );
 		$order->add_item( $tax_item );
+		$order->set_cart_tax( '1.76' );
+		$order->set_total( 1.76 );
 		$order->save();
 
 		$snapshot = $this->invoke_protected_method( 'snapshot_order_taxes', array( $order ) );
 
-		// Simulate wipe: remove all tax items.
-		foreach ( $order->get_taxes() as $t ) {
-			$order->remove_item( $t->get_id() );
-		}
-		$order->save();
-		$this->assertCount( 0, $order->get_taxes() );
-
-		// Act: restore from snapshot.
-		$this->invoke_protected_method( 'restore_order_taxes', array( $order, $snapshot ) );
-
-		// Re-fetch order to confirm DB was updated.
-		$restored_order = wc_get_order( $order->get_id() );
-		$this->assertCount( 1, $restored_order->get_taxes() );
-
-		$taxes_list   = $restored_order->get_taxes();
-		$restored_tax = reset( $taxes_list );
-		$this->assertEquals( 6, $restored_tax->get_rate_id() );
-		$this->assertEquals( '1.76', $restored_tax->get_tax_total() );
-
-		// Clean up.
-		$order->delete( true );
-	}
-
-	// -------------------------------------------------------------------------
-	// calculate_order_taxes_via_taxjar() happy path tests
-	// -------------------------------------------------------------------------
-
-	/**
-	 * Test happy path: calculate_order_taxes_via_taxjar calls TaxJar API
-	 * and sets response_rate_ids / response_line_items on success.
-	 */
-	public function test_calculate_order_taxes_happy_path_sets_response_properties() {
-		// Arrange: empty response_rate_ids (REST context, not cart).
-		$this->set_private_property( 'response_rate_ids', array() );
-
-		// Create a real order with a product line item.
-		$product = WC_Helper_Product::create_simple_product();
-		$product->save();
-
-		$order = wc_create_order();
-		$order->add_product( $product, 1 );
-		$order->set_shipping_country( 'US' );
-		$order->set_shipping_state( 'TX' );
-		$order->set_shipping_postcode( '78701' );
-		$order->set_shipping_city( 'Austin' );
-		$order->set_shipping_address_1( '123 Main St' );
-		$order->save();
-
-		// Mock calculate_tax() to return a fake successful response.
-		$fake_taxes = array(
-			'rate_ids'   => array( $product->get_id() . '-1' => array( 42 ) ),
-			'line_items' => array(
-				$product->get_id() . '-1' => (object) array(
-					'tax_collectable'   => 1.23,
-					'combined_tax_rate' => 0.0825,
-					'line_total'        => 18.00,
-				),
-			),
-		);
-
-		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
-			->disableOriginalConstructor()
-			->onlyMethods( array( 'calculate_tax', 'get_backend_line_items', '_log' ) )
-			->getMock();
-		$integration->method( 'get_backend_line_items' )->willReturn( array() );
-		$integration->method( 'calculate_tax' )->willReturn( $fake_taxes );
-		$integration->method( '_log' )->willReturn( null );
-
-		// Pre-set empty response_rate_ids on the mock.
-		$reflection = new ReflectionProperty( 'WC_Connect_TaxJar_Integration', 'response_rate_ids' );
-		$reflection->setAccessible( true );
-		$reflection->setValue( $integration, array() );
-
-		// Need WC()->customer for calculate_tax guard.
-		if ( is_null( WC()->customer ) ) {
-			WC()->customer = new WC_Customer( $order->get_customer_id() );
-		}
-
-		// Act.
-		$integration->calculate_order_taxes_via_taxjar( array(), $order );
-
-		// Assert response properties were set.
-		$rate_ids = $reflection->getValue( $integration );
-		// After running, response_rate_ids should have been set (not empty from fake_taxes).
-		// We check via the mock that calculate_tax was called once.
-		// (response_rate_ids would be set to $fake_taxes['rate_ids']).
-		$response_rate_ids_prop = new ReflectionProperty( 'WC_Connect_TaxJar_Integration', 'response_rate_ids' );
-		$response_rate_ids_prop->setAccessible( true );
-		$this->assertEquals( $fake_taxes['rate_ids'], $response_rate_ids_prop->getValue( $integration ) );
-
-		$response_line_items_prop = new ReflectionProperty( 'WC_Connect_TaxJar_Integration', 'response_line_items' );
-		$response_line_items_prop->setAccessible( true );
-		$this->assertNotEmpty( $response_line_items_prop->getValue( $integration ) );
-
-		// Clean up.
-		WC_Helper_Product::delete_product( $product->get_id() );
-		$order->delete( true );
-	}
-
-	// -------------------------------------------------------------------------
-	// calculate_order_taxes_via_taxjar() failure fallback tests
-	// -------------------------------------------------------------------------
-
-	/**
-	 * Test that failure flag is set when TaxJar API fails.
-	 */
-	public function test_calculate_order_taxes_sets_failure_flag_on_api_error() {
-		$order       = wc_create_order();
-		$integration = $this->getMockBuilder( WC_Connect_TaxJar_Integration::class )
-			->disableOriginalConstructor()
-			->onlyMethods( array( 'calculate_tax', 'get_backend_line_items', '_log' ) )
-			->getMock();
-		$integration->method( 'calculate_tax' )->willReturn( false );
-		$integration->method( 'get_backend_line_items' )->willReturn( array() );
-		$integration->method( '_log' )->willReturn( null );
-
-		$integration->calculate_order_taxes_via_taxjar( array(), $order );
-
-		$prop = new ReflectionProperty( WC_Connect_TaxJar_Integration::class, 'taxjar_recalculation_failed' );
-		$prop->setAccessible( true );
-		$this->assertTrue( $prop->getValue( $integration ) );
-		$order->delete( true );
-	}
-
-	/**
-	 * Test that restore hook is registered when TaxJar API fails.
-	 */
-	public function test_calculate_order_taxes_registers_restore_hook_on_api_failure() {
-		remove_all_actions( 'woocommerce_order_after_calculate_totals' );
-		$order       = wc_create_order();
-		$integration = $this->getMockBuilder( WC_Connect_TaxJar_Integration::class )
-			->disableOriginalConstructor()
-			->onlyMethods( array( 'calculate_tax', 'get_backend_line_items', '_log' ) )
-			->getMock();
-		$integration->method( 'calculate_tax' )->willReturn( false );
-		$integration->method( 'get_backend_line_items' )->willReturn( array() );
-		$integration->method( '_log' )->willReturn( null );
-
-		$integration->calculate_order_taxes_via_taxjar( array(), $order );
-
-		$this->assertGreaterThan( 0, has_action( 'woocommerce_order_after_calculate_totals' ) );
-		remove_all_actions( 'woocommerce_order_after_calculate_totals' );
-		$order->delete( true );
-	}
-
-	/**
-	 * End-to-end test: when TaxJar API fails, original taxes are preserved.
-	 */
-	public function test_calculate_order_taxes_preserves_existing_taxes_on_api_failure() {
-		// Create order with a real tax line.
-		$product = WC_Helper_Product::create_simple_product();
-		$product->save();
-
-		$order = wc_create_order();
-		$order->add_product( $product, 1 );
-		$order->set_shipping_country( 'US' );
-		$order->set_shipping_state( 'TX' );
-		$order->set_shipping_postcode( '78701' );
-		$order->save();
-
-		// Add a TaxJar-style tax line.
-		$tax_item = new WC_Order_Item_Tax();
-		$tax_item->set_rate_id( 6 );
-		$tax_item->set_tax_total( '1.76' );
-		$tax_item->set_shipping_tax_total( '0.00' );
-		$order->add_item( $tax_item );
-		$order->save();
-
-		$this->assertCount( 1, $order->get_taxes() );
-
-		// Mock integration with failing API.
-		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
-			->disableOriginalConstructor()
-			->onlyMethods( array( 'calculate_tax', 'get_backend_line_items', '_log' ) )
-			->getMock();
-		$integration->method( 'calculate_tax' )->willReturn( false );
-		$integration->method( 'get_backend_line_items' )->willReturn( array() );
-		$integration->method( '_log' )->willReturn( null );
-
-		foreach ( array( 'response_rate_ids', 'taxjar_recalculation_failed', 'pre_recalculation_tax_snapshot' ) as $prop ) {
-			$r = new ReflectionProperty( 'WC_Connect_TaxJar_Integration', $prop );
-			$r->setAccessible( true );
-			$r->setValue( $integration, 'taxjar_recalculation_failed' === $prop ? false : array() );
-		}
-
-		if ( is_null( WC()->customer ) ) {
-			WC()->customer = new WC_Customer( $order->get_customer_id() );
-		}
-
-		// Simulate the full flow: run our hook, then wipe taxes (as WC would), then trigger after hook.
-		$integration->calculate_order_taxes_via_taxjar( array(), $order );
-
-		// Simulate WC wiping taxes (what update_taxes() does when no rates found).
+		// Simulate WC wiping the taxes for a changed address.
 		foreach ( $order->get_taxes() as $t ) {
 			$order->remove_item( $t->get_id() );
 		}
 		$order->set_cart_tax( 0 );
+		$order->set_total( 0 );
 		$order->save();
 		$this->assertCount( 0, $order->get_taxes() );
 
-		// Simulate woocommerce_order_after_calculate_totals firing.
-		do_action( 'woocommerce_order_after_calculate_totals', true, $order );
+		$this->invoke_protected_method( 'restore_order_taxes', array( $order, $snapshot ) );
 
-		// Assert: tax line was restored.
 		$restored = wc_get_order( $order->get_id() );
 		$this->assertCount( 1, $restored->get_taxes() );
-		$taxes_list   = $restored->get_taxes();
-		$restored_tax = reset( $taxes_list );
-		$this->assertEquals( 6, $restored_tax->get_rate_id() );
-		$this->assertEquals( '1.76', $restored_tax->get_tax_total() );
 
-		// Clean up.
+		$taxes = $restored->get_taxes();
+		$line  = reset( $taxes );
+		$this->assertEquals( 6, $line->get_rate_id() );
+		$this->assertEquals( 'US-CA-TAX-1', $line->get_rate_code() );
+		$this->assertEquals( 'CA Tax', $line->get_label() );
+		$this->assertEquals( '1.76', $line->get_tax_total() );
+		$this->assertEqualsWithDelta( 1.76, (float) $restored->get_total_tax(), 0.001 );
+
+		$order->delete( true );
+	}
+
+	// -------------------------------------------------------------------------
+	// End-to-end preservation test
+	// -------------------------------------------------------------------------
+
+	/**
+	 * End-to-end: a recalculation triggered by an address change on an existing order
+	 * preserves the recorded taxes instead of wiping them to zero, and rebases the
+	 * order total on the preserved tax.
+	 */
+	public function test_preserve_order_taxes_end_to_end_on_address_change() {
+		remove_all_actions( 'woocommerce_order_before_calculate_taxes' );
 		remove_all_actions( 'woocommerce_order_after_calculate_totals' );
-		WC_Helper_Product::delete_product( $product->get_id() );
+		$this->set_private_property( 'response_rate_ids', array() );
+
+		$this->product = WC_Helper_Product::create_simple_product();
+		$this->product->set_regular_price( '100' );
+		$this->product->save();
+
+		$order   = wc_create_order();
+		$item_id = $order->add_product( $this->product, 1 );
+		$order->set_shipping_country( 'US' );
+		$order->set_shipping_state( 'CA' );
+		$order->set_shipping_postcode( '90210' );
+
+		// Record a TaxJar-style tax of 8.25% on the line item and the order.
+		$line_item = $order->get_item( $item_id );
+		$line_item->set_taxes(
+			array(
+				'total'    => array( 6 => '8.25' ),
+				'subtotal' => array( 6 => '8.25' ),
+			)
+		);
+
+		$tax_item = new WC_Order_Item_Tax();
+		$tax_item->set_rate_id( 6 );
+		$tax_item->set_rate_code( 'US-CA-TAX-1' );
+		$tax_item->set_label( 'CA Tax' );
+		$tax_item->set_rate_percent( 8.25 );
+		$tax_item->set_tax_total( '8.25' );
+		$tax_item->set_shipping_tax_total( '0.00' );
+		$order->add_item( $tax_item );
+		$order->set_cart_tax( '8.25' );
+		$order->set_total( 108.25 );
+		$order->save();
+
+		$this->assertEqualsWithDelta( 8.25, (float) $order->get_total_tax(), 0.001 );
+
+		// Recalculate as a REST/programmatic update would after an address change.
+		add_action( 'woocommerce_order_before_calculate_taxes', array( $this->integration, 'preserve_order_taxes_on_recalculation' ), 10, 2 );
+		$order->set_shipping_postcode( '90211' );
+		$order->calculate_totals( true );
+
+		$reloaded = wc_get_order( $order->get_id() );
+
+		// The recorded tax is preserved rather than wiped to zero.
+		$this->assertEqualsWithDelta( 8.25, (float) $reloaded->get_total_tax(), 0.001, 'Recorded tax should be preserved.' );
+		$this->assertCount( 1, $reloaded->get_taxes(), 'The original tax line should be preserved.' );
+
+		$taxes    = $reloaded->get_taxes();
+		$restored = reset( $taxes );
+		$this->assertEquals( 'CA Tax', $restored->get_label(), 'Tax label should survive the recalculation.' );
+		$this->assertEquals( 6, $restored->get_rate_id() );
+
+		// The total reflects the preserved tax on top of the (unchanged) line total.
+		$this->assertEqualsWithDelta( 108.25, (float) $reloaded->get_total(), 0.01, 'Order total should include the preserved tax.' );
+
+		remove_all_actions( 'woocommerce_order_before_calculate_taxes' );
+		remove_all_actions( 'woocommerce_order_after_calculate_totals' );
+		$order->delete( true );
+	}
+
+	/**
+	 * End-to-end: when a recalculation also changes the shipping amount, the
+	 * preserved tax is rebased onto the new non-tax total (so the total reflects the
+	 * updated shipping while the recorded tax is kept).
+	 */
+	public function test_preserve_order_taxes_rebases_total_when_shipping_changes() {
+		remove_all_actions( 'woocommerce_order_before_calculate_taxes' );
+		remove_all_actions( 'woocommerce_order_after_calculate_totals' );
+		$this->set_private_property( 'response_rate_ids', array() );
+
+		$this->product = WC_Helper_Product::create_simple_product();
+		$this->product->set_regular_price( '100' );
+		$this->product->save();
+
+		$order   = wc_create_order();
+		$item_id = $order->add_product( $this->product, 1 );
+
+		$shipping = new WC_Order_Item_Shipping();
+		$shipping->set_method_title( 'Flat rate' );
+		$shipping->set_total( '10' );
+		$order->add_item( $shipping );
+
+		$order->set_shipping_country( 'US' );
+		$order->set_shipping_state( 'CA' );
+		$order->set_shipping_postcode( '90210' );
+
+		// Record 8.25% tax on the $100 product (shipping not taxed).
+		$line_item = $order->get_item( $item_id );
+		$line_item->set_taxes(
+			array(
+				'total'    => array( 6 => '8.25' ),
+				'subtotal' => array( 6 => '8.25' ),
+			)
+		);
+
+		$tax_item = new WC_Order_Item_Tax();
+		$tax_item->set_rate_id( 6 );
+		$tax_item->set_label( 'CA Tax' );
+		$tax_item->set_tax_total( '8.25' );
+		$tax_item->set_shipping_tax_total( '0.00' );
+		$order->add_item( $tax_item );
+		$order->set_cart_tax( '8.25' );
+		$order->set_shipping_total( '10' );
+		$order->set_total( 118.25 );
+		$order->save();
+
+		// Recalculate with a changed shipping amount ($10 -> $25) and address.
+		add_action( 'woocommerce_order_before_calculate_taxes', array( $this->integration, 'preserve_order_taxes_on_recalculation' ), 10, 2 );
+		$order->set_shipping_postcode( '90211' );
+		foreach ( $order->get_shipping_methods() as $ship ) {
+			$ship->set_total( '25' );
+			$order->add_item( $ship );
+		}
+		$order->calculate_totals( true );
+
+		$reloaded = wc_get_order( $order->get_id() );
+
+		// Tax preserved, total rebased on the new $25 shipping: 100 + 25 + 8.25.
+		$this->assertEqualsWithDelta( 8.25, (float) $reloaded->get_total_tax(), 0.001, 'Recorded tax should be preserved.' );
+		$this->assertEqualsWithDelta( 133.25, (float) $reloaded->get_total(), 0.01, 'Total should use the new shipping amount plus the preserved tax.' );
+
+		remove_all_actions( 'woocommerce_order_before_calculate_taxes' );
+		remove_all_actions( 'woocommerce_order_after_calculate_totals' );
 		$order->delete( true );
 	}
 

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -1359,4 +1359,131 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		WC_Helper_Product::delete_product( $product->get_id() );
 		$order->delete( true );
 	}
+
+	// -------------------------------------------------------------------------
+	// calculate_order_taxes_via_taxjar() failure fallback tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test that API failure sets taxjar_recalculation_failed and registers restore hook.
+	 */
+	public function test_calculate_order_taxes_api_failure_registers_restore_hook() {
+		// Arrange.
+		$this->set_private_property( 'response_rate_ids', array() );
+
+		$order = wc_create_order();
+		$order->set_shipping_country( 'US' );
+		$order->set_shipping_state( 'TX' );
+		$order->set_shipping_postcode( '78701' );
+		$order->save();
+
+		// Mock integration to make calculate_tax() return false.
+		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'calculate_tax', 'get_backend_line_items', '_log' ) )
+			->getMock();
+		$integration->method( 'calculate_tax' )->willReturn( false );
+		$integration->method( 'get_backend_line_items' )->willReturn( array() );
+		$integration->method( '_log' )->willReturn( null );
+
+		foreach ( array( 'response_rate_ids', 'taxjar_recalculation_failed', 'pre_recalculation_tax_snapshot' ) as $prop ) {
+			$r = new ReflectionProperty( 'WC_Connect_TaxJar_Integration', $prop );
+			$r->setAccessible( true );
+			$r->setValue( $integration, is_string( $prop ) && 'taxjar_recalculation_failed' === $prop ? false : array() );
+		}
+
+		if ( is_null( WC()->customer ) ) {
+			WC()->customer = new WC_Customer( $order->get_customer_id() );
+		}
+
+		// Act.
+		$integration->calculate_order_taxes_via_taxjar( array(), $order );
+
+		// Assert: failure flag set.
+		$failed_prop = new ReflectionProperty( 'WC_Connect_TaxJar_Integration', 'taxjar_recalculation_failed' );
+		$failed_prop->setAccessible( true );
+		$this->assertTrue( $failed_prop->getValue( $integration ) );
+
+		// Assert: restore hook was registered.
+		$this->assertGreaterThan(
+			0,
+			has_action( 'woocommerce_order_after_calculate_totals' ),
+			'Restore hook should be registered on woocommerce_order_after_calculate_totals'
+		);
+
+		// Clean up.
+		remove_all_actions( 'woocommerce_order_after_calculate_totals' );
+		$order->delete( true );
+	}
+
+	/**
+	 * End-to-end test: when TaxJar API fails, original taxes are preserved.
+	 */
+	public function test_calculate_order_taxes_api_failure_preserves_existing_taxes() {
+		// Create order with a real tax line.
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		$order = wc_create_order();
+		$order->add_product( $product, 1 );
+		$order->set_shipping_country( 'US' );
+		$order->set_shipping_state( 'TX' );
+		$order->set_shipping_postcode( '78701' );
+		$order->save();
+
+		// Add a TaxJar-style tax line.
+		$tax_item = new WC_Order_Item_Tax();
+		$tax_item->set_rate_id( 6 );
+		$tax_item->set_tax_total( '1.76' );
+		$tax_item->set_shipping_tax_total( '0.00' );
+		$order->add_item( $tax_item );
+		$order->save();
+
+		$this->assertCount( 1, $order->get_taxes() );
+
+		// Mock integration with failing API.
+		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'calculate_tax', 'get_backend_line_items', '_log' ) )
+			->getMock();
+		$integration->method( 'calculate_tax' )->willReturn( false );
+		$integration->method( 'get_backend_line_items' )->willReturn( array() );
+		$integration->method( '_log' )->willReturn( null );
+
+		foreach ( array( 'response_rate_ids', 'taxjar_recalculation_failed', 'pre_recalculation_tax_snapshot' ) as $prop ) {
+			$r = new ReflectionProperty( 'WC_Connect_TaxJar_Integration', $prop );
+			$r->setAccessible( true );
+			$r->setValue( $integration, 'taxjar_recalculation_failed' === $prop ? false : array() );
+		}
+
+		if ( is_null( WC()->customer ) ) {
+			WC()->customer = new WC_Customer( $order->get_customer_id() );
+		}
+
+		// Simulate the full flow: run our hook, then wipe taxes (as WC would), then trigger after hook.
+		$integration->calculate_order_taxes_via_taxjar( array(), $order );
+
+		// Simulate WC wiping taxes (what update_taxes() does when no rates found).
+		foreach ( $order->get_taxes() as $t ) {
+			$order->remove_item( $t->get_id() );
+		}
+		$order->set_cart_tax( 0 );
+		$order->save();
+		$this->assertCount( 0, $order->get_taxes() );
+
+		// Simulate woocommerce_order_after_calculate_totals firing.
+		do_action( 'woocommerce_order_after_calculate_totals', true, $order );
+
+		// Assert: tax line was restored.
+		$restored = wc_get_order( $order->get_id() );
+		$this->assertCount( 1, $restored->get_taxes() );
+		$restored_tax = reset( $restored->get_taxes() );
+		$this->assertEquals( 6, $restored_tax->get_rate_id() );
+		$this->assertEquals( '1.76', $restored_tax->get_tax_total() );
+
+		// Clean up.
+		remove_all_actions( 'woocommerce_order_after_calculate_totals' );
+		WC_Helper_Product::delete_product( $product->get_id() );
+		$order->delete( true );
+	}
 }

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -35,6 +35,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		require_once __DIR__ . '/../../classes/class-wc-connect-api-client.php';
 		require_once __DIR__ . '/../../classes/class-wc-connect-logger.php';
 		require_once __DIR__ . '/../../classes/class-wc-connect-tracks.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-custom-surcharge.php';
 	}
 
 	/**
@@ -1302,7 +1303,8 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$restored_order = wc_get_order( $order->get_id() );
 		$this->assertCount( 1, $restored_order->get_taxes() );
 
-		$restored_tax = reset( $restored_order->get_taxes() );
+		$taxes_list   = $restored_order->get_taxes();
+		$restored_tax = reset( $taxes_list );
 		$this->assertEquals( 6, $restored_tax->get_rate_id() );
 		$this->assertEquals( '1.76', $restored_tax->get_tax_total() );
 
@@ -1349,7 +1351,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 
 		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'calculate_tax', 'get_backend_line_items', '_log' ) )
+			->onlyMethods( array( 'calculate_tax', 'get_backend_line_items', '_log' ) )
 			->getMock();
 		$integration->method( 'get_backend_line_items' )->willReturn( array() );
 		$integration->method( 'calculate_tax' )->willReturn( $fake_taxes );
@@ -1396,7 +1398,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	public function test_calculate_order_taxes_sets_failure_flag_on_api_error() {
 		$order       = wc_create_order();
 		$integration = $this->getMockBuilder( WC_Connect_TaxJar_Integration::class )
-			->setConstructorArgs( array( $this->mock_connect_api_client, $this->mock_error_notice, $this->mock_logger ) )
+			->disableOriginalConstructor()
 			->onlyMethods( array( 'calculate_tax', 'get_backend_line_items', '_log' ) )
 			->getMock();
 		$integration->method( 'calculate_tax' )->willReturn( false );
@@ -1425,7 +1427,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		remove_all_actions( 'woocommerce_order_after_calculate_totals' );
 		$order       = wc_create_order();
 		$integration = $this->getMockBuilder( WC_Connect_TaxJar_Integration::class )
-			->setConstructorArgs( array( $this->mock_connect_api_client, $this->mock_error_notice, $this->mock_logger ) )
+			->disableOriginalConstructor()
 			->onlyMethods( array( 'calculate_tax', 'get_backend_line_items', '_log' ) )
 			->getMock();
 		$integration->method( 'calculate_tax' )->willReturn( false );
@@ -1467,7 +1469,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		// Mock integration with failing API.
 		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'calculate_tax', 'get_backend_line_items', '_log' ) )
+			->onlyMethods( array( 'calculate_tax', 'get_backend_line_items', '_log' ) )
 			->getMock();
 		$integration->method( 'calculate_tax' )->willReturn( false );
 		$integration->method( 'get_backend_line_items' )->willReturn( array() );
@@ -1500,7 +1502,8 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		// Assert: tax line was restored.
 		$restored = wc_get_order( $order->get_id() );
 		$this->assertCount( 1, $restored->get_taxes() );
-		$restored_tax = reset( $restored->get_taxes() );
+		$taxes_list   = $restored->get_taxes();
+		$restored_tax = reset( $taxes_list );
 		$this->assertEquals( 6, $restored_tax->get_rate_id() );
 		$this->assertEquals( '1.76', $restored_tax->get_tax_total() );
 

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -1206,4 +1206,81 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		// Act.
 		$this->integration->calculate_order_taxes_via_taxjar( array(), $order );
 	}
+
+	// -------------------------------------------------------------------------
+	// snapshot_order_taxes() and restore_order_taxes() tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test that snapshot_order_taxes captures existing tax lines and item taxes.
+	 */
+	public function test_snapshot_order_taxes_captures_tax_state() {
+		// Create a real order with a tax line item.
+		$order = wc_create_order();
+
+		// Add a tax line.
+		$tax_item = new WC_Order_Item_Tax();
+		$tax_item->set_rate_code( 'US-CA-TAX-1' );
+		$tax_item->set_rate_id( 6 );
+		$tax_item->set_label( 'CA Tax' );
+		$tax_item->set_tax_total( '1.76' );
+		$tax_item->set_shipping_tax_total( '0.00' );
+		$order->add_item( $tax_item );
+		$order->save();
+
+		// Act.
+		$snapshot = $this->invoke_protected_method( 'snapshot_order_taxes', array( $order ) );
+
+		// Assert structure.
+		$this->assertArrayHasKey( 'tax_lines', $snapshot );
+		$this->assertArrayHasKey( 'item_taxes', $snapshot );
+		$this->assertCount( 1, $snapshot['tax_lines'] );
+
+		$saved_tax = reset( $snapshot['tax_lines'] );
+		$this->assertEquals( 6, $saved_tax['rate_id'] );
+		$this->assertEquals( '1.76', $saved_tax['tax_total'] );
+		$this->assertEquals( '0.00', $saved_tax['shipping_tax_total'] );
+
+		// Clean up.
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that restore_order_taxes re-adds tax lines removed from an order.
+	 */
+	public function test_restore_order_taxes_restores_tax_lines() {
+		// Create a real order.
+		$order = wc_create_order();
+
+		// Add a tax line and save snapshot before wiping.
+		$tax_item = new WC_Order_Item_Tax();
+		$tax_item->set_rate_id( 6 );
+		$tax_item->set_tax_total( '1.76' );
+		$tax_item->set_shipping_tax_total( '0.00' );
+		$order->add_item( $tax_item );
+		$order->save();
+
+		$snapshot = $this->invoke_protected_method( 'snapshot_order_taxes', array( $order ) );
+
+		// Simulate wipe: remove all tax items.
+		foreach ( $order->get_taxes() as $t ) {
+			$order->remove_item( $t->get_id() );
+		}
+		$order->save();
+		$this->assertCount( 0, $order->get_taxes() );
+
+		// Act: restore from snapshot.
+		$this->invoke_protected_method( 'restore_order_taxes', array( $order, $snapshot ) );
+
+		// Re-fetch order to confirm DB was updated.
+		$restored_order = wc_get_order( $order->get_id() );
+		$this->assertCount( 1, $restored_order->get_taxes() );
+
+		$restored_tax = reset( $restored_order->get_taxes() );
+		$this->assertEquals( 6, $restored_tax->get_rate_id() );
+		$this->assertEquals( '1.76', $restored_tax->get_tax_total() );
+
+		// Clean up.
+		$order->delete( true );
+	}
 }

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -1406,16 +1406,9 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 
 		$integration->calculate_order_taxes_via_taxjar( array(), $order );
 
-		$props = ( new ReflectionClass( $integration ) )->getProperties( ReflectionProperty::IS_PRIVATE );
-		$flag  = false;
-		foreach ( $props as $prop ) {
-			if ( 'taxjar_recalculation_failed' === $prop->getName() ) {
-				$prop->setAccessible( true );
-				$flag = $prop->getValue( $integration );
-				break;
-			}
-		}
-		$this->assertTrue( $flag );
+		$prop = new ReflectionProperty( WC_Connect_TaxJar_Integration::class, 'taxjar_recalculation_failed' );
+		$prop->setAccessible( true );
+		$this->assertTrue( $prop->getValue( $integration ) );
 		$order->delete( true );
 	}
 

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -1500,6 +1500,181 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that snapshot/restore round-trips every tax line when an order has more than one.
+	 */
+	public function test_restore_order_taxes_restores_multiple_tax_lines() {
+		$order = wc_create_order();
+
+		$state_tax = new WC_Order_Item_Tax();
+		$state_tax->set_rate_id( 6 );
+		$state_tax->set_rate_code( 'US-CA-STATE-1' );
+		$state_tax->set_label( 'CA State Tax' );
+		$state_tax->set_rate_percent( 6.0 );
+		$state_tax->set_tax_total( '6.00' );
+		$state_tax->set_shipping_tax_total( '0.00' );
+		$order->add_item( $state_tax );
+
+		$county_tax = new WC_Order_Item_Tax();
+		$county_tax->set_rate_id( 7 );
+		$county_tax->set_rate_code( 'US-CA-COUNTY-1' );
+		$county_tax->set_label( 'LA County Tax' );
+		$county_tax->set_rate_percent( 2.25 );
+		$county_tax->set_tax_total( '2.25' );
+		$county_tax->set_shipping_tax_total( '0.00' );
+		$order->add_item( $county_tax );
+
+		$order->set_cart_tax( '8.25' );
+		$order->set_total( 8.25 );
+		$order->save();
+
+		$snapshot = $this->invoke_protected_method( 'snapshot_order_taxes', array( $order ) );
+		$this->assertCount( 2, $snapshot['tax_lines'], 'Both tax lines should be snapshotted.' );
+
+		foreach ( $order->get_taxes() as $t ) {
+			$order->remove_item( $t->get_id() );
+		}
+		$order->set_cart_tax( 0 );
+		$order->set_total( 0 );
+		$order->save();
+
+		$this->invoke_protected_method( 'restore_order_taxes', array( $order, $snapshot ) );
+
+		$restored = wc_get_order( $order->get_id() );
+		$this->assertCount( 2, $restored->get_taxes(), 'Both tax lines should be restored.' );
+
+		$labels = array();
+		foreach ( $restored->get_taxes() as $line ) {
+			$labels[ $line->get_rate_id() ] = $line->get_label();
+		}
+		$this->assertEquals( 'CA State Tax', $labels[6], 'State tax label should be restored.' );
+		$this->assertEquals( 'LA County Tax', $labels[7], 'County tax label should be restored.' );
+		$this->assertEqualsWithDelta( 8.25, (float) $restored->get_total_tax(), 0.001, 'Combined tax should be restored.' );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that a compound tax line's compound flag survives snapshot and restore.
+	 */
+	public function test_restore_order_taxes_preserves_compound_flag() {
+		$order = wc_create_order();
+
+		$tax_item = new WC_Order_Item_Tax();
+		$tax_item->set_rate_id( 8 );
+		$tax_item->set_rate_code( 'CA-GST-1' );
+		$tax_item->set_label( 'GST' );
+		$tax_item->set_rate_percent( 5.0 );
+		$tax_item->set_compound( true );
+		$tax_item->set_tax_total( '5.00' );
+		$tax_item->set_shipping_tax_total( '0.00' );
+		$order->add_item( $tax_item );
+		$order->set_cart_tax( '5.00' );
+		$order->set_total( 5.00 );
+		$order->save();
+
+		$snapshot = $this->invoke_protected_method( 'snapshot_order_taxes', array( $order ) );
+
+		foreach ( $order->get_taxes() as $t ) {
+			$order->remove_item( $t->get_id() );
+		}
+		$order->save();
+
+		$this->invoke_protected_method( 'restore_order_taxes', array( $order, $snapshot ) );
+
+		$restored = wc_get_order( $order->get_id() );
+		$taxes    = $restored->get_taxes();
+		$line     = reset( $taxes );
+		$this->assertTrue( $line->get_compound(), 'Compound flag should survive snapshot and restore.' );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that the order-level discount tax total is restored from the snapshot.
+	 */
+	public function test_restore_order_taxes_restores_discount_tax() {
+		$order = wc_create_order();
+
+		$tax_item = new WC_Order_Item_Tax();
+		$tax_item->set_rate_id( 6 );
+		$tax_item->set_label( 'CA Tax' );
+		$tax_item->set_tax_total( '1.76' );
+		$tax_item->set_shipping_tax_total( '0.00' );
+		$order->add_item( $tax_item );
+		$order->set_cart_tax( '1.76' );
+		$order->set_discount_tax( '0.50' );
+		$order->set_total( 1.76 );
+		$order->save();
+
+		$snapshot = $this->invoke_protected_method( 'snapshot_order_taxes', array( $order ) );
+		$this->assertEqualsWithDelta( 0.50, (float) $snapshot['discount_tax'], 0.001, 'Discount tax should be snapshotted.' );
+
+		foreach ( $order->get_taxes() as $t ) {
+			$order->remove_item( $t->get_id() );
+		}
+		$order->set_discount_tax( 0 );
+		$order->save();
+
+		$this->invoke_protected_method( 'restore_order_taxes', array( $order, $snapshot ) );
+
+		$restored = wc_get_order( $order->get_id() );
+		$this->assertEqualsWithDelta( 0.50, (float) $restored->get_discount_tax(), 0.001, 'Discount tax should be restored.' );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that a bare calculate_taxes() leaves the snapshot pending (documented gap:
+	 * no restore fires on that hook), and that the pending snapshot is then restored by
+	 * the handler a following calculate_totals() invokes, without double-applying.
+	 */
+	public function test_preserve_order_taxes_pending_snapshot_restores_via_handler() {
+		remove_all_actions( 'woocommerce_order_after_calculate_totals' );
+		$this->set_private_property( 'response_rate_ids', array() );
+
+		$order    = wc_create_order();
+		$tax_item = new WC_Order_Item_Tax();
+		$tax_item->set_rate_id( 6 );
+		$tax_item->set_label( 'CA Tax' );
+		$tax_item->set_tax_total( '8.25' );
+		$tax_item->set_shipping_tax_total( '0.00' );
+		$order->add_item( $tax_item );
+		$order->set_cart_tax( '8.25' );
+		$order->set_total( 8.25 );
+		$order->save();
+
+		$this->integration->preserve_order_taxes_on_recalculation( array(), $order );
+
+		$this->assertNotFalse(
+			has_action( 'woocommerce_order_after_calculate_totals', array( $this->integration, 'restore_order_taxes_after_recalculation' ) ),
+			'A single restore handler should be registered.'
+		);
+
+		// Simulate WC wiping the tax lines during the recalculation.
+		foreach ( $order->get_taxes() as $t ) {
+			$order->remove_item( $t->get_id() );
+		}
+		$order->set_cart_tax( 0 );
+		$order->set_total( 0 );
+		$order->save();
+
+		$this->integration->restore_order_taxes_after_recalculation( true, $order );
+
+		$restored = wc_get_order( $order->get_id() );
+		$this->assertCount( 1, $restored->get_taxes(), 'The recorded tax line should be restored.' );
+		$this->assertEqualsWithDelta( 8.25, (float) $restored->get_total_tax(), 0.001, 'The recorded tax should be restored.' );
+
+		// The snapshot is cleared once restored, so a second handler call is a no-op and
+		// cannot duplicate the tax or leak into a later recalculation.
+		$this->integration->restore_order_taxes_after_recalculation( true, wc_get_order( $order->get_id() ) );
+		$again = wc_get_order( $order->get_id() );
+		$this->assertCount( 1, $again->get_taxes(), 'Restoring twice must not duplicate tax lines.' );
+
+		remove_all_actions( 'woocommerce_order_after_calculate_totals' );
+		$order->delete( true );
+	}
+
+	/**
 	 * A tax calculation whose taxable amount is zero must not zero out the tax rate.
 	 *
 	 * When a subscription is switched, or when a free-trial subscription's initial
@@ -1524,7 +1699,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 
 		// taxable_amount and the top-level rate are 0, but the line item still
 		// carries the real jurisdiction rates (city 1.5%, county 1.25%, state 4.225%).
-		$line_item = (object) array(
+		$line_item    = (object) array(
 			'id'                   => '351-regressionkey',
 			'city_tax_rate'        => 0.015,
 			'county_tax_rate'      => 0.0125,

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -1212,12 +1212,8 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	 * Test that calculate_order_taxes_via_taxjar skips when wp_doing_ajax() is true.
 	 */
 	public function test_calculate_order_taxes_skips_when_doing_ajax() {
-		if ( ! defined( 'DOING_AJAX' ) ) {
-			define( 'DOING_AJAX', true );
-		}
-		if ( ! DOING_AJAX ) {
-			$this->markTestSkipped( 'DOING_AJAX constant cannot be overridden in this environment.' );
-		}
+		// Use a filter instead of define() — constants pollute the entire test run.
+		add_filter( 'wp_doing_ajax', '__return_true' );
 
 		// Arrange: response_rate_ids is empty so the first gate does not trigger.
 		$this->set_private_property( 'response_rate_ids', array() );
@@ -1232,6 +1228,9 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 
 		// Act.
 		$this->integration->calculate_order_taxes_via_taxjar( array(), $order );
+
+		// Clean up.
+		remove_filter( 'wp_doing_ajax', '__return_true' );
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -1207,6 +1207,32 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$this->integration->calculate_order_taxes_via_taxjar( array(), $order );
 	}
 
+	/**
+	 * Test that calculate_order_taxes_via_taxjar skips when wp_doing_ajax() is true.
+	 */
+	public function test_calculate_order_taxes_skips_when_doing_ajax() {
+		if ( ! defined( 'DOING_AJAX' ) ) {
+			define( 'DOING_AJAX', true );
+		}
+		if ( ! DOING_AJAX ) {
+			$this->markTestSkipped( 'DOING_AJAX constant cannot be overridden in this environment.' );
+		}
+
+		// Arrange: response_rate_ids is empty so the first gate does not trigger.
+		$this->set_private_property( 'response_rate_ids', array() );
+
+		$order = $this->getMockBuilder( 'WC_Order' )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_id' ) )
+			->getMock();
+
+		// Assert: get_id() is never reached because the AJAX gate fires first.
+		$order->expects( $this->never() )->method( 'get_id' );
+
+		// Act.
+		$this->integration->calculate_order_taxes_via_taxjar( array(), $order );
+	}
+
 	// -------------------------------------------------------------------------
 	// snapshot_order_taxes() and restore_order_taxes() tests
 	// -------------------------------------------------------------------------

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -1283,4 +1283,80 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		// Clean up.
 		$order->delete( true );
 	}
+
+	// -------------------------------------------------------------------------
+	// calculate_order_taxes_via_taxjar() happy path tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test happy path: calculate_order_taxes_via_taxjar calls TaxJar API
+	 * and sets response_rate_ids / response_line_items on success.
+	 */
+	public function test_calculate_order_taxes_happy_path_sets_response_properties() {
+		// Arrange: empty response_rate_ids (REST context, not cart).
+		$this->set_private_property( 'response_rate_ids', array() );
+
+		// Create a real order with a product line item.
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		$order = wc_create_order();
+		$order->add_product( $product, 1 );
+		$order->set_shipping_country( 'US' );
+		$order->set_shipping_state( 'TX' );
+		$order->set_shipping_postcode( '78701' );
+		$order->set_shipping_city( 'Austin' );
+		$order->set_shipping_address_1( '123 Main St' );
+		$order->save();
+
+		// Mock calculate_tax() to return a fake successful response.
+		$fake_taxes = array(
+			'rate_ids'   => array( $product->get_id() . '-1' => array( 42 ) ),
+			'line_items' => array(
+				$product->get_id() . '-1' => (object) array(
+					'tax_collectable'   => 1.23,
+					'combined_tax_rate' => 0.0825,
+					'line_total'        => 18.00,
+				),
+			),
+		);
+
+		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'calculate_tax', 'get_backend_line_items', '_log' ) )
+			->getMock();
+		$integration->method( 'get_backend_line_items' )->willReturn( array() );
+		$integration->method( 'calculate_tax' )->willReturn( $fake_taxes );
+		$integration->method( '_log' )->willReturn( null );
+
+		// Pre-set empty response_rate_ids on the mock.
+		$reflection = new ReflectionProperty( 'WC_Connect_TaxJar_Integration', 'response_rate_ids' );
+		$reflection->setAccessible( true );
+		$reflection->setValue( $integration, array() );
+
+		// Need WC()->customer for calculate_tax guard.
+		if ( is_null( WC()->customer ) ) {
+			WC()->customer = new WC_Customer( $order->get_customer_id() );
+		}
+
+		// Act.
+		$integration->calculate_order_taxes_via_taxjar( array(), $order );
+
+		// Assert response properties were set.
+		$rate_ids = $reflection->getValue( $integration );
+		// After running, response_rate_ids should have been set (not empty from fake_taxes).
+		// We check via the mock that calculate_tax was called once.
+		// (response_rate_ids would be set to $fake_taxes['rate_ids']).
+		$response_rate_ids_prop = new ReflectionProperty( 'WC_Connect_TaxJar_Integration', 'response_rate_ids' );
+		$response_rate_ids_prop->setAccessible( true );
+		$this->assertEquals( $fake_taxes['rate_ids'], $response_rate_ids_prop->getValue( $integration ) );
+
+		$response_line_items_prop = new ReflectionProperty( 'WC_Connect_TaxJar_Integration', 'response_line_items' );
+		$response_line_items_prop->setAccessible( true );
+		$this->assertNotEmpty( $response_line_items_prop->getValue( $integration ) );
+
+		// Clean up.
+		WC_Helper_Product::delete_product( $product->get_id() );
+		$order->delete( true );
+	}
 }

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -1169,4 +1169,41 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$this->assertEmpty( $result['line_items'] );
 		$this->assertEquals( 0, $result['has_nexus'] );
 	}
+
+	/**
+	 * Test that calculate_order_taxes_via_taxjar skips when response_rate_ids already set (cart path ran).
+	 */
+	public function test_calculate_order_taxes_skips_when_response_rate_ids_populated() {
+		// Arrange: pre-populate response_rate_ids as the cart path would.
+		$this->set_private_property( 'response_rate_ids', array( 'product-key' => array( 1, 2 ) ) );
+
+		$order = $this->getMockBuilder( 'WC_Order' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		// Assert: get_id() should never be called if gate triggers.
+		$order->expects( $this->never() )->method( 'get_id' );
+
+		// Act.
+		$this->integration->calculate_order_taxes_via_taxjar( array(), $order );
+	}
+
+	/**
+	 * Test that calculate_order_taxes_via_taxjar skips when order ID is 0 (new order).
+	 */
+	public function test_calculate_order_taxes_skips_when_order_id_is_zero() {
+		// Arrange: response_rate_ids is empty (REST context).
+		$this->set_private_property( 'response_rate_ids', array() );
+
+		$order = $this->getMockBuilder( 'WC_Order' )
+			->disableOriginalConstructor()
+			->getMock();
+		$order->method( 'get_id' )->willReturn( 0 );
+
+		// Assert: get_shipping_country() should never be called if gate triggers.
+		$order->expects( $this->never() )->method( 'get_shipping_country' );
+
+		// Act.
+		$this->integration->calculate_order_taxes_via_taxjar( array(), $order );
+	}
 }

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -1365,53 +1365,50 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Test that API failure sets taxjar_recalculation_failed and registers restore hook.
+	 * Test that failure flag is set when TaxJar API fails.
 	 */
-	public function test_calculate_order_taxes_api_failure_registers_restore_hook() {
-		// Arrange.
-		$this->set_private_property( 'response_rate_ids', array() );
-
-		$order = wc_create_order();
-		$order->set_shipping_country( 'US' );
-		$order->set_shipping_state( 'TX' );
-		$order->set_shipping_postcode( '78701' );
-		$order->save();
-
-		// Mock integration to make calculate_tax() return false.
-		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
-			->disableOriginalConstructor()
-			->setMethods( array( 'calculate_tax', 'get_backend_line_items', '_log' ) )
+	public function test_calculate_order_taxes_sets_failure_flag_on_api_error() {
+		$order       = wc_create_order();
+		$integration = $this->getMockBuilder( WC_Connect_TaxJar_Integration::class )
+			->setConstructorArgs( array( $this->mock_connect_api_client, $this->mock_error_notice, $this->mock_logger ) )
+			->onlyMethods( array( 'calculate_tax', 'get_backend_line_items', '_log' ) )
 			->getMock();
 		$integration->method( 'calculate_tax' )->willReturn( false );
 		$integration->method( 'get_backend_line_items' )->willReturn( array() );
 		$integration->method( '_log' )->willReturn( null );
 
-		foreach ( array( 'response_rate_ids', 'taxjar_recalculation_failed', 'pre_recalculation_tax_snapshot' ) as $prop ) {
-			$r = new ReflectionProperty( 'WC_Connect_TaxJar_Integration', $prop );
-			$r->setAccessible( true );
-			$r->setValue( $integration, is_string( $prop ) && 'taxjar_recalculation_failed' === $prop ? false : array() );
-		}
-
-		if ( is_null( WC()->customer ) ) {
-			WC()->customer = new WC_Customer( $order->get_customer_id() );
-		}
-
-		// Act.
 		$integration->calculate_order_taxes_via_taxjar( array(), $order );
 
-		// Assert: failure flag set.
-		$failed_prop = new ReflectionProperty( 'WC_Connect_TaxJar_Integration', 'taxjar_recalculation_failed' );
-		$failed_prop->setAccessible( true );
-		$this->assertTrue( $failed_prop->getValue( $integration ) );
+		$props = ( new ReflectionClass( $integration ) )->getProperties( ReflectionProperty::IS_PRIVATE );
+		$flag  = false;
+		foreach ( $props as $prop ) {
+			if ( 'taxjar_recalculation_failed' === $prop->getName() ) {
+				$prop->setAccessible( true );
+				$flag = $prop->getValue( $integration );
+				break;
+			}
+		}
+		$this->assertTrue( $flag );
+		$order->delete( true );
+	}
 
-		// Assert: restore hook was registered.
-		$this->assertGreaterThan(
-			0,
-			has_action( 'woocommerce_order_after_calculate_totals' ),
-			'Restore hook should be registered on woocommerce_order_after_calculate_totals'
-		);
+	/**
+	 * Test that restore hook is registered when TaxJar API fails.
+	 */
+	public function test_calculate_order_taxes_registers_restore_hook_on_api_failure() {
+		remove_all_actions( 'woocommerce_order_after_calculate_totals' );
+		$order       = wc_create_order();
+		$integration = $this->getMockBuilder( WC_Connect_TaxJar_Integration::class )
+			->setConstructorArgs( array( $this->mock_connect_api_client, $this->mock_error_notice, $this->mock_logger ) )
+			->onlyMethods( array( 'calculate_tax', 'get_backend_line_items', '_log' ) )
+			->getMock();
+		$integration->method( 'calculate_tax' )->willReturn( false );
+		$integration->method( 'get_backend_line_items' )->willReturn( array() );
+		$integration->method( '_log' )->willReturn( null );
 
-		// Clean up.
+		$integration->calculate_order_taxes_via_taxjar( array(), $order );
+
+		$this->assertGreaterThan( 0, has_action( 'woocommerce_order_after_calculate_totals' ) );
 		remove_all_actions( 'woocommerce_order_after_calculate_totals' );
 		$order->delete( true );
 	}
@@ -1419,7 +1416,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	/**
 	 * End-to-end test: when TaxJar API fails, original taxes are preserved.
 	 */
-	public function test_calculate_order_taxes_api_failure_preserves_existing_taxes() {
+	public function test_calculate_order_taxes_preserves_existing_taxes_on_api_failure() {
 		// Create order with a real tax line.
 		$product = WC_Helper_Product::create_simple_product();
 		$product->save();

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -86,6 +86,29 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that calculate_order_taxes_via_taxjar hook is registered after init().
+	 */
+	public function test_calculate_order_taxes_hook_registered_after_init() {
+		// Arrange: enable automated taxes option so init() does not bail early.
+		update_option( WC_Connect_TaxJar_Integration::OPTION_NAME, 'yes' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+
+		// Act.
+		$this->integration->init();
+
+		// Assert.
+		$this->assertNotFalse(
+			has_action( 'woocommerce_order_before_calculate_taxes', array( $this->integration, 'calculate_order_taxes_via_taxjar' ) ),
+			'Hook woocommerce_order_before_calculate_taxes should be registered'
+		);
+
+		// Clean up.
+		remove_all_actions( 'woocommerce_order_before_calculate_taxes' );
+		delete_option( WC_Connect_TaxJar_Integration::OPTION_NAME );
+		delete_option( 'woocommerce_calc_taxes' );
+	}
+
+	/**
 	 * Helper to invoke protected methods via reflection.
 	 *
 	 * @param string $method_name Method name.


### PR DESCRIPTION
## Description

When an external integration (e.g. UPS itembase) sends a REST API PUT request to update a WooCommerce order's `shipping_lines` and includes a `shipping` address that differs from the original order address, all TaxJar tax line items are wiped from the order — leaving `total_tax: 0` and `tax_lines: []`.

**Root cause:** `WC_Abstract_Order::calculate_taxes()` calls `WC_Tax::find_rates()` with the new shipping address. TaxJar's WC rate records are stored scoped to the original checkout address. When the address changes (even slightly — e.g. postcode `90210` → `90211`), `find_rates()` returns empty and `update_taxes()` removes all existing tax line items. TaxJar's override hooks are no-ops in REST context because `$this->response_rate_ids` is never populated outside of cart/checkout.

**Fix:** Once an order is placed, its tax is a record of what was actually charged, so we preserve it rather than recompute it against a changed address. A new handler hooked on `woocommerce_order_before_calculate_taxes` snapshots the order's existing tax state before WC recalculates, and a matching handler on `woocommerce_order_after_calculate_totals` restores it once the totals have been recalculated:

1. `preserve_order_taxes_on_recalculation()` snapshots the tax line items (with full metadata), per-item tax arrays, and order-level tax totals, keyed by order id.
2. WC recalculates the order (and, for a changed address, wipes the tax lines).
3. `restore_order_taxes_after_recalculation()` puts the snapshotted taxes back and rebases the order total on the preserved tax, while keeping any updated non-tax amounts (such as a changed shipping total).

The handler only runs in REST/programmatic context — it bails for the cart/checkout flow (`response_rate_ids` populated), admin AJAX edits (handled by `calculate_backend_totals()`), new orders (id `0`), and orders that have no existing tax lines (so a first-time calculation still runs normally). The snapshot is stashed by order id rather than in a per-call closure, so a batch can recalculate many orders without stacking one-shot callbacks.

### Related issue(s)

Fixes [WOOSHIP-2256](https://linear.app/a8c/issue/WOOSHIP-2256/order-updates-through-rest-api-requests-drop-woocommerce-tax-line)

### Steps to reproduce & screenshots/GIFs

**Before fix:**

1. Create an order with TaxJar tax lines (e.g. CA / Beverly Hills / 90210)
2. Send a REST API PUT to `/wc/v3/orders/{id}` with `shipping_lines` + a `shipping` address with a different postcode (e.g. `90211`) or different state
3. GET the order — `tax_lines` is empty, `total_tax` is `0.00`

**After fix:**

Same PUT request → the recorded tax lines are preserved instead of being wiped, and the order total is rebased on the preserved tax (accounting for any updated shipping amount).

Verified via Postman:

| Test | Payload | Before | After |
|------|---------|--------|-------|
| A | `shipping_lines` only | Taxes preserved | Taxes preserved |
| B | `shipping_lines` + same address | Taxes preserved | Taxes preserved |
| C | `shipping_lines` + different postcode | **Taxes wiped** | Taxes preserved |
| D | `shipping_lines` + different state | **Taxes wiped** | Taxes preserved |

### Checklist

- [x] unit tests
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added
