### PR TITLE
[WOOTAX-19] Fix - Prevent duplicate tax rate rows for semicolon cities

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.6.7 - 2026-xx-xx =
+* Fix   - Prevent unbounded growth of WooCommerce tax rate rows when checkout city contains a semicolon.
+
 = 3.6.6 - 2026-06-22 =
 * Tweak - WooCommerce 10.9 Compatibility.
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -700,7 +700,7 @@ class WC_Connect_TaxJar_Integration {
 					'country'   => $country,
 					'state'     => $state,
 					'postcode'  => $postcode,
-					'city'      => strtoupper( $city ),
+					'city'      => strtoupper( self::normalize_city( $city ) ),
 					'tax_class' => $tax_class,
 				)
 			);
@@ -1788,9 +1788,10 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		$city = str_replace( ';', ' ', $city );
-		$city = preg_replace( '/\s+/', ' ', $city );
+		$city = preg_replace( '/\s+/u', ' ', $city );
 
-		return trim( $city );
+		// `preg_replace` returns null on malformed UTF-8 with the /u flag; cast so trim() stays safe.
+		return trim( (string) $city );
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -670,7 +670,7 @@ class WC_Connect_TaxJar_Integration {
 		$to_country = isset( $taxable_address[0] ) && ! empty( $taxable_address[0] ) ? strtoupper( $taxable_address[0] ) : false;
 		$to_state   = isset( $taxable_address[1] ) && ! empty( $taxable_address[1] ) ? strtoupper( $taxable_address[1] ) : false;
 		$to_zip     = isset( $taxable_address[2] ) && ! empty( $taxable_address[2] ) ? $taxable_address[2] : false;
-		$to_city    = isset( $taxable_address[3] ) && ! empty( $taxable_address[3] ) ? $taxable_address[3] : false;
+		$to_city    = isset( $taxable_address[3] ) && ! empty( $taxable_address[3] ) ? self::normalize_city( $taxable_address[3] ) : false;
 		$to_street  = isset( $taxable_address[4] ) && ! empty( $taxable_address[4] ) ? $taxable_address[4] : false;
 
 		return array(
@@ -917,7 +917,7 @@ class WC_Connect_TaxJar_Integration {
 		$to_country = isset( $_POST['country'] ) ? strtoupper( wc_clean( $_POST['country'] ) ) : false;
 		$to_state   = isset( $_POST['state'] ) ? strtoupper( wc_clean( $_POST['state'] ) ) : false;
 		$to_zip     = isset( $_POST['postcode'] ) ? strtoupper( wc_clean( $_POST['postcode'] ) ) : false;
-		$to_city    = isset( $_POST['city'] ) ? strtoupper( wc_clean( $_POST['city'] ) ) : false;
+		$to_city    = isset( $_POST['city'] ) ? self::normalize_city( strtoupper( wc_clean( $_POST['city'] ) ) ) : false;
 		$to_street  = isset( $_POST['street'] ) ? strtoupper( wc_clean( $_POST['street'] ) ) : false;
     // phpcs:enable WordPress.Security.NonceVerification.Missing
 
@@ -1765,6 +1765,35 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	/**
+	 * Normalize a city value for safe round-trips through WooCommerce's tax rate tables.
+	 *
+	 * `WC_Tax::_update_tax_rate_cities()` treats `;` as a multi-city separator (it
+	 * `explode(';', ...)`s the input), but `WC_Tax::find_rates()` queries the city
+	 * column with a single `location_code = '<CITY>'` literal — so a checkout city
+	 * containing `;` (e.g. typo'd `Casse;Berry`) gets stored as two separate location
+	 * rows (`CASSE`, `BERRY`) yet looked up as the joined string `CASSE;BERRY`.
+	 * That asymmetry causes `find_rates()` to miss on every subsequent calculation,
+	 * which makes `create_or_update_tax_rate()` insert a fresh row each checkout —
+	 * unbounded growth of `wp_woocommerce_tax_rates`. See WOOTAX-19.
+	 *
+	 * Stripping `;` (and collapsing the resulting whitespace runs) before any path
+	 * touches the tax-rate tables or the TaxJar API restores the round-trip.
+	 *
+	 * @param string $city Raw city value, possibly user-entered.
+	 * @return string Normalized city, safe for `_update_tax_rate_cities` and `find_rates`.
+	 */
+	protected static function normalize_city( $city ) {
+		if ( ! is_string( $city ) || '' === $city ) {
+			return $city;
+		}
+
+		$city = str_replace( ';', ' ', $city );
+		$city = preg_replace( '/\s+/', ' ', $city );
+
+		return trim( $city );
+	}
+
+	/**
 	 * Add or update WooCommerce tax rate.
 	 *
 	 * @param  array     $location
@@ -1823,7 +1852,7 @@ class WC_Connect_TaxJar_Integration {
 				'country'   => $location['to_country'],
 				'state'     => str_replace( ' ', '', $to_state ),
 				'postcode'  => $location['to_zip'],
-				'city'      => strtoupper( $location['to_city'] ),
+				'city'      => strtoupper( self::normalize_city( $location['to_city'] ) ),
 				'tax_class' => $tax_class,
 			)
 		);
@@ -1858,7 +1887,7 @@ class WC_Connect_TaxJar_Integration {
 			// VAT is always country wide, no need to create separate entires for each zip and city.
 			if ( 'VAT' !== $tax_rate_name ) {
 				WC_Tax::_update_tax_rate_postcodes( $rate_id, wc_normalize_postcode( wc_clean( $location['to_zip'] ) ) );
-				WC_Tax::_update_tax_rate_cities( $rate_id, wc_clean( $location['to_city'] ) );
+				WC_Tax::_update_tax_rate_cities( $rate_id, self::normalize_city( wc_clean( $location['to_city'] ) ) );
 			}
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.6.7 - 2026-xx-xx =
+* Fix   - Prevent unbounded growth of WooCommerce tax rate rows when checkout city contains a semicolon.
+
 = 3.6.6 - 2026-06-22 =
 * Tweak - WooCommerce 10.9 Compatibility.
 

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -1172,7 +1172,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 
 		// taxable_amount and the top-level rate are 0, but the line item still
 		// carries the real jurisdiction rates (city 1.5%, county 1.25%, state 4.225%).
-		$line_item = (object) array(
+		$line_item    = (object) array(
 			'id'                   => '351-regressionkey',
 			'city_tax_rate'        => 0.015,
 			'county_tax_rate'      => 0.0125,
@@ -1251,7 +1251,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	/**
 	 * Data provider for `test_normalize_city_strips_semicolons_and_normalizes_whitespace`.
 	 *
-	 * @return array<string, array{0: string, 1: string}>
+	 * @return array<string, array{0: mixed, 1: mixed}>
 	 */
 	public function normalize_city_provider() {
 		return array(
@@ -1262,9 +1262,37 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			'trailing semicolon'                  => array( 'Casselberry;', 'Casselberry' ),
 			'consecutive semicolons'              => array( 'Casse;;Berry', 'Casse Berry' ),
 			'wrapped in whitespace'               => array( '  Casselberry  ', 'Casselberry' ),
+			'tab and newline collapse to space'   => array( "Casse;\t\nBerry", 'Casse Berry' ),
 			'empty string'                        => array( '', '' ),
 			'multi-segment with mixed separators' => array( ' Casse; ;Berry ', 'Casse Berry' ),
+			'null — returned unchanged'           => array( null, null ),
+			'false — returned unchanged'          => array( false, false ),
 		);
+	}
+
+	/**
+	 * `get_backend_address()` strips a semicolon from an admin order city.
+	 *
+	 * The admin "Recalculate" path builds its taxable address from `$_POST`, so a
+	 * `;`-bearing city must be normalized there too — otherwise backend recalculations
+	 * would reintroduce the stored/looked-up asymmetry the frontend path now avoids.
+	 *
+	 * @see WOOTAX-19
+	 */
+	public function test_get_backend_address_normalizes_semicolon_city() {
+		$_POST['country']  = 'US';
+		$_POST['state']    = 'FL';
+		$_POST['postcode'] = '33033';
+		$_POST['city']     = 'Casse;Berry';
+
+		try {
+			$address = $this->invoke_protected_method( 'get_backend_address' );
+		} finally {
+			unset( $_POST['country'], $_POST['state'], $_POST['postcode'], $_POST['city'] );
+		}
+
+		$this->assertStringNotContainsString( ';', $address['to_city'], 'Backend order city must not retain a semicolon — `_update_tax_rate_cities()` would split it.' );
+		$this->assertSame( 'CASSE BERRY', $address['to_city'] );
 	}
 
 	/**

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -1226,4 +1226,88 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		// top-level rate. This is the core guard against the zeroing-out regression.
 		$this->assertEqualsWithDelta( 6.975, array_sum( $persisted ), 0.0001, 'Existing tax rate must not be zeroed out by a $0 calculation.' );
 	}
+
+	/**
+	 * `normalize_city()` strips semicolons and collapses whitespace.
+	 *
+	 * `WC_Tax::_update_tax_rate_cities()` treats `;` as a multi-city separator,
+	 * but `WC_Tax::find_rates()` treats it as a literal character. `normalize_city()`
+	 * strips `;` (and collapses whitespace) so the round-trip stays symmetric.
+	 *
+	 * @see WOOTAX-19
+	 *
+	 * @dataProvider normalize_city_provider
+	 *
+	 * @param string $input    Raw city value to normalize.
+	 * @param string $expected Expected normalized output.
+	 */
+	public function test_normalize_city_strips_semicolons_and_normalizes_whitespace( $input, $expected ) {
+		$reflection = new ReflectionMethod( 'WC_Connect_TaxJar_Integration', 'normalize_city' );
+		$reflection->setAccessible( true );
+
+		$this->assertSame( $expected, $reflection->invoke( null, $input ) );
+	}
+
+	/**
+	 * Data provider for `test_normalize_city_strips_semicolons_and_normalizes_whitespace`.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function normalize_city_provider() {
+		return array(
+			'no semicolon — unchanged'            => array( 'New York', 'New York' ),
+			'simple semicolon between words'      => array( 'Casse;Berry', 'Casse Berry' ),
+			'semicolon with following space'      => array( 'Casse; Berry', 'Casse Berry' ),
+			'leading semicolon'                   => array( ';Casselberry', 'Casselberry' ),
+			'trailing semicolon'                  => array( 'Casselberry;', 'Casselberry' ),
+			'consecutive semicolons'              => array( 'Casse;;Berry', 'Casse Berry' ),
+			'wrapped in whitespace'               => array( '  Casselberry  ', 'Casselberry' ),
+			'empty string'                        => array( '', '' ),
+			'multi-segment with mixed separators' => array( ' Casse; ;Berry ', 'Casse Berry' ),
+		);
+	}
+
+	/**
+	 * `create_or_update_tax_rate()` is idempotent across semicolon-bearing cities.
+	 *
+	 * Regression test for the unbounded `wp_woocommerce_tax_rates` growth:
+	 * `create_or_update_tax_rate()` called twice with the same semicolon-bearing
+	 * city must reuse the existing rate row instead of inserting a duplicate.
+	 *
+	 * @see WOOTAX-19
+	 */
+	public function test_create_or_update_tax_rate_does_not_duplicate_rows_for_semicolon_city() {
+		global $wpdb;
+
+		$location = array(
+			'to_country' => 'US',
+			'to_state'   => 'FL',
+			'to_zip'     => '33033',
+			'to_city'    => 'Casse;Berry',
+			'from_state' => 'FL',
+		);
+
+		// Snapshot the row count BEFORE the first call so the test isn't sensitive
+		// to fixtures/seed data (test DB might already have rates from other tests).
+		$rates_table        = $wpdb->prefix . 'woocommerce_tax_rates';
+		$initial_rate_count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$rates_table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$first_id  = $this->integration->create_or_update_tax_rate( $location, 0.07, '', 1, 1, 'Tax' );
+		$second_id = $this->integration->create_or_update_tax_rate( $location, 0.07, '', 1, 1, 'Tax' );
+
+		// Same row id on both calls — find_rates() matched the second time.
+		$this->assertSame( (int) $first_id, (int) $second_id, 'Second create_or_update_tax_rate() inserted a new row instead of reusing the existing one — find_rates() city lookup is asymmetric with _update_tax_rate_cities() storage.' );
+
+		// Exactly one new row added, not two.
+		$final_rate_count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$rates_table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$this->assertSame( $initial_rate_count + 1, $final_rate_count, 'Expected exactly one new tax rate row after two create_or_update_tax_rate() calls with the same Casse;Berry city.' );
+
+		// Stored city in the locations table should be normalized — no `;`.
+		$locations_table = $wpdb->prefix . 'woocommerce_tax_rate_locations';
+		$stored_cities   = $wpdb->get_col( $wpdb->prepare( "SELECT location_code FROM {$locations_table} WHERE tax_rate_id = %d AND location_type = %s", (int) $first_id, 'city' ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$this->assertNotEmpty( $stored_cities );
+		foreach ( $stored_cities as $city ) {
+			$this->assertStringNotContainsString( ';', $city, 'Tax rate city stored with a semicolon — `_update_tax_rate_cities()` will split it and break find_rates() on subsequent lookups.' );
+		}
+	}
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

WooCommerce core treats a `;` in a city value asymmetrically between storage and lookup:

- `WC_Tax::_update_tax_rate_cities()` `explode(';', ...)`s the input, treating `;` as a **multi-city separator** — so a city like `Casse;Berry` is stored as two location rows (`CASSE` and `BERRY`).
- `WC_Tax::find_rates()` queries the city column as a **single literal** (`location_code = 'CASSE;BERRY'`).

Because of this mismatch, `find_rates()` never matches the stored rows, so `create_or_update_tax_rate()` believes no rate exists and **inserts a fresh `wp_woocommerce_tax_rates` row on every tax calculation** — unbounded table growth for any store whose checkout city contains a semicolon (typo'd or pasted addresses).

This PR adds a `normalize_city()` helper that strips `;` and collapses the resulting whitespace, applied at every point that feeds the tax-rate tables or the TaxJar API:

- the cart/checkout taxable-address entry,
- the admin order POST entry,
- the `find_rates()` lookup in `create_or_update_tax_rate()`,
- the `_update_tax_rate_cities()` storage call.

This restores round-trip symmetry: the value stored is the value looked up, so existing rows are reused instead of duplicated.

### Related issue(s)

Closes [WOOTAX-19](https://linear.app/a8c/issue/WOOTAX-19)

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

**Before this fix:**
1. Configure TaxJar tax calculation for a US store.
2. Place (or recalculate) an order whose city contains a semicolon, e.g. `Casse;Berry`.
3. Inspect `wp_woocommerce_tax_rates` — each recalculation adds a new duplicate row, and tax lookups keep missing the existing rate.

**After this fix:**
1. Repeat the steps above.
2. The city is normalized to `Casse Berry`; the rate row is created once and reused on every subsequent calculation — no duplicate rows.

Automated coverage (run `composer test`):
- `test_normalize_city_strips_semicolons_and_normalizes_whitespace` — data-provider unit test for the helper (semicolons, leading/trailing/consecutive separators, whitespace).
- `test_create_or_update_tax_rate_does_not_duplicate_rows_for_semicolon_city` — DB round-trip regression test asserting two consecutive calls with `Casse;Berry` reuse the same `tax_rate_id` and add exactly one row.

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added