### PR TITLE
Fix/issue WOOTAX-298 - Prevent StoreApi fatal on sites running old WooCommerce

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.6.7 - 2026-xx-xx =
+* Fix   - Prevent fatal error on sites running WooCommerce versions without StoreApi support.
+
 = 3.6.6 - 2026-06-22 =
 * Tweak - WooCommerce 10.9 Compatibility.
 

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.6.7 - 2026-xx-xx =
+* Fix   - Prevent fatal error on sites running WooCommerce versions without StoreApi support.
+
 = 3.6.6 - 2026-06-22 =
 * Tweak - WooCommerce 10.9 Compatibility.
 

--- a/tests/php/test-woocommerce-connect-client.php
+++ b/tests/php/test-woocommerce-connect-client.php
@@ -248,54 +248,62 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * When WooCommerce Blocks have not loaded yet, the Store API extension
-	 * registration is deferred to the `woocommerce_blocks_loaded` action rather
-	 * than run inline. On WooCommerce versions without the Store API that action
-	 * never fires, so the extension is skipped instead of fataling.
+	 * When the StoreApi class is present, extend_store_api() registers the
+	 * plugin's Store API extensions.
 	 *
-	 * @covers WC_Connect_Loader::maybe_extend_store_api
+	 * @covers WC_Connect_Loader::extend_store_api
 	 */
-	public function test_maybe_extend_store_api_defers_until_blocks_loaded() {
+	public function test_extend_store_api_registers_when_store_api_available() {
 		$sut = $this->getMockBuilder( 'WC_Connect_Loader' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'is_store_api_loaded', 'extend_store_api' ) )
+			->setMethods( array( 'is_store_api_available', 'register_store_api_extensions' ) )
 			->getMock();
 
-		$sut->method( 'is_store_api_loaded' )->willReturn( false );
-		$sut->expects( $this->never() )->method( 'extend_store_api' );
+		$sut->method( 'is_store_api_available' )->willReturn( true );
+		$sut->expects( $this->once() )->method( 'register_store_api_extensions' );
 
-		remove_all_actions( 'woocommerce_blocks_loaded' );
-
-		$sut->maybe_extend_store_api();
-
-		$this->assertNotFalse(
-			has_action( 'woocommerce_blocks_loaded', array( $sut, 'extend_store_api' ) ),
-			'extend_store_api() should be hooked to woocommerce_blocks_loaded when Blocks are not loaded yet.'
-		);
+		$sut->extend_store_api();
 	}
 
 	/**
-	 * When WooCommerce Blocks have already loaded, the Store API extension is
-	 * registered immediately and not deferred.
+	 * On WooCommerce versions without the StoreApi class, extend_store_api()
+	 * skips registration instead of fataling on the missing class. This is the
+	 * guard that prevents the `Class "…\StoreApi" not found` fatal (WOOTAX-298).
 	 *
-	 * @covers WC_Connect_Loader::maybe_extend_store_api
+	 * @covers WC_Connect_Loader::extend_store_api
 	 */
-	public function test_maybe_extend_store_api_runs_immediately_when_blocks_loaded() {
+	public function test_extend_store_api_skips_registration_when_store_api_unavailable() {
 		$sut = $this->getMockBuilder( 'WC_Connect_Loader' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'is_store_api_loaded', 'extend_store_api' ) )
+			->setMethods( array( 'is_store_api_available', 'register_store_api_extensions' ) )
 			->getMock();
 
-		$sut->method( 'is_store_api_loaded' )->willReturn( true );
-		$sut->expects( $this->once() )->method( 'extend_store_api' );
+		$sut->method( 'is_store_api_available' )->willReturn( false );
+		$sut->expects( $this->never() )->method( 'register_store_api_extensions' );
 
-		remove_all_actions( 'woocommerce_blocks_loaded' );
+		// Must not throw when the StoreApi class is absent.
+		$this->assertNull( $sut->extend_store_api() );
+	}
 
