### PR TITLE
[WOOTAX-313] Refactor - Migrate the TaxJar read seam onto the Address value object

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,8 @@
 
 = 3.6.12 - 2026-xx-xx =
 * Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
+* Fix   - Restore tax rate lookups for local pickup orders, which could return no rates at all.
+* Fix   - Preserve apostrophes in city and street when taxes are recalculated from the order edit screen.
 
 = 3.6.11 - 2026-08-05 =
 * Fix   - Prevent a fatal error during cart and checkout tax calculation when TaxJar returns an incomplete tax response.

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
 * Fix   - Restore tax rate lookups for local pickup orders, which could return no rates at all.
 * Fix   - Preserve apostrophes in city and street when taxes are recalculated from the order edit screen.
+* Fix   - Prevent a fatal error during cart and checkout tax calculation when a customization supplies an invalid store address.
 
 = 3.6.11 - 2026-08-05 =
 * Fix   - Prevent a fatal error during cart and checkout tax calculation when TaxJar returns an incomplete tax response.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,12 @@
 *** WooCommerce Tax Changelog ***
 
 = 3.6.12 - 2026-xx-xx =
-* Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
 * Fix   - Restore tax rate lookups for local pickup orders, which could return no rates at all.
 * Fix   - Preserve apostrophes in city and street when taxes are recalculated from the order edit screen.
 * Fix   - Prevent a fatal error during cart and checkout tax calculation when a customization supplies an invalid store address.
