### PR TITLE
Quality: Undefined variable used in subscription activation logic

### DIFF
--- a/classes/class-wc-rest-connect-subscription-activate-controller.php
+++ b/classes/class-wc-rest-connect-subscription-activate-controller.php
@@ -20,7 +20,7 @@ class WC_REST_Connect_Subscription_Activate_Controller extends WC_REST_Connect_B
 			return $response;
 		}
 
-		$activated = wp_remote_retrieve_response_code( $activation_response ) === 200;
+		$activated = wp_remote_retrieve_response_code( $response ) === 200;
 		$body      = json_decode( wp_remote_retrieve_body( $response ), true );
 		if ( ( ! $activated && ! empty( $body['code'] ) && 'already_connected' === $body['code'] ) ) {
 			return new WP_Error(


### PR DESCRIPTION
## Summary

Quality: Undefined variable used in subscription activation logic

## Problem

**Severity**: `High` | **File**: `classes/class-wc-rest-connect-subscription-activate-controller.php:L22`

The `$activation_response` variable is used in `wp_remote_retrieve_response_code` and `wp_remote_retrieve_body`, but it is never defined in the scope. It appears to be a typo, as the correct variable should be `$response`.

## Solution

Replace `$activation_response` with `$response` to correctly evaluate the API response.

## Changes

- `classes/class-wc-rest-connect-subscription-activate-controller.php` (modified)