### PR TITLE
[WOOTAX-305] Tweak - WooCommerce 11.0 Compatibility.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.6.10 - 2026-xx-xx =
+* Tweak - WooCommerce 11.0 Compatibility.
+
 = 3.6.9 - 2026-07-20 =
 * Fix   - Prevent a rare fatal error when the WooCommerce Store API cannot be initialized on incomplete installations.
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Requires PHP: 7.4
 Requires at least: 6.9
 Requires Plugins: woocommerce
 Tested up to: 7.0
-WC requires at least: 10.7
-WC tested up to: 10.9
+WC requires at least: 10.8
+WC tested up to: 11.0
 Stable tag: 3.6.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -69,6 +69,9 @@ This plugin relies on the following external services:
 2. Checking on the health of WooCommerce Tax
 
 == Changelog ==
+
+= 3.6.10 - 2026-xx-xx =
+* Tweak - WooCommerce 11.0 Compatibility.
 
 = 3.6.9 - 2026-07-20 =
 * Fix   - Prevent a rare fatal error when the WooCommerce Store API cannot be initialized on incomplete installations.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -13,8 +13,8 @@
  * Requires PHP: 7.4
  * Requires at least: 6.9
  * Tested up to: 7.0
- * WC requires at least: 10.7
- * WC tested up to: 10.9
+ * WC requires at least: 10.8
+ * WC tested up to: 11.0
  *
  * Copyright (c) 2017-2023 Automattic
  *


### PR DESCRIPTION
Bumps WooCommerce compatibility headers for the WooCommerce 11.0 release. Tested with WooCommerce 11.0, no issues found.

- `WC requires at least`: 10.7 -> 10.8
- `WC tested up to`: 10.9 -> 11.0
- Added changelog entry for version 3.6.10.

Part of WOOTAX-305.
https://linear.app/a8c/issue/WOOTAX-305/ensure-woocommerce-110-compatibility-woocommerce-services-woo-tax
