### PR TITLE
[WOOTAX-306] Add - AGENTS.md backward compatibility guardrail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,16 @@ The husky pre-commit hook (`bin/wc-phpcbf.sh` via lint-staged) auto-fixes staged
 - Keep changes in source files; do not hand-edit generated build outputs in `dist/`.
 - Follow existing WordPress/WooCommerce coding standards and linting rules in this repository.
 
+## Backward Compatibility
+
+The `WC_Connect_*` classes live in the global namespace and are referenced by third-party code; treat them all as externally exposed.
+
+Any change to the signature of a public or externally exposed class, interface, function, method, or hook is high-risk and must state its backward-compatibility impact in the PR description.
+
+- Treat a symbol as externally exposed when code outside this repository (other plugins, themes, or site snippets) can call, extend, implement, or hook into it. When in doubt, assume it is exposed and state the BC impact.
+- Adding a method to an interface (or an abstract method to a base class) that external code can implement is breaking: existing implementers fatal on load. Removing a required method is breaking too. Prefer a non-breaking alternative: add the method to the concrete class, or provide a default implementation in a base class.
+- Deprecate, don't rename or remove. Keep the old symbol working with a deprecation notice, introduce the replacement alongside it, and give consumers a migration window before removal.
+
 ## Architecture Notes
 - `has_only_tax_functionality()` and `should_load_shipping_features()` in `woocommerce-services.php` are core gates for tax-only vs shipping-enabled behavior.
 - Shipping behavior must remain compatibility-only for eligible legacy stores.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,13 +54,37 @@ The husky pre-commit hook (`bin/wc-phpcbf.sh` via lint-staged) auto-fixes staged
 
 ## Backward Compatibility
 
-The `WC_Connect_*` classes live in the global namespace and are referenced by third-party code; treat them all as externally exposed.
+Any change to a **public or externally exposed** class, interface, function, or method signature is **high-risk** and **must state its backward-compatibility impact in the PR description** - regardless of which namespace the symbol lives in. The `WC_Connect_*` classes live in the global namespace and are referenced by third-party code; treat all of them as externally exposed. Newer code under `Automattic\WCServices\*` is not automatically safe either: a modern namespace is a code-organization choice, not a privacy guarantee, and anything reachable from outside can already have consumers.
 
-Any change to the signature of a public or externally exposed class, interface, function, method, or hook is high-risk and must state its backward-compatibility impact in the PR description.
+Treat a symbol as **externally exposed** when it is implemented or consumed outside this repository - by other plugins, themes, or site snippets - even if it looks internal. When in doubt, assume it is exposed and state the BC impact.
 
