### PR TITLE
Fix - Validate TaxJar response before applying tax rate override (WOOTAX-74)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix   - TaxJar tax lines wiped when REST API order update includes address change.
 * Fix   - Prevent fatal error on sites running WooCommerce versions without StoreApi support.
 * Fix   - Prevent unbounded growth of WooCommerce tax rate rows when checkout city contains a semicolon.
+* Fix   - Prevent a fatal error during cart and checkout tax calculation when TaxJar returns an incomplete tax response.
 
 = 3.6.7 - 2026-07-06 =
 * Fix   - Prevent fatal error on Atomic sites caused by incorrect path resolution when loading the API client class.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Tax Changelog ***
 
 = 3.6.10 - 2026-xx-xx =
+* Fix   - Prevent a fatal error during cart and checkout tax calculation when TaxJar returns an incomplete tax response.
 * Tweak - WooCommerce 11.0 Compatibility.
 
 = 3.6.9 - 2026-07-20 =
@@ -10,7 +11,6 @@
 * Fix   - TaxJar tax lines wiped when REST API order update includes address change.
 * Fix   - Prevent fatal error on sites running WooCommerce versions without StoreApi support.
 * Fix   - Prevent unbounded growth of WooCommerce tax rate rows when checkout city contains a semicolon.
-* Fix   - Prevent a fatal error during cart and checkout tax calculation when TaxJar returns an incomplete tax response.
 
 = 3.6.7 - 2026-07-06 =
 * Fix   - Prevent fatal error on Atomic sites caused by incorrect path resolution when loading the API client class.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1658,13 +1658,8 @@ class WC_Connect_TaxJar_Integration {
 
 		// Decode Response.
 		$taxjar_response = json_decode( $response['body'] );
-		// TaxJar's `tax` node is always a JSON object; domestic and international
-		// responses differ only in the inner `breakdown` shape (US uses
-		// state_/county_/city_ fields, international uses country_ fields), not in
-		// the type of `tax` itself. Validate the type at this boundary so both
-		// maybe_override_taxjar_tax() and get_itemized_tax_rates() can rely on an
-		// object — a malformed non-object response bails here instead of fataling
-		// downstream on the first property access.
+		// Bail on a malformed response: maybe_override_taxjar_tax() and
+		// get_itemized_tax_rates() both access `tax` as an object.
 		if ( empty( $taxjar_response->tax ) || ! is_object( $taxjar_response->tax ) ) {
 			return false;
 		}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1330,16 +1330,17 @@ class WC_Connect_TaxJar_Integration {
 	/**
 	 * This method is used to override the TaxJar result.
 	 *
+	 * The caller (calculate_tax) guarantees a non-empty object here, so this
+	 * method always receives — and returns — the tax object. Malformed *inner*
+	 * members (a missing/null breakdown or shipping, a non-object line item) are
+	 * still tolerated below; only those, not the tax node itself, are unreliable.
+	 *
 	 * @param object $taxjar_resp_tax TaxJar response object.
 	 * @param array  $body            Body of TaxJar request.
 	 *
 	 * @return object
 	 */
 	public function maybe_override_taxjar_tax( $taxjar_resp_tax, $body ) {
-		if ( ! isset( $taxjar_resp_tax ) || ! is_object( $taxjar_resp_tax ) ) {
-			return $taxjar_resp_tax;
-		}
-
 		$original_rate = isset( $taxjar_resp_tax->rate ) ? floatval( $taxjar_resp_tax->rate ) : 0.0;
 		$new_tax_rate  = floatval( apply_filters( 'woocommerce_services_override_tax_rate', $taxjar_resp_tax->rate ?? 0, $taxjar_resp_tax, $body ) );
 
@@ -1657,7 +1658,14 @@ class WC_Connect_TaxJar_Integration {
 
 		// Decode Response.
 		$taxjar_response = json_decode( $response['body'] );
-		if ( empty( $taxjar_response->tax ) ) {
+		// TaxJar's `tax` node is always a JSON object; domestic and international
+		// responses differ only in the inner `breakdown` shape (US uses
+		// state_/county_/city_ fields, international uses country_ fields), not in
+		// the type of `tax` itself. Validate the type at this boundary so both
+		// maybe_override_taxjar_tax() and get_itemized_tax_rates() can rely on an
+		// object — a malformed non-object response bails here instead of fataling
+		// downstream on the first property access.
+		if ( empty( $taxjar_response->tax ) || ! is_object( $taxjar_response->tax ) ) {
 			return false;
 		}
 		$taxjar_taxes = $this->maybe_override_taxjar_tax( $taxjar_response->tax, $body );

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1330,17 +1330,24 @@ class WC_Connect_TaxJar_Integration {
 	/**
 	 * This method is used to override the TaxJar result.
 	 *
-	 * The caller (calculate_tax) guarantees a non-empty object here, so this
-	 * method always receives — and returns — the tax object. Malformed *inner*
-	 * members (a missing/null breakdown or shipping, a non-object line item) are
-	 * still tolerated below; only those, not the tax node itself, are unreliable.
+	 * The tax node is validated by calculate_tax() before this is called, so
+	 * in-plugin callers always pass an object. The type check below is a net for
+	 * third-party callers of this public method: overriding a rate is meaningless
+	 * without a tax object, and a property write on a non-object is the very fatal
+	 * this method exists to prevent. Malformed *inner* members (a missing/null
+	 * breakdown or shipping, a non-object line item) are tolerated further down.
 	 *
-	 * @param object $taxjar_resp_tax TaxJar response object.
-	 * @param array  $body            Body of TaxJar request.
+	 * @param mixed $taxjar_resp_tax TaxJar response tax node. Expected to be an object.
+	 * @param array $body            Body of TaxJar request.
 	 *
-	 * @return object
+	 * @return mixed The tax object with its rates overridden, or the input returned
+	 *               unchanged when it is not an object.
 	 */
 	public function maybe_override_taxjar_tax( $taxjar_resp_tax, $body ) {
+		if ( ! is_object( $taxjar_resp_tax ) ) {
+			return $taxjar_resp_tax;
+		}
+
 		$original_rate = isset( $taxjar_resp_tax->rate ) ? floatval( $taxjar_resp_tax->rate ) : 0.0;
 		$new_tax_rate  = floatval( apply_filters( 'woocommerce_services_override_tax_rate', $taxjar_resp_tax->rate ?? 0, $taxjar_resp_tax, $body ) );
 
@@ -1663,6 +1670,7 @@ class WC_Connect_TaxJar_Integration {
 		if ( empty( $taxjar_response->tax ) || ! is_object( $taxjar_response->tax ) ) {
 			return false;
 		}
+
 		$taxjar_taxes = $this->maybe_override_taxjar_tax( $taxjar_response->tax, $body );
 		$taxes        = $this->get_itemized_tax_rates( $taxes, $taxjar_taxes, $options );
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1336,34 +1336,52 @@ class WC_Connect_TaxJar_Integration {
 	 * @return object
 	 */
 	public function maybe_override_taxjar_tax( $taxjar_resp_tax, $body ) {
-		if ( ! isset( $taxjar_resp_tax ) ) {
-			return;
-		}
-
-		$new_tax_rate = floatval( apply_filters( 'woocommerce_services_override_tax_rate', $taxjar_resp_tax->rate, $taxjar_resp_tax, $body ) );
-
-		if ( $new_tax_rate === floatval( $taxjar_resp_tax->rate ) ) {
+		if ( ! isset( $taxjar_resp_tax ) || ! is_object( $taxjar_resp_tax ) ) {
 			return $taxjar_resp_tax;
 		}
 
-		if ( ! empty( $taxjar_resp_tax->breakdown->line_items ) ) {
-			$taxjar_resp_tax->breakdown->line_items = array_map(
-				function ( $line_item ) use ( $new_tax_rate ) {
-					$line_item->combined_tax_rate       = $new_tax_rate;
-					$line_item->country_tax_rate        = $new_tax_rate;
-					$line_item->country_tax_collectable = $line_item->country_taxable_amount * $new_tax_rate;
-					$line_item->tax_collectable         = $line_item->taxable_amount * $new_tax_rate;
+		$original_rate = isset( $taxjar_resp_tax->rate ) ? floatval( $taxjar_resp_tax->rate ) : 0.0;
+		$new_tax_rate  = floatval( apply_filters( 'woocommerce_services_override_tax_rate', $taxjar_resp_tax->rate ?? 0, $taxjar_resp_tax, $body ) );
 
-					return $line_item;
-				},
-				$taxjar_resp_tax->breakdown->line_items
-			);
+		if ( $new_tax_rate === $original_rate ) {
+			return $taxjar_resp_tax;
 		}
 
-		$taxjar_resp_tax->breakdown->combined_tax_rate           = $new_tax_rate;
-		$taxjar_resp_tax->breakdown->country_tax_rate            = $new_tax_rate;
-		$taxjar_resp_tax->breakdown->shipping->combined_tax_rate = $new_tax_rate;
-		$taxjar_resp_tax->breakdown->shipping->country_tax_rate  = $new_tax_rate;
+		// Guard against malformed TaxJar responses: the breakdown and its nested
+		// members are not always present or well-formed, and assigning properties
+		// on a missing/null member (or a non-object line item) fatals. See WOOTAX-74.
+		if ( isset( $taxjar_resp_tax->breakdown ) && is_object( $taxjar_resp_tax->breakdown ) ) {
+			$breakdown = $taxjar_resp_tax->breakdown;
+
+			if ( ! empty( $breakdown->line_items ) && is_array( $breakdown->line_items ) ) {
+				$breakdown->line_items = array_map(
+					function ( $line_item ) use ( $new_tax_rate ) {
+						if ( ! is_object( $line_item ) ) {
+							return $line_item;
+						}
+
+						$country_taxable_amount = isset( $line_item->country_taxable_amount ) ? $line_item->country_taxable_amount : 0;
+						$taxable_amount         = isset( $line_item->taxable_amount ) ? $line_item->taxable_amount : 0;
+
+						$line_item->combined_tax_rate       = $new_tax_rate;
+						$line_item->country_tax_rate        = $new_tax_rate;
+						$line_item->country_tax_collectable = $country_taxable_amount * $new_tax_rate;
+						$line_item->tax_collectable         = $taxable_amount * $new_tax_rate;
+
+						return $line_item;
+					},
+					$breakdown->line_items
+				);
+			}
+
+			$breakdown->combined_tax_rate = $new_tax_rate;
+			$breakdown->country_tax_rate  = $new_tax_rate;
+
+			if ( isset( $breakdown->shipping ) && is_object( $breakdown->shipping ) ) {
+				$breakdown->shipping->combined_tax_rate = $new_tax_rate;
+				$breakdown->shipping->country_tax_rate  = $new_tax_rate;
+			}
+		}
 
 		$taxjar_resp_tax->rate = $new_tax_rate;
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1357,7 +1357,7 @@ class WC_Connect_TaxJar_Integration {
 
 		// Guard against malformed TaxJar responses: the breakdown and its nested
 		// members are not always present or well-formed, and assigning properties
-		// on a missing/null member (or a non-object line item) fatals. See WOOTAX-74.
+		// on a missing/null member (or a non-object line item) fatals.
 		if ( isset( $taxjar_resp_tax->breakdown ) && is_object( $taxjar_resp_tax->breakdown ) ) {
 			$breakdown = $taxjar_resp_tax->breakdown;
 

--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,7 @@ This plugin relies on the following external services:
 * Fix   - TaxJar tax lines wiped when REST API order update includes address change.
 * Fix   - Prevent fatal error on sites running WooCommerce versions without StoreApi support.
 * Fix   - Prevent unbounded growth of WooCommerce tax rate rows when checkout city contains a semicolon.
+* Fix   - Prevent a fatal error during cart and checkout tax calculation when TaxJar returns an incomplete tax response.
 
 = 3.6.7 - 2026-07-06 =
 * Fix   - Prevent fatal error on Atomic sites caused by incorrect path resolution when loading the API client class.

--- a/readme.txt
+++ b/readme.txt
@@ -71,6 +71,7 @@ This plugin relies on the following external services:
 == Changelog ==
 
 = 3.6.10 - 2026-xx-xx =
+* Fix   - Prevent a fatal error during cart and checkout tax calculation when TaxJar returns an incomplete tax response.
 * Tweak - WooCommerce 11.0 Compatibility.
 
 = 3.6.9 - 2026-07-20 =
@@ -80,7 +81,6 @@ This plugin relies on the following external services:
 * Fix   - TaxJar tax lines wiped when REST API order update includes address change.
 * Fix   - Prevent fatal error on sites running WooCommerce versions without StoreApi support.
 * Fix   - Prevent unbounded growth of WooCommerce tax rate rows when checkout city contains a semicolon.
-* Fix   - Prevent a fatal error during cart and checkout tax calculation when TaxJar returns an incomplete tax response.
 
 = 3.6.7 - 2026-07-06 =
 * Fix   - Prevent fatal error on Atomic sites caused by incorrect path resolution when loading the API client class.

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -1975,7 +1975,12 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 
 		$result = $this->integration->maybe_override_taxjar_tax( $resp, array() );
 
+		// The method mutates and returns the same handle, so identity alone proves
+		// nothing — assert the individual fields are untouched at every level.
 		$this->assertSame( $resp, $result );
 		$this->assertSame( 0.08, $result->rate );
+		$this->assertSame( 0.08, $result->breakdown->combined_tax_rate );
+		$this->assertSame( 0.08, $result->breakdown->shipping->combined_tax_rate );
+		$this->assertSame( 0.08, $result->breakdown->line_items[0]->combined_tax_rate );
 	}
 }

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -1865,4 +1865,117 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			$this->assertStringNotContainsString( ';', $city, 'Tax rate city stored with a semicolon — `_update_tax_rate_cities()` will split it and break find_rates() on subsequent lookups.' );
 		}
 	}
+
+	/**
+	 * Build a well-formed TaxJar tax response object (as returned under
+	 * $taxjar_response->tax) with a base rate of 0.08.
+	 *
+	 * @return object
+	 */
+	private function build_taxjar_tax_response() {
+		return (object) array(
+			'rate'      => 0.08,
+			'breakdown' => (object) array(
+				'combined_tax_rate' => 0.08,
+				'country_tax_rate'  => 0.0,
+				'shipping'          => (object) array(
+					'combined_tax_rate' => 0.08,
+					'country_tax_rate'  => 0.0,
+				),
+				'line_items'        => array(
+					(object) array(
+						'combined_tax_rate'       => 0.08,
+						'country_tax_rate'        => 0.0,
+						'country_taxable_amount'  => 100.0,
+						'taxable_amount'          => 100.0,
+						'country_tax_collectable' => 0.0,
+						'tax_collectable'         => 8.0,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * The override filter should still rewrite every rate on a well-formed
+	 * response (behavior preserved).
+	 */
+	public function test_maybe_override_taxjar_tax_applies_override_to_wellformed_response() {
+		add_filter( 'woocommerce_services_override_tax_rate', '__return_zero' );
+
+		$resp   = $this->build_taxjar_tax_response();
+		$result = $this->integration->maybe_override_taxjar_tax( $resp, array() );
+
+		$this->assertSame( 0.0, $result->rate );
+		$this->assertSame( 0.0, $result->breakdown->combined_tax_rate );
+		$this->assertSame( 0.0, $result->breakdown->country_tax_rate );
+		$this->assertSame( 0.0, $result->breakdown->shipping->combined_tax_rate );
+		$this->assertSame( 0.0, $result->breakdown->shipping->country_tax_rate );
+
+		$line_item = $result->breakdown->line_items[0];
+		$this->assertSame( 0.0, $line_item->combined_tax_rate );
+		$this->assertSame( 0.0, $line_item->country_tax_rate );
+		$this->assertSame( 0.0, $line_item->country_tax_collectable );
+		$this->assertSame( 0.0, $line_item->tax_collectable );
+	}
+
+	/**
+	 * A null (or otherwise non-object) line item must not fatal; it is left
+	 * untouched while valid line items are still overridden. Regression for the
+	 * reported "Attempt to assign property on null" fatal (WOOTAX-74).
+	 */
+	public function test_maybe_override_taxjar_tax_survives_null_line_item() {
+		add_filter( 'woocommerce_services_override_tax_rate', '__return_zero' );
+
+		$resp                        = $this->build_taxjar_tax_response();
+		$valid_line_item             = $resp->breakdown->line_items[0];
+		$resp->breakdown->line_items = array( null, $valid_line_item );
+
+		$result = $this->integration->maybe_override_taxjar_tax( $resp, array() );
+
+		$this->assertSame( 0.0, $result->rate );
+		$this->assertNull( $result->breakdown->line_items[0] );
+		$this->assertSame( 0.0, $result->breakdown->line_items[1]->combined_tax_rate );
+	}
+
+	/**
+	 * A response with no breakdown must not fatal. Regression for WOOTAX-74.
+	 */
+	public function test_maybe_override_taxjar_tax_survives_missing_breakdown() {
+		add_filter( 'woocommerce_services_override_tax_rate', '__return_zero' );
+
+		$resp = (object) array( 'rate' => 0.08 );
+
+		$result = $this->integration->maybe_override_taxjar_tax( $resp, array() );
+
+		$this->assertSame( 0.0, $result->rate );
+		$this->assertObjectNotHasProperty( 'breakdown', $result );
+	}
+
+	/**
+	 * A breakdown missing its shipping member must not fatal. Regression for WOOTAX-74.
+	 */
+	public function test_maybe_override_taxjar_tax_survives_missing_shipping() {
+		add_filter( 'woocommerce_services_override_tax_rate', '__return_zero' );
+
+		$resp = $this->build_taxjar_tax_response();
+		unset( $resp->breakdown->shipping );
+
+		$result = $this->integration->maybe_override_taxjar_tax( $resp, array() );
+
+		$this->assertSame( 0.0, $result->rate );
+		$this->assertSame( 0.0, $result->breakdown->combined_tax_rate );
+	}
+
+	/**
+	 * With no override filter registered the response is returned unchanged.
+	 */
+	public function test_maybe_override_taxjar_tax_returns_unchanged_without_override() {
+		$resp = $this->build_taxjar_tax_response();
+
+		$result = $this->integration->maybe_override_taxjar_tax( $resp, array() );
+
+		$this->assertSame( $resp, $result );
+		$this->assertSame( 0.08, $result->rate );
+	}
 }

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -71,6 +71,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	public function tear_down() {
 		// Remove any filters added during tests.
 		remove_all_filters( 'woocommerce_tax_line_item_location' );
+		remove_all_filters( 'woocommerce_services_override_tax_rate' );
 
 		// Clean up products.
 		if ( $this->product ) {
@@ -1982,5 +1983,43 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$this->assertSame( 0.08, $result->breakdown->combined_tax_rate );
 		$this->assertSame( 0.08, $result->breakdown->shipping->combined_tax_rate );
 		$this->assertSame( 0.08, $result->breakdown->line_items[0]->combined_tax_rate );
+	}
+
+	/**
+	 * A non-object tax node is returned unchanged rather than fataling.
+	 *
+	 * The override filter is what makes this reachable: with a filter that leaves
+	 * the rate at 0 the method early-returns anyway, so only a filter returning a
+	 * *different* rate drives execution as far as the `->rate` write. calculate_tax()
+	 * validates the tax node so this cannot happen in-plugin, but the method is
+	 * public and third-party callers are not bound by that guarantee.
+	 *
+	 * @dataProvider provide_non_object_tax_nodes
+	 *
+	 * @param mixed $tax_node Non-object value passed in place of the tax node.
+	 */
+	public function test_maybe_override_taxjar_tax_returns_non_object_unchanged( $tax_node ) {
+		add_filter(
+			'woocommerce_services_override_tax_rate',
+			function () {
+				return 0.15;
+			}
+		);
+
+		$this->assertSame( $tax_node, $this->integration->maybe_override_taxjar_tax( $tax_node, array() ) );
+	}
+
+	/**
+	 * Non-object values a third-party caller could pass as the tax node.
+	 *
+	 * @return array
+	 */
+	public function provide_non_object_tax_nodes() {
+		return array(
+			'null'   => array( null ),
+			'false'  => array( false ),
+			'array'  => array( array( 'rate' => 0.08 ) ),
+			'string' => array( 'not a tax object' ),
+		);
 	}
 }


### PR DESCRIPTION
### Summary

Fixes [WOOTAX-74](https://linear.app/a8c/issue/WOOTAX-74/validate-taxjar-response-object).

`WC_Connect_TaxJar_Integration::maybe_override_taxjar_tax()` assumed the TaxJar tax response was always well-formed. When a rate-override filter (e.g. `woocommerce_services_override_tax_rate`) changes the rate, the method rewrote properties on `breakdown`, `breakdown->shipping` and every `line_item` **unconditionally**. If TaxJar returned an incomplete response — a `null`/non-object line item, or a missing `breakdown`/`shipping` member — this fataled during cart and checkout tax calculation:

```
PHP Fatal error: Uncaught Error: Attempt to assign property "combined_tax_rate" on null
  in .../classes/class-wc-connect-taxjar-integration.php:1042
```

A merchant hit this via a custom `woocommerce_services_override_tax_rate` filter (used to force CA tax to 0% because of a separate upstream TaxJar data issue). The malformed response took down the mini-cart / product archive pages with a white screen.

### Changes

The response is now validated at **three** levels, each covering callers the others cannot:

1. **The request boundary** — `calculate_tax()` bails on a response whose `tax` node is missing or not an object. This is what protects `get_itemized_tax_rates()`, which dereferences the tax node unconditionally; a guard inside `maybe_override_taxjar_tax()` structurally cannot reach that.
2. **The method boundary** — `maybe_override_taxjar_tax()` returns a non-object input unchanged. `calculate_tax()` already guarantees an object, so this is a safety net for third-party callers of a `public` method, preserving the behaviour `trunk` had.
3. **The inner members** — the actual reported bug. Only mutate `breakdown` and `breakdown->shipping` when present and object-typed; skip non-object line items instead of assigning properties on them; default missing `taxable_amount` / `country_taxable_amount` to `0` so the collectable math can't warn or fatal.

Behaviour is **unchanged for well-formed responses** — the override still rewrites every rate exactly as before.

### Backward compatibility

Per the AGENTS.md backward-compatibility rules: `WC_Connect_TaxJar_Integration` is a `WC_Connect_*` class in the global namespace, so it is treated as externally exposed, and `maybe_override_taxjar_tax()` is `public`.

- **Method signature: unchanged.** No parameters added, removed, reordered or type-declared. A PHP `object` type declaration was considered and deliberately rejected — it would convert a silent no-op into a hard `TypeError`, i.e. *add* a possible fatal in a PR whose purpose is removing one.
- **Behaviour for a well-formed object: unchanged.** Byte-identical output, covered by `..._applies_override_to_wellformed_response`.
- **Behaviour for a non-object input: preserved as on `trunk`.** `trunk` had `if ( ! isset( $taxjar_resp_tax ) ) { return; }`. An earlier revision of this PR removed it once `calculate_tax()` validated the node; that was a BC change to a public method and has been reverted. The guard is back, now covering `false`/array/string as well as `null`.
- **Hooks: unchanged.** `woocommerce_services_override_tax_rate` fires with the same three arguments, in the same order, at the same point. It no longer fires at all when a non-object is passed in — but on `trunk` that input returned before the filter too, so this is not a change for any real consumer.
- **Return type: documented as `mixed`.** Only the docblock changed; the method already returned its input unchanged on `trunk`'s guard path. No consumer sees a different value.
- **Globals / multisite / install layout:** not touched. This change adds only type checks inside an existing code path.

### Tests

Adds 6 test cases (9 with data-provider expansion) to `test-class-wc-connect-taxjar-integration.php`:

- `..._applies_override_to_wellformed_response` — behaviour preservation (override still rewrites all rates).
- `..._survives_null_line_item` — reproduces the exact reported fatal; fails on `trunk`, passes with this fix.
- `..._survives_missing_breakdown`
- `..._survives_missing_shipping`
- `..._returns_unchanged_without_override` — asserts every level is untouched, not just object identity.
- `..._returns_non_object_unchanged` — data provider over `null` / `false` / `array` / `string`. Each case registers a **rate-changing** filter, because the method early-returns when the rate is unchanged; without that the test would pass with no guard at all. Removing the guard fails all four with `Error: Attempt to assign property "rate" on …`.

Also clears `woocommerce_services_override_tax_rate` in `tear_down()` — the existing override tests registered filters and never removed them.

Full suite via `composer test`: **226 tests, 492 assertions green**. PHPCS clean on the changed regions.
