### PR TITLE
Fix/issue WOOTAX-303 - Harden StoreApiExtendSchema against container resolution failure

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 3.6.8 - 2026-xx-xx =
 * Fix   - Prevent fatal error on sites running WooCommerce versions without StoreApi support.
+* Fix   - Prevent a rare fatal error when the WooCommerce Store API cannot be initialized on incomplete installations.
 
 = 3.6.7 - 2026-07-06 =
 * Fix   - Prevent fatal error on Atomic sites caused by incorrect path resolution when loading the API client class.

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,7 @@ This plugin relies on the following external services:
 
 = 3.6.8 - 2026-xx-xx =
 * Fix   - Prevent fatal error on sites running WooCommerce versions without StoreApi support.
+* Fix   - Prevent a rare fatal error when the WooCommerce Store API cannot be initialized on incomplete installations.
 
 = 3.6.7 - 2026-07-06 =
 * Fix   - Prevent fatal error on Atomic sites caused by incorrect path resolution when loading the API client class.

--- a/src/StoreApi/StoreApiExtendSchema.php
+++ b/src/StoreApi/StoreApiExtendSchema.php
@@ -47,15 +47,30 @@ class StoreApiExtendSchema {
 
 	/**
 	 * ExtendSchemaService constructor.
+	 *
+	 * Protected rather than private so tests can subclass and override
+	 * resolve_extend_schema() to exercise the resolution-failure path.
 	 */
-	private function __construct() {
+	protected function __construct() {
 		self::$attempted = true;
 
 		try {
-			self::$instance = StoreApi::container()->get( ExtendSchema::class );
+			self::$instance = static::resolve_extend_schema();
 		} catch ( Throwable $e ) {
 			wc_get_logger()->debug( 'Failed to get ExtendSchema instance.', array( 'exception' => $e ) );
 		}
+	}
+
+	/**
+	 * Resolve the ExtendSchema instance from the Store API container.
+	 *
+	 * Extracted as a seam so a broken container can be simulated in tests (subclass
+	 * and override to throw) without needing a genuinely partial WooCommerce install.
+	 *
+	 * @return ExtendSchema
+	 */
+	protected static function resolve_extend_schema(): ExtendSchema {
+		return StoreApi::container()->get( ExtendSchema::class );
 	}
 
 	/**
@@ -67,7 +82,7 @@ class StoreApiExtendSchema {
 	 */
 	public static function instance(): ?ExtendSchema {
 		if ( ! self::$attempted ) {
-			new self();
+			new static();
 		}
 
 		return self::$instance;

--- a/src/StoreApi/StoreApiExtendSchema.php
+++ b/src/StoreApi/StoreApiExtendSchema.php
@@ -31,8 +31,10 @@ class StoreApiExtendSchema {
 	/**
 	 * Whether resolving the ExtendSchema instance has been attempted.
 	 *
-	 * Guards against re-running container resolution (and re-logging) on every
-	 * request when resolution fails on an install with a broken Store API.
+	 * Guards against re-running container resolution (and re-logging) more than
+	 * once within a single request when resolution fails. Note this cannot span
+	 * requests: PHP statics reset on every page load, so a broken install still
+	 * logs once per request.
 	 *
 	 * @var bool
 	 */
@@ -57,7 +59,13 @@ class StoreApiExtendSchema {
 		try {
 			self::$instance = static::resolve_extend_schema();
 		} catch ( Throwable $e ) {
-			wc_get_logger()->debug( 'Failed to get ExtendSchema instance.', array( 'exception' => $e ) );
+			wc_get_logger()->debug(
+				'Failed to get ExtendSchema instance.',
+				array(
+					'source'    => 'woocommerce-services',
+					'exception' => $e,
+				)
+			);
 		}
 	}
 

--- a/src/StoreApi/StoreApiExtendSchema.php
+++ b/src/StoreApi/StoreApiExtendSchema.php
@@ -11,7 +11,7 @@ namespace Automattic\WCServices\StoreApi;
 
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 use Automattic\WooCommerce\StoreApi\StoreApi;
-use Exception;
+use Throwable;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -22,9 +22,21 @@ class StoreApiExtendSchema {
 	/**
 	 * Stores Store API ExtendSchema instance.
 	 *
-	 * @var ExtendSchema
+	 * Null when the instance has not been resolved, or when resolution failed.
+	 *
+	 * @var ExtendSchema|null
 	 */
-	private static ExtendSchema $instance;
+	private static ?ExtendSchema $instance = null;
+
+	/**
+	 * Whether resolving the ExtendSchema instance has been attempted.
+	 *
+	 * Guards against re-running container resolution (and re-logging) on every
+	 * request when resolution fails on an install with a broken Store API.
+	 *
+	 * @var bool
+	 */
+	private static bool $attempted = false;
 
 	/**
 	 * Plugin Identifier
@@ -37,18 +49,24 @@ class StoreApiExtendSchema {
 	 * ExtendSchemaService constructor.
 	 */
 	private function __construct() {
+		self::$attempted = true;
+
 		try {
 			self::$instance = StoreApi::container()->get( ExtendSchema::class );
-		} catch ( Exception $e ) {
+		} catch ( Throwable $e ) {
 			wc_get_logger()->debug( 'Failed to get ExtendSchema instance.', array( 'exception' => $e ) );
 		}
 	}
 
 	/**
-	 * Returns the ExtendSchema instance.
+	 * Returns the ExtendSchema instance, or null when it cannot be resolved.
+	 *
+	 * Callers MUST check for null before use: on a partial or broken WooCommerce
+	 * install the container can fail to resolve ExtendSchema even when the
+	 * top-level StoreApi class exists.
 	 */
-	public static function instance(): ExtendSchema {
-		if ( ! isset( self::$instance ) ) {
+	public static function instance(): ?ExtendSchema {
+		if ( ! self::$attempted ) {
 			new self();
 		}
 

--- a/tests/php/class-wcservices-throwing-store-api-extend-schema.php
+++ b/tests/php/class-wcservices-throwing-store-api-extend-schema.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Test double for StoreApiExtendSchema that simulates container resolution failure.
+ *
+ * @package Automattic/WCServices
+ */
+
+// No direct access please.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'WCServices_Throwing_Store_Api_Extend_Schema' ) ) {
+
+	/**
+	 * Forces StoreApiExtendSchema's container resolution to fail with a TypeError, so the
+	 * catch ( Throwable ) path in instance() can be exercised without a broken WooCommerce
+	 * install (WOOTAX-303).
+	 */
+	class WCServices_Throwing_Store_Api_Extend_Schema extends \Automattic\WCServices\StoreApi\StoreApiExtendSchema {
+
+		// phpcs:disable Squiz.Commenting.FunctionComment.InvalidNoReturn -- Test double intentionally always throws to simulate a resolution failure.
+		/**
+		 * Simulate a container that cannot resolve ExtendSchema.
+		 *
+		 * @throws \TypeError Always, to mimic a container resolution failure.
+		 * @return \Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema
+		 */
+		protected static function resolve_extend_schema(): \Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema {
+			throw new \TypeError( 'Simulated container resolution failure.' );
+		}
+		// phpcs:enable Squiz.Commenting.FunctionComment.InvalidNoReturn
+	}
+}

--- a/tests/php/test-woocommerce-connect-client.php
+++ b/tests/php/test-woocommerce-connect-client.php
@@ -404,4 +404,70 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 			$instance->setValue( $orig_instance );
 		}
 	}
+
+	/**
+	 * The $attempted latch is what stops container resolution (and its debug log)
+	 * from re-running on every request. This asserts the latch engages on the first
+	 * call regardless of whether resolution succeeds or fails (WOOTAX-303).
+	 *
+	 * @testdox instance() sets the attempted latch on the first call.
+	 * @covers Automattic\WCServices\StoreApi\StoreApiExtendSchema::instance
+	 */
+	public function test_instance_latches_attempted_on_first_call() {
+		$class     = '\Automattic\WCServices\StoreApi\StoreApiExtendSchema';
+		$attempted = new ReflectionProperty( $class, 'attempted' );
+		$instance  = new ReflectionProperty( $class, 'instance' );
+		$attempted->setAccessible( true );
+		$instance->setAccessible( true );
+
+		$orig_attempted = $attempted->getValue();
+		$orig_instance  = $instance->getValue();
+
+		try {
+			$attempted->setValue( false );
+			$instance->setValue( null );
+
+			\Automattic\WCServices\StoreApi\StoreApiExtendSchema::instance();
+
+			$this->assertTrue( $attempted->getValue(), 'instance() must latch $attempted on the first call so resolution runs at most once per request.' );
+		} finally {
+			$attempted->setValue( $orig_attempted );
+			$instance->setValue( $orig_instance );
+		}
+	}
+
+	/**
+	 * Once resolution has been attempted, instance() must return the already-resolved
+	 * instance without re-entering the container. A distinct ExtendSchema sentinel
+	 * (built without the constructor, so it is never the container's shared instance)
+	 * makes this deterministic: if the $attempted guard were removed, instance() would
+	 * re-resolve and return a different object, failing the identity assertion. This
+	 * avoids the working-container dependency of the null-path test (WOOTAX-303).
+	 *
+	 * @testdox instance() returns the cached instance without re-resolving once attempted.
+	 * @covers Automattic\WCServices\StoreApi\StoreApiExtendSchema::instance
+	 */
+	public function test_instance_returns_cached_instance_without_reresolving() {
+		$class     = '\Automattic\WCServices\StoreApi\StoreApiExtendSchema';
+		$attempted = new ReflectionProperty( $class, 'attempted' );
+		$instance  = new ReflectionProperty( $class, 'instance' );
+		$attempted->setAccessible( true );
+		$instance->setAccessible( true );
+
+		$orig_attempted = $attempted->getValue();
+		$orig_instance  = $instance->getValue();
+
+		// ExtendSchema is final; build a distinct real instance without its constructor.
+		$sentinel = ( new ReflectionClass( '\Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema' ) )->newInstanceWithoutConstructor();
+
+		try {
+			$attempted->setValue( true );
+			$instance->setValue( $sentinel );
+
+			$this->assertSame( $sentinel, \Automattic\WCServices\StoreApi\StoreApiExtendSchema::instance(), 'instance() must return the cached instance without re-resolving once resolution has been attempted.' );
+		} finally {
+			$attempted->setValue( $orig_attempted );
+			$instance->setValue( $orig_instance );
+		}
+	}
 }

--- a/tests/php/test-woocommerce-connect-client.php
+++ b/tests/php/test-woocommerce-connect-client.php
@@ -394,6 +394,10 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 			$attempted->setValue( true );   // resolution already attempted...
 			$instance->setValue( null );    // ...and it failed.
 
+			// Non-vacuity relies on the test harness container resolving a real
+			// instance on re-entry: if the $attempted guard were removed, instance()
+			// would re-run the constructor and return that non-null instance,
+			// failing this assertion.
 			$this->assertNull( \Automattic\WCServices\StoreApi\StoreApiExtendSchema::instance() );
 		} finally {
 			$attempted->setValue( $orig_attempted );

--- a/tests/php/test-woocommerce-connect-client.php
+++ b/tests/php/test-woocommerce-connect-client.php
@@ -370,4 +370,34 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 		// Must not throw a TypeError; the early return yields void (null).
 		$this->assertNull( $method->invoke( $sut ) );
 	}
+
+	/**
+	 * When resolution has already been attempted and failed, instance() returns
+	 * null instead of fataling on an uninitialized typed static, and the $attempted
+	 * guard prevents a re-resolution (which, against the working test-harness
+	 * container, would otherwise return a non-null instance) (WOOTAX-303).
+	 *
+	 * @covers Automattic\WCServices\StoreApi\StoreApiExtendSchema::instance
+	 */
+	public function test_instance_returns_null_when_resolution_failed() {
+		$class     = '\Automattic\WCServices\StoreApi\StoreApiExtendSchema';
+		$attempted = new ReflectionProperty( $class, 'attempted' );
+		$instance  = new ReflectionProperty( $class, 'instance' );
+		$attempted->setAccessible( true );
+		$instance->setAccessible( true );
+
+		// Static state leaks across tests; capture and restore it.
+		$orig_attempted = $attempted->getValue();
+		$orig_instance  = $instance->getValue();
+
+		try {
+			$attempted->setValue( true );   // resolution already attempted...
+			$instance->setValue( null );    // ...and it failed.
+
+			$this->assertNull( \Automattic\WCServices\StoreApi\StoreApiExtendSchema::instance() );
+		} finally {
+			$attempted->setValue( $orig_attempted );
+			$instance->setValue( $orig_instance );
+		}
+	}
 }

--- a/tests/php/test-woocommerce-connect-client.php
+++ b/tests/php/test-woocommerce-connect-client.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/class-wcservices-throwing-store-api-extend-schema.php';
+
 class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 
 	const SERVICE_SCRIPT_HANDLE = 'wc_connect_admin';
@@ -466,6 +468,49 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 
 			$this->assertSame( $sentinel, \Automattic\WCServices\StoreApi\StoreApiExtendSchema::instance(), 'instance() must return the cached instance without re-resolving once resolution has been attempted.' );
 		} finally {
+			$attempted->setValue( $orig_attempted );
+			$instance->setValue( $orig_instance );
+		}
+	}
+
+	/**
+	 * When the container throws while resolving ExtendSchema, instance() must catch it
+	 * and return null instead of fataling. A TypeError is used deliberately: it is a
+	 * Throwable but not an Exception, so pre-fix code (catch Exception) would let it
+	 * propagate. The failure must also be logged once (WOOTAX-303).
+	 *
+	 * @testdox instance() returns null and logs when the container throws a non-Exception Throwable.
+	 * @covers Automattic\WCServices\StoreApi\StoreApiExtendSchema::instance
+	 */
+	public function test_instance_returns_null_when_container_throws() {
+		$class     = '\Automattic\WCServices\StoreApi\StoreApiExtendSchema';
+		$attempted = new ReflectionProperty( $class, 'attempted' );
+		$instance  = new ReflectionProperty( $class, 'instance' );
+		$attempted->setAccessible( true );
+		$instance->setAccessible( true );
+
+		$orig_attempted = $attempted->getValue();
+		$orig_instance  = $instance->getValue();
+
+		$logger = $this->getMockBuilder( 'WC_Logger_Interface' )->getMock();
+		$logger->expects( $this->once() )
+			->method( 'debug' )
+			->with( 'Failed to get ExtendSchema instance.', $this->anything() );
+
+		$inject_logger = function () use ( $logger ) {
+			return $logger;
+		};
+		add_filter( 'woocommerce_logging_class', $inject_logger );
+
+		try {
+			$attempted->setValue( false );
+			$instance->setValue( null );
+
+			$result = WCServices_Throwing_Store_Api_Extend_Schema::instance();
+
+			$this->assertNull( $result, 'instance() must return null - not fatal - when the container throws a non-Exception Throwable.' );
+		} finally {
+			remove_filter( 'woocommerce_logging_class', $inject_logger );
 			$attempted->setValue( $orig_attempted );
 			$instance->setValue( $orig_instance );
 		}

--- a/tests/php/test-woocommerce-connect-client.php
+++ b/tests/php/test-woocommerce-connect-client.php
@@ -86,7 +86,6 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 	public function test_class_exists() {
 
 		$this->assertTrue( class_exists( 'WC_Connect_Loader' ) );
-
 	}
 
 	/**
@@ -104,7 +103,6 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 
 		$attached = has_action( 'before_woocommerce_init', array( $loader, 'pre_wc_init' ) );
 		$this->assertNotFalse( $attached, 'WC_Connect_Loader::pre_wc_init() not attached to `before_woocommerce_init`.' );
-
 	}
 
 	/**
@@ -121,7 +119,6 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 		$loader->set_logger( $logger );
 
 		$this->assertEquals( $logger, $loader->get_logger() );
-
 	}
 
 	/**
@@ -138,7 +135,6 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 		$loader->set_api_client( $client );
 
 		$this->assertEquals( $client, $loader->get_api_client() );
-
 	}
 
 	/**
@@ -156,7 +152,6 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 		$loader->set_service_schemas_store( $store );
 
 		$this->assertEquals( $store, $loader->get_service_schemas_store() );
-
 	}
 
 	/**
@@ -173,7 +168,6 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 		$loader->set_service_schemas_validator( $validator );
 
 		$this->assertEquals( $validator, $loader->get_service_schemas_validator() );
-
 	}
 
 	/**
@@ -218,7 +212,6 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 		$this->assertEquals( $loader->get_logger(), $method->get_logger() );
 		$this->assertEquals( $loader->get_api_client(), $method->get_api_client() );
 		$this->assertEquals( $service_data, $method->get_service_schema() );
-
 	}
 
 	/**
@@ -229,7 +222,6 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 
 		$this->assertTrue( $loader->is_wc_connect_shipping_service( 'test_method_that_is_from_wc_connect' ) );
 		$this->assertFalse( $loader->is_wc_connect_shipping_service( 'test_method_that_is_not_from_wc_connect' ) );
-
 	}
 
 	/**
@@ -357,4 +349,25 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 		delete_transient( 'wcservices_store_api_unavailable_logged' );
 	}
 
+	/**
+	 * When the container cannot resolve ExtendSchema, get_store_api_extend_schema()
+	 * returns null and register_store_api_extensions() must skip quietly instead of
+	 * passing null into StoreApiExtensionController's typed constructor (WOOTAX-303).
+	 *
+	 * @covers WC_Connect_Loader::register_store_api_extensions
+	 */
+	public function test_register_store_api_extensions_skips_when_schema_unavailable() {
+		$sut = $this->getMockBuilder( 'WC_Connect_Loader' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'get_store_api_extend_schema' ) )
+			->getMock();
+
+		$sut->method( 'get_store_api_extend_schema' )->willReturn( null );
+
+		$method = new ReflectionMethod( 'WC_Connect_Loader', 'register_store_api_extensions' );
+		$method->setAccessible( true );
+
+		// Must not throw a TypeError; the early return yields void (null).
+		$this->assertNull( $method->invoke( $sut ) );
+	}
 }

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -52,6 +52,7 @@ use Automattic\WCServices\Integrations\WooCommerceBlocksIntegration;
 use Automattic\WCServices\StoreApi\Extensions\StoreNoticesExtension;
 use Automattic\WCServices\StoreApi\StoreApiExtendSchema;
 use Automattic\WCServices\StoreApi\StoreApiExtensionController;
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 
 if ( ! class_exists( 'WC_Connect_Loader' ) ) {
@@ -1033,7 +1034,15 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * Register the plugin's Store API extensions.
 		 */
 		protected function register_store_api_extensions() {
-			$store_api_extend_schema        = StoreApiExtendSchema::instance();
+			$store_api_extend_schema = $this->get_store_api_extend_schema();
+
+			// The container can fail to resolve ExtendSchema on a partial or broken
+			// WooCommerce install even when the top-level StoreApi class exists. Skip
+			// registration quietly rather than passing null into typed constructors.
+			if ( ! $store_api_extend_schema instanceof ExtendSchema ) {
+				return;
+			}
+
 			$store_api_extension_controller = new StoreApiExtensionController( $store_api_extend_schema );
 
 			// Register Store API extensions.
@@ -1041,6 +1050,18 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			// Extend the Store API.
 			$store_api_extension_controller->extend_store();
+		}
+
+		/**
+		 * Resolve the plugin's ExtendSchema wrapper.
+		 *
+		 * Extracted as a seam so tests can substitute an unavailable schema
+		 * (returning null) without exercising the WooCommerce container.
+		 *
+		 * @return ExtendSchema|null
+		 */
+		protected function get_store_api_extend_schema(): ?ExtendSchema {
+			return StoreApiExtendSchema::instance();
 		}
 
 		/**


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

WOOTAX-298 (#2971) added a `class_exists( '\Automattic\WooCommerce\StoreApi\StoreApi' )` guard so the plugin no longer fatals on WooCommerce versions that don't ship the Store API. This PR closes the residual, narrower path through the same class that can still fatal even when that class **is** present: on a partial or broken WooCommerce install where the container fails to resolve `ExtendSchema`.

Previously, if `StoreApi::container()->get( ExtendSchema::class )` threw, `StoreApiExtendSchema` caught it and logged a debug line but never assigned `self::$instance`. Three gaps:

1. `$instance` was a typed static with no default, so `instance()` returned an uninitialized typed property and fataled with *"Typed static property must not be accessed before initialization."*
2. The `catch` only handled `Exception` — an `Error` or `TypeError` from the container would propagate straight up.
3. The `: ExtendSchema` return type meant the wrapper couldn't signal failure, so the caller kept going and called `extend_store()` on an unusable instance.

**The fix** (`src/StoreApi/StoreApiExtendSchema.php`):
- `private static ?ExtendSchema $instance = null;` — nullable and defaulted, so it can never be read uninitialized.
- Added `private static bool $attempted = false;`, set **before** the `try`, so container resolution (and its logging) runs at most once per request even when it throws.
- `catch ( Throwable $e )` instead of `Exception` — covers `Error`/`TypeError`.
- `public static function instance(): ?ExtendSchema` — nullable return to signal failure.

And in `woocommerce-services.php`, `register_store_api_extensions()` resolves through a `get_store_api_extend_schema()` seam and returns early when the result is not an `ExtendSchema` instance, before constructing the typed-constructor controllers. If the container can't hand us an `ExtendSchema`, registration is skipped quietly instead of fataling.

This is defensive hardening for a low-probability path, not a fix for an observed crash.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

- Fixes [WOOTAX-303](https://linear.app/a8c/issue/WOOTAX-303/storeapiextendschemainstance-can-still-fatal-if-the-container-fails-to)
- Follow-up to WOOTAX-298 (#2971)
- Follow-up: [WOOTAX-304](https://linear.app/a8c/issue/WOOTAX-304/storeapiextensioncontroller-still-catches-only-exception-not-throwable) - widen `StoreApiExtensionController` catch blocks to `Throwable` (same broken-install exposure, one step later in the same call path)

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

This path is hard to hit on a healthy store — you need a partial/broken WooCommerce install where the top-level `StoreApi` class exists but the container cannot resolve `ExtendSchema` (so `StoreApi::container()->get( ExtendSchema::class )` throws).

**Before:** on such an install, `StoreApiExtendSchema::instance()` fatals with *"Typed static property `$instance` must not be accessed before initialization"* (or an uncaught `Error`/`TypeError` from the container), taking down the request during `woocommerce_blocks_loaded`.

**After:** resolution failure is caught (`Throwable`), `instance()` returns `null`, and `register_store_api_extensions()` skips registration quietly — no fatal.

Covered by unit tests rather than a manual repro:
- Both new tests pass; full suite `OK (186 tests, 403 assertions)`.
- Each test was verified non-vacuous by temporarily reverting the guard and confirming it fails with the exact predicted error.

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