-- Treat a symbol as externally exposed when code outside this repository (other plugins, themes, or site snippets) can call, extend, implement, or hook into it. When in doubt, assume it is exposed and state the BC impact.
-- Adding a method to an interface (or an abstract method to a base class) that external code can implement is breaking: existing implementers fatal on load. Removing a required method is breaking too. Prefer a non-breaking alternative: add the method to the concrete class, or provide a default implementation in a base class.
-- Deprecate, don't rename or remove. Keep the old symbol working with a deprecation notice, introduce the replacement alongside it, and give consumers a migration window before removal.
+**Adding a method to an interface that external code can implement must be flagged explicitly.** It is a backward-incompatible change: existing implementers fatal on load because they no longer satisfy the contract. Likewise, **removing a required method from an interface is breaking** for existing implementers (they carry a now-dead method, which static analysis such as PHPStan will flag). Prefer a non-breaking alternative: add the method to the concrete class rather than the interface, introduce a separate new interface, or supply a default implementation via an abstract base class.
+
+**Deprecate, don't rename.** For existing public symbols (classes, interfaces, methods, constants, hooks), never rename or remove them in place. Mark the old symbol `@deprecated`, introduce the replacement alongside it, and keep both working through a deprecation window so external consumers have time to migrate.
+
+> This rule exists because WooCommerce 10.9.0 was reverted on WP Cloud: a required method added to a published interface fataled every older WooCommerce Stripe Gateway version that implemented it. The same failure mode applies to any contract this plugin publishes.
+
+Deprecation also cuts the other way here: because shipping is compatibility-only for grandfathered installs, removing or narrowing an existing shipping surface is a BC change for those stores, not cleanup. See Product Scope.
+
+### The compatibility surface is wider than PHP signatures
+
+WordPress exposes more contracts than class and function signatures. The following are equally binding: a change to any of them is **high-risk** and requires the same backward-compatibility impact statement in the PR description.
+
+**Hooks and filters are public contracts.** Every `do_action` and `apply_filters` call is an interface that third-party callbacks depend on, including this plugin's `wc_connect_*`, `wc_services_*`, `wcservices_*`, and `wcship_*` hooks. Removing a hook, renaming it, or removing/reordering its arguments breaks every attached callback. Changing *when* or *whether* a hook fires can break consumers that depend on its timing. Additive is the safe path: append new arguments at the end, never remove or reorder existing ones. To retire a hook, fire it through `do_action_deprecated()` / `apply_filters_deprecated()` for a deprecation window instead of deleting it.
+
+**Do not assume global state.** Tax calculation is reachable from the cart and checkout, the Store API, the REST API, cron, WP-CLI, and webhooks, and not all of those set the globals a front-end request does (`$post`, `$wp_query`, an initialized session or cart). A newly introduced read of a global, or of `WC()->...` state, in a path reachable outside a standard request is a fatal or a silent misbehavior in the contexts that do not set it - REST order updates are a repeat offender in this repo. Guard the exact dependency explicitly: use `function_exists`/`class_exists` for symbols, `isset` for variables, `did_action` for lifecycle state, and verify that `WC()` and the required component are initialized before dereferencing `WC()->...`.
+
+**Do not assume single-site.** Multisite changes where data lives: site-scoped vs network-scoped options (`get_option` vs `get_site_option`), per-site tables, user roles and capabilities, and upload paths all differ. This plugin's settings, service schemas, and connection state are site-scoped, so a network-activated install holds one set per site. A change that reads or writes site state must state in its PR whether it behaves correctly under multisite - and if it was not tested there, say so explicitly.
+
+**Do not assume install layout.** WordPress could be configured to run in a subdirectory, with relocated `wp-content`, and behind reverse proxies. Never build paths or URLs by concatenation from the domain root; derive them (`plugins_url()`, `plugin_dir_path()`, `wp_upload_dir()`, and mind the `home_url()` vs `site_url()` distinction). This matters for `dist/` asset URLs and for any store URL sent to the Connect server. A path that works on a root install and breaks elsewhere is a compatibility bug, not an edge case.
+
+### Before changing any public or externally exposed surface (agent checklist)
+
+1. Identify the contract you are touching: signature, hook, global/scope expectation, site topology, or install layout.
+2. Assume unseen consumers. You cannot enumerate third-party code; if the surface is reachable from outside this plugin, someone consumes it.
+3. Prefer the additive path (new optional method, appended hook argument, new symbol + deprecation) over changing what exists.
+4. State the impact in the PR description: what changed, who could consume it, and why it is safe or what the deprecation path is.
+5. If you cannot establish the impact, stop and flag it to the user as needing review.
 
 ## Architecture Notes
 - `has_only_tax_functionality()` and `should_load_shipping_features()` in `woocommerce-services.php` are core gates for tax-only vs shipping-enabled behavior.


### PR DESCRIPTION
## Description

Adds a Backward Compatibility section to AGENTS.md, copied from [WooCommerce Core's canonical guardrail](https://github.com/woocommerce/woocommerce/blob/trunk/AGENTS.md#backward-compatibility) and adapted to this plugin.

The core rule: any signature change to externally exposed code is high-risk and must state its BC impact in the PR description. Following review feedback, the section has been refreshed against Core trunk to pick up woocommerce/woocommerce#66572, which widened the guardrail beyond PHP signatures to cover hooks and filters, global state, multisite, and install layout, and added an agent checklist.

Adapted to this plugin:

- The global `WC_Connect_*` classes stay called out as exposed surface, and the newer `Automattic\WCServices\*` namespace is noted as no safer by default.
- The `wc_connect_*`, `wc_services_*`, `wcservices_*`, and `wcship_*` hooks are named as public contracts.
- Deprecation is tied to this repo's grandfathering rule: because shipping is compatibility-only for eligible installs, removing or narrowing an existing shipping surface is a BC change for those stores rather than cleanup.
- The global-state rule is grounded in the REST and Store API tax paths, which have regressed this way before (see the recent TaxJar tax-line fix on REST order updates).

Docs-only change; no changelog entry, matching prior AGENTS.md-only PRs. No code touched, so there is no BC impact from this PR itself.

Linear: WOOTAX-306

### Testing instructions

1. Read the Backward Compatibility section in AGENTS.md.
2. Compare it against [Core's trunk section](https://github.com/woocommerce/woocommerce/blob/trunk/AGENTS.md#backward-compatibility) and confirm every rule is carried over: the signature rule, interface additions/removals, deprecate-don't-rename, the wider surface (hooks, global state, multisite, install layout), and the agent checklist.
3. Confirm the plugin-specific details are accurate for this repo.

### Checklist

- [ ] unit tests - N/A, docs-only
- [ ] `changelog.txt` entry added - N/A, docs-only
- [ ] `readme.txt` entry added - N/A, docs-only