+* Fix   - Send the same values for empty address fields whether taxes are calculated at checkout or from the order edit screen.
+* Fix   - Ignore array-valued address fields when taxes are recalculated from the order edit screen.
+* Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
 
 = 3.6.11 - 2026-08-05 =
 * Fix   - Prevent a fatal error during cart and checkout tax calculation when TaxJar returns an incomplete tax response.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -446,6 +446,13 @@ class WC_Connect_TaxJar_Integration {
 	 * Modified version of TaxJar's plugin.
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L910
 	 *
+	 * The `taxjar_store_settings` return value is guaranteed to be an array, matching
+	 * this method's documented contract. The filter is public and unguarded, so a
+	 * callback returning null / false / a string would otherwise flow into callers that
+	 * index it — and, since the address value object declares `array $settings`, into an
+	 * uncaught TypeError on every cart and checkout render that resolves a base address.
+	 * A non-array return is treated as "no opinion" and the unfiltered settings are used.
+	 *
 	 * @return array
 	 */
 	public function get_store_settings() {
@@ -457,7 +464,15 @@ class WC_Connect_TaxJar_Integration {
 			'postcode' => WC()->countries->get_base_postcode(),
 		);
 
-		return apply_filters( 'taxjar_store_settings', $store_settings, array() );
+		$filtered = apply_filters( 'taxjar_store_settings', $store_settings, array() );
+
+		if ( ! is_array( $filtered ) ) {
+			$this->_log( 'Warning: the taxjar_store_settings filter returned a non-array value; ignoring it and using the store address.' );
+
+			return $store_settings;
+		}
+
+		return $filtered;
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1328,8 +1328,8 @@ class WC_Connect_TaxJar_Integration {
 	 * plugin's own pipeline whenever the street was empty.
 	 *
 	 * @param array $address Positional taxable-address tuple, four or five elements.
-	 * @return array The same tuple, same length, with the base address substituted for
-	 *               local pickup.
+	 * @return array The tuple with the base address substituted for local pickup,
+	 *               its length clamped to four or five elements to match the input.
 	 */
 	public function append_base_address_to_customer_taxable_address( $address ) {
 		$tax_based_on = '';
@@ -1357,16 +1357,11 @@ class WC_Connect_TaxJar_Integration {
 		$tuple = Address::from_taxable_tuple( array( $country, $state, $postcode, $city, $street ) )->to_taxable_tuple();
 
 		/*
-		 * Return the arity we were handed, rather than a length of our own choosing.
-		 * Deliberately expressed as "preserve the input" and not as "core sends four,
-		 * we send five": this stays correct if a WooCommerce version we did not test
-		 * against fires the filter with a different shape, and it does not depend on
-		 * the plugin's declared minimum WooCommerce version holding.
-		 *
-		 * `$tuple` always has five elements, so `array_slice()` bounds the upper end on
-		 * its own. The only clamp needed is the lower one, which keeps a malformed
-		 * short tuple from being propagated below the four fields every consumer of
-		 * this filter reads.
+		 * Return the arity we were handed, clamped to the two shapes this filter is
+		 * known to carry: four elements (core) or five (this plugin). `$tuple` is
+		 * rebuilt with exactly five elements, so a longer input loses anything past
+		 * the street slot, and a shorter one is padded up to the four fields every
+		 * consumer of this filter reads.
 		 */
 		return array_slice( $tuple, 0, max( 4, $tuple_length ) );
 	}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1338,9 +1338,19 @@ class WC_Connect_TaxJar_Integration {
 
 		$tuple = Address::from_taxable_tuple( array( $country, $state, $postcode, $city, $street ) )->to_taxable_tuple();
 
-		// Return the arity we were handed. Clamped to the two lengths this filter is
-		// ever fired with, so a malformed input tuple cannot propagate its own shape.
-		return array_slice( $tuple, 0, max( 4, min( 5, $tuple_length ) ) );
+		/*
+		 * Return the arity we were handed, rather than a length of our own choosing.
+		 * Deliberately expressed as "preserve the input" and not as "core sends four,
+		 * we send five": this stays correct if a WooCommerce version we did not test
+		 * against fires the filter with a different shape, and it does not depend on
+		 * the plugin's declared minimum WooCommerce version holding.
+		 *
+		 * `$tuple` always has five elements, so `array_slice()` bounds the upper end on
+		 * its own. The only clamp needed is the lower one, which keeps a malformed
+		 * short tuple from being propagated below the four fields every consumer of
+		 * this filter reads.
+		 */
+		return array_slice( $tuple, 0, max( 4, $tuple_length ) );
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -446,12 +446,15 @@ class WC_Connect_TaxJar_Integration {
 	 * Modified version of TaxJar's plugin.
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L910
 	 *
-	 * The `taxjar_store_settings` return value is guaranteed to be an array, matching
-	 * this method's documented contract. The filter is public and unguarded, so a
-	 * callback returning null / false / a string would otherwise flow into callers that
-	 * index it — and, since the address value object declares `array $settings`, into an
-	 * uncaught TypeError on every cart and checkout render that resolves a base address.
-	 * A non-array return is treated as "no opinion" and the unfiltered settings are used.
+	 * The `taxjar_store_settings` return value is guaranteed to be an array carrying
+	 * all five address keys, matching this method's documented contract. The filter is
+	 * public and unguarded, so a callback returning null / false / a string would
+	 * otherwise flow into callers that index it — and, since the address value object
+	 * declares `array $settings`, into an uncaught TypeError on every cart and checkout
+	 * render that resolves a base address. A non-array return is treated as "no
+	 * opinion" and the unfiltered settings are used; keys missing from an array return
+	 * are backfilled from the unfiltered settings, so callers can keep indexing the
+	 * result directly.
 	 *
 	 * @return array
 	 */
@@ -472,7 +475,7 @@ class WC_Connect_TaxJar_Integration {
 			return $store_settings;
 		}
 
-		return $filtered;
+		return array_merge( $store_settings, $filtered );
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -673,6 +673,10 @@ class WC_Connect_TaxJar_Integration {
 	/**
 	 * Get formatted address for tax calculation.
 	 *
+	 * Empty fields come back as `false` rather than `''`. That is the historic shape of
+	 * this array and `Address::to_legacy_options()` is the single place the choice is
+	 * made, so `get_backend_address()` cannot drift away from it.
+	 *
 	 * @param string|null $location_type Location type: 'base', 'shipping', or 'billing'.
 	 *                                   If null, uses default behavior from get_taxable_address().
 	 * @return array Address array with to_country, to_state, etc.
@@ -681,19 +685,7 @@ class WC_Connect_TaxJar_Integration {
 		$taxable_address = $this->get_taxable_address( $location_type );
 		$taxable_address = is_array( $taxable_address ) ? $taxable_address : array();
 
-		$to_country = isset( $taxable_address[0] ) && ! empty( $taxable_address[0] ) ? strtoupper( $taxable_address[0] ) : false;
-		$to_state   = isset( $taxable_address[1] ) && ! empty( $taxable_address[1] ) ? strtoupper( $taxable_address[1] ) : false;
-		$to_zip     = isset( $taxable_address[2] ) && ! empty( $taxable_address[2] ) ? $taxable_address[2] : false;
-		$to_city    = isset( $taxable_address[3] ) && ! empty( $taxable_address[3] ) ? self::normalize_city( $taxable_address[3] ) : false;
-		$to_street  = isset( $taxable_address[4] ) && ! empty( $taxable_address[4] ) ? $taxable_address[4] : false;
-
-		return array(
-			'to_country' => $to_country,
-			'to_state'   => $to_state,
-			'to_zip'     => $to_zip,
-			'to_city'    => $to_city,
-			'to_street'  => $to_street,
-		);
+		return Address::from_taxable_tuple( $taxable_address )->to_legacy_options();
 	}
 
 	/**
@@ -873,6 +865,11 @@ class WC_Connect_TaxJar_Integration {
 	/**
 	 * Get taxable address.
 	 *
+	 * The address is built through {@see Address}, so country/state casing, the
+	 * comma-list postcode split and the city semicolon rules are applied once here
+	 * rather than re-derived by each consumer. The return value stays WooCommerce's
+	 * positional 5-tuple — `Address` is internal and never crosses the filter.
+	 *
 	 * @param string|null $location_type Location type: 'base', 'shipping', or 'billing'.
 	 *                                   If null, uses woocommerce_tax_based_on option with
 	 *                                   local pickup override. Null is kept for backward
@@ -892,56 +889,55 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		if ( 'base' === $tax_based_on ) {
-			$store_settings = $this->get_store_settings();
-			$country        = $store_settings['country'];
-			$state          = $store_settings['state'];
-			$postcode       = $store_settings['postcode'];
-			$city           = $store_settings['city'];
-			$street         = $store_settings['street'];
+			$address = Address::from_store_settings( $this->get_store_settings() );
 		} elseif ( null === WC()->customer ) {
 			$this->_log( 'Warning: WC()->customer is null when resolving ' . $tax_based_on . ' address.' );
 			return array( '', '', '', '', '' );
 		} elseif ( 'billing' === $tax_based_on ) {
-			$country  = WC()->customer->get_billing_country();
-			$state    = WC()->customer->get_billing_state();
-			$postcode = WC()->customer->get_billing_postcode();
-			$city     = WC()->customer->get_billing_city();
-			$street   = WC()->customer->get_billing_address();
+			$address = Address::from_customer_billing( WC()->customer );
 		} else {
-			$country  = WC()->customer->get_shipping_country();
-			$state    = WC()->customer->get_shipping_state();
-			$postcode = WC()->customer->get_shipping_postcode();
-			$city     = WC()->customer->get_shipping_city();
-			$street   = WC()->customer->get_shipping_address();
+			$address = Address::from_customer_shipping( WC()->customer );
 		}
 
-		return apply_filters( 'woocommerce_customer_taxable_address', array( $country, $state, $postcode, $city, $street ) );
+		return apply_filters( 'woocommerce_customer_taxable_address', $address->to_taxable_tuple() );
 	}
 
 	/**
 	 * Get address details of customer for backend orders
 	 *
-	 * Unchanged from the TaxJar plugin.
+	 * Derived from the TaxJar plugin.
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/4b481f5/includes/class-wc-taxjar-integration.php#L607
+	 *
+	 * Sanitization (and the `wp_unslash()` that used to be missing here) now lives in
+	 * `Address::from_post_request()`, and the empty-field representation comes from
+	 * `Address::to_legacy_options()` — the same one `get_address()` uses, so the cart and
+	 * admin-recalculate paths can no longer put different values on the wire for the
+	 * same empty input.
+	 *
+	 * Security: WooCommerce has already verified the nonce and capability by the time
+	 * `woocommerce_before_save_order_items` fires.
 	 *
 	 * @return array
 	 */
 	protected function get_backend_address() {
-    // phpcs:disable WordPress.Security.NonceVerification.Missing --- Security handled by WooCommerce
-		$to_country = isset( $_POST['country'] ) ? strtoupper( wc_clean( $_POST['country'] ) ) : false;
-		$to_state   = isset( $_POST['state'] ) ? strtoupper( wc_clean( $_POST['state'] ) ) : false;
-		$to_zip     = isset( $_POST['postcode'] ) ? strtoupper( wc_clean( $_POST['postcode'] ) ) : false;
-		$to_city    = isset( $_POST['city'] ) ? self::normalize_city( strtoupper( wc_clean( $_POST['city'] ) ) ) : false;
-		$to_street  = isset( $_POST['street'] ) ? strtoupper( wc_clean( $_POST['street'] ) ) : false;
-    // phpcs:enable WordPress.Security.NonceVerification.Missing
+		$address = Address::from_post_request()->to_legacy_options();
 
-		return array(
-			'to_country' => $to_country,
-			'to_state'   => $to_state,
-			'to_zip'     => $to_zip,
-			'to_city'    => $to_city,
-			'to_street'  => $to_street,
-		);
+		/*
+		 * Historic behaviour of this method, preserved deliberately: the admin path
+		 * upper-cases every field, not only country and state (which `Address` already
+		 * normalises). It is load-bearing for the city, which reaches the
+		 * `wp_woocommerce_tax_rates` city column, and pinned by
+		 * `test_get_backend_address_normalizes_semicolon_city()`. Reconciling the casing
+		 * asymmetry between this path and `get_address()` belongs with the rate-table
+		 * seam, where both ends of the write/read round trip can move together.
+		 */
+		foreach ( array( 'to_zip', 'to_city', 'to_street' ) as $key ) {
+			if ( is_string( $address[ $key ] ) ) {
+				$address[ $key ] = strtoupper( $address[ $key ] );
+			}
+		}
+
+		return $address;
 	}
 
 	/**
@@ -1294,13 +1290,32 @@ class WC_Connect_TaxJar_Integration {
 	/**
 	 * Set customer zip code and state to store if local shipping option set
 	 *
-	 * Unchanged from the TaxJar plugin.
+	 * Derived from the TaxJar plugin.
 	 * See: https://github.com/taxjar/taxjar-woocommerce-plugin/blob/82bf7c587/includes/class-wc-taxjar-integration.php#L653
 	 *
-	 * @return array
+	 * This is a callback on `woocommerce_customer_taxable_address`, and that filter is
+	 * fired with two different tuple lengths depending on who fires it:
+	 *
+	 * - WooCommerce core (`WC_Customer::get_taxable_address()`) passes **four** elements —
+	 *   country, state, postcode, city. `WC_Tax::get_rates_from_location()` then gates on
+	 *   `count( $location ) === 4`, a strict comparison, so a five-element return makes
+	 *   core skip `WC_Tax::find_rates()` and hand back an empty rate set.
+	 * - This plugin (`get_taxable_address()`) passes **five**, the fifth being the street,
+	 *   which `get_address()` reads off index `[4]`.
+	 *
+	 * The callback therefore returns a tuple of exactly the length it was handed. It used
+	 * to key the length off whether the street was empty instead, which returned five
+	 * elements into core's four-element pipeline on any local-pickup checkout where the
+	 * store has a street address configured, and dropped the street slot from the
+	 * plugin's own pipeline whenever the street was empty.
+	 *
+	 * @param array $address Positional taxable-address tuple, four or five elements.
+	 * @return array The same tuple, same length, with the base address substituted for
+	 *               local pickup.
 	 */
 	public function append_base_address_to_customer_taxable_address( $address ) {
 		$tax_based_on = '';
+		$tuple_length = count( $address );
 
 		list( $country, $state, $postcode, $city, $street ) = array_pad( $address, 5, '' );
 
@@ -1321,11 +1336,11 @@ class WC_Connect_TaxJar_Integration {
 			$street         = $store_settings['street'];
 		}
 
-		if ( '' != $street ) {
-			return array( $country, $state, $postcode, $city, $street );
-		}
+		$tuple = Address::from_taxable_tuple( array( $country, $state, $postcode, $city, $street ) )->to_taxable_tuple();
 
-		return array( $country, $state, $postcode, $city );
+		// Return the arity we were handed. Clamped to the two lengths this filter is
+		// ever fired with, so a malformed input tuple cannot propagate its own shape.
+		return array_slice( $tuple, 0, max( 4, min( 5, $tuple_length ) ) );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -71,10 +71,12 @@ This plugin relies on the following external services:
 == Changelog ==
 
 = 3.6.12 - 2026-xx-xx =
-* Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
 * Fix   - Restore tax rate lookups for local pickup orders, which could return no rates at all.
 * Fix   - Preserve apostrophes in city and street when taxes are recalculated from the order edit screen.
 * Fix   - Prevent a fatal error during cart and checkout tax calculation when a customization supplies an invalid store address.
+* Fix   - Send the same values for empty address fields whether taxes are calculated at checkout or from the order edit screen.
+* Fix   - Ignore array-valued address fields when taxes are recalculated from the order edit screen.
+* Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
 
 = 3.6.11 - 2026-08-05 =
 * Fix   - Prevent a fatal error during cart and checkout tax calculation when TaxJar returns an incomplete tax response.

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,8 @@ This plugin relies on the following external services:
 
 = 3.6.12 - 2026-xx-xx =
 * Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
+* Fix   - Restore tax rate lookups for local pickup orders, which could return no rates at all.
+* Fix   - Preserve apostrophes in city and street when taxes are recalculated from the order edit screen.
 
 = 3.6.11 - 2026-08-05 =
 * Fix   - Prevent a fatal error during cart and checkout tax calculation when TaxJar returns an incomplete tax response.

--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,7 @@ This plugin relies on the following external services:
 * Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
 * Fix   - Restore tax rate lookups for local pickup orders, which could return no rates at all.
 * Fix   - Preserve apostrophes in city and street when taxes are recalculated from the order edit screen.
+* Fix   - Prevent a fatal error during cart and checkout tax calculation when a customization supplies an invalid store address.
 
 = 3.6.11 - 2026-08-05 =
 * Fix   - Prevent a fatal error during cart and checkout tax calculation when TaxJar returns an incomplete tax response.

--- a/src/Tax/Address.php
+++ b/src/Tax/Address.php
@@ -620,8 +620,10 @@ final class Address {
 	/**
 	 * Back-compat shape used by `get_address()` and `get_backend_address()` return
 	 * values: `to_country`, `to_state`, `to_zip`, `to_city`, `to_street` — but with
-	 * empty-string fields converted to `false` to match the legacy "isset && !empty"
-	 * extraction logic.
+	 * empty-string fields converted to `false`, the value the legacy
+	 * "isset && !empty" extraction produced for a missing field. Deliberately
+	 * narrower than `! empty()`: a literal `'0'` is preserved, where the legacy
+	 * check collapsed it to `false`.
 	 *
 	 * @param string $prefix Either 'to_' (default) or 'from_'.
 	 * @return array<string, string|false>

--- a/src/Tax/Address.php
+++ b/src/Tax/Address.php
@@ -268,14 +268,20 @@ final class Address {
 	/**
 	 * Build from an admin-order `$_POST` payload.
 	 *
-	 * Applies `wp_unslash()` then `wc_clean()` to each field. Caller must have already
-	 * verified the nonce / capability — this method does not check authorization.
+	 * Unslashes the superglobal once, then applies `wc_clean()` to each field. Caller
+	 * must have already verified the nonce / capability — this method does not check
+	 * authorization.
 	 *
 	 * The unslashing is load-bearing, not ceremony. WordPress slashes every superglobal
 	 * on load and `wc_clean()` sanitizes without unslashing, so an apostrophe in an admin
 	 * order address would otherwise reach TaxJar — and the `wp_woocommerce_tax_rates`
 	 * city column — as the literal `O\'Brien`, which can never match the unslashed value
 	 * the cart path writes for the same address.
+	 *
+	 * It happens exactly once, and only on the superglobal. `wp_unslash()` is
+	 * `stripslashes_deep()`, which is not idempotent: a second pass over an already
+	 * unslashed value eats real backslashes (`A\B` becomes `AB`). The `$post` override
+	 * is a test seam that is never slashed, so it must not be unslashed either.
 	 *
 	 * @param array|null $post Override source for testing. Defaults to `$_POST`.
 	 * @return self
@@ -286,7 +292,7 @@ final class Address {
 		$source = is_array( $post ) ? $post : wp_unslash( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce/capability verified by the caller (see docblock); each field is sanitized via wc_clean() below.
 
 		$pluck = static function ( $key ) use ( $source ) {
-			return isset( $source[ $key ] ) ? (string) wc_clean( wp_unslash( $source[ $key ] ) ) : '';
+			return isset( $source[ $key ] ) ? (string) wc_clean( $source[ $key ] ) : '';
 		};
 
 		return new self(

--- a/src/Tax/Address.php
+++ b/src/Tax/Address.php
@@ -291,8 +291,10 @@ final class Address {
 		// so unslash the superglobal here. The $post test override is never slashed.
 		$source = is_array( $post ) ? $post : wp_unslash( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce/capability verified by the caller (see docblock); each field is sanitized via wc_clean() below.
 
+		// is_scalar() drops array-valued fields (e.g. a crafted `city[]=x`), which
+		// would otherwise cast to the literal string "Array" with a PHP warning.
 		$pluck = static function ( $key ) use ( $source ) {
-			return isset( $source[ $key ] ) ? (string) wc_clean( $source[ $key ] ) : '';
+			return isset( $source[ $key ] ) && is_scalar( $source[ $key ] ) ? (string) wc_clean( $source[ $key ] ) : '';
 		};
 
 		return new self(

--- a/src/Tax/Address.php
+++ b/src/Tax/Address.php
@@ -268,8 +268,14 @@ final class Address {
 	/**
 	 * Build from an admin-order `$_POST` payload.
 	 *
-	 * Applies `wc_clean()` to each field. Caller must have already verified the
-	 * nonce / capability — this method does not check authorization.
+	 * Applies `wp_unslash()` then `wc_clean()` to each field. Caller must have already
+	 * verified the nonce / capability — this method does not check authorization.
+	 *
+	 * The unslashing is load-bearing, not ceremony. WordPress slashes every superglobal
+	 * on load and `wc_clean()` sanitizes without unslashing, so an apostrophe in an admin
+	 * order address would otherwise reach TaxJar — and the `wp_woocommerce_tax_rates`
+	 * city column — as the literal `O\'Brien`, which can never match the unslashed value
+	 * the cart path writes for the same address.
 	 *
 	 * @param array|null $post Override source for testing. Defaults to `$_POST`.
 	 * @return self
@@ -280,7 +286,7 @@ final class Address {
 		$source = is_array( $post ) ? $post : wp_unslash( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce/capability verified by the caller (see docblock); each field is sanitized via wc_clean() below.
 
 		$pluck = static function ( $key ) use ( $source ) {
-			return isset( $source[ $key ] ) ? (string) wc_clean( $source[ $key ] ) : '';
+			return isset( $source[ $key ] ) ? (string) wc_clean( wp_unslash( $source[ $key ] ) ) : '';
 		};
 
 		return new self(

--- a/tests/php/Tax/test-address.php
+++ b/tests/php/Tax/test-address.php
@@ -203,6 +203,24 @@ class WP_Test_WCServices_Tax_Address extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * An array-valued field (e.g. a crafted `city[]=x`) is treated as empty.
+	 *
+	 * Without the scalar guard it would cast to the literal string "Array" with a
+	 * PHP warning, and reach the TaxJar body and the tax rate city column.
+	 */
+	public function test_from_post_request_ignores_array_valued_fields() {
+		$address = Address::from_post_request(
+			array(
+				'country' => 'US',
+				'city'    => array( 'Homestead' ),
+			)
+		);
+
+		$this->assertSame( 'US', $address->country() );
+		$this->assertSame( '', $address->city() );
+	}
+
+	/**
 	 * `from_jurisdictions` accepts an `stdClass` (matches TaxJar response shape).
 	 */
 	public function test_from_jurisdictions_extracts_partial_fields() {

--- a/tests/php/Tax/test-address.php
+++ b/tests/php/Tax/test-address.php
@@ -712,6 +712,25 @@ class WP_Test_WCServices_Tax_Address extends WC_Unit_Test_Case {
 		$this->assertFalse( $legacy['to_street'] );
 	}
 
+	/**
+	 * `to_legacy_options` preserves a literal '0', unlike the legacy `! empty()`
+	 * check, which collapsed it to `false`. Only the empty string maps to `false`.
+	 */
+	public function test_to_legacy_options_preserves_literal_zero() {
+		$address = Address::from_options(
+			array(
+				'to_zip'  => '0',
+				'to_city' => '0',
+			)
+		);
+
+		$legacy = $address->to_legacy_options( 'to_' );
+
+		$this->assertSame( '0', $legacy['to_zip'] );
+		$this->assertSame( '0', $legacy['to_city'] );
+		$this->assertFalse( $legacy['to_street'] );
+	}
+
 	/* ──── Validation ──── */
 
 	/**

--- a/tests/php/Tax/test-address.php
+++ b/tests/php/Tax/test-address.php
@@ -144,7 +144,7 @@ class WP_Test_WCServices_Tax_Address extends WC_Unit_Test_Case {
 	 * `wp_unslash()` a value like `O'Brien` would be stored as `O\'Brien`.
 	 */
 	public function test_from_post_request_unslashes_superglobal() {
-		$original_post = $_POST;
+		$original_post = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test fixture; nothing is processed, the superglobal is saved and restored.
 
 		// Simulate the slashing WordPress applies to $_POST on real requests.
 		$_POST = array(
@@ -159,6 +159,47 @@ class WP_Test_WCServices_Tax_Address extends WC_Unit_Test_Case {
 		$this->assertSame( "123 O'Malley St", $address->street() );
 
 		$_POST = $original_post;
+	}
+
+	/**
+	 * `from_post_request` unslashes exactly once.
+	 *
+	 * `wp_unslash()` is `stripslashes_deep()` and is not idempotent, so a second pass
+	 * would consume a backslash that is genuinely part of the value. A street entered
+	 * as `A\B` arrives slashed as `A\\B`; one pass restores `A\B`, two passes destroy
+	 * it to `AB`. Pins that only the superglobal is unslashed, not each field again.
+	 */
+	public function test_from_post_request_unslashes_only_once() {
+		$original_post = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Test fixture; nothing is processed, the superglobal is saved and restored.
+
+		// WP slashes a literal backslash, so `A\B` arrives as `A\\B`.
+		$_POST = array(
+			'country' => 'US',
+			'street'  => 'A\\\\B',
+		);
+
+		$address = Address::from_post_request();
+
+		$this->assertSame( 'A\\B', $address->street() );
+
+		$_POST = $original_post;
+	}
+
+	/**
+	 * The `$post` override is a test seam and is never slashed, so it is not unslashed.
+	 *
+	 * Unslashing it would silently corrupt any caller that passes an already-clean
+	 * array containing a backslash.
+	 */
+	public function test_from_post_request_does_not_unslash_the_override() {
+		$address = Address::from_post_request(
+			array(
+				'country' => 'US',
+				'street'  => 'A\\B',
+			)
+		);
+
+		$this->assertSame( 'A\\B', $address->street() );
 	}
 
 	/**

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -27,6 +27,13 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	private $product;
 
 	/**
+	 * Closure registered on `taxjar_store_settings` by the local-pickup helper.
+	 *
+	 * @var Closure|null
+	 */
+	private $store_settings_filter;
+
+	/**
 	 * Load required classes before running tests.
 	 */
 	public static function set_up_before_class() {
@@ -526,19 +533,19 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	 * @param mixed $returned Value the filter callback returns.
 	 */
 	public function test_get_taxable_address_survives_non_array_store_settings( $returned ) {
-		add_filter(
-			'taxjar_store_settings',
-			static function () use ( $returned ) {
-				return $returned;
-			}
-		);
+		$callback = static function () use ( $returned ) {
+			return $returned;
+		};
+		add_filter( 'taxjar_store_settings', $callback );
 
 		$store_country = WC()->countries->get_base_country();
 		$store_state   = WC()->countries->get_base_state();
 
-		$address = $this->invoke_protected_method( 'get_taxable_address', array( 'base' ) );
-
-		remove_all_filters( 'taxjar_store_settings' );
+		try {
+			$address = $this->invoke_protected_method( 'get_taxable_address', array( 'base' ) );
+		} finally {
+			remove_filter( 'taxjar_store_settings', $callback );
+		}
 
 		$this->assertIsArray( $address );
 		$this->assertEquals( $store_country, $address[0] );
@@ -2144,15 +2151,13 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	private function force_local_pickup_with_store_street( $street ) {
 		WC()->session->set( 'chosen_shipping_methods', array( 'local_pickup:1' ) );
 
-		add_filter(
-			'taxjar_store_settings',
-			function ( $settings ) use ( $street ) {
-				$settings['street']   = $street;
-				$settings['city']     = 'Homestead';
-				$settings['postcode'] = '33033';
-				return $settings;
-			}
-		);
+		$this->store_settings_filter = function ( $settings ) use ( $street ) {
+			$settings['street']   = $street;
+			$settings['city']     = 'Homestead';
+			$settings['postcode'] = '33033';
+			return $settings;
+		};
+		add_filter( 'taxjar_store_settings', $this->store_settings_filter );
 	}
 
 	/**
@@ -2162,7 +2167,11 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	 */
 	private function reset_local_pickup_with_store_street() {
 		WC()->session->set( 'chosen_shipping_methods', array() );
-		remove_all_filters( 'taxjar_store_settings' );
+
+		if ( $this->store_settings_filter ) {
+			remove_filter( 'taxjar_store_settings', $this->store_settings_filter );
+			$this->store_settings_filter = null;
+		}
 	}
 
 	/**

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -2301,6 +2301,15 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	 * `""`. `Address::to_legacy_options()` is the single source of that decision.
 	 */
 	public function test_read_seam_uses_one_empty_value_representation() {
+		// WC()->customer is a singleton that outlives this test; restore it below.
+		$original_shipping = array(
+			'country'  => WC()->customer->get_shipping_country(),
+			'state'    => WC()->customer->get_shipping_state(),
+			'postcode' => WC()->customer->get_shipping_postcode(),
+			'city'     => WC()->customer->get_shipping_city(),
+			'address'  => WC()->customer->get_shipping_address(),
+		);
+
 		WC()->customer->set_shipping_country( 'US' );
 		WC()->customer->set_shipping_state( 'FL' );
 		WC()->customer->set_shipping_postcode( '33033' );
@@ -2318,6 +2327,12 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			$backend  = $this->invoke_protected_method( 'get_backend_address' );
 		} finally {
 			unset( $_POST['country'], $_POST['state'], $_POST['postcode'], $_POST['city'], $_POST['street'] );
+
+			WC()->customer->set_shipping_country( $original_shipping['country'] );
+			WC()->customer->set_shipping_state( $original_shipping['state'] );
+			WC()->customer->set_shipping_postcode( $original_shipping['postcode'] );
+			WC()->customer->set_shipping_city( $original_shipping['city'] );
+			WC()->customer->set_shipping_address( $original_shipping['address'] );
 		}
 
 		$this->assertSame(

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -2290,6 +2290,10 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 
 	/**
 	 * A populated street survives the round trip untouched.
+	 *
+	 * Note: this is a behavior pin, not one of the defect reproductions. The
+	 * pre-fix code also passed it, since a populated street already returned a
+	 * five-element tuple with the street intact.
 	 */
 	public function test_append_base_address_keeps_populated_street() {
 		$address = $this->integration->append_base_address_to_customer_taxable_address(

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -560,6 +560,35 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * A `taxjar_store_settings` callback returning a partial array must not drop keys.
+	 *
+	 * Callers index the result directly, so a missing key used to raise undefined
+	 * key warnings and feed null into strtoupper(). Missing keys are backfilled
+	 * from the unfiltered store settings; keys the callback did set still win.
+	 */
+	public function test_get_store_settings_backfills_partial_array() {
+		$callback = static function () {
+			return array( 'postcode' => '90210' );
+		};
+		add_filter( 'taxjar_store_settings', $callback );
+
+		try {
+			$settings = $this->integration->get_store_settings();
+		} finally {
+			remove_filter( 'taxjar_store_settings', $callback );
+		}
+
+		$this->assertSame( '90210', $settings['postcode'] );
+
+		foreach ( array( 'street', 'city', 'state', 'country' ) as $key ) {
+			$this->assertArrayHasKey( $key, $settings );
+		}
+
+		$this->assertSame( WC()->countries->get_base_country(), $settings['country'] );
+		$this->assertSame( WC()->countries->get_base_city(), $settings['city'] );
+	}
+
+	/**
 	 * Test that location_type 'shipping' returns customer shipping address.
 	 */
 	public function test_get_taxable_address_shipping_returns_customer_address() {

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -513,6 +513,53 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * A `taxjar_store_settings` callback returning a non-array must not fatal.
+	 *
+	 * The filter is public and unguarded. Before `get_store_settings()` enforced its own
+	 * documented `@return array`, a callback returning null / false / a string reached
+	 * `Address::from_store_settings( array $settings )` and raised an uncaught TypeError
+	 * on every cart and checkout render resolving a base address. The unfiltered store
+	 * address is used instead.
+	 *
+	 * @dataProvider provider_non_array_store_settings
+	 *
+	 * @param mixed $returned Value the filter callback returns.
+	 */
+	public function test_get_taxable_address_survives_non_array_store_settings( $returned ) {
+		add_filter(
+			'taxjar_store_settings',
+			static function () use ( $returned ) {
+				return $returned;
+			}
+		);
+
+		$store_country = WC()->countries->get_base_country();
+		$store_state   = WC()->countries->get_base_state();
+
+		$address = $this->invoke_protected_method( 'get_taxable_address', array( 'base' ) );
+
+		remove_all_filters( 'taxjar_store_settings' );
+
+		$this->assertIsArray( $address );
+		$this->assertEquals( $store_country, $address[0] );
+		$this->assertEquals( $store_state, $address[1] );
+	}
+
+	/**
+	 * Non-array return values a `taxjar_store_settings` callback might produce.
+	 *
+	 * @return array<string, array{0: mixed}>
+	 */
+	public function provider_non_array_store_settings() {
+		return array(
+			'null'   => array( null ),
+			'false'  => array( false ),
+			'string' => array( 'not-an-address' ),
+			'object' => array( new stdClass() ),
+		);
+	}
+
+	/**
 	 * Test that location_type 'shipping' returns customer shipping address.
 	 */
 	public function test_get_taxable_address_shipping_returns_customer_address() {

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -2053,4 +2053,171 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			'string' => array( 'not a tax object' ),
 		);
 	}
+
+	// -------------------------------------------------------------------------
+	// Read seam — address tuple arity, empty-value representation, slashing
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Force the local-pickup branch of `append_base_address_to_customer_taxable_address()`
+	 * and give the store a non-empty street.
+	 *
+	 * @param string $street Store street to report through `taxjar_store_settings`.
+	 * @return void
+	 */
+	private function force_local_pickup_with_store_street( $street ) {
+		WC()->session->set( 'chosen_shipping_methods', array( 'local_pickup:1' ) );
+
+		add_filter(
+			'taxjar_store_settings',
+			function ( $settings ) use ( $street ) {
+				$settings['street']   = $street;
+				$settings['city']     = 'Homestead';
+				$settings['postcode'] = '33033';
+				return $settings;
+			}
+		);
+	}
+
+	/**
+	 * Undo `force_local_pickup_with_store_street()`.
+	 *
+	 * @return void
+	 */
+	private function reset_local_pickup_with_store_street() {
+		WC()->session->set( 'chosen_shipping_methods', array() );
+		remove_all_filters( 'taxjar_store_settings' );
+	}
+
+	/**
+	 * `append_base_address_to_customer_taxable_address()` must not change the length
+	 * of the tuple it was handed.
+	 *
+	 * WooCommerce core fires `woocommerce_customer_taxable_address` with a **four**
+	 * element tuple (`WC_Customer::get_taxable_address()` — no street), and
+	 * `WC_Tax::get_rates_from_location()` gates on `count( $location ) === 4` with a
+	 * strict comparison. Returning five elements there makes core skip
+	 * `WC_Tax::find_rates()` entirely and hand back an empty rate set.
+	 *
+	 * That is exactly what happens today on a local-pickup checkout: the callback
+	 * substitutes the store street into the empty slot, which flips the return from
+	 * four elements to five. The plugin's own `allow_street_address_for_matched_rates()`
+	 * override happens to paper over it for `woocommerce_matched_rates` consumers, but
+	 * every other caller of `WC_Tax::get_rates()` sees zero rates.
+	 */
+	public function test_append_base_address_preserves_four_element_core_tuple() {
+		$this->force_local_pickup_with_store_street( '1 Store Street' );
+
+		try {
+			$address = $this->integration->append_base_address_to_customer_taxable_address(
+				array( 'US', 'FL', '33030', 'Miami' )
+			);
+		} finally {
+			$this->reset_local_pickup_with_store_street();
+		}
+
+		$this->assertCount(
+			4,
+			$address,
+			'WC_Tax::get_rates_from_location() requires exactly 4 elements; returning 5 makes core return an empty rate set.'
+		);
+	}
+
+	/**
+	 * The mirror of the above: a five-element tuple in must stay five elements out.
+	 *
+	 * `WC_Connect_TaxJar_Integration::get_taxable_address()` fires the same filter with
+	 * a five-element tuple and `get_address()` reads index `[4]` off the result. Dropping
+	 * the trailing element whenever the street is empty means the plugin's own contract
+	 * silently changes arity based on the data, which is what allows a populated street to
+	 * be lost when the tuple is rebuilt downstream.
+	 */
+	public function test_append_base_address_preserves_five_element_plugin_tuple() {
+		$address = $this->integration->append_base_address_to_customer_taxable_address(
+			array( 'US', 'FL', '33030', 'Miami', '' )
+		);
+
+		$this->assertCount( 5, $address, 'A 5-tuple in must stay a 5-tuple out — get_address() reads index [4].' );
+		$this->assertSame( '', $address[4] );
+	}
+
+	/**
+	 * A populated street survives the round trip untouched.
+	 */
+	public function test_append_base_address_keeps_populated_street() {
+		$address = $this->integration->append_base_address_to_customer_taxable_address(
+			array( 'US', 'FL', '33030', 'Miami', '123 Ocean Drive' )
+		);
+
+		$this->assertCount( 5, $address );
+		$this->assertSame( '123 Ocean Drive', $address[4] );
+	}
+
+	/**
+	 * `get_address()` and `get_backend_address()` must represent an empty field the
+	 * same way.
+	 *
+	 * Both feed `calculate_tax()`, which builds the TaxJar request body straight from
+	 * these values — so the two paths currently put different JSON on the wire for the
+	 * same empty input: the cart path sends `false`, the admin-recalculate path sends
+	 * `""`. `Address::to_legacy_options()` is the single source of that decision.
+	 */
+	public function test_read_seam_uses_one_empty_value_representation() {
+		WC()->customer->set_shipping_country( 'US' );
+		WC()->customer->set_shipping_state( 'FL' );
+		WC()->customer->set_shipping_postcode( '33033' );
+		WC()->customer->set_shipping_city( '' );
+		WC()->customer->set_shipping_address( '' );
+
+		$_POST['country']  = 'US';
+		$_POST['state']    = 'FL';
+		$_POST['postcode'] = '33033';
+		$_POST['city']     = '';
+		$_POST['street']   = '';
+
+		try {
+			$frontend = $this->invoke_protected_method( 'get_address', array( 'shipping' ) );
+			$backend  = $this->invoke_protected_method( 'get_backend_address' );
+		} finally {
+			unset( $_POST['country'], $_POST['state'], $_POST['postcode'], $_POST['city'], $_POST['street'] );
+		}
+
+		$this->assertSame(
+			$frontend['to_city'],
+			$backend['to_city'],
+			'Cart and admin-recalculate paths disagree on how an empty city is represented.'
+		);
+		$this->assertSame(
+			$frontend['to_street'],
+			$backend['to_street'],
+			'Cart and admin-recalculate paths disagree on how an empty street is represented.'
+		);
+		$this->assertFalse( $backend['to_city'] );
+		$this->assertFalse( $backend['to_street'] );
+	}
+
+	/**
+	 * `get_backend_address()` must unslash `$_POST` before sanitizing it.
+	 *
+	 * WordPress slashes every superglobal, and `wc_clean()` sanitizes without
+	 * unslashing. So an apostrophe in an admin order address arrives as `O\'Brien`
+	 * and is passed through verbatim — into the TaxJar request body and, via
+	 * `create_or_update_tax_rate()`, into the `wp_woocommerce_tax_rates` city column,
+	 * where it can never match the unslashed value the cart path stores.
+	 */
+	public function test_get_backend_address_unslashes_post_values() {
+		$_POST['country'] = 'US';
+		$_POST['state']   = 'FL';
+		$_POST['city']    = "O\\'Brien";
+		$_POST['street']  = "123 O\\'Malley Way";
+
+		try {
+			$address = $this->invoke_protected_method( 'get_backend_address' );
+		} finally {
+			unset( $_POST['country'], $_POST['state'], $_POST['city'], $_POST['street'] );
+		}
+
+		$this->assertSame( "O'BRIEN", $address['to_city'], 'Backend city retained the WordPress-added slash.' );
+		$this->assertSame( "123 O'MALLEY WAY", $address['to_street'], 'Backend street retained the WordPress-added slash.' );
+	}
 }

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -2168,6 +2168,25 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			$address,
 			'WC_Tax::get_rates_from_location() requires exactly 4 elements; returning 5 makes core return an empty rate set.'
 		);
+
+		/*
+		 * The arity assertion above only means something while the local-pickup base
+		 * substitution actually runs. If it stops running — a session not started under
+		 * a different bootstrap, another test leaving `woocommerce_apply_base_tax_for_local_pickup`
+		 * filtered false, a change in `wc_get_chosen_shipping_method_ids()` semantics —
+		 * then `$street` stays empty, and the pre-fix implementation returned four
+		 * elements too. The test would keep passing against the very defect it exists to
+		 * catch.
+		 *
+		 * Asserting the substituted values makes that failure loud instead of silent: the
+		 * store postcode and city (33033 / HOMESTEAD) are observable proof the branch was
+		 * taken, and neither matches the customer values fed in (33030 / Miami).
+		 */
+		$this->assertSame(
+			array( 'US', 'FL', '33033', 'HOMESTEAD' ),
+			$address,
+			'The local-pickup base substitution did not run, so the arity assertion above is vacuous.'
+		);
 	}
 
 	/**

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -2237,6 +2237,49 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Without local pickup, core's four-element tuple passes through unchanged.
+	 *
+	 * This is the most common core path: no substitution runs and the callback
+	 * must behave as a no-op.
+	 */
+	public function test_append_base_address_passes_through_core_tuple_without_local_pickup() {
+		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate:1' ) );
+
+		$address = $this->integration->append_base_address_to_customer_taxable_address(
+			array( 'US', 'FL', '33030', 'Miami' )
+		);
+
+		$this->assertSame( array( 'US', 'FL', '33030', 'Miami' ), $address );
+	}
+
+	/**
+	 * A malformed short tuple is padded up to the four fields every consumer reads.
+	 */
+	public function test_append_base_address_pads_short_tuple_to_four_elements() {
+		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate:1' ) );
+
+		$address = $this->integration->append_base_address_to_customer_taxable_address(
+			array( 'US', 'FL', '33030' )
+		);
+
+		$this->assertSame( array( 'US', 'FL', '33030', '' ), $address );
+	}
+
+	/**
+	 * Anything past the street slot is dropped: the output is clamped to five
+	 * elements even when an earlier callback appended a sixth.
+	 */
+	public function test_append_base_address_clamps_long_tuple_to_five_elements() {
+		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate:1' ) );
+
+		$address = $this->integration->append_base_address_to_customer_taxable_address(
+			array( 'US', 'FL', '33030', 'Miami', '123 Ocean Drive', 'extra' )
+		);
+
+		$this->assertSame( array( 'US', 'FL', '33030', 'Miami', '123 Ocean Drive' ), $address );
+	}
+
+	/**
 	 * A populated street survives the round trip untouched.
 	 */
 	public function test_append_base_address_keeps_populated_street() {


### PR DESCRIPTION
### Stacked PR

**Base is `chore/wootax-313` (#2984), not `trunk`.** This is R1.2 of the address/rate-table
refactor; #2984 is R1.1 and is still open. Review #2984 first — this diff only makes sense on
top of the value object it lands. If #2984 merges, this will be rebased onto `trunk` and the
base updated.

R1.1 landed `Automattic\WCServices\Tax\Address` unwired. R1.2 wires the **read seam**: the four
places that build an address for a tax calculation now construct exactly one `Address` each and
convert back at the boundary, so normalisation policy has a single home instead of being
re-derived per call site.

| Call site | Now |
|---|---|
| `get_taxable_address()` | `Address::from_store_settings()` / `from_customer_billing()` / `from_customer_shipping()` → `to_taxable_tuple()` |
| `get_address()` | `Address::from_taxable_tuple( … )->to_legacy_options()` |
| `get_backend_address()` | `Address::from_post_request()->to_legacy_options()` |
| `append_base_address_to_customer_taxable_address()` | arity-preserving rebuild through the value object |

Three defects fall out of unifying the seam. Each has a regression test that **fails against the
base branch**.

---

## 1. The taxable-address tuple changed length depending on its data

This is the one worth reading closely, because the fix is the opposite of what it looks like.

`woocommerce_customer_taxable_address` is fired with **two different arities**:

- **WooCommerce core** — `WC_Customer::get_taxable_address()` fires it with **four** elements:
  country, state, postcode, city. No street.
- **This plugin** — `WC_Connect_TaxJar_Integration::get_taxable_address()` fires the *same*
  filter with **five**, the fifth being the street, which `get_address()` reads off index `[4]`.

And core's consumer checks that length strictly:

```php
// WC_Tax::get_rates_from_location()
if ( count( $location ) === 4 ) {
    list( $country, $state, $postcode, $city ) = $location;
    $matched_tax_rates = self::find_rates( … );
}
return apply_filters( 'woocommerce_matched_rates', $matched_tax_rates, $tax_class, $customer );
```

Five elements ⇒ `find_rates()` is never called and core returns an **empty rate set**.

`append_base_address_to_customer_taxable_address()` used to size its return by whether the
street happened to be empty:

```php
if ( '' != $street ) {
    return array( $country, $state, $postcode, $city, $street );
}
return array( $country, $state, $postcode, $city );
```

So it returned **five elements into core's four-element pipeline** on any local-pickup checkout
where the store has a street address configured — because the `'base'` branch substitutes the
store street into the previously-empty slot. And it **dropped the fifth slot from this plugin's
own pipeline** whenever the street was empty, which is the originally-reported symptom.

The reason this has not been reported as "local pickup collects no tax" is that
`allow_street_address_for_matched_rates()` is unconditionally hooked on
`woocommerce_matched_rates` and replaces the (empty) result wholesale with its own
`find_rates()` call. So the damage is contained to callers of `WC_Tax::get_rates()` /
`get_rates_from_location()` that read the return value before that filter — and to anything that
removes or reorders our filter.

**Fix:** return a tuple of exactly the length we were handed, clamped to the two lengths this
filter is ever fired with.

Both directions are covered: `test_append_base_address_preserves_four_element_core_tuple()` and
`test_append_base_address_preserves_five_element_plugin_tuple()`.

> **Note for R2.** The `woocommerce_get_tax_location` override planned for the jurisdiction work
> returns `$location` straight back into that same strict `count( $location ) === 4` check. It
> must not grow a street element either.

## 2. The two getters disagreed on how to represent an empty field

`get_address()` returned `false` for an empty field. `get_backend_address()` returned `''` for a
`$_POST` key that was present but blank. Both feed `calculate_tax()`, which serialises the values
straight into the TaxJar request body — so the cart path and the admin-recalculate path put
different JSON on the wire for the same empty input.

`Address::to_legacy_options()` is now the single place that decision is made, and
`test_read_seam_uses_one_empty_value_representation()` asserts the two paths agree.

## 3. `get_backend_address()` never unslashed `$_POST`

WordPress slashes every superglobal on load, and `wc_clean()` sanitises without unslashing. So an
apostrophe in an admin order address reached TaxJar — and, via `create_or_update_tax_rate()`, the
`wp_woocommerce_tax_rates` city column — as the literal `O\'Brien`. That value can never match
the unslashed city the cart path writes for the same address, so recalculating an order from the
order-edit screen could mint a second rate row for a city the store already has one for.

`wp_unslash()` is now applied ahead of `wc_clean()` in `Address::from_post_request()`.
Covered by `test_get_backend_address_unslashes_post_values()`.

---

## Backward compatibility

Per AGENTS.md, this section covers signatures, hooks, global-state assumptions, multisite and
install layout.

**Hooks**

- `woocommerce_customer_taxable_address` keeps receiving and returning WooCommerce's positional
  tuple. No argument is added, removed or reordered. Its **arity is now preserved** rather than
  data-dependent, which is a fix in both directions: core callbacks stop seeing an unexpected
  fifth element, and this plugin's callbacks stop losing the fifth slot. A third-party callback
  registered after ours that previously branched on `count( $address )` will now see a stable
  length — that is the contract core documents, and the previous behaviour was not something a
  consumer could have depended on deliberately.
- **The values passed to that filter are now normalised before it fires, rather than after.**
  Country and state upper-cased, city semicolon-stripped and whitespace-collapsed, a comma-list
  postcode reduced to its first segment. Every one of those transformations was already applied
  by this plugin *downstream* of the filter, so our own pipeline is unchanged; the difference is
  that third-party callbacks now receive the canonical value instead of the raw one. Called out
  explicitly because it is the only change here that a consumer could observe without asking for
  it.
- No other hook is added, removed, renamed or re-timed. `taxjar_store_settings` and
  `woocommerce_taxjar_nexus_address` are untouched.

**Public / externally exposed methods**

- `get_taxable_address()` — public. Signature and return shape unchanged. The
  `array( '', '', '', '', '' )` early return for a null `WC()->customer` is untouched and still
  bypasses the filter; two existing tests pin it.
- `append_base_address_to_customer_taxable_address()` — public. Signature unchanged; return shape
  unchanged apart from the arity fix described above. The `@param` tag it was missing is now
  documented.
- `get_address()` and `get_backend_address()` are `protected`. A subclass outside this repo could
  be calling them, so both keep their array shape and key names.
- `get_backend_address()` **keeps its historic `strtoupper()` over postcode, city and street**,
  applied after the value object builds them. This looks like a leftover and is not: the city
  casing feeds the rate-table write path and is pinned by
  `test_get_backend_address_normalizes_semicolon_city()`, while `get_address()` does *not*
  upper-case. Reconciling that asymmetry means moving both ends of the write/read round trip
  together, which is R1.4's job. There is a comment on it in the code so it does not get
  "cleaned up" in isolation.
- `WC_Connect_TaxJar_Integration::normalize_city()` keeps its deprecated delegate and still raises
  **no** `_deprecated_function()` notice. R1.2 moved two of its five in-repo call sites; the three
  that remain are all on the rate-table seam, and a notice would fire on every checkout until
  R1.4 moves them.

**Two behaviour changes worth a reviewer's eye**

1. `'0'` is no longer treated as an empty field. The old `! empty()` extraction turned a postcode
   or city of `"0"` into `false`; `Address::to_legacy_options()` only maps `''`. Strictly a fix,
   but it is a change.
2. A `$_POST` field that is present but blank now yields `false` rather than `''` from
   `get_backend_address()`. That is defect 2 above, and it makes the admin path match the cart
   path.

**Global state, multisite, install layout**

- No new read of a global or of `WC()->…` state is introduced. `get_taxable_address()` already
  null-guarded `WC()->customer` and still does.
  `append_base_address_to_customer_taxable_address()`'s pre-existing `WC()->session` dereference
  is in the WC < 2.6.2 fallback branch only and is unchanged.
- No option, table or upload path is read or written, so there is no site-scoped vs
  network-scoped question. Behaviour under multisite is unchanged; not separately tested, because
  nothing here touches storage.
- No path or URL construction. Install layout is not a factor.

---

## Follow-up this PR deliberately does not action

**`append_base_address_to_customer_taxable_address()` looks redundant against modern
WooCommerce core, not just buggy.** Core's `WC_Customer::get_taxable_address()` already performs
the local-pickup → base substitution itself, for all four fields, reading the same
`WC()->countries->get_base_*` values that `get_store_settings()` reads:

```php
if ( true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && count( array_intersect( wc_get_chosen_shipping_method_ids(), … ) ) > 0 ) {
    $tax_based_on = TaxBasedOn::BASE;
}
if ( TaxBasedOn::BASE === $tax_based_on ) {
    $country  = WC()->countries->get_base_country();
    …
}
```

So on core's invocation of the filter, our callback re-derives postcode / city / street to the
values core already put there, and its only *observable* effect was the arity change that broke
the rate lookup. On this plugin's own invocation it is likewise near-redundant, since
`get_taxable_address()` has already resolved `'base'` before firing the filter — and it is
arguably incoherent, because it overrides postcode / city / street to the store's while leaving
country and state as the customer's.

Retiring it is a backward-compatibility change (a public method and a registered callback on a
public filter), so per AGENTS.md it wants its own ticket, a deprecation window, and a check on
whether any grandfathered local-pickup behaviour depends on the street it appends. Filing that
separately rather than bundling it here — bundling unrelated concerns is one of the four reasons
the earlier PR #2906 was closed.

---

## Verification

- `composer test` → **OK (285 tests, 613 assertions)**. 280 on the base branch, +5 new, zero
  regressions.
- PHPCS → **zero new violations, net −2** against the base branch (3821 → 3819): one
  `Squiz.Commenting.FunctionComment.MissingParamTag` fixed by documenting `$address`, one
  `Universal.Operators.StrictComparisons.LooseNotEqual` removed with `'' != $street`.
  Measured by diffing `phpcs --standard=./phpcs.xml.dist --report=source` before and after —
  `check-all` is **not** green on this repo's trunk (~3841 pre-existing violations, 2223 of them
  in `i18n/strings.php`), so "zero new" is the achievable bar, not "green".
- `php -l` clean on all three changed files, matching the CI lint step.

## Testing instructions

1. Configure a US store with a **street address** set in WooCommerce → Settings → General.
2. Enable Automated Taxes.
3. Add a local pickup shipping method and choose it in the cart. Confirm tax is calculated and,
   with `WC_Tax::get_rates()` called directly (e.g. via WP-CLI `wp eval`), that it now returns
   rates instead of an empty array.
4. Place an order to a US destination, open it in the admin, change the city to one containing an
   apostrophe (e.g. `O'Brien`), and recalculate. Confirm the city stored in
   `wp_woocommerce_tax_rates` / `wp_woocommerce_tax_rate_locations` has no backslash.
5. Confirm a second recalculation of the same order does not add a new rate row.
