### PR TITLE
Tweak - Match TaxJar cache entries across cart and order paths (WOOTAX-258)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@
 * Fix   - Calculate tax correctly for carts mixing taxable and non-taxable products, so a non-taxable product no longer resets the standard tax rate to zero.
 * Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
 * Tweak - Store tax rate rows against the postcode the rate was quoted for when the address postcode holds more than one comma-separated value.
+* Tweak - Reduce redundant TaxJar API calls by matching cached tax responses across the cart and order paths and ignoring irrelevant formatting differences.
 
 = 3.6.11 - 2026-08-05 =
 * Fix   - Prevent a fatal error during cart and checkout tax calculation when TaxJar returns an incomplete tax response.
@@ -21,7 +22,6 @@
 
 = 3.6.10 - 2026-07-27 =
 * Tweak - WooCommerce 11.0 Compatibility.
-* Tweak - Reduce redundant TaxJar API calls by matching cached tax responses across the cart and order paths and ignoring irrelevant formatting differences.
 
 = 3.6.9 - 2026-07-20 =
 * Fix   - Prevent a rare fatal error when the WooCommerce Store API cannot be initialized on incomplete installations.

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@
 
 = 3.6.10 - 2026-07-27 =
 * Tweak - WooCommerce 11.0 Compatibility.
