### PR TITLE
[WOOTAX-27] Fix - Fail CI when PHPUnit runs zero tests

### DIFF
--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -95,4 +95,18 @@ jobs:
       - name: Install Composer dependencies
         run: composer install
       - name: Run PHPUnit tests
-        run: ./vendor/bin/phpunit -c phpunit.xml.dist
+        # PHPUnit exits 0 even when it executes zero tests (it prints
+        # "No tests executed!"), so a broken bootstrap or misconfigured suite
+        # silently turned CI green before (see #2638). Preserve PHPUnit's own
+        # exit code via PIPESTATUS (tee must not mask it) and additionally fail
+        # the build on an empty run.
+        shell: bash
+        run: |
+          set +e
+          ./vendor/bin/phpunit -c phpunit.xml.dist 2>&1 | tee phpunit-output.log
+          status=${PIPESTATUS[0]}
+          if grep -q 'No tests executed' phpunit-output.log; then
+            echo "::error::PHPUnit executed zero tests — failing the build."
+            exit 1
+          fi
+          exit "$status"

--- a/.github/workflows/unit_test_runner.yml
+++ b/.github/workflows/unit_test_runner.yml
@@ -99,4 +99,18 @@ jobs:
       - name: Install Composer dependencies
         run: composer install
       - name: Run PHPUnit tests
-        run: ./vendor/bin/phpunit -c phpunit.xml.dist
+        # PHPUnit exits 0 even when it executes zero tests (it prints
+        # "No tests executed!"), so a broken bootstrap or misconfigured suite
+        # silently turned CI green before (see #2638). Preserve PHPUnit's own
+        # exit code via PIPESTATUS (tee must not mask it) and additionally fail
+        # the build on an empty run.
+        shell: bash
+        run: |
+          set +e
+          ./vendor/bin/phpunit -c phpunit.xml.dist 2>&1 | tee phpunit-output.log
+          status=${PIPESTATUS[0]}
+          if grep -q 'No tests executed' phpunit-output.log; then
+            echo "::error::PHPUnit executed zero tests — failing the build."
+            exit 1
+          fi
+          exit "$status"


### PR DESCRIPTION
## Description
<!-- Explain the motivation for making this change -->

PHPUnit exits with code `0` even when it executes **zero** tests (it prints `No tests executed!`). A broken bootstrap, a bad path in `phpunit.xml.dist`, or a suite that fails to load can therefore make CI pass green without running anything — which happened before in #2638 and went unnoticed.

This guards the direct `./vendor/bin/phpunit -c phpunit.xml.dist` invocation in both CI workflows (`php_tests.yml` and `unit_test_runner.yml`):

- Preserves PHPUnit's real exit code via `PIPESTATUS`, so genuine test failures still propagate (`tee` can't mask them).
- Additionally fails the build when the run reports `No tests executed`.

Because CI already runs the full suite, the guard adds **no** extra runtime, and it works on the pinned PHPUnit 8 — no version bump (the built-in `--fail-on-empty-test-suite` is 9.6+).

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Closes [WOOTAX-27](https://linear.app/a8c/issue/WOOTAX-27)
Fixes #2645
Context: #2638 — the incident where the suite silently stopped running yet CI stayed green.

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

CI-only change, no UI. To verify by intentionally breaking the suite (the ticket's own acceptance step):

1. Make zero tests match — e.g. point the `<directory>` in `phpunit.xml.dist` at an empty folder, or rename `tests/php/test-*.php` so none match the `test-` prefix.
2. **Before** (`trunk`): `./vendor/bin/phpunit -c phpunit.xml.dist` prints `No tests executed!` and exits `0` → CI passes (the bug).
3. **After** (this PR): the step prints `::error::PHPUnit executed zero tests — failing the build.` and exits `1` → CI fails (the fix).
4. Normal runs are unaffected: a green suite still passes, and real test failures still exit non-zero via `PIPESTATUS`.

The guard's exit-code logic was validated against 5 scenarios (pass, real-failure, empty, empty+non-zero, fatal) — each yields the correct exit code.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

> CI-only change (workflow YAML): no user-facing behavior change, so no `changelog.txt` / `readme.txt` entry — consistent with recent CI/dev-tooling merges (e.g. WOOTAX-287, #2961). No unit-test framework covers workflow YAML; the guard logic was verified via shell simulation (see testing steps above).