-		$sut->maybe_extend_store_api();
+	/**
+	 * is_store_api_available() reflects whether the StoreApi class the plugin
+	 * depends on actually exists, so the guard tracks the real class.
+	 *
+	 * @covers WC_Connect_Loader::is_store_api_available
+	 */
+	public function test_is_store_api_available_tracks_store_api_class() {
+		$sut = $this->getMockBuilder( 'WC_Connect_Loader' )
+			->disableOriginalConstructor()
+			->setMethods( null )
+			->getMock();
 
-		$this->assertFalse(
-			has_action( 'woocommerce_blocks_loaded', array( $sut, 'extend_store_api' ) ),
-			'extend_store_api() should not be deferred when Blocks are already loaded.'
+		$method = new ReflectionMethod( 'WC_Connect_Loader', 'is_store_api_available' );
+		$method->setAccessible( true );
+
+		$this->assertSame(
+			class_exists( '\Automattic\WooCommerce\StoreApi\StoreApi' ),
+			$method->invoke( $sut ),
+			'is_store_api_available() should mirror the existence of the StoreApi class.'
 		);
 	}
 

--- a/tests/php/test-woocommerce-connect-client.php
+++ b/tests/php/test-woocommerce-connect-client.php
@@ -286,12 +286,21 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * is_store_api_available() reflects whether the StoreApi class the plugin
-	 * depends on actually exists, so the guard tracks the real class.
+	 * is_store_api_available() returns true when the StoreApi class the plugin
+	 * depends on is present. The PHPUnit harness loads WooCommerce, so the class
+	 * exists here - pinning to true means a typo or rename in the guarded class
+	 * string would fail this test rather than silently tracking the change.
 	 *
 	 * @covers WC_Connect_Loader::is_store_api_available
 	 */
-	public function test_is_store_api_available_tracks_store_api_class() {
+	public function test_is_store_api_available_returns_true_when_store_api_class_present() {
+		// Precondition: the harness must actually load the StoreApi class for the
+		// assertion below to be meaningful.
+		$this->assertTrue(
+			class_exists( '\Automattic\WooCommerce\StoreApi\StoreApi' ),
+			'Test precondition: the StoreApi class must be loaded in the test harness.'
+		);
+
 		$sut = $this->getMockBuilder( 'WC_Connect_Loader' )
 			->disableOriginalConstructor()
 			->setMethods( null )
@@ -300,11 +309,52 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 		$method = new ReflectionMethod( 'WC_Connect_Loader', 'is_store_api_available' );
 		$method->setAccessible( true );
 
-		$this->assertSame(
-			class_exists( '\Automattic\WooCommerce\StoreApi\StoreApi' ),
+		$this->assertTrue(
 			$method->invoke( $sut ),
-			'is_store_api_available() should mirror the existence of the StoreApi class.'
+			'is_store_api_available() should return true when the StoreApi class is present.'
 		);
+	}
+
+	/**
+	 * On the unavailable path, extend_store_api() logs a notice - but at most
+	 * once per day, because it runs on `woocommerce_blocks_loaded` (nearly every
+	 * request). The throttle transient must suppress the second same-day call.
+	 *
+	 * @covers WC_Connect_Loader::extend_store_api
+	 * @covers WC_Connect_Loader::log_store_api_unavailable
+	 */
+	public function test_extend_store_api_logs_unavailable_notice_once_per_day() {
+		delete_transient( 'wcservices_store_api_unavailable_logged' );
+
+		// Spy logger injected via the woocommerce_logging_class filter. Returning
+		// an object bypasses wc_get_logger()'s static cache.
+		$logger = $this->getMockBuilder( 'WC_Logger_Interface' )->getMock();
+		$logger->expects( $this->once() )
+			->method( 'notice' )
+			->with(
+				'StoreApi class not found. Store API extensions will not be registered.',
+				array( 'source' => 'woocommerce-services' )
+			);
+
+		$inject_logger = function () use ( $logger ) {
+			return $logger;
+		};
+		add_filter( 'woocommerce_logging_class', $inject_logger );
+
+		$sut = $this->getMockBuilder( 'WC_Connect_Loader' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'is_store_api_available', 'register_store_api_extensions' ) )
+			->getMock();
+
+		$sut->method( 'is_store_api_available' )->willReturn( false );
+		$sut->expects( $this->never() )->method( 'register_store_api_extensions' );
+
+		// First skip logs the notice; the second same-day skip is throttled.
+		$sut->extend_store_api();
+		$sut->extend_store_api();
+
+		remove_filter( 'woocommerce_logging_class', $inject_logger );
+		delete_transient( 'wcservices_store_api_unavailable_logged' );
 	}
 
 }

--- a/tests/php/test-woocommerce-connect-client.php
+++ b/tests/php/test-woocommerce-connect-client.php
@@ -247,4 +247,56 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 		$this->assertEquals( 2, did_action( 'wc_connect_shipping_zone_method_added' ) );
 	}
 
