### PR TITLE
Fix/issue WOOTAX-297 - Prevent fatal error on Atomic sites from malformed API client require path

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.6.7 - 2026-xx-xx =
+* Fix   - Prevent fatal error on Atomic sites caused by incorrect path resolution when loading the API client class.
+
 = 3.6.6 - 2026-06-22 =
 * Tweak - WooCommerce 10.9 Compatibility.
 

--- a/classes/class-wc-connect-api-client-live.php
+++ b/classes/class-wc-connect-api-client-live.php
@@ -10,7 +10,7 @@ if ( ! defined( 'WOOCOMMERCE_CONNECT_SERVER_URL' ) ) {
 }
 
 if ( ! class_exists( 'WC_Connect_API_Client_Live' ) ) {
-	require_once plugin_basename( 'class-wc-connect-api-client.php' );
+	require_once __DIR__ . '/class-wc-connect-api-client.php';
 
 	class WC_Connect_API_Client_Live extends WC_Connect_API_Client {
 

--- a/classes/class-wc-connect-compatibility.php
+++ b/classes/class-wc-connect-compatibility.php
@@ -49,11 +49,11 @@ if ( ! class_exists( 'WC_Connect_Compatibility' ) ) {
 		 */
 		private static function select_compatibility() {
 			if ( version_compare( self::$version, '6.9.0', '<' ) ) {
-				require_once 'class-wc-connect-compatibility-wc30.php';
+				require_once __DIR__ . '/class-wc-connect-compatibility-wc30.php';
 
 				return new WC_Connect_Compatibility_WC30();
 			} else {
-				require_once 'class-wc-connect-compatibility-wc69.php';
+				require_once __DIR__ . '/class-wc-connect-compatibility-wc69.php';
 
 				return new WC_Connect_Compatibility_WC69();
 			}
@@ -95,6 +95,5 @@ if ( ! class_exists( 'WC_Connect_Compatibility' ) ) {
 		 * @return bool|WC_Order|WC_Order_Refund.
 		 */
 		abstract public function init_theorder_object( $post_or_order_object );
-
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.6.7 - 2026-xx-xx =
+* Fix   - Prevent fatal error on Atomic sites caused by incorrect path resolution when loading the API client class.
+
 = 3.6.6 - 2026-06-22 =
 * Tweak - WooCommerce 10.9 Compatibility.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

WooCommerce Services was throwing a PHP fatal error on Atomic (WordPress.com) sites on every page load, accounting for ~3,833 errors over 7 days. The root cause is a misuse of `plugin_basename()` in `classes/class-wc-connect-api-client-live.php` — the function is passed a bare relative filename instead of an absolute path. On Atomic, Jetpack's symlink entries in WordPress's `$wp_plugin_paths` table corrupt the path, producing `jetpackclass-wc-connect-api-client.php` which PHP cannot open.

The fix replaces `plugin_basename( 'class-wc-connect-api-client.php' )` with `__DIR__ . '/class-wc-connect-api-client.php'`, using PHP's magic constant that resolves to the file's own directory at compile time — bypassing WordPress path manipulation entirely. This matches the pattern used by every other `require_once` in the codebase.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Fixes [WOOTAX-297](https://linear.app/a8c/issue/WOOTAX-297/fatal-error-failed-opening-required-jetpackclass-wc-connect-api), [WOOTAX-300](https://linear.app/a8c/issue/WOOTAX-300/harden-bare-relative-require-once-calls-in-class-wc-connect)

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

**Before (Atomic sites only):**
1. Install WooCommerce Services on an Atomic (WordPress.com) site with Jetpack active
2. Activate the plugin
3. Observe: `PHP Fatal error: Uncaught Error: Failed opening required 'jetpackclass-wc-connect-api-client.php'`

**After:**
1. Install WooCommerce Services on an Atomic site with Jetpack active
2. Activate the plugin
3. Plugin loads without error

N/A — no UI changes.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added
