### PR TITLE
Fix - Non-taxable product no longer zeroes shared standard tax rate (WOOTAX-240)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@
 * Fix   - TaxJar tax lines wiped when REST API order update includes address change.
 * Fix   - Prevent fatal error on sites running WooCommerce versions without StoreApi support.
 * Fix   - Prevent unbounded growth of WooCommerce tax rate rows when checkout city contains a semicolon.
+* Fix   - Calculate tax correctly for carts mixing taxable and non-taxable products, so a non-taxable product no longer resets the standard tax rate to zero.
 
 = 3.6.7 - 2026-07-06 =
 * Fix   - Prevent fatal error on Atomic sites caused by incorrect path resolution when loading the API client class.

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Fix   - Fall back to the store address when a custom nexus address is incomplete instead of abandoning the calculation.
 * Fix   - Prevent unbounded growth of WooCommerce tax rate rows when the customer state contains a character WooCommerce strips before storing it, such as a period or an accented letter.
 * Fix   - Restore tax rates on the price display, shipping tax and coupon paths for addresses whose state was stored in a normalized form.
+* Fix   - Calculate tax correctly for carts mixing taxable and non-taxable products, so a non-taxable product no longer resets the standard tax rate to zero.
 * Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
 * Tweak - Store tax rate rows against the postcode the rate was quoted for when the address postcode holds more than one comma-separated value.
 
@@ -28,7 +29,6 @@
 * Fix   - TaxJar tax lines wiped when REST API order update includes address change.
 * Fix   - Prevent fatal error on sites running WooCommerce versions without StoreApi support.
 * Fix   - Prevent unbounded growth of WooCommerce tax rate rows when checkout city contains a semicolon.
-* Fix   - Calculate tax correctly for carts mixing taxable and non-taxable products, so a non-taxable product no longer resets the standard tax rate to zero.
 
 = 3.6.7 - 2026-07-06 =
 * Fix   - Prevent fatal error on Atomic sites caused by incorrect path resolution when loading the API client class.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1791,6 +1791,17 @@ class WC_Connect_TaxJar_Integration {
 					$tax_class = $this->backend_tax_classes[ $product_id ];
 				}
 