+	/**
+	 * When WooCommerce Blocks have not loaded yet, the Store API extension
+	 * registration is deferred to the `woocommerce_blocks_loaded` action rather
+	 * than run inline. On WooCommerce versions without the Store API that action
+	 * never fires, so the extension is skipped instead of fataling.
+	 *
+	 * @covers WC_Connect_Loader::maybe_extend_store_api
+	 */
+	public function test_maybe_extend_store_api_defers_until_blocks_loaded() {
+		$sut = $this->getMockBuilder( 'WC_Connect_Loader' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'is_store_api_loaded', 'extend_store_api' ) )
+			->getMock();
+
+		$sut->method( 'is_store_api_loaded' )->willReturn( false );
+		$sut->expects( $this->never() )->method( 'extend_store_api' );
+
+		remove_all_actions( 'woocommerce_blocks_loaded' );
+
+		$sut->maybe_extend_store_api();
+
+		$this->assertNotFalse(
+			has_action( 'woocommerce_blocks_loaded', array( $sut, 'extend_store_api' ) ),
+			'extend_store_api() should be hooked to woocommerce_blocks_loaded when Blocks are not loaded yet.'
+		);
+	}
+
+	/**
+	 * When WooCommerce Blocks have already loaded, the Store API extension is
+	 * registered immediately and not deferred.
+	 *
+	 * @covers WC_Connect_Loader::maybe_extend_store_api
+	 */
+	public function test_maybe_extend_store_api_runs_immediately_when_blocks_loaded() {
+		$sut = $this->getMockBuilder( 'WC_Connect_Loader' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'is_store_api_loaded', 'extend_store_api' ) )
+			->getMock();
+
+		$sut->method( 'is_store_api_loaded' )->willReturn( true );
+		$sut->expects( $this->once() )->method( 'extend_store_api' );
+
+		remove_all_actions( 'woocommerce_blocks_loaded' );
+
+		$sut->maybe_extend_store_api();
+
+		$this->assertFalse(
+			has_action( 'woocommerce_blocks_loaded', array( $sut, 'extend_store_api' ) ),
+			'extend_store_api() should not be deferred when Blocks are already loaded.'
+		);
+	}
+
 }

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -817,7 +817,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->service_settings_store->migrate_legacy_services();
 			$this->attach_hooks();
 			$this->init_store_notices();
-			$this->extend_store_api();
+			$this->maybe_extend_store_api();
 		}
 
 		/**
@@ -976,17 +976,36 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		/**
-		 * Extend the Store API.
+		 * Register the Store API extension once WooCommerce Blocks are available.
+		 *
+		 * The Store API only exists on WooCommerce versions that ship the Blocks
+		 * package, which fires `woocommerce_blocks_loaded`. Deferring registration
+		 * to that action means the extension is never registered - and never fatals
+		 * on the missing StoreApi class - on WooCommerce versions too old to include
+		 * it. When Blocks have already loaded (the usual case) it registers inline.
 		 */