+* Tweak - Reduce redundant TaxJar API calls by matching cached tax responses across the cart and order paths and ignoring irrelevant formatting differences.
 
 = 3.6.9 - 2026-07-20 =
 * Fix   - Prevent a rare fatal error when the WooCommerce Store API cannot be initialized on incomplete installations.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1165,7 +1165,7 @@ class WC_Connect_TaxJar_Integration {
 	 * identical lines — an order can legitimately hold the same product twice at the
 	 * same price — distinct, so neither loses its rate.
 	 *
-	 * @since 3.4.0
+	 * @since 3.6.10
 	 *
 	 * @param array $line_items Line items whose 'id' is currently the bare product ID.
 	 *
@@ -1207,7 +1207,7 @@ class WC_Connect_TaxJar_Integration {
 	 * cache keys and line item fingerprints — never to build the request sent to
 	 * TaxJar, which keeps the merchant's values verbatim.
 	 *
-	 * @since 3.4.0
+	 * @since 3.6.10
 	 *
 	 * @param mixed $value Value to normalize.
 	 *
@@ -1237,7 +1237,7 @@ class WC_Connect_TaxJar_Integration {
 	 * silently reinterpreted — notably ZIP codes, where "01234" must never become
 	 * "1234".
 	 *
-	 * @since 3.4.0
+	 * @since 3.6.10
 	 *
 	 * @param mixed $value Value to normalize.
 	 *
@@ -1274,7 +1274,7 @@ class WC_Connect_TaxJar_Integration {
 	 *
 	 * Only the cache key is derived from this. The body sent to TaxJar is untouched.
 	 *
-	 * @since 3.4.0
+	 * @since 3.6.10
 	 *
 	 * @param string $json Encoded TaxJar request body.
 	 *
@@ -1297,7 +1297,7 @@ class WC_Connect_TaxJar_Integration {
 	 * value, because several address fields hold digit-only strings that must keep
 	 * their exact form (a leading-zero ZIP above all).
 	 *
-	 * @since 3.4.0
+	 * @since 3.6.10
 	 *
 	 * @param mixed  $value Value to canonicalize.
 	 * @param string $key   Key the value was found under.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1165,7 +1165,7 @@ class WC_Connect_TaxJar_Integration {
 	 * identical lines — an order can legitimately hold the same product twice at the
 	 * same price — distinct, so neither loses its rate.
 	 *
-	 * @since 3.7.0
+	 * @since 3.6.12
 	 *
 	 * @param array $line_items Line items whose 'id' is currently the bare product ID.
 	 *
@@ -1207,7 +1207,7 @@ class WC_Connect_TaxJar_Integration {
 	 * cache keys and line item fingerprints — never to build the request sent to
 	 * TaxJar, which keeps the merchant's values verbatim.
 	 *
-	 * @since 3.7.0
+	 * @since 3.6.12
 	 *
 	 * @param mixed $value Value to normalize.
 	 *
@@ -1237,7 +1237,7 @@ class WC_Connect_TaxJar_Integration {
 	 * silently reinterpreted — notably ZIP codes, where "01234" must never become
 	 * "1234".
 	 *
-	 * @since 3.7.0
+	 * @since 3.6.12
 	 *
 	 * @param mixed $value Value to normalize.
 	 *
@@ -1274,7 +1274,7 @@ class WC_Connect_TaxJar_Integration {
 	 *
 	 * Only the cache key is derived from this. The body sent to TaxJar is untouched.
 	 *
-	 * @since 3.7.0
+	 * @since 3.6.12
 	 *
 	 * @param string $json Encoded TaxJar request body.
 	 *
@@ -1297,7 +1297,7 @@ class WC_Connect_TaxJar_Integration {
 	 * value, because several address fields hold digit-only strings that must keep
 	 * their exact form (a leading-zero ZIP above all).
 	 *
-	 * @since 3.7.0
+	 * @since 3.6.12
 	 *
 	 * @param mixed  $value Value to canonicalize.
 	 * @param string $key   Key the value was found under.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1165,7 +1165,7 @@ class WC_Connect_TaxJar_Integration {
 	 * identical lines — an order can legitimately hold the same product twice at the
 	 * same price — distinct, so neither loses its rate.
 	 *
-	 * @since 3.6.10
+	 * @since 3.7.0
 	 *
 	 * @param array $line_items Line items whose 'id' is currently the bare product ID.
 	 *
@@ -1207,7 +1207,7 @@ class WC_Connect_TaxJar_Integration {
 	 * cache keys and line item fingerprints — never to build the request sent to
 	 * TaxJar, which keeps the merchant's values verbatim.
 	 *
-	 * @since 3.6.10
+	 * @since 3.7.0
 	 *
 	 * @param mixed $value Value to normalize.
 	 *
@@ -1237,7 +1237,7 @@ class WC_Connect_TaxJar_Integration {
 	 * silently reinterpreted — notably ZIP codes, where "01234" must never become
 	 * "1234".
 	 *
-	 * @since 3.6.10
+	 * @since 3.7.0
 	 *
 	 * @param mixed $value Value to normalize.
 	 *
@@ -1274,7 +1274,7 @@ class WC_Connect_TaxJar_Integration {
 	 *
 	 * Only the cache key is derived from this. The body sent to TaxJar is untouched.
 	 *
-	 * @since 3.6.10
+	 * @since 3.7.0
 	 *
 	 * @param string $json Encoded TaxJar request body.
 	 *
@@ -1297,7 +1297,7 @@ class WC_Connect_TaxJar_Integration {
 	 * value, because several address fields hold digit-only strings that must keep
 	 * their exact form (a leading-zero ZIP above all).
 	 *
-	 * @since 3.6.10
+	 * @since 3.7.0
 	 *
 	 * @param mixed  $value Value to canonicalize.
 	 * @param string $key   Key the value was found under.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -617,9 +617,11 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		foreach ( $wc_cart_object->get_cart() as $cart_item_key => $cart_item ) {
-			$product       = $cart_item['data'];
-			$line_item_key = $product->get_id() . '-' . $cart_item_key;
-			if ( isset( $taxes['line_items'][ $line_item_key ] ) && ! $taxes['line_items'][ $line_item_key ]->combined_tax_rate ) {
+			$product = $cart_item['data'];
+			// get_line_items() keys by cart item key and stores the canonical TaxJar ID
+			// under 'id'; the response is keyed by that canonical ID.
+			$line_item_key = $line_items[ $cart_item_key ]['id'] ?? null;
+			if ( null !== $line_item_key && isset( $taxes['line_items'][ $line_item_key ] ) && ! $taxes['line_items'][ $line_item_key ]->combined_tax_rate ) {
 				if ( method_exists( $product, 'set_tax_status' ) ) {
 					$product->set_tax_status( 'none' ); // Woo 3.0+
 				} else {
@@ -680,9 +682,10 @@ class WC_Connect_TaxJar_Integration {
 			 * @var WC_Order_Item_Product $item Product Order Item.
 			 */
 			foreach ( $order->get_items() as $item_key => $item ) {
-				$product_id    = $item->get_product_id();
-				$line_item_key = $product_id . '-' . $item_key;
-				if ( isset( $taxes['rate_ids'][ $line_item_key ] ) ) {
+				// get_backend_line_items() keys by order item ID and stores the canonical
+				// TaxJar ID under 'id'; the response is keyed by that canonical ID.
+				$line_item_key = $line_items[ $item_key ]['id'] ?? null;
+				if ( null !== $line_item_key && isset( $taxes['rate_ids'][ $line_item_key ] ) ) {
 					$rate_id  = $taxes['rate_ids'][ $line_item_key ];
 					$item_tax = new WC_Order_Item_Tax();
 					$item_tax->set_rate( $rate_id );
@@ -967,10 +970,13 @@ class WC_Connect_TaxJar_Integration {
 	/**
 	 * Get line items at checkout
 	 *
-	 * Unchanged from the TaxJar plugin.
+	 * Based on the TaxJar plugin, with canonical line item IDs added.
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L645
 	 *
-	 * @return array
+	 * @param WC_Cart $wc_cart_object Cart object.
+	 *
+	 * @return array Line items keyed by cart item key. Each item's 'id' is the
+	 *               canonical TaxJar line item ID, not the cart item key.
 	 */
 	protected function get_line_items( $wc_cart_object ) {
 		$line_items                   = array();
@@ -1049,29 +1055,29 @@ class WC_Connect_TaxJar_Integration {
 				$this->_log( 'Tax location override for product ' . $id . ': ' . $default_location . ' -> ' . $tax_location );
 			}
 
-			array_push(
-				$line_items,
-				array(
-					'id'               => $id . '-' . $cart_item_key,
-					'quantity'         => $quantity,
-					'product_tax_code' => $tax_code,
-					'unit_price'       => $unit_price,
-					'discount'         => $discount,
-					'tax_location'     => $tax_location,
-				)
+			$line_items[ $cart_item_key ] = array(
+				'id'               => $id,
+				'quantity'         => $quantity,
+				'product_tax_code' => $tax_code,
+				'unit_price'       => $unit_price,
+				'discount'         => $discount,
+				'tax_location'     => $tax_location,
 			);
 		}
 
-		return $line_items;
+		return $this->assign_canonical_line_item_ids( $line_items );
 	}
 
 	/**
 	 * Get line items for backend orders
 	 *
-	 * Unchanged from the TaxJar plugin.
+	 * Based on the TaxJar plugin, with canonical line item IDs added.
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/96b5d57/includes/class-wc-taxjar-integration.php#L695
 	 *
-	 * @return array
+	 * @param WC_Order $order Order object.
+	 *
+	 * @return array Line items keyed by order item ID. Each item's 'id' is the
+	 *               canonical TaxJar line item ID, not the order item ID.
 	 */
 	protected function get_backend_line_items( $order ) {
 		$line_items                   = array();
@@ -1120,20 +1126,17 @@ class WC_Connect_TaxJar_Integration {
 			}
 
 			if ( $unit_price ) {
-				array_push(
-					$line_items,
-					array(
-						'id'               => $id . '-' . $item_key,
-						'quantity'         => $quantity,
-						'product_tax_code' => $tax_code,
-						'unit_price'       => $unit_price,
-						'discount'         => $discount,
-						'tax_location'     => $tax_location,
-					)
+				$line_items[ $item_key ] = array(
+					'id'               => $id,
+					'quantity'         => $quantity,
+					'product_tax_code' => $tax_code,
+					'unit_price'       => $unit_price,
+					'discount'         => $discount,
+					'tax_location'     => $tax_location,
 				);
 			}
 		}
-		return $line_items;
+		return $this->assign_canonical_line_item_ids( $line_items );
 	}
 
 	protected function get_line_item( $id, $line_items ) {
@@ -1143,6 +1146,195 @@ class WC_Connect_TaxJar_Integration {
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Replace each line item's product ID with a canonical TaxJar line item ID.
+	 *
+	 * The cart path used to key line items by WooCommerce's cart item key and the
+	 * order path by the numeric order item ID, so the same basket produced two
+	 * different request bodies — and therefore two different cache keys — depending
+	 * on which path built it. TaxJar treats `id` as an opaque echo field, so the two
+	 * paths can agree on one value derived purely from the tax-relevant inputs:
+	 * product, tax code, quantity, unit price, discount and tax location.
+	 *
+	 * Format is `<product_id>-<fingerprint>-<occurrence>`. The product ID stays the
+	 * first `-` segment because `get_itemized_tax_rates()` recovers the product from
+	 * it, and `override_cart_item_tax_rates()` / `override_order_item_taxes()` match
+	 * on the `<product_id>-` prefix. The occurrence counter keeps two otherwise
+	 * identical lines — an order can legitimately hold the same product twice at the
+	 * same price — distinct, so neither loses its rate.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param array $line_items Line items whose 'id' is currently the bare product ID.
+	 *
+	 * @return array The same array with 'id' expanded to the canonical ID.
+	 */
+	private function assign_canonical_line_item_ids( array $line_items ): array {
+		$occurrences = array();
+
+		foreach ( $line_items as $key => $line_item ) {
+			$product_id = $line_item['id'];
+
+			$fingerprint = hash(
+				'md5',
+				(string) wp_json_encode(
+					array(
+						'product_id'       => (string) $product_id,
+						'product_tax_code' => $this->normalize_cache_string( $line_item['product_tax_code'] ),
+						'quantity'         => $this->normalize_cache_number( $line_item['quantity'] ),
+						'unit_price'       => $this->normalize_cache_number( $line_item['unit_price'] ),
+						'discount'         => $this->normalize_cache_number( $line_item['discount'] ),
+						'tax_location'     => $this->normalize_cache_string( $line_item['tax_location'] ),
+					)
+				)
+			);
+
+			$occurrences[ $fingerprint ] = isset( $occurrences[ $fingerprint ] ) ? $occurrences[ $fingerprint ] + 1 : 0;
+
+			$line_items[ $key ]['id'] = $product_id . '-' . substr( $fingerprint, 0, 12 ) . '-' . $occurrences[ $fingerprint ];
+		}
+
+		return $line_items;
+	}
+
+	/**
+	 * Normalize a string for cache-key purposes.
+	 *
+	 * Trims, collapses runs of whitespace and upper-cases, so that "beverly hills",
+	 * "Beverly  Hills" and "Beverly Hills " all hash the same. Used only to derive
+	 * cache keys and line item fingerprints — never to build the request sent to
+	 * TaxJar, which keeps the merchant's values verbatim.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param mixed $value Value to normalize.
+	 *
+	 * @return string
+	 */
+	private function normalize_cache_string( $value ): string {
+		if ( is_bool( $value ) ) {
+			$value = $value ? '1' : '0';
+		}
+
+		if ( ! is_scalar( $value ) && null !== $value ) {
+			return '';
+		}
+
+		$value = preg_replace( '/\s+/u', ' ', trim( (string) $value ) );
+
+		return function_exists( 'mb_strtoupper' ) ? mb_strtoupper( $value, 'UTF-8' ) : strtoupper( $value );
+	}
+
+	/**
+	 * Normalize a numeric value for cache-key purposes.
+	 *
+	 * Amounts reach the request body as `wc_format_decimal()` strings with varying
+	 * precision, so 5, "5" and "5.00" are the same money but three different bytes.
+	 * Collapses them to one representation. Non-numeric input is left to
+	 * normalize_cache_string() so a value that is not really a number cannot be
+	 * silently reinterpreted — notably ZIP codes, where "01234" must never become
+	 * "1234".
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param mixed $value Value to normalize.
+	 *
+	 * @return string
+	 */
+	private function normalize_cache_number( $value ): string {
+		if ( ! is_numeric( $value ) ) {
+			return $this->normalize_cache_string( $value );
+		}
+
+		$normalized = number_format( (float) $value, 6, '.', '' );
+
+		if ( false !== strpos( $normalized, '.' ) ) {
+			$normalized = rtrim( rtrim( $normalized, '0' ), '.' );
+		}
+
+		// rtrim() eats the whole string for 0.000000, and -0 is still 0.
+		if ( '' === $normalized || '-' === $normalized || '-0' === $normalized ) {
+			$normalized = '0';
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Build the cache signature for a TaxJar request body.
+	 *
+	 * Hashing the raw JSON makes the cache byte-sensitive: a differently-cased city,
+	 * a stray double space in a street address or "5" versus "5.00" for the same
+	 * price all miss a cache entry that would have answered correctly. This projects
+	 * the body onto a canonical form first — whitespace and case folded, amounts
+	 * given one representation, key order fixed, line items sorted — so equivalent
+	 * requests share one entry.
+	 *
+	 * Only the cache key is derived from this. The body sent to TaxJar is untouched.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param string $json Encoded TaxJar request body.
+	 *
+	 * @return string Canonical signature, or the input unchanged if it will not decode.
+	 */
+	private function get_cache_signature( $json ): string {
+		$body = json_decode( (string) $json, true );
+
+		if ( ! is_array( $body ) ) {
+			return (string) $json;
+		}
+
+		return (string) wp_json_encode( $this->canonicalize_cache_payload( $body ) );
+	}
+
+	/**
+	 * Recursively canonicalize a request body for cache-key derivation.
+	 *
+	 * Numeric normalization is applied by field name rather than by looking at the
+	 * value, because several address fields hold digit-only strings that must keep
+	 * their exact form (a leading-zero ZIP above all).
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param mixed  $value Value to canonicalize.
+	 * @param string $key   Key the value was found under.
+	 *
+	 * @return mixed
+	 */
+	private function canonicalize_cache_payload( $value, $key = '' ) {
+		$numeric_fields = array( 'amount', 'shipping', 'quantity', 'unit_price', 'discount' );
+
+		if ( is_array( $value ) ) {
+			$canonical = array();
+
+			foreach ( $value as $child_key => $child_value ) {
+				$canonical[ $child_key ] = $this->canonicalize_cache_payload( $child_value, (string) $child_key );
+			}
+
+			if ( wp_is_numeric_array( $canonical ) ) {
+				// Lists (line items, nexus addresses) carry no meaning in their order,
+				// so sort them to keep the signature independent of how they were built.
+				usort(
+					$canonical,
+					function ( $first, $second ) {
+						return strcmp( (string) wp_json_encode( $first ), (string) wp_json_encode( $second ) );
+					}
+				);
+			} else {
+				ksort( $canonical );
+			}
+
+			return $canonical;
+		}
+
+		if ( in_array( $key, $numeric_fields, true ) ) {
+			return $this->normalize_cache_number( $value );
+		}
+
+		return $this->normalize_cache_string( $value );
 	}
 
 	/**
@@ -1173,7 +1365,7 @@ class WC_Connect_TaxJar_Integration {
 		$product_id = $product->get_id();
 
 		// Find the matching line_item_key in response_rate_ids.
-		// Format is "product_id-cart_item_key". The trailing "-" delimiter prevents
+		// Format is "product_id-fingerprint-occurrence". The trailing "-" delimiter prevents
 		// false prefix matches (e.g. product ID 1 won't match "10-xyz" because "1-" != "10").
 		// First-match-wins is safe: if the same product ID appears multiple times (e.g.
 		// two bookings), they share the same tax_location and thus the same tax rates.
@@ -1240,7 +1432,7 @@ class WC_Connect_TaxJar_Integration {
 			return;
 		}
 
-		// Find matching rate_ids by product_id prefix (format: "product_id-cart_item_key").
+		// Find matching rate_ids by product_id prefix (format: "product_id-fingerprint-occurrence").
 		// The trailing "-" delimiter prevents false prefix matches between IDs (e.g. 1 vs 10).
 		// First-match-wins is safe: same product always shares the same tax_location and rates.
 		$matching_rate_ids = null;
@@ -1709,7 +1901,9 @@ class WC_Connect_TaxJar_Integration {
 		if ( empty( $line_items ) ) {
 			$body['amount'] = 0.01;
 		} else {
-			$body['line_items'] = $line_items;
+			// Line items arrive keyed by cart item key / order item ID; TaxJar expects a
+			// JSON array, and a string-keyed PHP array would encode as an object.
+			$body['line_items'] = array_values( $line_items );
 		}
 
 		$response = $this->smartcalcs_cache_request( wp_json_encode( $body ), $from_state );
@@ -2113,7 +2307,8 @@ class WC_Connect_TaxJar_Integration {
 	/**
 	 * Wrap SmartCalcs API requests in a transient-based caching layer.
 	 *
-	 * Unchanged from the TaxJar plugin.
+	 * Based on the TaxJar plugin. The cache key is derived from a canonical
+	 * projection of the body rather than its raw bytes — see get_cache_signature().
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L451
 	 *
 	 * @param $json
@@ -2122,7 +2317,7 @@ class WC_Connect_TaxJar_Integration {
 	 * @return mixed|WP_Error
 	 */
 	public function smartcalcs_cache_request( $json, $from_state ) {
-		$cache_key           = 'tj_tax_' . hash( 'md5', $json );
+		$cache_key           = 'tj_tax_' . hash( 'md5', $this->get_cache_signature( $json ) );
 		$zip_state_cache_key = false;
 		$request             = json_decode( $json );
 		$to_zip              = isset( $request->to_zip ) ? (string) $request->to_zip : false;

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1065,7 +1065,20 @@ class WC_Connect_TaxJar_Integration {
 			);
 		}
 
-		return $this->assign_canonical_line_item_ids( $line_items );
+		$line_items = $this->assign_canonical_line_item_ids( $line_items );
+
+		// The exempt record was keyed while ids were still context-specific; move it onto
+		// the canonical ids, which is what get_itemized_tax_rates() looks up.
+		$non_taxable = array();
+		foreach ( array_keys( $this->non_taxable_line_items ) as $legacy_key ) {
+			$item_key = substr( $legacy_key, (int) strpos( $legacy_key, '-' ) + 1 );
+			if ( isset( $line_items[ $item_key ] ) ) {
+				$non_taxable[ $line_items[ $item_key ]['id'] ] = true;
+			}
+		}
+		$this->non_taxable_line_items = $non_taxable;
+
+		return $line_items;
 	}
 
 	/**
@@ -1136,7 +1149,21 @@ class WC_Connect_TaxJar_Integration {
 				);
 			}
 		}
-		return $this->assign_canonical_line_item_ids( $line_items );
+
+		$line_items = $this->assign_canonical_line_item_ids( $line_items );
+
+		// The exempt record was keyed while ids were still context-specific; move it onto
+		// the canonical ids, which is what get_itemized_tax_rates() looks up.
+		$non_taxable = array();
+		foreach ( array_keys( $this->non_taxable_line_items ) as $legacy_key ) {
+			$item_key = substr( $legacy_key, (int) strpos( $legacy_key, '-' ) + 1 );
+			if ( isset( $line_items[ $item_key ] ) ) {
+				$non_taxable[ $line_items[ $item_key ]['id'] ] = true;
+			}
+		}
+		$this->non_taxable_line_items = $non_taxable;
+
+		return $line_items;
 	}
 
 	protected function get_line_item( $id, $line_items ) {

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,7 @@ This plugin relies on the following external services:
 * Fix   - Calculate tax correctly for carts mixing taxable and non-taxable products, so a non-taxable product no longer resets the standard tax rate to zero.
 * Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
 * Tweak - Store tax rate rows against the postcode the rate was quoted for when the address postcode holds more than one comma-separated value.
+* Tweak - Reduce redundant TaxJar API calls by matching cached tax responses across the cart and order paths and ignoring irrelevant formatting differences.
 
 = 3.6.11 - 2026-08-05 =
 * Fix   - Prevent a fatal error during cart and checkout tax calculation when TaxJar returns an incomplete tax response.
@@ -91,7 +92,6 @@ This plugin relies on the following external services:
 
 = 3.6.10 - 2026-07-27 =
 * Tweak - WooCommerce 11.0 Compatibility.
-* Tweak - Reduce redundant TaxJar API calls by matching cached tax responses across the cart and order paths and ignoring irrelevant formatting differences.
 
 = 3.6.9 - 2026-07-20 =
 * Fix   - Prevent a rare fatal error when the WooCommerce Store API cannot be initialized on incomplete installations.

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,7 @@ This plugin relies on the following external services:
 
 = 3.6.10 - 2026-07-27 =
 * Tweak - WooCommerce 11.0 Compatibility.
+* Tweak - Reduce redundant TaxJar API calls by matching cached tax responses across the cart and order paths and ignoring irrelevant formatting differences.
 
 = 3.6.9 - 2026-07-20 =
 * Fix   - Prevent a rare fatal error when the WooCommerce Store API cannot be initialized on incomplete installations.

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -182,11 +182,14 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$this->assertNotEmpty( $line_items );
 		$this->assertCount( 1, $line_items );
 
+		// Line items are keyed by cart item key, so take the first value.
+		$first_item = reset( $line_items );
+
 		// Assert tax_location key exists.
-		$this->assertArrayHasKey( 'tax_location', $line_items[0] );
+		$this->assertArrayHasKey( 'tax_location', $first_item );
 
 		// Default should be 'shipping' (the WooCommerce default).
-		$this->assertEquals( 'shipping', $line_items[0]['tax_location'] );
+		$this->assertEquals( 'shipping', $first_item['tax_location'] );
 	}
 
 	/**
@@ -207,7 +210,8 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$line_items = $this->invoke_protected_method( 'get_line_items', array( WC()->cart ) );
 
 		// Assert tax_location uses billing.
-		$this->assertEquals( 'billing', $line_items[0]['tax_location'] );
+		$first_item = reset( $line_items );
+		$this->assertEquals( 'billing', $first_item['tax_location'] );
 
 		// Clean up option.
 		delete_option( 'woocommerce_tax_based_on' );
@@ -238,7 +242,8 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$line_items = $this->invoke_protected_method( 'get_line_items', array( WC()->cart ) );
 
 		// Assert filter overrode the location.
-		$this->assertEquals( 'base', $line_items[0]['tax_location'] );
+		$first_item = reset( $line_items );
+		$this->assertEquals( 'base', $first_item['tax_location'] );
 	}
 
 	/**
@@ -313,7 +318,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		// Assert we have 2 line items.
 		$this->assertCount( 2, $line_items );
 
-		// Find items by product ID (they're in format "product_id-cart_key").
+		// Find items by product ID (they're in format "product_id-fingerprint-occurrence").
 		$item_a = null;
 		$item_b = null;
 		foreach ( $line_items as $item ) {
@@ -428,7 +433,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		// Assert structure.
 		$this->assertCount( 1, $line_items );
 
-		$item = $line_items[0];
+		$item = reset( $line_items );
 		$this->assertArrayHasKey( 'id', $item );
 		$this->assertArrayHasKey( 'quantity', $item );
 		$this->assertArrayHasKey( 'product_tax_code', $item );
@@ -4001,5 +4006,320 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$order->delete( true );
 		WC_Helper_Product::delete_product( $taxable_id );
 		WC_Helper_Product::delete_product( $shipping_only_id );
+	}
+
+	/**
+	 * The cart path must key its return value by cart item key.
+	 *
+	 * calculate_totals() looks the canonical ID up by cart item key to decide which
+	 * products to mark non-taxable, so this is a contract, not an implementation
+	 * detail. Regression for WOOTAX-258.
+	 */
+	public function test_get_line_items_is_keyed_by_cart_item_key() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( '10.00' );
+		$product->save();
+
+		$cart_item_key = WC()->cart->add_to_cart( $product->get_id(), 2 );
+		WC()->cart->calculate_totals();
+
+		$line_items = $this->invoke_protected_method( 'get_line_items', array( WC()->cart ) );
+
+		$this->assertArrayHasKey( $cart_item_key, $line_items );
+		$this->assertNotEquals( $cart_item_key, $line_items[ $cart_item_key ]['id'], 'The id must be the canonical TaxJar id, not the cart item key.' );
+	}
+
+	/**
+	 * The same basket must produce the same TaxJar line item id whether it was built
+	 * from the cart or from a saved order.
+	 *
+	 * This is the substance of WOOTAX-258: the cart path used to emit
+	 * "<product>-<cart item key>" and the order path "<product>-<order item id>", so
+	 * the two request bodies never hashed alike and the admin order-save path always
+	 * missed the transient cache written at checkout.
+	 */
+	public function test_canonical_line_item_id_matches_across_cart_and_order_paths() {
+		// Taxes must be on: the cart path routes the tax code through is_taxable(),
+		// which is false whenever taxes are globally disabled, while the order path
+		// reads get_tax_status() directly. With taxes off the two paths disagree on
+		// product_tax_code — but TaxJar is never called then either.
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( '10.00' );
+		$product->save();
+
+		WC()->cart->add_to_cart( $product->get_id(), 2 );
+		WC()->cart->calculate_totals();
+		$cart_line_items = $this->invoke_protected_method( 'get_line_items', array( WC()->cart ) );
+
+		$order = new WC_Order();
+		$item  = new WC_Order_Item_Product();
+		$item->set_product( $product );
+		$item->set_quantity( 2 );
+		$item->set_subtotal( 20 );
+		$item->set_total( 20 );
+		$order->add_item( $item );
+		$order->save();
+
+		$order_line_items = $this->invoke_protected_method( 'get_backend_line_items', array( $order ) );
+
+		$cart_item  = reset( $cart_line_items );
+		$order_item = reset( $order_line_items );
+
+		$this->assertNotFalse( $cart_item );
+		$this->assertNotFalse( $order_item );
+		$this->assertSame(
+			$cart_item['id'],
+			$order_item['id'],
+			'Cart and order paths produced different TaxJar line item ids for the same product, quantity and price — the order path will always miss the cache.'
+		);
+
+		delete_option( 'woocommerce_calc_taxes' );
+	}
+
+	/**
+	 * Two order lines that are identical in every tax-relevant respect must still
+	 * receive distinct ids, or the second silently overwrites the first in the
+	 * response map and loses its rate.
+	 */
+	public function test_canonical_line_item_id_distinguishes_identical_lines() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( '10.00' );
+		$product->save();
+
+		$order = new WC_Order();
+		foreach ( array( 1, 2 ) as $unused ) {
+			$item = new WC_Order_Item_Product();
+			$item->set_product( $product );
+			$item->set_quantity( 1 );
+			$item->set_subtotal( 10 );
+			$item->set_total( 10 );
+			$order->add_item( $item );
+		}
+		$order->save();
+
+		$line_items = $this->invoke_protected_method( 'get_backend_line_items', array( $order ) );
+		$ids        = wp_list_pluck( $line_items, 'id' );
+
+		$this->assertCount( 2, $ids );
+		$this->assertCount( 2, array_unique( $ids ), 'Two identical order lines collapsed onto one TaxJar line item id.' );
+	}
+
+	/**
+	 * get_itemized_tax_rates() recovers the product with explode( '-', $key )[0], and
+	 * override_cart_item_tax_rates() matches on the "<product_id>-" prefix, so the
+	 * product ID has to stay the first segment of the canonical id.
+	 */
+	public function test_canonical_line_item_id_keeps_product_id_prefix() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( '10.00' );
+		$product->save();
+
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		$line_items = $this->invoke_protected_method( 'get_line_items', array( WC()->cart ) );
+		$item       = reset( $line_items );
+		$chunks     = explode( '-', $item['id'] );
+
+		$this->assertEquals( $product->get_id(), $chunks[0] );
+		$this->assertSame( 0, strpos( $item['id'], $product->get_id() . '-' ) );
+	}
+
+	/**
+	 * Build a representative TaxJar request body for cache-signature tests.
+	 *
+	 * @param array $overrides Values to replace.
+	 *
+	 * @return string Encoded body.
+	 */
+	private function get_taxjar_request_body( $overrides = array() ) {
+		$body = array_merge(
+			array(
+				'from_country' => 'US',
+				'from_state'   => 'CA',
+				'from_zip'     => '90210',
+				'from_city'    => 'Beverly Hills',
+				'from_street'  => '1 Main St',
+				'to_country'   => 'US',
+				'to_state'     => 'CA',
+				'to_zip'       => '90210',
+				'to_city'      => 'Beverly Hills',
+				'to_street'    => '2 Other St',
+				'shipping'     => '5.00',
+				'plugin'       => 'woo',
+				'line_items'   => array(
+					array(
+						'id'               => '42-abc123def456-0',
+						'quantity'         => 2,
+						'product_tax_code' => '',
+						'unit_price'       => '10.00',
+						'discount'         => '0',
+						'tax_location'     => 'shipping',
+					),
+				),
+			),
+			$overrides
+		);
+
+		return wp_json_encode( $body );
+	}
+
+	/**
+	 * Case and whitespace differences in the address must not split the cache.
+	 *
+	 * Raised by Sam Najian on WOOTAX-258: the key was an md5 of the raw JSON, so
+	 * "Beverly Hills" and "beverly hills" were two entries for one answer.
+	 */
+	public function test_cache_signature_ignores_address_case_and_whitespace() {
+		$baseline_body = $this->get_taxjar_request_body();
+		$variant_body  = $this->get_taxjar_request_body(
+			array(
+				'to_city'   => ' beverly  hills ',
+				'to_street' => '2 other st',
+			)
+		);
+
+		// Baseline: these bodies are not byte-identical, so hashing the raw JSON —
+		// what the plugin did before — produced two cache entries.
+		$this->assertNotSame( $baseline_body, $variant_body );
+
+		$baseline = $this->invoke_protected_method( 'get_cache_signature', array( $baseline_body ) );
+		$variant  = $this->invoke_protected_method( 'get_cache_signature', array( $variant_body ) );
+
+		$this->assertSame( $baseline, $variant );
+	}
+
+	/**
+	 * Amounts reach the body as wc_format_decimal() strings of varying precision, so
+	 * the same money must not hash differently.
+	 */
+	public function test_cache_signature_ignores_amount_formatting() {
+		$baseline_body = $this->get_taxjar_request_body();
+		$variant_body  = $this->get_taxjar_request_body(
+			array(
+				'shipping'   => 5,
+				'line_items' => array(
+					array(
+						'id'               => '42-abc123def456-0',
+						'quantity'         => '2',
+						'product_tax_code' => '',
+						'unit_price'       => 10,
+						'discount'         => '0.000',
+						'tax_location'     => 'shipping',
+					),
+				),
+			)
+		);
+
+		// Baseline: byte-different, so the raw-JSON key missed.
+		$this->assertNotSame( $baseline_body, $variant_body );
+
+		$baseline = $this->invoke_protected_method( 'get_cache_signature', array( $baseline_body ) );
+		$variant  = $this->invoke_protected_method( 'get_cache_signature', array( $variant_body ) );
+
+		$this->assertSame( $baseline, $variant );
+	}
+
+	/**
+	 * Line item order carries no meaning, and the cart and order paths do not
+	 * necessarily iterate in the same order.
+	 */
+	public function test_cache_signature_ignores_line_item_order() {
+		$first  = array(
+			'id'               => '42-aaaaaaaaaaaa-0',
+			'quantity'         => 1,
+			'product_tax_code' => '',
+			'unit_price'       => '10.00',
+			'discount'         => '0',
+			'tax_location'     => 'shipping',
+		);
+		$second = array(
+			'id'               => '43-bbbbbbbbbbbb-0',
+			'quantity'         => 1,
+			'product_tax_code' => '',
+			'unit_price'       => '20.00',
+			'discount'         => '0',
+			'tax_location'     => 'shipping',
+		);
+
+		$baseline_body = $this->get_taxjar_request_body( array( 'line_items' => array( $first, $second ) ) );
+		$reversed_body = $this->get_taxjar_request_body( array( 'line_items' => array( $second, $first ) ) );
+
+		// Baseline: byte-different, so the raw-JSON key missed.
+		$this->assertNotSame( $baseline_body, $reversed_body );
+
+		$baseline = $this->invoke_protected_method( 'get_cache_signature', array( $baseline_body ) );
+		$reversed = $this->invoke_protected_method( 'get_cache_signature', array( $reversed_body ) );
+
+		$this->assertSame( $baseline, $reversed );
+	}
+
+	/**
+	 * A leading-zero ZIP must never be treated as a number — "01234" and "1234" are
+	 * different places and must not share a cached tax response.
+	 */
+	public function test_cache_signature_preserves_leading_zero_zip() {
+		$padded = $this->invoke_protected_method( 'get_cache_signature', array( $this->get_taxjar_request_body( array( 'to_zip' => '01234' ) ) ) );
+		$bare   = $this->invoke_protected_method( 'get_cache_signature', array( $this->get_taxjar_request_body( array( 'to_zip' => '1234' ) ) ) );
+
+		$this->assertNotSame( $padded, $bare );
+	}
+
+	/**
+	 * Normalization must not become over-collapsing: anything that can change the
+	 * tax owed still has to produce a fresh API call.
+	 *
+	 * @dataProvider provide_cache_signature_distinguishing_changes
+	 *
+	 * @param array $overrides Body values that differ from the baseline.
+	 */
+	public function test_cache_signature_changes_when_tax_relevant_input_changes( $overrides ) {
+		$baseline = $this->invoke_protected_method( 'get_cache_signature', array( $this->get_taxjar_request_body() ) );
+		$variant  = $this->invoke_protected_method( 'get_cache_signature', array( $this->get_taxjar_request_body( $overrides ) ) );
+
+		$this->assertNotSame( $baseline, $variant );
+	}
+
+	/**
+	 * Body changes that must each invalidate the cache.
+	 *
+	 * @return array
+	 */
+	public function provide_cache_signature_distinguishing_changes() {
+		$line_item = array(
+			'id'               => '42-abc123def456-0',
+			'quantity'         => 2,
+			'product_tax_code' => '',
+			'unit_price'       => '10.00',
+			'discount'         => '0',
+			'tax_location'     => 'shipping',
+		);
+
+		return array(
+			'destination zip'   => array( array( 'to_zip' => '10001' ) ),
+			'destination state' => array( array( 'to_state' => 'NY' ) ),
+			'origin zip'        => array( array( 'from_zip' => '10001' ) ),
+			'shipping amount'   => array( array( 'shipping' => '7.00' ) ),
+			'quantity'          => array( array( 'line_items' => array( array_merge( $line_item, array( 'quantity' => 3 ) ) ) ) ),
+			'unit price'        => array( array( 'line_items' => array( array_merge( $line_item, array( 'unit_price' => '11.00' ) ) ) ) ),
+			'discount'          => array( array( 'line_items' => array( array_merge( $line_item, array( 'discount' => '2.00' ) ) ) ) ),
+			'tax code'          => array( array( 'line_items' => array( array_merge( $line_item, array( 'product_tax_code' => '99999' ) ) ) ) ),
+			'tax location'      => array( array( 'line_items' => array( array_merge( $line_item, array( 'tax_location' => 'base' ) ) ) ) ),
+			'extra line item'   => array( array( 'line_items' => array( $line_item, array_merge( $line_item, array( 'id' => '43-bbbbbbbbbbbb-0' ) ) ) ) ),
+		);
+	}
+
+	/**
+	 * A body that will not decode must fall back to hashing the raw string rather
+	 * than collapsing every malformed request onto one cache entry.
+	 */
+	public function test_cache_signature_falls_back_for_undecodable_body() {
+		$signature = $this->invoke_protected_method( 'get_cache_signature', array( 'not json' ) );
+		$other     = $this->invoke_protected_method( 'get_cache_signature', array( 'also not json' ) );
+
+		$this->assertSame( 'not json', $signature );
+		$this->assertNotSame( $signature, $other );
 	}
 }

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -4322,4 +4322,150 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$this->assertSame( 'not json', $signature );
 		$this->assertNotSame( $signature, $other );
 	}
+
+	// -------------------------------------------------------------------------
+	// Encoded request body and cache-hit tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * calculate_backend_totals() hands calculate_tax() the order-item-ID-keyed map
+	 * from get_backend_line_items() without re-indexing it, so array_values() in
+	 * calculate_tax() is the only thing keeping 'line_items' a JSON array. A
+	 * string-keyed PHP array encodes as a JSON object, which TaxJar would reject —
+	 * silently, on every admin-side request.
+	 */
+	public function test_calculate_tax_encodes_keyed_line_items_as_json_list() {
+		$captured = null;
+
+		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'smartcalcs_cache_request', 'get_store_settings', '_log' ) )
+			->getMock();
+
+		// Same state as the destination below, so the cross-state guard does not return early.
+		$integration->method( 'get_store_settings' )->willReturn(
+			array(
+				'country'  => 'US',
+				'state'    => 'CA',
+				'postcode' => '94110',
+				'city'     => 'San Francisco',
+				'street'   => '1 Main St',
+			)
+		);
+
+		$integration->method( 'smartcalcs_cache_request' )->willReturnCallback(
+			function ( $json ) use ( &$captured ) {
+				$captured = $json;
+				// The encoded body is all this test needs; bail before any HTTP work.
+				return false;
+			}
+		);
+
+		WC()->customer->set_is_vat_exempt( false );
+
+		$integration->calculate_tax(
+			array(
+				'to_country'      => 'US',
+				'to_state'        => 'CA',
+				'to_zip'          => '94110',
+				'to_city'         => 'San Francisco',
+				'to_street'       => '2 Other St',
+				'shipping_amount' => 0,
+				// Keyed by order item ID, exactly as get_backend_line_items() returns it.
+				'line_items'      => array(
+					'12' => array(
+						'id'         => '42-abc123def456-0',
+						'quantity'   => 1,
+						'unit_price' => '25.00',
+					),
+					'34' => array(
+						'id'         => '43-bbbbbbbbbbbb-0',
+						'quantity'   => 2,
+						'unit_price' => '10.00',
+					),
+				),
+			)
+		);
+
+		$this->assertNotNull( $captured, 'calculate_tax() returned before encoding a request body.' );
+
+		$decoded = json_decode( $captured, true );
+
+		$this->assertArrayHasKey( 'line_items', $decoded );
+		// A JSON object would decode to keys '12' and '34' instead.
+		$this->assertSame( array( 0, 1 ), array_keys( $decoded['line_items'] ) );
+		$this->assertSame( '42-abc123def456-0', $decoded['line_items'][0]['id'] );
+		$this->assertSame( '43-bbbbbbbbbbbb-0', $decoded['line_items'][1]['id'] );
+		// Assert on the raw JSON too, since json_decode() hides the array/object distinction.
+		$this->assertStringContainsString( '"line_items":[{', $captured );
+	}
+
+	/**
+	 * The point of the canonical signature: two bodies that differ only in
+	 * formatting must share one cache entry, so the second request never reaches
+	 * the API. Exercises smartcalcs_cache_request() end to end rather than
+	 * comparing get_cache_signature() outputs in isolation.
+	 */
+	public function test_smartcalcs_cache_request_serves_equivalent_bodies_from_one_entry() {
+		$call_count = 0;
+
+		$api_client = $this->getMockBuilder( 'WC_Connect_API_Client' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$logger = $this->getMockBuilder( 'WC_Connect_Logger' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$tracks = $this->getMockBuilder( 'WC_Connect_Tracks' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		// Real notifier: clear_notices() is static (so it cannot be stubbed) and is a
+		// no-op without a WC session, which the unit-test context does not set up.
+		$notifier = new Automattic\WCServices\StoreNotices\StoreNoticesNotifier( false );
+
+		// Real constructor, so cache_time is populated and the transient is written with it.
+		$integration = $this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )
+			->setConstructorArgs( array( $api_client, $logger, 'https://example.com', $tracks, $notifier ) )
+			->onlyMethods( array( 'smartcalcs_request' ) )
+			->getMock();
+
+		$api_response = array(
+			'response' => array( 'code' => 200 ),
+			'body'     => wp_json_encode( array( 'tax' => array( 'amount_to_collect' => 2.5 ) ) ),
+		);
+
+		$integration->method( 'smartcalcs_request' )->willReturnCallback(
+			function () use ( &$call_count, $api_response ) {
+				++$call_count;
+				return $api_response;
+			}
+		);
+
+		$baseline = $this->get_taxjar_request_body();
+		$variant  = $this->get_taxjar_request_body(
+			array(
+				'to_city'  => '  beverly   hills ',
+				'shipping' => '5',
+			)
+		);
+
+		// Documents the pre-fix baseline: without canonicalization these are two cache entries.
+		$this->assertNotSame( $baseline, $variant, 'The two bodies must differ byte-wise or this test proves nothing.' );
+
+		// from_state 'CA' skips the California nexus check on both the fresh and cached path.
+		$first  = $integration->smartcalcs_cache_request( $baseline, 'CA' );
+		$second = $integration->smartcalcs_cache_request( $variant, 'CA' );
+
+		$this->assertSame( 1, $call_count, 'The equivalent second body should have been served from the cache.' );
+		$this->assertEquals( $api_response, $first );
+		$this->assertEquals( $api_response, $second );
+
+		// The hit must come from the signature key, not the zip/state key — that one
+		// only ever caches 400 zip-to-state mismatches and would mask a broken signature.
+		$signature = $this->invoke_protected_method( 'get_cache_signature', array( $baseline ) );
+		$this->assertEquals( $api_response, get_transient( 'tj_tax_' . hash( 'md5', $signature ) ) );
+		$this->assertFalse( get_transient( 'tj_tax_90210_ca' ) );
+	}
 }

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -3862,9 +3862,13 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$recorded   = $this->get_private_property( 'non_taxable_line_items' );
 
 		$this->assertCount( 1, $line_items );
+
+		// get_line_items() keys by cart item key, not position.
+		$line_item = reset( $line_items );
+
 		$this->assertNotSame(
 			'99999',
-			$line_items[0]['product_tax_code'],
+			$line_item['product_tax_code'],
 			'The cart path excludes "Shipping only" from the exempt branch, so it is sent to TaxJar as taxable.'
 		);
 		$this->assertSame(
@@ -3897,15 +3901,19 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$recorded   = $this->get_private_property( 'non_taxable_line_items' );
 
 		$this->assertCount( 1, $line_items );
+
+		// get_line_items() keys by cart item key, not position.
+		$line_item = reset( $line_items );
+
 		$this->assertSame(
 			'99999',
-			$line_items[0]['product_tax_code'],
+			$line_item['product_tax_code'],
 			'A "None" product is still emitted as exempt on the cart path.'
 		);
 		$this->assertArrayHasKey(
-			$line_items[0]['id'],
+			$line_item['id'],
 			$recorded,
-			'A line emitted as exempt must stay recorded, or its 0% rate overwrites the shared Standard row.'
+			'A line emitted as exempt must stay recorded under its canonical id, or its 0% rate overwrites the shared Standard row.'
 		);
 
 		WC()->cart->empty_cart();
@@ -3931,9 +3939,13 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$line_items = $this->invoke_protected_method( 'get_backend_line_items', array( $order ) );
 
 		$this->assertCount( 1, $line_items );
+
+		// get_backend_line_items() keys by order item ID, not position.
+		$line_item = reset( $line_items );
+
 		$this->assertSame(
 			'99999',
-			$line_items[0]['product_tax_code'],
+			$line_item['product_tax_code'],
 			'A "Shipping only" product must be sent to TaxJar as exempt on the backend order path.'
 		);
 


### PR DESCRIPTION
## Description

The TaxJar transient cache key was an md5 of the raw request body, so two requests that
would receive the same answer from TaxJar routinely missed each other. Two independent
causes, fixed together.

**1. The line item `id` was context-specific.** `get_line_items()` built it from
WooCommerce's cart item key, `get_backend_line_items()` from the numeric order item ID, so
the same basket produced two different bodies and the order path missed every time. Both
builders now derive `id` from the tax-relevant inputs alone — product, tax code, quantity,
unit price, discount, tax location — as `<product_id>-<fingerprint>-<occurrence>`. TaxJar
treats `id` as an opaque echo field, so nothing about the request semantics changes. The
occurrence counter keeps two genuinely identical order lines distinct so neither loses its
rate. The product ID stays the first `-` segment, which `get_itemized_tax_rates()`,
`override_cart_item_tax_rates()` and `override_order_item_taxes()` all depend on.

**2. The key was byte-sensitive.** A differently-cased city, a stray double space, or `"5"`
versus `"5.00"` each split the cache. The key now comes from a canonical projection of the
body — whitespace collapsed, case folded, amounts given one representation, object keys
sorted, lists sorted. **The body sent to TaxJar is unchanged**; only key derivation moved.
Numeric normalization is applied by field name rather than by sniffing values, specifically
so a leading-zero ZIP is never reinterpreted (`01234` must not collapse onto `1234`).

### Reviewer notes

- `get_line_items()` and `get_backend_line_items()` now return arrays **keyed by cart item
  key / order item ID** instead of lists, because `calculate_totals()` and
  `calculate_backend_totals()` need to get from their own key to the canonical one.
  `calculate_tax()` gained an `array_values()` so the body still encodes as a JSON array
  rather than an object.
- `get_line_item()` needed no change — it already searched by `['id']`.
- **Known conflict:** `tests/php/test-class-wc-connect-taxjar-integration.php` conflicts at
  the trailing append point with anything else that appends tests to the same class. No
  logic overlaps — resolution is "keep all blocks".
  - #2978 is **resolved**: merged to trunk on 2026-07-27 and merged into this branch, with
    both blocks kept. Suite green at 247 afterwards.
  - #2979 is still open and will conflict the same way. Same resolution applies. The class
    file, `changelog.txt` and `readme.txt` all auto-merge with it.
- **Out of scope, raised separately:** the two builders disagree on `product_tax_code` in
  two independent, pre-existing ways. Both would need a payload change to fix, so neither
  belongs in a caching PR.
  1. **Zero-rate tax classes** (WOOTAX-309): the cart routes the decision through
     `is_taxable()`, the order path reads `get_tax_status()`.
  2. **Multi-word tax class names** (WOOTAX-320): the cart takes the *last* `-` segment
     (`is_numeric( end( $parts ) )`), the order path takes the *second*
     (`is_numeric( $parts[1] )`). The order rule only holds when the class name is exactly
     one word, so it breaks on any slug with an internal hyphen.

     An earlier revision of this description called this "three or more segments", which
     understated it — the trigger is any tax class whose **display name is more than one
     word**, including WooCommerce's built-in *Reduced rate* and *Zero rate*:

     | `tax_class` slug | cart | order | |
     |---|---|---|---|
     | `standard-12345` | `12345` | `12345` | ✓ |
     | `clothing-40030` | `40030` | `40030` | ✓ |
     | `reduced-rate-12345` | `12345` | `""` | ✗ |
     | `zero-rate-99999` | `99999` | `""` | ✗ |
     | `digital-goods-31000` | `31000` | `""` | ✗ |

     Filed as WOOTAX-320, and it is **worse than a cache miss**: the order path sends no
     product tax code at all, so TaxJar prices that request at the general rate. Where the
     code carries a category exemption or reduced rate, an admin order recalculation can
     return a different figure than the customer was charged. Pre-existing since 2017
     (`706c6b10` / `78114e8a`), untouched by this PR.

  Consequence for this PR: cross-path cache hits are **not** achieved for zero-rate items,
  nor for stores whose tax class display name is more than one word. Every other store gets
  the full benefit.

### Backward compatibility

Two `protected` methods on `WC_Connect_TaxJar_Integration` change shape. The class is in the
global namespace, so per our BC policy these count as externally exposed even though nothing
in this repo subclasses it.

| Surface | Before | After |
|---|---|---|
| `get_line_items()` / `get_backend_line_items()` return value | list (`0..n`) | map keyed by cart item key / order item ID |
| line item `id` format | `<product_id>-<cart_key_or_item_id>` | `<product_id>-<fingerprint>-<occurrence>` |

**Who could notice:** a subclass that overrides either method and indexes the parent result
positionally (`parent::get_line_items()[0]`), or any code that parses `id` past the product
prefix to recover a cart key or order item ID.

**Why it is judged low risk:** the `<product_id>-` prefix is unchanged, which is the only
part of `id` that this plugin's own consumers (`get_itemized_tax_rates()`,
`override_cart_item_tax_rates()`, `override_order_item_taxes()`) rely on. `array_values()` in
`calculate_tax()` keeps the outgoing request body a JSON array, so the wire format TaxJar
sees is unchanged. No public method signature, hook, or hook argument is added, removed, or
reordered.

**Not deprecation-eligible:** these are return-shape changes inside existing methods, not
renames, so there is no old symbol to keep alive alongside a new one. Flagging rather than
deprecating is the available path here.

### Related issue(s)

[WOOTAX-258](https://linear.app/a8c/issue/WOOTAX-258/optimize-cache-taxjar-api-responses-to-avoid-redundant-calls-during)

### Steps to reproduce & screenshots/GIFs

Watch `smartcalcs_request()` — that is the only method that makes a real API call.
`maybe_calculate_totals()` call counts are not a useful metric, since it early-returns in
most contexts.

**Cache now hits (fails on trunk):**

1. Enable automated taxes with a US store address.
2. Add a product to the cart and complete checkout. Note one `smartcalcs_request()` call.
3. Within the hour (`cache_time = HOUR_IN_SECONDS`), open the order in wp-admin and save
   the order items. **Before:** a second API call. **After:** no second call.
4. Re-enter the same destination address with different casing or an extra internal space.
   **Before:** a fresh API call. **After:** served from cache.

**Must still miss the cache (regression check):**

5. Change the destination ZIP, the state, the quantity, or apply a coupon that changes the
   discount. Each must produce a fresh `smartcalcs_request()` call.
6. Confirm calculated tax totals and per-line rate assignment are identical to trunk in
   every case above, including a mixed cart with a non-taxable item and a two-location
   cart (WOOTAX-250 grouping).
7. An order holding the same product twice at the same price — both lines must receive
   their own rate.

**Automated:** `composer test` → 247 tests, 532 assertions, green (measured after merging
`trunk`, so the total includes #2978). This PR adds 12 test methods to
`tests/php/test-class-wc-connect-taxjar-integration.php` (62 → 74 versus trunk), which data
providers expand to 21 PHPUnit cases. The three "normalization ignores X" tests each first
assert the two raw bodies are *not* byte-identical, so they document the pre-fix baseline
and cannot pass vacuously. PHPCS reports 0 new violations on the changed files, verified by
diffing `--report=json` against the trunk version rather than reading the report.

Two of those close gaps raised in review — both cover paths where a regression would be
silent rather than loud:

- `test_calculate_tax_encodes_keyed_line_items_as_json_list` captures the encoded body and
  asserts `line_items` is a zero-indexed list. `calculate_backend_totals()` passes the
  order-item-ID-keyed map straight through without `group_items_by_location()` re-indexing
  it, so `array_values()` is the only thing preventing a JSON object on every admin-side
  request — and the pre-existing `calculate_tax()` test returns at the cross-state guard
  before reaching it. The assertion checks the raw JSON as well as the decoded array,
  because `json_decode()` hides the array/object distinction.
- `test_smartcalcs_cache_request_serves_equivalent_bodies_from_one_entry` exercises the
  PR's central claim end to end: two equivalent-but-byte-different bodies, one
  `smartcalcs_request()` invocation. It asserts specifically on the
  `tj_tax_<md5(signature)>` transient *and* on the absence of the `tj_tax_<zip>_<state>`
  key — that second key only ever caches 400 zip-to-state mismatches, and asserting on
  call count alone would let it mask a broken signature.

Both were verified to fail against deliberately mutated guards (`array_values()` removed;
`get_cache_signature()` reverted to returning the raw body) rather than assumed to be
meaningful because they pass.

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added