+				// A product with Tax Status = "None" is exempt from tax but can still
+				// carry the standard Tax Class. TaxJar returns a 0% breakdown line for
+				// it, and because tax rate rows are keyed by tax class, writing that 0%
+				// overwrites the shared class rate used by genuinely taxable products in
+				// the same class — zeroing tax for the whole cart. Skip rate-row writes
+				// for non-taxable products; WooCommerce already applies no tax to them.
+				// See WOOTAX-240.
+				if ( $product && 'none' === $product->get_tax_status() ) {
+					continue;
+				}
+
 				$_tax_rates = (array) $line_item;
 				$priority   = 1;
 				foreach ( $_tax_rates as $tax_rate_name => $tax_rate ) {

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -87,6 +87,17 @@ class WC_Connect_TaxJar_Integration {
 	private $backend_tax_classes;
 
 	/**
+	 * Line items WooCommerce will not apply item tax to.
+	 *
+	 * Recorded while the TaxJar request is built and read back when the response is
+	 * turned into tax rate rows, so both halves share a single taxability decision
+	 * instead of each re-deriving one. Keyed by TaxJar line item id, values unused.
+	 *
+	 * @var array<string, bool>
+	 */
+	private $non_taxable_line_items = array();
+
+	/**
 	 * Tracks instance.
 	 *
 	 * @var WC_Connect_Tracks
@@ -962,8 +973,9 @@ class WC_Connect_TaxJar_Integration {
 	 * @return array
 	 */
 	protected function get_line_items( $wc_cart_object ) {
-		$line_items       = array();
-		$default_location = get_option( 'woocommerce_tax_based_on', 'shipping' );
+		$line_items                   = array();
+		$this->non_taxable_line_items = array();
+		$default_location             = get_option( 'woocommerce_tax_based_on', 'shipping' );
 
 		foreach ( $wc_cart_object->get_cart() as $cart_item_key => $cart_item ) {
 			$product       = $cart_item['data'];
@@ -981,6 +993,14 @@ class WC_Connect_TaxJar_Integration {
 
 			if ( 'shipping' !== $product->get_tax_status() && ( ! $product->is_taxable() || 'zero-rate' == sanitize_title( $product->get_tax_class() ) ) ) {
 				$tax_code = '99999';
+			}
+
+			// WC_Cart_Totals gates item tax on is_taxable(), which is filterable, so a
+			// product can be untaxed while still reporting Tax Status "taxable". Record
+			// the decision here rather than re-deriving it from the response, where the
+			// two can disagree and a 0% line ends up overwriting a shared rate row.
+			if ( ! $product->is_taxable() ) {
+				$this->non_taxable_line_items[ $id . '-' . $cart_item_key ] = true;
 			}
 
 			// Get WC Subscription sign-up fees for calculations
@@ -1039,9 +1059,10 @@ class WC_Connect_TaxJar_Integration {
 	 * @return array
 	 */
 	protected function get_backend_line_items( $order ) {
-		$line_items                = array();
-		$this->backend_tax_classes = array();
-		$default_location          = get_option( 'woocommerce_tax_based_on', 'shipping' );
+		$line_items                   = array();
+		$this->backend_tax_classes    = array();
+		$this->non_taxable_line_items = array();
+		$default_location             = get_option( 'woocommerce_tax_based_on', 'shipping' );
 
 		foreach ( $order->get_items() as $item_key => $item ) {
 			if ( is_object( $item ) ) { // Woo 3.0+
@@ -1069,6 +1090,11 @@ class WC_Connect_TaxJar_Integration {
 			}
 			if ( 'taxable' !== $tax_status ) {
 				$tax_code = '99999';
+
+				// WC_Order_Item::calculate_taxes() gates item tax on the raw tax status,
+				// so the order path records exactly what it emitted as exempt. See the
+				// matching note in get_line_items() for why this is recorded, not derived.
+				$this->non_taxable_line_items[ $id . '-' . $item_key ] = true;
 			}
 
 			/** This filter is documented in get_line_items() */
@@ -1780,6 +1806,15 @@ class WC_Connect_TaxJar_Integration {
 
 			// Add line item tax rates.
 			foreach ( $taxes['line_items'] as $line_item_key => $line_item ) {
+				// A line item WooCommerce will not tax was sent to TaxJar as exempt, so its
+				// breakdown line comes back at 0% — yet it keeps its Tax Class. Since rate
+				// rows are keyed by tax class, writing that 0% overwrites the shared row
+				// used by genuinely taxable products in the same class, zeroing tax for the
+				// whole cart. Skip the write; WooCommerce applies no item tax to it anyway.
+				if ( isset( $this->non_taxable_line_items[ $line_item_key ] ) ) {
+					continue;
+				}
+
 				$line_item_key_chunks = explode( '-', $line_item_key );
 				$product_id           = $line_item_key_chunks[0];
 				$product              = wc_get_product( $product_id );
@@ -1789,16 +1824,6 @@ class WC_Connect_TaxJar_Integration {
 					$tax_class = $product->get_tax_class();
 				} elseif ( isset( $this->backend_tax_classes[ $product_id ] ) ) {
 					$tax_class = $this->backend_tax_classes[ $product_id ];
-				}
-
-				// Products that are not fully taxable (Tax Status "None" or "Shipping
-				// only") are sent to TaxJar as exempt, so their breakdown line returns 0% —
-				// yet they keep their Tax Class. Since rate rows are keyed by tax class,
-				// writing that 0% overwrites the shared row used by genuinely taxable
-				// products in the same class, zeroing tax for the whole cart. Skip the
-				// write; WooCommerce applies no item tax to either status anyway.
-				if ( $product && 'taxable' !== $product->get_tax_status() ) {
-					continue;
 				}
 
 				$_tax_rates = (array) $line_item;

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -999,7 +999,22 @@ class WC_Connect_TaxJar_Integration {
 			// product can be untaxed while still reporting Tax Status "taxable". Record
 			// the decision here rather than re-deriving it from the response, where the
 			// two can disagree and a 0% line ends up overwriting a shared rate row.
-			if ( ! $product->is_taxable() ) {
+			//
+			// The 'shipping' exclusion mirrors the exempt branch directly above, and has
+			// to: a "Shipping only" product is excluded there, so this path sends it to
+			// TaxJar as taxable and its breakdown line comes back with a real, non-zero
+			// rate. Recording it would make get_itemized_tax_rates() skip that write --
+			// the one case where skipping discards good data instead of preventing a 0%
+			// clobber. WooCommerce applies no *item* tax to such a product, but the row
+			// still matters: it carries `tax_rate_shipping`, and with the default
+			// `woocommerce_shipping_tax_class = 'inherit'` WooCommerce resolves the
+			// shipping tax class to this product's class and looks the rate up there.
+			// TaxJar's own shipping write only ever covers the standard class.
+			//
+			// The backend order path records on `'taxable' !== $tax_status` instead, and
+			// that is correct rather than inconsistent: there the same condition is what
+			// sets the 99999 exempt code, so it too records exactly what it emitted.
+			if ( 'shipping' !== $product->get_tax_status() && ! $product->is_taxable() ) {
 				$this->non_taxable_line_items[ $id . '-' . $cart_item_key ] = true;
 			}
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1791,14 +1791,13 @@ class WC_Connect_TaxJar_Integration {
 					$tax_class = $this->backend_tax_classes[ $product_id ];
 				}
 
-				// A product with Tax Status = "None" is exempt from tax but can still
-				// carry the standard Tax Class. TaxJar returns a 0% breakdown line for
-				// it, and because tax rate rows are keyed by tax class, writing that 0%
-				// overwrites the shared class rate used by genuinely taxable products in
-				// the same class — zeroing tax for the whole cart. Skip rate-row writes
-				// for non-taxable products; WooCommerce already applies no tax to them.
-				// See WOOTAX-240.
-				if ( $product && 'none' === $product->get_tax_status() ) {
+				// Products that are not fully taxable (Tax Status "None" or "Shipping
+				// only") are sent to TaxJar as exempt, so their breakdown line returns 0% —
+				// yet they keep their Tax Class. Since rate rows are keyed by tax class,
+				// writing that 0% overwrites the shared row used by genuinely taxable
+				// products in the same class, zeroing tax for the whole cart. Skip the
+				// write; WooCommerce applies no item tax to either status anyway.
+				if ( $product && 'taxable' !== $product->get_tax_status() ) {
 					continue;
 				}
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,7 @@ This plugin relies on the following external services:
 * Fix   - Fall back to the store address when a custom nexus address is incomplete instead of abandoning the calculation.
 * Fix   - Prevent unbounded growth of WooCommerce tax rate rows when the customer state contains a character WooCommerce strips before storing it, such as a period or an accented letter.
 * Fix   - Restore tax rates on the price display, shipping tax and coupon paths for addresses whose state was stored in a normalized form.
+* Fix   - Calculate tax correctly for carts mixing taxable and non-taxable products, so a non-taxable product no longer resets the standard tax rate to zero.
 * Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
 * Tweak - Store tax rate rows against the postcode the rate was quoted for when the address postcode holds more than one comma-separated value.
 
@@ -98,7 +99,6 @@ This plugin relies on the following external services:
 * Fix   - TaxJar tax lines wiped when REST API order update includes address change.
 * Fix   - Prevent fatal error on sites running WooCommerce versions without StoreApi support.
 * Fix   - Prevent unbounded growth of WooCommerce tax rate rows when checkout city contains a semicolon.
-* Fix   - Calculate tax correctly for carts mixing taxable and non-taxable products, so a non-taxable product no longer resets the standard tax rate to zero.
 
 = 3.6.7 - 2026-07-06 =
 * Fix   - Prevent fatal error on Atomic sites caused by incorrect path resolution when loading the API client class.

--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,7 @@ This plugin relies on the following external services:
 * Fix   - TaxJar tax lines wiped when REST API order update includes address change.
 * Fix   - Prevent fatal error on sites running WooCommerce versions without StoreApi support.
 * Fix   - Prevent unbounded growth of WooCommerce tax rate rows when checkout city contains a semicolon.
+* Fix   - Calculate tax correctly for carts mixing taxable and non-taxable products, so a non-taxable product no longer resets the standard tax rate to zero.
 
 = 3.6.7 - 2026-07-06 =
 * Fix   - Prevent fatal error on Atomic sites caused by incorrect path resolution when loading the API client class.

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -3588,4 +3588,88 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			);
 		}
 	}
+
+	/**
+	 * A non-taxable product (Tax Status = "None") that shares the standard Tax
+	 * Class with a taxable product must not zero out the shared Standard rate row.
+	 *
+	 * TaxJar returns a 0% breakdown line for the exempt product (sent as code
+	 * 99999). Because rate rows are keyed by tax class — and Tax Status "None"
+	 * does not change the Tax Class — that 0% would overwrite the same Standard
+	 * row the taxable product just populated, zeroing tax for the whole cart.
+	 * Regression for WOOTAX-240.
+	 */
+	public function test_get_itemized_tax_rates_non_taxable_line_does_not_zero_standard_rate() {
+		$taxable_product = WC_Helper_Product::create_simple_product();
+		$taxable_product->set_tax_status( 'taxable' );
+		$taxable_product->set_tax_class( '' );
+		$taxable_product->save();
+
+		$exempt_product = WC_Helper_Product::create_simple_product();
+		$exempt_product->set_tax_status( 'none' );
+		$exempt_product->set_tax_class( '' );
+		$exempt_product->save();
+
+		$taxable_id  = $taxable_product->get_id();
+		$exempt_id   = $exempt_product->get_id();
+		$taxable_key = $taxable_id . '-taxable_item';
+		$exempt_key  = $exempt_id . '-exempt_item';
+
+		// Taxable line is listed first, so without the fix the exempt line would
+		// overwrite the shared Standard rate row to 0% afterwards.
+		$taxjar_taxes = (object) array(
+			'freight_taxable' => 0,
+			'has_nexus'       => 1,
+			'rate'            => 0.0725,
+			'jurisdictions'   => (object) array(
+				'county' => '',
+				'city'   => '',
+			),
+			'breakdown'       => (object) array(
+				'line_items' => array(
+					(object) array(
+						'id'                => $taxable_key,
+						'combined_tax_rate' => 0.0725,
+						'state_tax_rate'    => 0.0725,
+					),
+					(object) array(
+						'id'                => $exempt_key,
+						'combined_tax_rate' => 0.0,
+						'state_tax_rate'    => 0.0,
+					),
+				),
+			),
+		);
+
+		$options = array(
+			'to_country' => 'US',
+			'to_state'   => 'CA',
+			'to_zip'     => '90210',
+			'to_city'    => 'Beverly Hills',
+		);
+
+		$result = $this->invoke_protected_method(
+			'get_itemized_tax_rates',
+			array(
+				array(
+					'rate_ids'   => array(),
+					'line_items' => array(),
+				),
+				$taxjar_taxes,
+				$options,
+			)
+		);
+
+		// The exempt line must not create or update any tax rate row.
+		$this->assertArrayNotHasKey( $exempt_key, $result['rate_ids'], 'Non-taxable line item should not write a tax rate row.' );
+
+		// The taxable line's Standard rate row must remain at 7.25%, not clobbered to 0.
+		$this->assertArrayHasKey( $taxable_key, $result['rate_ids'] );
+		$taxable_rate_id = $result['rate_ids'][ $taxable_key ][0];
+		$rate_data       = WC_Tax::_get_tax_rate( $taxable_rate_id );
+		$this->assertSame( 7.25, (float) $rate_data['tax_rate'], 'Standard rate row was zeroed by the non-taxable line item (WOOTAX-240).' );
+
+		WC_Helper_Product::delete_product( $taxable_id );
+		WC_Helper_Product::delete_product( $exempt_id );
+	}
 }

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -3828,12 +3828,6 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Tax Status "Shipping only" is exempt from item tax, and the backend order path
-	 * sends it to TaxJar as exempt (code 99999) — unlike the cart path, which excludes
-	 * that status from the exempt branch. This is the input side of the zeroing bug:
-	 * an exempt code is what makes TaxJar return the 0% breakdown line.
-	 */
-	/**
 	 * Cart path: a "Shipping only" product must NOT be recorded as non-taxable.
 	 *
 	 * The exempt branch in `get_line_items()` deliberately excludes Tax Status
@@ -3913,6 +3907,12 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 
+	/**
+	 * Tax Status "Shipping only" is exempt from item tax, and the backend order path
+	 * sends it to TaxJar as exempt (code 99999) — unlike the cart path, which excludes
+	 * that status from the exempt branch. This is the input side of the zeroing bug:
+	 * an exempt code is what makes TaxJar return the 0% breakdown line.
+	 */
 	public function test_get_backend_line_items_sends_shipping_only_status_as_exempt() {
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_tax_status( 'shipping' );

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -86,6 +86,9 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		// Remove any filters added during tests.
 		remove_all_filters( 'woocommerce_tax_line_item_location' );
 		remove_all_filters( 'woocommerce_services_override_tax_rate' );
+		remove_all_filters( 'woocommerce_product_is_taxable' );
+
+		delete_option( 'woocommerce_calc_taxes' );
 
 		// Clean up products.
 		if ( $this->product ) {
@@ -3590,6 +3593,71 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Find the TaxJar line item id emitted for a given product.
+	 *
+	 * The id is a composite of the product id and the cart/order item key, so tests
+	 * must read it back from the request side rather than reconstruct it.
+	 *
+	 * @param array $line_items Line items as built for the TaxJar request.
+	 * @param int   $product_id Product id to look for.
+	 * @return string|null
+	 */
+	private function find_taxjar_line_item_id( $line_items, $product_id ) {
+		foreach ( $line_items as $line_item ) {
+			$chunks = explode( '-', $line_item['id'] );
+			if ( (int) $chunks[0] === (int) $product_id ) {
+				return $line_item['id'];
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Build a TaxJar response with an itemized breakdown.
+	 *
+	 * @param array $rate_by_key Map of TaxJar line item id => combined tax rate, in
+	 *                           the order the breakdown should list them.
+	 * @return object
+	 */
+	private function build_itemized_taxjar_response( $rate_by_key ) {
+		$breakdown_line_items = array();
+		foreach ( $rate_by_key as $line_item_key => $rate ) {
+			$breakdown_line_items[] = (object) array(
+				'id'                => $line_item_key,
+				'combined_tax_rate' => $rate,
+				'state_tax_rate'    => $rate,
+			);
+		}
+
+		return (object) array(
+			'freight_taxable' => 0,
+			'has_nexus'       => 1,
+			'rate'            => 0.0725,
+			'jurisdictions'   => (object) array(
+				'county' => '',
+				'city'   => '',
+			),
+			'breakdown'       => (object) array(
+				'line_items' => $breakdown_line_items,
+			),
+		);
+	}
+
+	/**
+	 * Destination used by the itemized rate tests.
+	 *
+	 * @return array
+	 */
+	private function itemized_rate_options() {
+		return array(
+			'to_country' => 'US',
+			'to_state'   => 'CA',
+			'to_zip'     => '90210',
+			'to_city'    => 'Beverly Hills',
+		);
+	}
+
+	/**
 	 * A non-taxable product (Tax Status = "None") that shares the standard Tax
 	 * Class with a taxable product must not zero out the shared Standard rate row.
 	 *
@@ -3597,9 +3665,15 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	 * 99999). Because rate rows are keyed by tax class — and Tax Status "None"
 	 * does not change the Tax Class — that 0% would overwrite the same Standard
 	 * row the taxable product just populated, zeroing tax for the whole cart.
-	 * Regression for WOOTAX-240.
+	 *
+	 * Driven through get_line_items() first: the skip decision is recorded while the
+	 * request is built, so a test that fabricates breakdown keys would not exercise it.
 	 */
 	public function test_get_itemized_tax_rates_non_taxable_line_does_not_zero_standard_rate() {
+		// is_taxable() is false for every product while taxes are off, and this path only
+		// runs on stores that have them on.
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+
 		$taxable_product = WC_Helper_Product::create_simple_product();
 		$taxable_product->set_tax_status( 'taxable' );
 		$taxable_product->set_tax_class( '' );
@@ -3610,42 +3684,26 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$exempt_product->set_tax_class( '' );
 		$exempt_product->save();
 
-		$taxable_id  = $taxable_product->get_id();
-		$exempt_id   = $exempt_product->get_id();
-		$taxable_key = $taxable_id . '-taxable_item';
-		$exempt_key  = $exempt_id . '-exempt_item';
+		$taxable_id = $taxable_product->get_id();
+		$exempt_id  = $exempt_product->get_id();
+
+		WC()->cart->add_to_cart( $taxable_id, 1 );
+		WC()->cart->add_to_cart( $exempt_id, 1 );
+
+		$line_items  = $this->invoke_protected_method( 'get_line_items', array( WC()->cart ) );
+		$taxable_key = $this->find_taxjar_line_item_id( $line_items, $taxable_id );
+		$exempt_key  = $this->find_taxjar_line_item_id( $line_items, $exempt_id );
+
+		$this->assertNotNull( $taxable_key );
+		$this->assertNotNull( $exempt_key );
 
 		// Taxable line is listed first, so without the fix the exempt line would
 		// overwrite the shared Standard rate row to 0% afterwards.
-		$taxjar_taxes = (object) array(
-			'freight_taxable' => 0,
-			'has_nexus'       => 1,
-			'rate'            => 0.0725,
-			'jurisdictions'   => (object) array(
-				'county' => '',
-				'city'   => '',
-			),
-			'breakdown'       => (object) array(
-				'line_items' => array(
-					(object) array(
-						'id'                => $taxable_key,
-						'combined_tax_rate' => 0.0725,
-						'state_tax_rate'    => 0.0725,
-					),
-					(object) array(
-						'id'                => $exempt_key,
-						'combined_tax_rate' => 0.0,
-						'state_tax_rate'    => 0.0,
-					),
-				),
-			),
-		);
-
-		$options = array(
-			'to_country' => 'US',
-			'to_state'   => 'CA',
-			'to_zip'     => '90210',
-			'to_city'    => 'Beverly Hills',
+		$taxjar_taxes = $this->build_itemized_taxjar_response(
+			array(
+				$taxable_key => 0.0725,
+				$exempt_key  => 0.0,
+			)
 		);
 
 		$result = $this->invoke_protected_method(
@@ -3656,7 +3714,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 					'line_items' => array(),
 				),
 				$taxjar_taxes,
-				$options,
+				$this->itemized_rate_options(),
 			)
 		);
 
@@ -3667,10 +3725,94 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$this->assertArrayHasKey( $taxable_key, $result['rate_ids'] );
 		$taxable_rate_id = $result['rate_ids'][ $taxable_key ][0];
 		$rate_data       = WC_Tax::_get_tax_rate( $taxable_rate_id );
-		$this->assertSame( 7.25, (float) $rate_data['tax_rate'], 'Standard rate row was zeroed by the non-taxable line item (WOOTAX-240).' );
+		$this->assertSame( 7.25, (float) $rate_data['tax_rate'], 'Standard rate row was zeroed by the non-taxable line item.' );
 
 		WC_Helper_Product::delete_product( $taxable_id );
 		WC_Helper_Product::delete_product( $exempt_id );
+	}
+
+	/**
+	 * Taxability is filterable: woocommerce_product_is_taxable can make a product
+	 * untaxed while it still reports Tax Status "taxable".
+	 *
+	 * get_line_items() sets the exempt code from is_taxable() (the filtered value),
+	 * which is also what WC_Cart_Totals gates item tax on. A response-side guard that
+	 * re-derives taxability from get_tax_status() (the raw value) disagrees with it,
+	 * and the resulting 0% line zeroes the shared Standard rate row.
+	 */
+	public function test_get_itemized_tax_rates_filtered_non_taxable_line_does_not_zero_standard_rate() {
+		// See the sibling "None" test: is_taxable() also depends on taxes being enabled.
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+
+		$taxable_product = WC_Helper_Product::create_simple_product();
+		$taxable_product->set_tax_status( 'taxable' );
+		$taxable_product->set_tax_class( '' );
+		$taxable_product->save();
+
+		// Tax Status stays "taxable"; only is_taxable() is filtered off.
+		$filtered_product = WC_Helper_Product::create_simple_product();
+		$filtered_product->set_tax_status( 'taxable' );
+		$filtered_product->set_tax_class( '' );
+		$filtered_product->save();
+
+		$taxable_id  = $taxable_product->get_id();
+		$filtered_id = $filtered_product->get_id();
+
+		add_filter(
+			'woocommerce_product_is_taxable',
+			function ( $taxable, $product ) use ( $filtered_id ) {
+				return $product->get_id() === $filtered_id ? false : $taxable;
+			},
+			10,
+			2
+		);
+
+		WC()->cart->add_to_cart( $taxable_id, 1 );
+		WC()->cart->add_to_cart( $filtered_id, 1 );
+
+		$line_items   = $this->invoke_protected_method( 'get_line_items', array( WC()->cart ) );
+		$taxable_key  = $this->find_taxjar_line_item_id( $line_items, $taxable_id );
+		$filtered_key = $this->find_taxjar_line_item_id( $line_items, $filtered_id );
+
+		$this->assertNotNull( $taxable_key );
+		$this->assertNotNull( $filtered_key );
+
+		// Input side: the filtered product is sent to TaxJar as exempt even though its
+		// Tax Status is "taxable" — this is what makes TaxJar return the 0% line.
+		foreach ( $line_items as $line_item ) {
+			if ( $line_item['id'] === $filtered_key ) {
+				$this->assertSame( '99999', $line_item['product_tax_code'], 'A product filtered non-taxable must be sent to TaxJar as exempt.' );
+			}
+		}
+
+		$taxjar_taxes = $this->build_itemized_taxjar_response(
+			array(
+				$taxable_key  => 0.0725,
+				$filtered_key => 0.0,
+			)
+		);
+
+		$result = $this->invoke_protected_method(
+			'get_itemized_tax_rates',
+			array(
+				array(
+					'rate_ids'   => array(),
+					'line_items' => array(),
+				),
+				$taxjar_taxes,
+				$this->itemized_rate_options(),
+			)
+		);
+
+		$this->assertArrayNotHasKey( $filtered_key, $result['rate_ids'], 'A line item filtered non-taxable should not write a tax rate row.' );
+
+		$this->assertArrayHasKey( $taxable_key, $result['rate_ids'] );
+		$taxable_rate_id = $result['rate_ids'][ $taxable_key ][0];
+		$rate_data       = WC_Tax::_get_tax_rate( $taxable_rate_id );
+		$this->assertSame( 7.25, (float) $rate_data['tax_rate'], 'Standard rate row was zeroed by a line item whose taxability was filtered off.' );
+
+		WC_Helper_Product::delete_product( $taxable_id );
+		WC_Helper_Product::delete_product( $filtered_id );
 	}
 
 	/**
@@ -3720,41 +3862,29 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$shipping_only_product->set_tax_class( '' );
 		$shipping_only_product->save();
 
-		$taxable_id        = $taxable_product->get_id();
-		$shipping_only_id  = $shipping_only_product->get_id();
-		$taxable_key       = $taxable_id . '-taxable_item';
-		$shipping_only_key = $shipping_only_id . '-shipping_only_item';
+		$taxable_id       = $taxable_product->get_id();
+		$shipping_only_id = $shipping_only_product->get_id();
+
+		// The backend order path is where "Shipping only" is emitted as exempt; the cart
+		// path excludes that status from the exempt branch (see get_line_items()).
+		$order = wc_create_order();
+		$order->add_product( $taxable_product, 1 );
+		$order->add_product( $shipping_only_product, 1 );
+		$order->save();
+
+		$line_items        = $this->invoke_protected_method( 'get_backend_line_items', array( $order ) );
+		$taxable_key       = $this->find_taxjar_line_item_id( $line_items, $taxable_id );
+		$shipping_only_key = $this->find_taxjar_line_item_id( $line_items, $shipping_only_id );
+
+		$this->assertNotNull( $taxable_key );
+		$this->assertNotNull( $shipping_only_key );
 
 		// Taxable line first, so the exempt line would overwrite the shared row after it.
-		$taxjar_taxes = (object) array(
-			'freight_taxable' => 0,
-			'has_nexus'       => 1,
-			'rate'            => 0.0725,
-			'jurisdictions'   => (object) array(
-				'county' => '',
-				'city'   => '',
-			),
-			'breakdown'       => (object) array(
-				'line_items' => array(
-					(object) array(
-						'id'                => $taxable_key,
-						'combined_tax_rate' => 0.0725,
-						'state_tax_rate'    => 0.0725,
-					),
-					(object) array(
-						'id'                => $shipping_only_key,
-						'combined_tax_rate' => 0.0,
-						'state_tax_rate'    => 0.0,
-					),
-				),
-			),
-		);
-
-		$options = array(
-			'to_country' => 'US',
-			'to_state'   => 'CA',
-			'to_zip'     => '90210',
-			'to_city'    => 'Beverly Hills',
+		$taxjar_taxes = $this->build_itemized_taxjar_response(
+			array(
+				$taxable_key       => 0.0725,
+				$shipping_only_key => 0.0,
+			)
 		);
 
 		$result = $this->invoke_protected_method(
@@ -3765,7 +3895,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 					'line_items' => array(),
 				),
 				$taxjar_taxes,
-				$options,
+				$this->itemized_rate_options(),
 			)
 		);
 
@@ -3776,6 +3906,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$rate_data       = WC_Tax::_get_tax_rate( $taxable_rate_id );
 		$this->assertSame( 7.25, (float) $rate_data['tax_rate'], 'Standard rate row was zeroed by a "Shipping only" line item.' );
 
+		$order->delete( true );
 		WC_Helper_Product::delete_product( $taxable_id );
 		WC_Helper_Product::delete_product( $shipping_only_id );
 	}

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -3672,4 +3672,111 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		WC_Helper_Product::delete_product( $taxable_id );
 		WC_Helper_Product::delete_product( $exempt_id );
 	}
+
+	/**
+	 * Tax Status "Shipping only" is exempt from item tax, and the backend order path
+	 * sends it to TaxJar as exempt (code 99999) — unlike the cart path, which excludes
+	 * that status from the exempt branch. This is the input side of the zeroing bug:
+	 * an exempt code is what makes TaxJar return the 0% breakdown line.
+	 */
+	public function test_get_backend_line_items_sends_shipping_only_status_as_exempt() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_tax_status( 'shipping' );
+		$product->set_tax_class( '' );
+		$product->save();
+
+		$order = wc_create_order();
+		$order->add_product( $product, 1 );
+		$order->save();
+
+		$line_items = $this->invoke_protected_method( 'get_backend_line_items', array( $order ) );
+
+		$this->assertCount( 1, $line_items );
+		$this->assertSame(
+			'99999',
+			$line_items[0]['product_tax_code'],
+			'A "Shipping only" product must be sent to TaxJar as exempt on the backend order path.'
+		);
+
+		$order->delete( true );
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
+	/**
+	 * Output side of the same case: the 0% breakdown line TaxJar returns for a
+	 * "Shipping only" product must not overwrite the shared Standard rate row.
+	 *
+	 * Guarding on `'none' === $tax_status` instead of `'taxable' !== $tax_status`
+	 * passes the sibling "None" test while still zeroing the cart here.
+	 */
+	public function test_get_itemized_tax_rates_shipping_only_line_does_not_zero_standard_rate() {
+		$taxable_product = WC_Helper_Product::create_simple_product();
+		$taxable_product->set_tax_status( 'taxable' );
+		$taxable_product->set_tax_class( '' );
+		$taxable_product->save();
+
+		$shipping_only_product = WC_Helper_Product::create_simple_product();
+		$shipping_only_product->set_tax_status( 'shipping' );
+		$shipping_only_product->set_tax_class( '' );
+		$shipping_only_product->save();
+
+		$taxable_id        = $taxable_product->get_id();
+		$shipping_only_id  = $shipping_only_product->get_id();
+		$taxable_key       = $taxable_id . '-taxable_item';
+		$shipping_only_key = $shipping_only_id . '-shipping_only_item';
+
+		// Taxable line first, so the exempt line would overwrite the shared row after it.
+		$taxjar_taxes = (object) array(
+			'freight_taxable' => 0,
+			'has_nexus'       => 1,
+			'rate'            => 0.0725,
+			'jurisdictions'   => (object) array(
+				'county' => '',
+				'city'   => '',
+			),
+			'breakdown'       => (object) array(
+				'line_items' => array(
+					(object) array(
+						'id'                => $taxable_key,
+						'combined_tax_rate' => 0.0725,
+						'state_tax_rate'    => 0.0725,
+					),
+					(object) array(
+						'id'                => $shipping_only_key,
+						'combined_tax_rate' => 0.0,
+						'state_tax_rate'    => 0.0,
+					),
+				),
+			),
+		);
+
+		$options = array(
+			'to_country' => 'US',
+			'to_state'   => 'CA',
+			'to_zip'     => '90210',
+			'to_city'    => 'Beverly Hills',
+		);
+
+		$result = $this->invoke_protected_method(
+			'get_itemized_tax_rates',
+			array(
+				array(
+					'rate_ids'   => array(),
+					'line_items' => array(),
+				),
+				$taxjar_taxes,
+				$options,
+			)
+		);
+
+		$this->assertArrayNotHasKey( $shipping_only_key, $result['rate_ids'], '"Shipping only" line item should not write a tax rate row.' );
+
+		$this->assertArrayHasKey( $taxable_key, $result['rate_ids'] );
+		$taxable_rate_id = $result['rate_ids'][ $taxable_key ][0];
+		$rate_data       = WC_Tax::_get_tax_rate( $taxable_rate_id );
+		$this->assertSame( 7.25, (float) $rate_data['tax_rate'], 'Standard rate row was zeroed by a "Shipping only" line item.' );
+
+		WC_Helper_Product::delete_product( $taxable_id );
+		WC_Helper_Product::delete_product( $shipping_only_id );
+	}
 }

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -153,6 +153,18 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Helper to read private properties via reflection.
+	 *
+	 * @param string $property_name Property name.
+	 * @return mixed Property value.
+	 */
+	private function get_private_property( $property_name ) {
+		$reflection = new ReflectionProperty( 'WC_Connect_TaxJar_Integration', $property_name );
+		$reflection->setAccessible( true );
+		return $reflection->getValue( $this->integration );
+	}
+
+	/**
 	 * Test that get_line_items includes tax_location key with default value.
 	 */
 	public function test_get_line_items_includes_tax_location_with_default() {
@@ -3821,6 +3833,86 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	 * that status from the exempt branch. This is the input side of the zeroing bug:
 	 * an exempt code is what makes TaxJar return the 0% breakdown line.
 	 */
+	/**
+	 * Cart path: a "Shipping only" product must NOT be recorded as non-taxable.
+	 *
+	 * The exempt branch in `get_line_items()` deliberately excludes Tax Status
+	 * "shipping", so the line is sent to TaxJar as taxable and its breakdown comes back
+	 * with a real, non-zero rate. Recording it would make `get_itemized_tax_rates()`
+	 * skip that write and throw the rate away — the one case where the skip discards
+	 * good data rather than preventing a 0% clobber.
+	 *
+	 * The row is not redundant: it carries `tax_rate_shipping`, and with the default
+	 * `woocommerce_shipping_tax_class = 'inherit'` WooCommerce resolves the shipping tax
+	 * class to this product's class and looks the rate up there. TaxJar's own shipping
+	 * write only covers the standard class.
+	 *
+	 * The backend order path legitimately differs — there the same status *is* emitted
+	 * as exempt, so there it *is* recorded. See
+	 * `test_get_backend_line_items_sends_shipping_only_status_as_exempt()`.
+	 */
+	public function test_get_line_items_does_not_record_shipping_only_status_as_non_taxable() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_tax_status( 'shipping' );
+		$product->set_tax_class( '' );
+		$product->save();
+
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		$line_items = $this->invoke_protected_method( 'get_line_items', array( WC()->cart ) );
+		$recorded   = $this->get_private_property( 'non_taxable_line_items' );
+
+		$this->assertCount( 1, $line_items );
+		$this->assertNotSame(
+			'99999',
+			$line_items[0]['product_tax_code'],
+			'The cart path excludes "Shipping only" from the exempt branch, so it is sent to TaxJar as taxable.'
+		);
+		$this->assertSame(
+			array(),
+			$recorded,
+			'Recording it would discard the real, non-zero rate TaxJar returns for this line.'
+		);
+
+		WC()->cart->empty_cart();
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
+	/**
+	 * The other side of the same boundary: excluding "Shipping only" must not stop a
+	 * genuinely untaxed product from being recorded.
+	 *
+	 * Tax Status "None" is emitted as exempt (99999) and comes back at 0%, which is the
+	 * rate that would overwrite the shared Standard row. Pins that the `'shipping' !==`
+	 * clause narrows the condition by exactly one status and no more.
+	 */
+	public function test_get_line_items_still_records_none_status_as_non_taxable() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_tax_status( 'none' );
+		$product->set_tax_class( '' );
+		$product->save();
+
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		$line_items = $this->invoke_protected_method( 'get_line_items', array( WC()->cart ) );
+		$recorded   = $this->get_private_property( 'non_taxable_line_items' );
+
+		$this->assertCount( 1, $line_items );
+		$this->assertSame(
+			'99999',
+			$line_items[0]['product_tax_code'],
+			'A "None" product is still emitted as exempt on the cart path.'
+		);
+		$this->assertArrayHasKey(
+			$line_items[0]['id'],
+			$recorded,
+			'A line emitted as exempt must stay recorded, or its 0% rate overwrites the shared Standard row.'
+		);
+
+		WC()->cart->empty_cart();
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
 	public function test_get_backend_line_items_sends_shipping_only_status_as_exempt() {
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_tax_status( 'shipping' );


### PR DESCRIPTION
### Summary

Fixes [WOOTAX-240](https://linear.app/a8c/issue/WOOTAX-240/mixed-carts-of-taxable-and-non-taxable-products-dont-calculate-tax).

When a cart mixes a **taxable** product and a **non-taxable** one (Tax Status = *None*, Tax Class = *Standard*), automated taxes stop calculating for the whole cart — the "Standard Rates" tax rate row is overwritten to **0%**, and it stays zeroed (adding another taxable product doesn't restore it; removing the non-taxable product does).

### Root cause

`get_itemized_tax_rates()` writes one WooCommerce tax rate row **per TaxJar breakdown line item**, and selects which row by the product's **Tax Class** — not its Tax Status:

```php
$tax_class = $product->get_tax_class();   // 'Standard' ('') even when Tax Status = None
...
$this->create_or_update_tax_rate( $location, round( $tax_rate * 100, 4 ), $tax_class, ... );
```

The non-taxable product is sent to TaxJar as exempt (code `99999`), so its breakdown line returns **0%** — but it still maps back to the **Standard** class. `create_or_update_tax_rate()` therefore updates the *same* rate row the taxable product just populated (same class + location) down to 0%. The zeroed row persists in `wp_woocommerce_tax_rates`, which is why the problem sticks.

> Note: the ticket's proposed change to `get_line_items()` (`! $product->is_taxable()` → `'none' === $tax_status`) is a **no-op** — `WC_Product::is_taxable()` already returns false for `tax_status = 'none'`, so the exempt product is already sent as `99999`. The defect is downstream, in how the itemized rate rows are written.

### Fix

Skip rate-row writes for line items whose product has Tax Status **None**. WooCommerce already applies no tax to such products (`override_cart_item_tax_rates()` falls back to core, which taxes nothing for a non-taxable item), so the shared class row is left intact for genuinely taxable items. Zero-rate **class** products are unaffected — they own a separate `zero-rate` row.

### Tests

Adds `test_get_itemized_tax_rates_non_taxable_line_does_not_zero_standard_rate`, which drives `get_itemized_tax_rates()` with a mixed taxable/exempt breakdown and asserts (a) the exempt line writes no rate row and (b) the taxable line's Standard row stays at 7.25%. It **fails on trunk** (exempt line writes/zeroes the shared row) and passes with this fix.

Full `WP_Test_WC_Connect_TaxJar_Integration` suite: **68 tests, 166 assertions green**. PHPCS clean on the changed files.


### Update — guard widened to "Shipping only" (review follow-up)

The guard now skips rate-row writes for **any** non-taxable Tax Status (`'taxable' !== $status`), not just `'None'`. `get_backend_line_items()` sends every non-taxable status to TaxJar as exempt (`99999`), so a **"Shipping only"** product returned the same 0% breakdown line and reproduced the zeroing bug on the admin order screen. `ProductTaxStatus` defines exactly three statuses and `set_tax_status()` normalises empty → `taxable`, so the new condition is precisely "none or shipping".

**Backward compatibility / scope:** this is a behaviour change on **both** paths, not just the backend one where the bug reproduces. A "Shipping only" product on the **cart** previously had a rate row written with a real (non-zero) rate; it is now skipped. This is safe — `WC_Cart_Totals` gates item tax on `is_taxable()` and `WC_Order_Item::calculate_taxes()` on `ProductTaxStatus::TAXABLE`, so core applies no item tax to either status, and the shipping tax rate row is written separately after this loop, so shipping tax is unaffected. No hook, signature, or option contract changes; no new global or `WC()` state reads; nothing site- or path-scoped, so multisite and non-root installs are unaffected.

Additional coverage: `get_backend_line_items()` sends a "Shipping only" product as exempt (input side), and its 0% line leaves the Standard row at 7.25% (output side). The latter was verified to fail against the previous `'none' ===` guard.

A pre-existing parent/variation Tax Class divergence found during this review is tracked separately in [WOOTAX-310](https://linear.app/a8c/issue/WOOTAX-310/itemized-tax-rate-rows-use-the-parents-tax-class-for-variations-on-the).



### Update — taxability recorded at emit time, not re-derived (review follow-up)

Review surfaced a third route to the same zeroing: `woocommerce_product_is_taxable` can filter a product to non-taxable while its Tax Status still reads `taxable`. `get_line_items()` sets the exempt code from the **filtered** `is_taxable()`, while the guard read the **raw** status — so the 0% line passed through and zeroed the shared Standard row. Confirmed against live TaxJar by the reviewer.

Rather than widen the guard a third time, the request side now records which line items WooCommerce will not tax (`$non_taxable_line_items`, keyed by TaxJar line item id) and the response side skips exactly those. The two halves share one decision instead of each re-deriving one from a different predicate.

The two paths deliberately record **different** predicates, because core gates them differently:

| Path | Core's item-tax gate | Location |
|---|---|---|
| Cart | `$item->product->is_taxable()` — filtered | `class-wc-cart-totals.php` 677 / 735 / 796 |
| Order | `ProductTaxStatus::TAXABLE === $this->get_tax_status()` — raw | `class-wc-order-item.php` 251 |

`WC_Order_Item::calculate_taxes()` never consults `is_taxable()`, so the order path has no filter divergence to close and recording the raw status is the accurate mirror there.

This is **not** implemented as "skip anything sent as `99999`" — zero-rate **class** products are emitted as exempt for an unrelated reason and must keep updating their own `zero-rate` row, so only the non-taxability reason is recorded.

Two earlier review points fall out as a side effect: the deleted-product case is now moot (the lookup never dereferences a possibly-gone product), as is any variation/parent-id mismatch at this seam, since the key is the emitted composite rather than a re-resolved product id.

**Backward compatibility:** the new property is private; no signature, hook, or option contract changes; no new global or `WC()` state reads; nothing site- or path-scoped, so multisite and non-root installs are unaffected. The only behaviour change is which rate rows are written, and only for line items core applies no item tax to.

**Tests:** the two output-side tests previously fabricated breakdown keys and called `get_itemized_tax_rates()` with no matching request — a shape that structurally cannot catch an emit/response divergence, which is why this survived two review rounds with a green suite. Both now drive the request side first and read the real emitted key back. The "Shipping only" case also moved to the **backend order path**, which is where that status is actually emitted as exempt; it had been asserting a cart scenario that cannot occur. New: `test_get_itemized_tax_rates_filtered_non_taxable_line_does_not_zero_standard_rate`, reproducing the filter case and asserting both the input side (`99999` emitted despite Tax Status "taxable") and the output side (shared row stays 7.25%) — verified red against the previous guard.

One gotcha for anyone re-running these: `is_taxable()` also requires `wc_tax_enabled()`, which is off in the bare WC test bootstrap, so the cart tests set `woocommerce_calc_taxes`.

`WP_Test_WC_Connect_TaxJar_Integration`: **80 tests, 206 assertions green**. Full suite: **235 tests, 521 assertions green**. PHPCS `--report=source` byte-identical to baseline on both changed files.

**Changelog retargeted:** 3.6.11 shipped from trunk while this PR was open, so the entry moved to a new unreleased `= 3.6.12 - 2026-xx-xx =` section in both `changelog.txt` and `readme.txt` rather than being merged into the released 3.6.11 block.