-		public function extend_store_api() {
-			if ( ! class_exists( 'Automattic\WooCommerce\StoreApi\StoreApi' ) ) {
-				wc_get_logger()->notice(
-					'StoreApi class not found. Store API extensions will not be registered.',
-					array( 'source' => 'woocommerce-services' )
-				);
+		public function maybe_extend_store_api() {
+			if ( $this->is_store_api_loaded() ) {
+				$this->extend_store_api();
 				return;
 			}
 
+			add_action( 'woocommerce_blocks_loaded', array( $this, 'extend_store_api' ) );
+		}
+
+		/**
+		 * Whether WooCommerce Blocks (and therefore the Store API) have loaded.
+		 *
+		 * @return bool
+		 */
+		protected function is_store_api_loaded() {
+			return (bool) did_action( 'woocommerce_blocks_loaded' );
+		}
+
+		/**
+		 * Extend the Store API.
+		 */
+		public function extend_store_api() {
 			$store_api_extend_schema        = StoreApiExtendSchema::instance();
 			$store_api_extension_controller = new StoreApiExtensionController( $store_api_extend_schema );
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -990,10 +990,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 */
 		public function extend_store_api() {
 			if ( ! $this->is_store_api_available() ) {
-				wc_get_logger()->notice(
-					'StoreApi class not found. Store API extensions will not be registered.',
-					array( 'source' => 'woocommerce-services' )
-				);
+				$this->log_store_api_unavailable();
 				return;
 			}
 
@@ -1007,6 +1004,29 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 */
 		protected function is_store_api_available() {
 			return class_exists( '\Automattic\WooCommerce\StoreApi\StoreApi' );
+		}
+
+		/**
+		 * Log, at most once per day, that the Store API is unavailable.
+		 *
+		 * `extend_store_api()` runs on `woocommerce_blocks_loaded`, which fires on
+		 * nearly every request. On installs missing the StoreApi class the notice
+		 * would otherwise be written on every page load, so it is throttled to once
+		 * per day via a transient.
+		 */
+		protected function log_store_api_unavailable() {
+			$transient_key = 'wcservices_store_api_unavailable_logged';
+
+			if ( get_transient( $transient_key ) ) {
+				return;
+			}
+
+			wc_get_logger()->notice(
+				'StoreApi class not found. Store API extensions will not be registered.',
+				array( 'source' => 'woocommerce-services' )
+			);
+
+			set_transient( $transient_key, 1, DAY_IN_SECONDS );
 		}
 
 		/**

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -702,6 +702,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 
 			add_action( 'woocommerce_blocks_loaded', array( $this, 'register_blocks_integration' ) );
+			add_action( 'woocommerce_blocks_loaded', array( $this, 'extend_store_api' ) );
 			add_action( 'before_woocommerce_init', array( $this, 'pre_wc_init' ) );
 		}
 
@@ -817,7 +818,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$this->service_settings_store->migrate_legacy_services();
 			$this->attach_hooks();
 			$this->init_store_notices();
-			$this->maybe_extend_store_api();
 		}
 
 		/**
@@ -976,36 +976,43 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		/**
-		 * Register the Store API extension once WooCommerce Blocks are available.
+		 * Extend the Store API when it is available.
 		 *
-		 * The Store API only exists on WooCommerce versions that ship the Blocks
-		 * package, which fires `woocommerce_blocks_loaded`. Deferring registration
-		 * to that action means the extension is never registered - and never fatals
-		 * on the missing StoreApi class - on WooCommerce versions too old to include
-		 * it. When Blocks have already loaded (the usual case) it registers inline.
+		 * Registered on `woocommerce_blocks_loaded` - the same hook the block
+		 * integration uses - because the Store API only exists once Blocks load and
+		 * our extension only surfaces notices in the block cart/checkout. On a
+		 * WooCommerce too old to ship Blocks the hook never fires, so nothing runs.
+		 *
+		 * The `class_exists()` guard covers the in-between case: WooCommerce versions
+		 * that ship Blocks (firing this hook) but predate the top-level
+		 * `Automattic\WooCommerce\StoreApi\StoreApi` class this plugin depends on.
+		 * Without the guard those versions would still fatal with `Class not found`.
 		 */
-		public function maybe_extend_store_api() {
-			if ( $this->is_store_api_loaded() ) {
-				$this->extend_store_api();
+		public function extend_store_api() {
+			if ( ! $this->is_store_api_available() ) {
+				wc_get_logger()->notice(
+					'StoreApi class not found. Store API extensions will not be registered.',
+					array( 'source' => 'woocommerce-services' )
+				);
 				return;
 			}
 
-			add_action( 'woocommerce_blocks_loaded', array( $this, 'extend_store_api' ) );
+			$this->register_store_api_extensions();
 		}
 
 		/**
-		 * Whether WooCommerce Blocks (and therefore the Store API) have loaded.
+		 * Whether the WooCommerce Store API is available on this installation.
 		 *
 		 * @return bool
 		 */
-		protected function is_store_api_loaded() {
-			return (bool) did_action( 'woocommerce_blocks_loaded' );
+		protected function is_store_api_available() {
+			return class_exists( '\Automattic\WooCommerce\StoreApi\StoreApi' );
 		}
 
 		/**
-		 * Extend the Store API.
+		 * Register the plugin's Store API extensions.
 		 */
-		public function extend_store_api() {
+		protected function register_store_api_extensions() {
 			$store_api_extend_schema        = StoreApiExtendSchema::instance();
 			$store_api_extension_controller = new StoreApiExtensionController( $store_api_extend_schema );
 

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -979,6 +979,14 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * Extend the Store API.
 		 */
 		public function extend_store_api() {
+			if ( ! class_exists( 'Automattic\WooCommerce\StoreApi\StoreApi' ) ) {
+				wc_get_logger()->notice(
+					'StoreApi class not found. Store API extensions will not be registered.',
+					array( 'source' => 'woocommerce-services' )
+				);
+				return;
+			}
+
 			$store_api_extend_schema        = StoreApiExtendSchema::instance();
 			$store_api_extension_controller = new StoreApiExtensionController( $store_api_extend_schema );
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

WooCommerce Tax was throwing a PHP fatal error on sites running an older WooCommerce version that does not include the `Automattic\WooCommerce\StoreApi\StoreApi` class (introduced when the Blocks StoreApi was merged into WooCommerce core). The plugin's stated minimum WC version (`10.7`) is advisory — WordPress does not enforce it at runtime — so sites that lagged behind on WooCommerce updates were still loading the plugin and fatalling inside `extend_store_api()`.

The fix has two parts:

1. **Register on `woocommerce_blocks_loaded`.** `extend_store_api()` now runs on the `woocommerce_blocks_loaded` action (the same hook the block integration already uses at line 704) instead of during `woocommerce_init`. Our extension only surfaces notices in the block cart/checkout, so it only needs to run once Blocks load. On a WooCommerce too old to ship Blocks the hook never fires, so nothing runs and there is no fatal.

2. **Guard on `class_exists()`.** WooCommerce versions between ~5.0 and ~6.3 ship Blocks (so they fire `woocommerce_blocks_loaded`) but predate the top-level `Automattic\WooCommerce\StoreApi\StoreApi` class this plugin imports — the hook alone would still fatal there. So `extend_store_api()` also guards on `class_exists( '\Automattic\WooCommerce\StoreApi\StoreApi' )`. If the class is absent, a `notice` is logged via `wc_get_logger()` and the method returns early. When the class is present the extension registers as before.

This addresses the review suggestion to fix the fatal structurally via the hook, while keeping the class check so the in-between versions are covered too.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Fixes [WOOTAX-298](https://linear.app/a8c/issue/WOOTAX-298/fatal-error-class-storeapistoreapi-not-found-in)

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

**Before (to reproduce the fatal):**
1. Install WooCommerce at a version that predates the top-level `Automattic\WooCommerce\StoreApi\StoreApi` class (before ~6.4). This includes both WC too old to ship Blocks at all, and WC ~5.0–6.3 that ships Blocks but under the older `Blocks\StoreApi` namespace.
2. Install or update WooCommerce Tax to this version.
3. Observe PHP fatal: `Uncaught Error: Class "Automattic\WooCommerce\StoreApi\StoreApi" not found in StoreApiExtendSchema.php:41`.

**After:**
1. Same setup.
2. No fatal in either case:
   - WC with no Blocks: `woocommerce_blocks_loaded` never fires, so registration never runs.
   - WC with Blocks but old StoreApi namespace: the hook fires, the `class_exists()` guard is false, and WC logs a notice: `StoreApi class not found. Store API extensions will not be registered.`
3. On a supported WooCommerce the extension registers as before. The rest of the plugin loads normally in all cases.

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

