### PR TITLE
[WOOTAX-313] Refactor - Migrate the TaxJar request seam onto the Address value object

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,8 @@
 * Fix   - Prevent a fatal error during cart and checkout tax calculation when a customization supplies an invalid store address.
 * Fix   - Send the same values for empty address fields whether taxes are calculated at checkout or from the order edit screen.
 * Fix   - Ignore array-valued address fields when taxes are recalculated from the order edit screen.
+* Fix   - Prevent tax calculation from failing when the store address postcode holds more than one comma-separated value.
+* Fix   - Accept lower-case country and state codes from the woocommerce_taxjar_nexus_address filter, and fall back to the store address when a custom nexus address is incomplete instead of abandoning the calculation.
 * Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
 
 = 3.6.11 - 2026-08-05 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,8 @@
 * Fix   - Send the same values for empty address fields whether taxes are calculated at checkout or from the order edit screen.
 * Fix   - Ignore array-valued address fields when taxes are recalculated from the order edit screen.
 * Fix   - Prevent tax calculation from failing when the store address postcode holds more than one comma-separated value.
-* Fix   - Accept lower-case country and state codes from the woocommerce_taxjar_nexus_address filter, and fall back to the store address when a custom nexus address is incomplete instead of abandoning the calculation.
+* Fix   - Accept lower-case country and state codes from the woocommerce_taxjar_nexus_address filter.
+* Fix   - Fall back to the store address when a custom nexus address is incomplete instead of abandoning the calculation.
 * Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
 
 = 3.6.11 - 2026-08-05 =

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1559,13 +1559,17 @@ class WC_Connect_TaxJar_Integration {
 			'tax_rate'        => 0,
 		);
 
-		// Strict conditions to be met before API call can be conducted.
+		// Strict conditions to be met before API call can be conducted. The postcode
+		// check runs on the normalised value, so a postcode that collapses to an
+		// empty string (for example a lone comma) aborts here; log the abort so the
+		// stop is diagnosable.
 		if (
 			empty( $destination->country() ) ||
 			( empty( $destination->postcode() ) && ! in_array( $destination->country(), WC()->countries->get_vat_countries() ) ) ||
 			( empty( $line_items ) && ( empty( $shipping_amount ) ) ) ||
 			WC()->customer->is_vat_exempt()
 		) {
+			$this->_log( 'Destination address or cart data is incomplete, or the customer is VAT exempt. Aborting.' );
 			return false;
 		}
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1720,28 +1720,13 @@ class WC_Connect_TaxJar_Integration {
 	 */
 	private function get_address_parts( $body ) {
 		return array(
-			'from_country' => strtoupper( $this->scalar_to_string( $body['nexus_addresses'][0]['country'] ?? $body['from_country'] ?? '' ) ),
-			'from_state'   => strtoupper( $this->scalar_to_string( $body['nexus_addresses'][0]['state'] ?? $body['from_state'] ?? '' ) ),
-			'from_zip'     => $this->scalar_to_string( $body['nexus_addresses'][0]['zip'] ?? $body['from_zip'] ?? '' ),
-			'to_country'   => strtoupper( $this->scalar_to_string( $body['to_country'] ?? '' ) ),
-			'to_state'     => strtoupper( $this->scalar_to_string( $body['to_state'] ?? '' ) ),
-			'to_zip'       => $this->scalar_to_string( $body['to_zip'] ?? '' ),
+			'from_country' => strtoupper( (string) ( $body['nexus_addresses'][0]['country'] ?? $body['from_country'] ?? '' ) ),
+			'from_state'   => strtoupper( (string) ( $body['nexus_addresses'][0]['state'] ?? $body['from_state'] ?? '' ) ),
+			'from_zip'     => (string) ( $body['nexus_addresses'][0]['zip'] ?? $body['from_zip'] ?? '' ),
+			'to_country'   => strtoupper( (string) ( $body['to_country'] ?? '' ) ),
+			'to_state'     => strtoupper( (string) ( $body['to_state'] ?? '' ) ),
+			'to_zip'       => (string) ( $body['to_zip'] ?? '' ),
 		);
-	}
-
-	/**
-	 * Cast a request body value to string, treating non-scalars as absent.
-	 *
-	 * A hand-built body handed to `validate_taxjar_request()` can carry non-scalar
-	 * values; casting those to string would yield 'Array' and slip past the country
-	 * checks.
-	 *
-	 * @param mixed $value Raw body value.
-	 *
-	 * @return string
-	 */
-	private function scalar_to_string( $value ): string {
-		return is_scalar( $value ) ? (string) $value : '';
 	}
 
 	/**

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1470,6 +1470,8 @@ class WC_Connect_TaxJar_Integration {
 
 		// The value object casts these fields to string, so reject anything that cannot
 		// survive that cast rather than triggering an array-to-string conversion.
+		// Booleans survive the cast but silently change the sent value (false becomes
+		// "" and true becomes "1"), so they are rejected too, as the old schema did.
 		//
 		// Only the fields the value object reads are checked. Any other key a filter
 		// added is passed through untouched below and is never cast, so it carries no
@@ -1482,8 +1484,11 @@ class WC_Connect_TaxJar_Integration {
 
 			$value = $address[ $field ];
 
-			if ( null !== $value && ! is_scalar( $value ) ) {
-				$this->logger->error( 'Nexus Address ERRORS: [' . $field . '] field must be a string' . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . wp_json_encode( $address ), 'WCS Tax' );
+			if ( null !== $value && ( ! is_scalar( $value ) || is_bool( $value ) ) ) {
+				// wp_json_encode() returns false for unencodable payloads, which is
+				// what this branch catches; fall back so the log keeps the address.
+				$encoded = wp_json_encode( $address );
+				$this->logger->error( 'Nexus Address ERRORS: [' . $field . '] field must be a string' . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . ( false === $encoded ? print_r( $address, true ) : $encoded ), 'WCS Tax' );
 
 				return false;
 			}

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1714,13 +1714,20 @@ class WC_Connect_TaxJar_Integration {
 	 * @return array
 	 */
 	private function get_address_parts( $body ) {
+		// A hand-built body handed to validate_taxjar_request() can carry non-scalar
+		// values; casting those to string would yield 'Array' and slip past the
+		// country checks, so treat them as absent instead.
+		$scalar = static function ( $value ) {
+			return is_scalar( $value ) ? (string) $value : '';
+		};
+
 		return array(
-			'from_country' => strtoupper( (string) ( $body['nexus_addresses'][0]['country'] ?? $body['from_country'] ?? '' ) ),
-			'from_state'   => strtoupper( (string) ( $body['nexus_addresses'][0]['state'] ?? $body['from_state'] ?? '' ) ),
-			'from_zip'     => (string) ( $body['nexus_addresses'][0]['zip'] ?? $body['from_zip'] ?? '' ),
-			'to_country'   => strtoupper( (string) ( $body['to_country'] ?? '' ) ),
-			'to_state'     => strtoupper( (string) ( $body['to_state'] ?? '' ) ),
-			'to_zip'       => (string) ( $body['to_zip'] ?? '' ),
+			'from_country' => strtoupper( $scalar( $body['nexus_addresses'][0]['country'] ?? $body['from_country'] ?? '' ) ),
+			'from_state'   => strtoupper( $scalar( $body['nexus_addresses'][0]['state'] ?? $body['from_state'] ?? '' ) ),
+			'from_zip'     => $scalar( $body['nexus_addresses'][0]['zip'] ?? $body['from_zip'] ?? '' ),
+			'to_country'   => strtoupper( $scalar( $body['to_country'] ?? '' ) ),
+			'to_state'     => strtoupper( $scalar( $body['to_state'] ?? '' ) ),
+			'to_zip'       => $scalar( $body['to_zip'] ?? '' ),
 		);
 	}
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1520,6 +1520,10 @@ class WC_Connect_TaxJar_Integration {
 		$errors = $nexus->validate( $required )->get_error_messages();
 
 		if ( ! empty( $errors ) ) {
+			// The schema names the field postcode; the nexus array key is zip. Report
+			// the key the filter author actually used.
+			$errors = str_replace( '[postcode]', '[zip]', $errors );
+
 			$this->logger->error( 'Nexus Address ERRORS: ' . implode( ', ', $errors ) . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . print_r( $address, true ), 'WCS Tax' );
 
 			return false;
@@ -1542,11 +1546,8 @@ class WC_Connect_TaxJar_Integration {
 		// Normalize options to an array and safely map to local variables.
 		$options = is_array( $options ) ? $options : array();
 
-		// Both ends of the request go through the same normalisation. That symmetry is
-		// the point: the destination postcode used to be reduced to its first
-		// comma-separated segment while the store's was sent verbatim, so a store
-		// postcode entered as a list reached `validate_taxjar_request()` intact and
-		// aborted the calculation.
+		// Both ends of the request go through the same normalisation, so the address
+		// that is validated is the address that is sent.
 		$destination     = Address::from_options( $options, 'to_' );
 		$shipping_amount = $options['shipping_amount'] ?? 0;
 		$line_items      = $options['line_items'] ?? null;
@@ -1565,7 +1566,7 @@ class WC_Connect_TaxJar_Integration {
 		// stop is diagnosable.
 		if (
 			empty( $destination->country() ) ||
-			( empty( $destination->postcode() ) && ! in_array( $destination->country(), WC()->countries->get_vat_countries() ) ) ||
+			( empty( $destination->postcode() ) && ! in_array( $destination->country(), WC()->countries->get_vat_countries(), true ) ) ||
 			( empty( $line_items ) && ( empty( $shipping_amount ) ) ) ||
 			WC()->customer->is_vat_exempt()
 		) {
@@ -1708,10 +1709,10 @@ class WC_Connect_TaxJar_Integration {
 	 * This must report what the body actually carries. Country and state are
 	 * upper-cased because they are compared against the literal `'US'` and against
 	 * each other, and this runs from the public `validate_taxjar_request()`, which
-	 * any caller can hand a hand-built body. The **postcodes are returned verbatim**:
-	 * re-deriving them here is what previously made the value that was validated
-	 * differ from the value that was sent. Postcode normalisation belongs where the
-	 * body is assembled, in `calculate_tax()`.
+	 * any caller can hand a hand-built body. Postcodes are returned verbatim:
+	 * normalising them here would make the value that is validated differ from the
+	 * value that is sent. Postcode normalisation belongs where the body is
+	 * assembled, in `calculate_tax()`.
 	 *
 	 * @param array $body Request body.
 	 *

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1438,19 +1438,18 @@ class WC_Connect_TaxJar_Integration {
 	/**
 	 * Validates a TaxJar nexus address against the shared address schema.
 	 *
-	 * Delegates to `Address::validate()` so the nexus address is checked by the same
-	 * rules the rest of the integration uses, and — because `calculate_tax()` sends
-	 * the normalised address — is checked in the shape it is sent.
+	 * Delegates to `Address::validate()`, and because `calculate_tax()` sends the
+	 * normalised address, the address is checked in the shape it is sent.
 	 *
 	 * Country is always required. State is required for the US only; see the inline
-	 * comment for the measurement behind that, and for why a blanket requirement
-	 * rejects the plugin's own nexus across most of TaxJar's supported list.
+	 * comment for the measurement behind that, and for why requiring it everywhere
+	 * would reject the plugin's own nexus for stores without a base state.
 	 *
 	 * Validation is deliberately confined to the fields the value object reads. Extra
-	 * keys supplied by a filter are neither validated nor rewritten — `calculate_tax()`
+	 * keys supplied by a filter are neither validated nor rewritten; `calculate_tax()`
 	 * passes them straight through to the request body.
 	 *
-	 * @param  array $address Nexus address, as returned by `woocommerce_taxjar_nexus_address`.
+	 * @param  mixed $address Nexus address, as returned by `woocommerce_taxjar_nexus_address`.
 	 *
 	 * @return bool
 	 */
@@ -1503,14 +1502,13 @@ class WC_Connect_TaxJar_Integration {
 		 * `has_nexus: false` and zero tax. It fails silently, which is exactly why the
 		 * check has to stay for the US.
 		 *
-		 * Requiring it everywhere is what makes this wrong. The nexus address this
-		 * plugin builds for its own store always carries a 'state' key, and
-		 * WC()->countries->get_base_state() is '' for 19 of the 31 countries in
-		 * get_supported_countries() -- so a blanket requirement rejected the store's own
-		 * nexus on every tax calculation for those merchants, dropping the nexus block
-		 * from the request and writing a forced error log plus a persistent admin error
-		 * notice. For a filter-supplied nexus it is worse than noise: falling back to
-		 * the store's from_* address changes which origin TaxJar rates against.
+		 * The carve-out keeps this migration from introducing a rejection that the old
+		 * inline schema never made. That schema skipped fields that were present but
+		 * blank, so the blank state a stateless store carries always passed.
+		 * Address::validate() fails a blank required field, so requiring state
+		 * everywhere would newly reject the store's own nexus on every calculation
+		 * for those stores, and would drop a filter-supplied nexus back to the
+		 * store's from_* address, changing which origin TaxJar rates against.
 		 */
 		$required = ( 'US' === $nexus->country() ) ? array( 'country', 'state' ) : array( 'country' );
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1436,55 +1436,17 @@ class WC_Connect_TaxJar_Integration {
 	}
 
 	/**
-	 * Validates TaxJar nexus address.
+	 * Validates a TaxJar nexus address against the shared address schema.
 	 *
-	 * @param  array $address
+	 * Delegates to `Address::validate()` so the nexus address is checked by the same
+	 * rules the rest of the integration uses, and — because `calculate_tax()` sends
+	 * the normalised address — is checked in the shape it is sent.
+	 *
+	 * @param  array $address Nexus address, as returned by `woocommerce_taxjar_nexus_address`.
 	 *
 	 * @return bool
 	 */
 	private function is_nexus_address_valid( $address ): bool {
-		$errors = array();
-		$schema = array(
-			'id'      => array(
-				'type'        => 'string',
-				'required'    => false,
-				'description' => 'Unique identifier for the nexus address (optional).',
-				'max_length'  => 255,
-			),
-			'country' => array(
-				'type'        => 'string',
-				'required'    => true,
-				'pattern'     => '/^[A-Z]{2}$/', // two-letter ISO alpha-2 (upper-case)
-				'description' => 'Two-letter ISO country code (e.g. "US").',
-				'max_length'  => 2,
-			),
-			'zip'     => array(
-				'type'        => 'string',
-				'required'    => false,
-				'description' => 'Postal code (format varies by country).',
-				'max_length'  => 20,
-			),
-			'state'   => array(
-				'type'        => 'string',
-				'required'    => true,
-				'pattern'     => '/^[A-Z0-9\-]{1,100}$/', // typical short code like "NY", "CA", "NSW"
-				'description' => 'Two-letter (or short) ISO state/province code where applicable.',
-				'max_length'  => 100,
-			),
-			'city'    => array(
-				'type'        => 'string',
-				'required'    => false,
-				'description' => 'City name.',
-				'max_length'  => 100,
-			),
-			'street'  => array(
-				'type'        => 'string',
-				'required'    => false,
-				'description' => 'Street address (line).',
-				'max_length'  => 255,
-			),
-		);
-
 		/**
 		 * Return without logging as empty array() or false
 		 * might be return on purpose from filter to remove nexus address.
@@ -1499,38 +1461,17 @@ class WC_Connect_TaxJar_Integration {
 			return false;
 		}
 
-		foreach ( $schema as $field => $rules ) {
-			$exists = array_key_exists( $field, $address );
-			$value  = $exists ? $address[ $field ] : null;
+		// The value object casts each field to string, so reject anything that cannot
+		// survive that cast rather than triggering an array-to-string conversion.
+		foreach ( $address as $field => $value ) {
+			if ( null !== $value && ! is_scalar( $value ) ) {
+				$this->logger->error( 'Nexus Address ERRORS: [' . $field . '] field must be a string' . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . wp_json_encode( $address ), 'WCS Tax' );
 
-			if ( ! empty( $rules['required'] ) && ! $exists ) {
-				$errors[] = "[$field] field is required";
-				continue;
-			}
-
-			if ( ! $exists || $value === '' || $value === null ) {
-				continue;
-			}
-
-			if ( isset( $rules['type'] ) ) {
-				if ( $rules['type'] === 'string' && ! is_string( $value ) ) {
-					$errors[] = "[$field] field must be a string";
-					continue;
-				}
-			}
-
-			if ( isset( $rules['max_length'] ) && is_string( $value ) ) {
-				if ( strlen( $value ) > $rules['max_length'] ) {
-					$errors[] = "[$field] field exceeds maximum length of {$rules['max_length']}";
-				}
-			}
-
-			if ( isset( $rules['pattern'] ) && is_string( $value ) ) {
-				if ( ! preg_match( $rules['pattern'], $value ) ) {
-					$errors[] = "[$field] field format is invalid";
-				}
+				return false;
 			}
 		}
+
+		$errors = Address::from_nexus( $address )->validate()->get_error_messages();
 
 		if ( ! empty( $errors ) ) {
 			$this->logger->error( 'Nexus Address ERRORS: ' . implode( ', ', $errors ) . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . print_r( $address, true ), 'WCS Tax' );
@@ -1555,11 +1496,12 @@ class WC_Connect_TaxJar_Integration {
 		// Normalize options to an array and safely map to local variables.
 		$options = is_array( $options ) ? $options : array();
 
-		$to_country      = isset( $options['to_country'] ) ? strtoupper( $options['to_country'] ) : null;
-		$to_state        = isset( $options['to_state'] ) ? strtoupper( $options['to_state'] ) : null;
-		$to_zip          = $options['to_zip'] ?? null;
-		$to_city         = $options['to_city'] ?? null;
-		$to_street       = $options['to_street'] ?? null;
+		// Both ends of the request go through the same normalisation. That symmetry is
+		// the point: the destination postcode used to be reduced to its first
+		// comma-separated segment while the store's was sent verbatim, so a store
+		// postcode entered as a list reached `validate_taxjar_request()` intact and
+		// aborted the calculation.
+		$destination     = Address::from_options( $options, 'to_' );
 		$shipping_amount = $options['shipping_amount'] ?? 0;
 		$line_items      = $options['line_items'] ?? null;
 
@@ -1573,48 +1515,29 @@ class WC_Connect_TaxJar_Integration {
 
 		// Strict conditions to be met before API call can be conducted.
 		if (
-			empty( $to_country ) ||
-			( empty( $to_zip ) && ! in_array( $to_country, WC()->countries->get_vat_countries() ) ) ||
+			empty( $destination->country() ) ||
+			( empty( $destination->postcode() ) && ! in_array( $destination->country(), WC()->countries->get_vat_countries() ) ) ||
 			( empty( $line_items ) && ( empty( $shipping_amount ) ) ) ||
 			WC()->customer->is_vat_exempt()
 		) {
 			return false;
 		}
 
-		$to_zip = explode( ',', $to_zip );
-		$to_zip = array_shift( $to_zip );
-
-		$store_settings = $this->get_store_settings();
-		$from_country   = strtoupper( $store_settings['country'] );
-		$from_state     = strtoupper( $store_settings['state'] );
-		$from_zip       = $store_settings['postcode'];
-		$from_city      = $store_settings['city'];
-		$from_street    = $store_settings['street'];
+		$store_address = Address::from_store_settings( $this->get_store_settings() );
+		$from_state    = $store_address->state();
 
 		$this->_log( ':::: TaxJar API called ::::' );
 
-		$body = array(
-			'from_country' => $from_country,
-			'from_state'   => $from_state,
-			'from_zip'     => $from_zip,
-			'from_city'    => $from_city,
-			'from_street'  => $from_street,
-			'to_country'   => $to_country,
-			'to_state'     => $to_state,
-			'to_zip'       => $to_zip,
-			'to_city'      => $to_city,
-			'to_street'    => $to_street,
-			'shipping'     => $shipping_amount,
-			'plugin'       => 'woo',
+		$body = array_merge(
+			$store_address->to_taxjar_body( 'from_' ),
+			$destination->to_taxjar_body( 'to_' ),
+			array(
+				'shipping' => $shipping_amount,
+				'plugin'   => 'woo',
+			)
 		);
 
-		$nexus_address = array(
-			'country' => $body['from_country'],
-			'zip'     => $body['from_zip'],
-			'state'   => $body['from_state'],
-			'city'    => $body['from_city'],
-			'street'  => $body['from_street'],
-		);
+		$nexus_address = $store_address->to_nexus_array();
 
 		/**
 		 * Filter to modify or disable the nexus address sent to TaxJar API.
@@ -1665,6 +1588,14 @@ class WC_Connect_TaxJar_Integration {
 			foreach ( $params_to_unset as $param ) {
 				unset( $body[ $param ] );
 			}
+
+			// Send the address in the shape it was validated in. Only the fields the
+			// value object knows about are rewritten; any other key a filter added is
+			// passed through untouched, so the documented array-in / array-out contract
+			// does not become a whitelist.
+			$normalized    = Address::from_nexus( $nexus_address )->to_nexus_array();
+			$nexus_address = array_merge( $nexus_address, array_intersect_key( $normalized, $nexus_address ) );
+
 			$body['nexus_addresses'] = array( $nexus_address );
 		}
 
@@ -1718,8 +1649,15 @@ class WC_Connect_TaxJar_Integration {
 
 
 	/**
-	 * Return address parts.
-	 * Primarily used in address validation to operate on normalized and predictable indexes.
+	 * Project the address out of a request body, for validation and the nexus gate.
+	 *
+	 * This must report what the body actually carries. Country and state are
+	 * upper-cased because they are compared against the literal `'US'` and against
+	 * each other, and this runs from the public `validate_taxjar_request()`, which
+	 * any caller can hand a hand-built body. The **postcodes are returned verbatim**:
+	 * re-deriving them here is what previously made the value that was validated
+	 * differ from the value that was sent. Postcode normalisation belongs where the
+	 * body is assembled, in `calculate_tax()`.
 	 *
 	 * @param array $body Request body.
 	 *
@@ -1727,12 +1665,12 @@ class WC_Connect_TaxJar_Integration {
 	 */
 	private function get_address_parts( $body ) {
 		return array(
-			'from_country' => strtoupper( $body['nexus_addresses'][0]['country'] ?? $body['from_country'] ?? '' ),
-			'from_state'   => strtoupper( $body['nexus_addresses'][0]['state'] ?? $body['from_state'] ?? '' ),
-			'from_zip'     => strtoupper( $body['nexus_addresses'][0]['zip'] ?? $body['from_zip'] ?? '' ),
-			'to_country'   => strtoupper( $body['to_country'] ?? '' ),
-			'to_state'     => strtoupper( $body['to_state'] ?? '' ),
-			'to_zip'       => strtoupper( $body['to_zip'] ?? '' ),
+			'from_country' => strtoupper( (string) ( $body['nexus_addresses'][0]['country'] ?? $body['from_country'] ?? '' ) ),
+			'from_state'   => strtoupper( (string) ( $body['nexus_addresses'][0]['state'] ?? $body['from_state'] ?? '' ) ),
+			'from_zip'     => (string) ( $body['nexus_addresses'][0]['zip'] ?? $body['from_zip'] ?? '' ),
+			'to_country'   => strtoupper( (string) ( $body['to_country'] ?? '' ) ),
+			'to_state'     => strtoupper( (string) ( $body['to_state'] ?? '' ) ),
+			'to_zip'       => (string) ( $body['to_zip'] ?? '' ),
 		);
 	}
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1590,17 +1590,21 @@ class WC_Connect_TaxJar_Integration {
 		 * Return false or an empty array to disable sending nexus addresses entirely,
 		 * which will cause the request to use the standard from_* address fields instead.
 		 *
-		 * The nexus address array should contain the following keys:
+		 * The nexus address array may contain the following keys:
 		 * - country: Two-letter country code (required).
-		 * - state: Two-letter state/province code (required for US/CA).
-		 * - zip: Postal/ZIP code (required).
-		 * - city: City name (required).
+		 * - state: State/province code (required for US nexus addresses).
+		 * - zip: Postal/ZIP code (optional).
+		 * - city: City name (optional).
 		 * - street: Street address (optional).
+		 *
+		 * The known keys are normalised before sending: case is folded, whitespace
+		 * trimmed, and only the first segment of a comma-separated postcode is kept.
+		 * Unknown keys pass through to the request body unchanged.
 		 *
 		 * @since 3.3.0
 		 *
 		 * @param array $nexus_address The nexus address array to be sent to TaxJar.
-		 * @param array $body          The complete TaxJar API request body.
+		 * @param array $body          The complete TaxJar API request body, already normalised.
 		 *
 		 * @return array|false Modified nexus address array, or false to disable nexus addresses.
 		 *

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1442,6 +1442,14 @@ class WC_Connect_TaxJar_Integration {
 	 * rules the rest of the integration uses, and — because `calculate_tax()` sends
 	 * the normalised address — is checked in the shape it is sent.
 	 *
+	 * Country is always required. State is required for the US only; see the inline
+	 * comment for the measurement behind that, and for why a blanket requirement
+	 * rejects the plugin's own nexus across most of TaxJar's supported list.
+	 *
+	 * Validation is deliberately confined to the fields the value object reads. Extra
+	 * keys supplied by a filter are neither validated nor rewritten — `calculate_tax()`
+	 * passes them straight through to the request body.
+	 *
 	 * @param  array $address Nexus address, as returned by `woocommerce_taxjar_nexus_address`.
 	 *
 	 * @return bool
@@ -1461,9 +1469,20 @@ class WC_Connect_TaxJar_Integration {
 			return false;
 		}
 
-		// The value object casts each field to string, so reject anything that cannot
+		// The value object casts these fields to string, so reject anything that cannot
 		// survive that cast rather than triggering an array-to-string conversion.
-		foreach ( $address as $field => $value ) {
+		//
+		// Only the fields the value object reads are checked. Any other key a filter
+		// added is passed through untouched below and is never cast, so it carries no
+		// conversion risk — rejecting the whole address over it would turn the
+		// documented array-in / array-out contract into a whitelist.
+		foreach ( array( 'id', 'country', 'state', 'zip', 'city', 'street' ) as $field ) {
+			if ( ! array_key_exists( $field, $address ) ) {
+				continue;
+			}
+
+			$value = $address[ $field ];
+
 			if ( null !== $value && ! is_scalar( $value ) ) {
 				$this->logger->error( 'Nexus Address ERRORS: [' . $field . '] field must be a string' . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . wp_json_encode( $address ), 'WCS Tax' );
 
@@ -1471,7 +1490,31 @@ class WC_Connect_TaxJar_Integration {
 			}
 		}
 
-		$errors = Address::from_nexus( $address )->validate()->get_error_messages();
+		$nexus = Address::from_nexus( $address );
+
+		/*
+		 * The origin state is required for the US, and only for the US.
+		 *
+		 * US nexus is determined from the ORIGIN state; VAT and GST countries rate from
+		 * the destination and ignore a blank origin state. Measured against the live
+		 * TaxJar API rather than assumed -- GB, FR, NL, DK, DE, ES, IT, IE, CA and AU
+		 * all return an identical rate whether the nexus carries its state or an empty
+		 * string, while a US nexus with a blank state returns HTTP 200 with
+		 * `has_nexus: false` and zero tax. It fails silently, which is exactly why the
+		 * check has to stay for the US.
+		 *
+		 * Requiring it everywhere is what makes this wrong. The nexus address this
+		 * plugin builds for its own store always carries a 'state' key, and
+		 * WC()->countries->get_base_state() is '' for 19 of the 31 countries in
+		 * get_supported_countries() -- so a blanket requirement rejected the store's own
+		 * nexus on every tax calculation for those merchants, dropping the nexus block
+		 * from the request and writing a forced error log plus a persistent admin error
+		 * notice. For a filter-supplied nexus it is worse than noise: falling back to
+		 * the store's from_* address changes which origin TaxJar rates against.
+		 */
+		$required = ( 'US' === $nexus->country() ) ? array( 'country', 'state' ) : array( 'country' );
+
+		$errors = $nexus->validate( $required )->get_error_messages();
 
 		if ( ! empty( $errors ) ) {
 			$this->logger->error( 'Nexus Address ERRORS: ' . implode( ', ', $errors ) . PHP_EOL . 'Nexus address removed from request body.' . PHP_EOL . print_r( $address, true ), 'WCS Tax' );

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1718,21 +1718,29 @@ class WC_Connect_TaxJar_Integration {
 	 * @return array
 	 */
 	private function get_address_parts( $body ) {
-		// A hand-built body handed to validate_taxjar_request() can carry non-scalar
-		// values; casting those to string would yield 'Array' and slip past the
-		// country checks, so treat them as absent instead.
-		$scalar = static function ( $value ) {
-			return is_scalar( $value ) ? (string) $value : '';
-		};
-
 		return array(
-			'from_country' => strtoupper( $scalar( $body['nexus_addresses'][0]['country'] ?? $body['from_country'] ?? '' ) ),
-			'from_state'   => strtoupper( $scalar( $body['nexus_addresses'][0]['state'] ?? $body['from_state'] ?? '' ) ),
-			'from_zip'     => $scalar( $body['nexus_addresses'][0]['zip'] ?? $body['from_zip'] ?? '' ),
-			'to_country'   => strtoupper( $scalar( $body['to_country'] ?? '' ) ),
-			'to_state'     => strtoupper( $scalar( $body['to_state'] ?? '' ) ),
-			'to_zip'       => $scalar( $body['to_zip'] ?? '' ),
+			'from_country' => strtoupper( $this->scalar_to_string( $body['nexus_addresses'][0]['country'] ?? $body['from_country'] ?? '' ) ),
+			'from_state'   => strtoupper( $this->scalar_to_string( $body['nexus_addresses'][0]['state'] ?? $body['from_state'] ?? '' ) ),
+			'from_zip'     => $this->scalar_to_string( $body['nexus_addresses'][0]['zip'] ?? $body['from_zip'] ?? '' ),
+			'to_country'   => strtoupper( $this->scalar_to_string( $body['to_country'] ?? '' ) ),
+			'to_state'     => strtoupper( $this->scalar_to_string( $body['to_state'] ?? '' ) ),
+			'to_zip'       => $this->scalar_to_string( $body['to_zip'] ?? '' ),
 		);
+	}
+
+	/**
+	 * Cast a request body value to string, treating non-scalars as absent.
+	 *
+	 * A hand-built body handed to `validate_taxjar_request()` can carry non-scalar
+	 * values; casting those to string would yield 'Array' and slip past the country
+	 * checks.
+	 *
+	 * @param mixed $value Raw body value.
+	 *
+	 * @return string
+	 */
+	private function scalar_to_string( $value ): string {
+		return is_scalar( $value ) ? (string) $value : '';
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -76,6 +76,8 @@ This plugin relies on the following external services:
 * Fix   - Prevent a fatal error during cart and checkout tax calculation when a customization supplies an invalid store address.
 * Fix   - Send the same values for empty address fields whether taxes are calculated at checkout or from the order edit screen.
 * Fix   - Ignore array-valued address fields when taxes are recalculated from the order edit screen.
+* Fix   - Prevent tax calculation from failing when the store address postcode holds more than one comma-separated value.
+* Fix   - Accept lower-case country and state codes from the woocommerce_taxjar_nexus_address filter, and fall back to the store address when a custom nexus address is incomplete instead of abandoning the calculation.
 * Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
 
 = 3.6.11 - 2026-08-05 =

--- a/readme.txt
+++ b/readme.txt
@@ -77,7 +77,8 @@ This plugin relies on the following external services:
 * Fix   - Send the same values for empty address fields whether taxes are calculated at checkout or from the order edit screen.
 * Fix   - Ignore array-valued address fields when taxes are recalculated from the order edit screen.
 * Fix   - Prevent tax calculation from failing when the store address postcode holds more than one comma-separated value.
-* Fix   - Accept lower-case country and state codes from the woocommerce_taxjar_nexus_address filter, and fall back to the store address when a custom nexus address is incomplete instead of abandoning the calculation.
+* Fix   - Accept lower-case country and state codes from the woocommerce_taxjar_nexus_address filter.
+* Fix   - Fall back to the store address when a custom nexus address is incomplete instead of abandoning the calculation.
 * Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
 
 = 3.6.11 - 2026-08-05 =

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -2699,10 +2699,9 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	 *
 	 * The non-scalar guard exists because the value object casts the fields it reads to
 	 * string. Keys it does not read are never cast — they are merged back untouched —
-	 * so they carry no conversion risk. Checking them anyway made a single custom key
-	 * holding an array discard the entire nexus address, silently swapping which nexus
-	 * TaxJar was asked about, and logged "[meta] field must be a string" for a field
-	 * that is never treated as a string.
+	 * so they carry no conversion risk. Checking them anyway would make a single
+	 * custom key holding an array discard the entire nexus address, silently swapping
+	 * which nexus TaxJar is asked about.
 	 */
 	public function test_non_scalar_unknown_nexus_key_is_passed_through() {
 		$body = $this->capture_taxjar_request_json(
@@ -2810,8 +2809,9 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	 * silent under-collection. Rejecting it here falls back to the store's `from_*`
 	 * address, which carries the real state.
 	 *
-	 * This passes before the relaxation too — it bounds the change rather than
-	 * demonstrating a fixed bug.
+	 * The old schema skipped blank fields, so this nexus was accepted, forwarded
+	 * with a blank state, and the US cross-state gate then dropped the calculation
+	 * without a request. This test fails on the base branch for that reason.
 	 */
 	public function test_blank_state_is_still_rejected_for_a_us_nexus() {
 		$body = $this->capture_taxjar_request_json(

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -2611,11 +2611,11 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			'A well-formed US body failed public validation.'
 		);
 
-		$body['from_zip'] = 'not-a-zip';
+		unset( $body['from_country'] );
 
 		$this->assertFalse(
 			$this->integration->validate_taxjar_request( wp_json_encode( $body ) ),
-			'A malformed US store postcode passed public validation.'
+			'A body without an origin country passed public validation.'
 		);
 	}
 

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -2592,11 +2592,9 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * `validate_taxjar_request()` is public and accepts any hand-built body.
-	 *
-	 * A nested JSON object decodes to an array; cast to string that becomes
-	 * `'Array'`, which is non-empty and would slip past every country check. It
-	 * must read as missing instead, so the request is stopped.
+	 * `validate_taxjar_request()` is public and accepts any hand-built body, so the
+	 * verbatim-postcode contract has to hold through it, not just through the
+	 * private projection.
 	 */
 	public function test_validate_taxjar_request_handles_a_hand_built_body() {
 		$body = array(
@@ -2613,11 +2611,11 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			'A well-formed US body failed public validation.'
 		);
 
-		$body['from_country'] = array( 'code' => 'US' );
+		$body['from_zip'] = 'not-a-zip';
 
 		$this->assertFalse(
 			$this->integration->validate_taxjar_request( wp_json_encode( $body ) ),
-			'A non-scalar origin country passed public validation.'
+			'A malformed US store postcode passed public validation.'
 		);
 	}
 

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -2493,19 +2493,26 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 
 		$integration = new WC_Connect_TaxJar_Integration( $api_client, $logger, 'https://example.com', $tracks, $notifier );
 
-		$store_filter = $this->force_store_settings( null === $store ? $this->default_store_settings() : $store );
-		if ( is_callable( $nexus_filter ) ) {
-			add_filter( 'woocommerce_taxjar_nexus_address', $nexus_filter, 10, 2 );
-		}
-		WC()->customer->set_is_vat_exempt( false );
+		$was_vat_exempt = WC()->customer->is_vat_exempt();
 
+		// Everything that touches shared state happens inside the try, so a throw
+		// anywhere leaves no filter and no customer flag behind.
 		try {
+			$store_filter = $this->force_store_settings( null === $store ? $this->default_store_settings() : $store );
+			if ( is_callable( $nexus_filter ) ) {
+				add_filter( 'woocommerce_taxjar_nexus_address', $nexus_filter, 10, 2 );
+			}
+			WC()->customer->set_is_vat_exempt( false );
+
 			$integration->calculate_tax( $options );
 		} finally {
 			if ( is_callable( $nexus_filter ) ) {
 				remove_filter( 'woocommerce_taxjar_nexus_address', $nexus_filter, 10 );
 			}
-			remove_filter( 'taxjar_store_settings', $store_filter, 99 );
+			if ( isset( $store_filter ) ) {
+				remove_filter( 'taxjar_store_settings', $store_filter, 99 );
+			}
+			WC()->customer->set_is_vat_exempt( $was_vat_exempt );
 		}
 
 		return null === $sent ? null : json_decode( $sent, true );

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -2571,6 +2571,36 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * `validate_taxjar_request()` is public and accepts any hand-built body.
+	 *
+	 * A nested JSON object decodes to an array; cast to string that becomes
+	 * `'Array'`, which is non-empty and would slip past every country check. It
+	 * must read as missing instead, so the request is stopped.
+	 */
+	public function test_validate_taxjar_request_handles_a_hand_built_body() {
+		$body = array(
+			'from_country' => 'US',
+			'from_state'   => 'CA',
+			'from_zip'     => '90210',
+			'to_country'   => 'US',
+			'to_state'     => 'CA',
+			'to_zip'       => '94103',
+		);
+
+		$this->assertTrue(
+			$this->integration->validate_taxjar_request( wp_json_encode( $body ) ),
+			'A well-formed US body failed public validation.'
+		);
+
+		$body['from_country'] = array( 'code' => 'US' );
+
+		$this->assertFalse(
+			$this->integration->validate_taxjar_request( wp_json_encode( $body ) ),
+			'A non-scalar origin country passed public validation.'
+		);
+	}
+
+	/**
 	 * Destination fields the caller omitted reach the body as empty strings.
 	 *
 	 * The body is built from the value object, which types every field as a string.

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -2751,6 +2751,55 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * A numeric nexus postcode is accepted and sent as a string.
+	 *
+	 * The old schema rejected every non-string; the scalar guard deliberately lets
+	 * numbers through and the value object casts them. This pins the accept side of
+	 * that delta — the reject side is covered by the boolean and array tests.
+	 */
+	public function test_numeric_nexus_postcode_is_accepted() {
+		$body = $this->capture_taxjar_request_json(
+			$this->in_state_options(),
+			function ( $nexus_address ) {
+				$nexus_address['zip'] = 90210;
+
+				return $nexus_address;
+			}
+		);
+
+		$this->assertIsArray( $body, 'A numeric nexus postcode aborted the request.' );
+		$this->assertArrayHasKey(
+			'nexus_addresses',
+			$body,
+			'A numeric nexus postcode was rejected instead of being cast to a string.'
+		);
+		$this->assertSame( '90210', $body['nexus_addresses'][0]['zip'] );
+	}
+
+	/**
+	 * City and street normalisation applies to the assembled body.
+	 *
+	 * The value object strips semicolons and collapses whitespace in cities and
+	 * trims streets. These values reach the wire and the md5 transient key, so the
+	 * normalisation is part of the request contract, not an internal detail.
+	 */
+	public function test_body_fields_are_normalised_on_assembly() {
+		$options              = $this->in_state_options();
+		$options['to_city']   = 'San;  Francisco';
+		$options['to_street'] = ' 1 Market St ';
+
+		$store         = $this->default_store_settings();
+		$store['city'] = 'Beverly;  Hills';
+
+		$body = $this->capture_taxjar_request_json( $options, null, $store );
+
+		$this->assertIsArray( $body, 'A city containing a semicolon aborted the request.' );
+		$this->assertSame( 'San Francisco', $body['to_city'] );
+		$this->assertSame( '1 Market St', $body['to_street'] );
+		$this->assertSame( 'Beverly Hills', $body['nexus_addresses'][0]['city'] );
+	}
+
+	/**
 	 * A boolean nexus field is rejected, not cast.
 	 *
 	 * `false` casts to `""` and `true` to `"1"`, either of which silently changes

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -2903,10 +2903,11 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Non-US TaxJar-supported countries, with and without WooCommerce states.
-	 *
-	 * The `has states` flag is recorded only to document that the split is deliberate —
-	 * nothing in the assertion depends on it, which is the point.
+	 * Non-US TaxJar-supported countries, one row per behaviour class: a country
+	 * WooCommerce gives no states, one it does, and CA, which needs a destination
+	 * state to clear `validate_taxjar_request()` while the store's own state stays
+	 * blank. Every row drives the same non-US branch, so more rows add runtime, not
+	 * coverage.
 	 *
 	 * @return array<string, array{0: string, 1: string, 2: string}>
 	 */
@@ -2914,15 +2915,9 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		return array(
 			// No states in WooCommerce.
 			'GB' => array( 'GB', 'SW1A 1AA', '' ),
-			'FR' => array( 'FR', '75001', '' ),
-			'NL' => array( 'NL', '1011 AB', '' ),
-			'DK' => array( 'DK', '1050', '' ),
 
-			// States in WooCommerce, but TaxJar rates them from the destination anyway.
+			// States in WooCommerce, but TaxJar rates from the destination anyway.
 			'DE' => array( 'DE', '10117', '' ),
-			'ES' => array( 'ES', '28001', '' ),
-			'IT' => array( 'IT', '00184', '' ),
-			'AU' => array( 'AU', '2000', '' ),
 
 			// CA needs a destination state to clear `validate_taxjar_request()`; the
 			// store's own state stays blank, which is what this test is about.

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -2667,4 +2667,144 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$this->assertIsArray( $body );
 		$this->assertArrayNotHasKey( 'nexus_addresses', $body );
 	}
+
+	/**
+	 * A non-scalar value under an unknown key must not reject the whole address.
+	 *
+	 * The non-scalar guard exists because the value object casts the fields it reads to
+	 * string. Keys it does not read are never cast — they are merged back untouched —
+	 * so they carry no conversion risk. Checking them anyway made a single custom key
+	 * holding an array discard the entire nexus address, silently swapping which nexus
+	 * TaxJar was asked about, and logged "[meta] field must be a string" for a field
+	 * that is never treated as a string.
+	 */
+	public function test_non_scalar_unknown_nexus_key_is_passed_through() {
+		$body = $this->capture_taxjar_request_json(
+			$this->in_state_options(),
+			function ( $nexus_address ) {
+				$nexus_address['meta'] = array( 'source' => 'erp' );
+
+				return $nexus_address;
+			}
+		);
+
+		$this->assertIsArray( $body );
+		$this->assertArrayHasKey(
+			'nexus_addresses',
+			$body,
+			'A non-scalar value under an unknown key rejected the whole nexus address.'
+		);
+		$this->assertSame( array( 'source' => 'erp' ), $body['nexus_addresses'][0]['meta'] );
+		$this->assertSame( 'US', $body['nexus_addresses'][0]['country'] );
+	}
+
+	/**
+	 * A store outside the US keeps its own nexus address even with a blank state.
+	 *
+	 * `to_nexus_array()` always emits a `state` key, and `WC()->countries->get_base_state()`
+	 * returns `''` for 19 of the 31 countries in `get_supported_countries()` — GB, FR,
+	 * NL, BE, DK, SE, PL, PT and the rest of the stateless EU. Requiring a non-blank
+	 * state therefore rejected the nexus this plugin builds for the merchant's own
+	 * store, on every tax calculation, and each rejection wrote a forced error log and
+	 * a persistent admin error notice.
+	 *
+	 * The provider deliberately mixes countries WooCommerce gives no states (GB, FR, NL,
+	 * DK) with ones it does (DE, ES, IT, CA, AU). Both groups belong here: measured
+	 * against the live TaxJar API, every one of them rates a blank-state nexus
+	 * identically to a populated one, because only the US derives nexus from the origin
+	 * state. Keying the requirement off "does WooCommerce model states for this country"
+	 * would pass the first group and wrongly reject the second.
+	 *
+	 * @dataProvider provider_non_us_store_countries
+	 *
+	 * @param string $country   Two-letter country code.
+	 * @param string $postcode  A postcode valid for that country.
+	 * @param string $to_state  Destination state. Only CA needs one — `validate_taxjar_request()`
+	 *                          requires a destination state for US and CA, which is a rule about
+	 *                          where the customer is, not about the store's nexus.
+	 */
+	public function test_non_us_store_keeps_its_nexus_address_without_a_state( $country, $postcode, $to_state = '' ) {
+		$store = array(
+			'street'   => '1 Store Way',
+			'city'     => 'Somewhere',
+			'state'    => '',
+			'country'  => $country,
+			'postcode' => $postcode,
+		);
+
+		$options               = $this->in_state_options();
+		$options['to_country'] = $country;
+		$options['to_state']   = $to_state;
+		$options['to_zip']     = $postcode;
+		$options['to_city']    = 'Somewhere';
+
+		$body = $this->capture_taxjar_request_json( $options, null, $store );
+
+		$this->assertIsArray( $body, sprintf( 'A %s store aborted the tax calculation.', $country ) );
+		$this->assertArrayHasKey(
+			'nexus_addresses',
+			$body,
+			sprintf( 'The store nexus was rejected for %s, where TaxJar does not need an origin state.', $country )
+		);
+		$this->assertSame( $country, $body['nexus_addresses'][0]['country'] );
+		$this->assertSame( '', $body['nexus_addresses'][0]['state'] );
+	}
+
+	/**
+	 * Non-US TaxJar-supported countries, with and without WooCommerce states.
+	 *
+	 * The `has states` flag is recorded only to document that the split is deliberate —
+	 * nothing in the assertion depends on it, which is the point.
+	 *
+	 * @return array<string, array{0: string, 1: string, 2: string}>
+	 */
+	public function provider_non_us_store_countries() {
+		return array(
+			// No states in WooCommerce.
+			'GB' => array( 'GB', 'SW1A 1AA', '' ),
+			'FR' => array( 'FR', '75001', '' ),
+			'NL' => array( 'NL', '1011 AB', '' ),
+			'DK' => array( 'DK', '1050', '' ),
+
+			// States in WooCommerce, but TaxJar rates them from the destination anyway.
+			'DE' => array( 'DE', '10117', '' ),
+			'ES' => array( 'ES', '28001', '' ),
+			'IT' => array( 'IT', '00184', '' ),
+			'AU' => array( 'AU', '2000', '' ),
+
+			// CA needs a destination state to clear `validate_taxjar_request()`; the
+			// store's own state stays blank, which is what this test is about.
+			'CA' => array( 'CA', 'M5H 2N2', 'ON' ),
+		);
+	}
+
+	/**
+	 * The US keeps the strict requirement, because there a blank state loses the tax.
+	 *
+	 * This is the one country the relaxation must not reach. US nexus is derived from
+	 * the origin state, and TaxJar does not reject a blank one — it returns HTTP 200
+	 * with `has_nexus: false` and zero tax, so an accepted blank-state US nexus is a
+	 * silent under-collection. Rejecting it here falls back to the store's `from_*`
+	 * address, which carries the real state.
+	 *
+	 * This passes before the relaxation too — it bounds the change rather than
+	 * demonstrating a fixed bug.
+	 */
+	public function test_blank_state_is_still_rejected_for_a_us_nexus() {
+		$body = $this->capture_taxjar_request_json(
+			$this->in_state_options(),
+			function ( $nexus_address ) {
+				$nexus_address['state'] = '';
+
+				return $nexus_address;
+			}
+		);
+
+		$this->assertIsArray( $body, 'A blank nexus state aborted the request instead of falling back.' );
+		$this->assertArrayNotHasKey(
+			'nexus_addresses',
+			$body,
+			'A US nexus address with a blank state was forwarded.'
+		);
+	}
 }

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -2701,19 +2701,16 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	/**
 	 * A store outside the US keeps its own nexus address even with a blank state.
 	 *
-	 * `to_nexus_array()` always emits a `state` key, and `WC()->countries->get_base_state()`
-	 * returns `''` for 19 of the 31 countries in `get_supported_countries()` — GB, FR,
-	 * NL, BE, DK, SE, PL, PT and the rest of the stateless EU. Requiring a non-blank
-	 * state therefore rejected the nexus this plugin builds for the merchant's own
-	 * store, on every tax calculation, and each rejection wrote a forced error log and
-	 * a persistent admin error notice.
+	 * `to_nexus_array()` always emits a `state` key, blank for a store with no base
+	 * state configured. The old inline schema skipped blank fields, so that nexus
+	 * always passed; `Address::validate()` fails a blank required field, so requiring
+	 * state everywhere would newly reject the store's own nexus on every calculation.
+	 * The US-only requirement prevents that regression.
 	 *
-	 * The provider deliberately mixes countries WooCommerce gives no states (GB, FR, NL,
-	 * DK) with ones it does (DE, ES, IT, CA, AU). Both groups belong here: measured
-	 * against the live TaxJar API, every one of them rates a blank-state nexus
-	 * identically to a populated one, because only the US derives nexus from the origin
-	 * state. Keying the requirement off "does WooCommerce model states for this country"
-	 * would pass the first group and wrongly reject the second.
+	 * The provider mixes countries WooCommerce gives no states with ones it does.
+	 * Both groups belong here: measured against the live TaxJar API, every one of
+	 * them rates a blank-state nexus identically to a populated one, because only
+	 * the US derives nexus from the origin state.
 	 *
 	 * @dataProvider provider_non_us_store_countries
 	 *

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -2571,6 +2571,25 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Destination fields the caller omitted reach the body as empty strings.
+	 *
+	 * The body is built from the value object, which types every field as a string.
+	 * `to_city` and `to_street` were sent as `null` when absent from the options;
+	 * `""` is the new wire value, and the changed JSON shifts the md5 transient
+	 * key, turning over one cache generation.
+	 */
+	public function test_omitted_destination_fields_are_sent_as_empty_strings() {
+		$options = $this->in_state_options();
+		unset( $options['to_city'], $options['to_street'] );
+
+		$body = $this->capture_taxjar_request_json( $options );
+
+		$this->assertIsArray( $body, 'Omitting optional destination fields aborted the request.' );
+		$this->assertSame( '', $body['to_city'] );
+		$this->assertSame( '', $body['to_street'] );
+	}
+
+	/**
 	 * A nexus address whose required field is present but blank must be rejected, so
 	 * the request falls back to the store address.
 	 *

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -2714,6 +2714,31 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * A boolean nexus field is rejected, not cast.
+	 *
+	 * `false` casts to `""` and `true` to `"1"`, either of which silently changes
+	 * the origin TaxJar rates against. The old schema rejected non-strings
+	 * outright; booleans keep that treatment while numeric postcodes are accepted.
+	 */
+	public function test_boolean_nexus_field_is_rejected() {
+		$body = $this->capture_taxjar_request_json(
+			$this->in_state_options(),
+			function ( $nexus_address ) {
+				$nexus_address['zip'] = false;
+
+				return $nexus_address;
+			}
+		);
+
+		$this->assertIsArray( $body, 'A boolean nexus field aborted the request instead of falling back.' );
+		$this->assertArrayNotHasKey(
+			'nexus_addresses',
+			$body,
+			'A nexus address with a boolean field was forwarded.'
+		);
+	}
+
+	/**
 	 * A non-scalar value under an unknown key must not reject the whole address.
 	 *
 	 * The non-scalar guard exists because the value object casts the fields it reads to

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -2386,4 +2386,285 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$this->assertSame( "O'BRIEN", $address['to_city'], 'Backend city retained the WordPress-added slash.' );
 		$this->assertSame( "123 O'MALLEY WAY", $address['to_street'], 'Backend street retained the WordPress-added slash.' );
 	}
+
+	// -------------------------------------------------------------------------
+	// Request seam — the address that gets validated must be the address that
+	// gets sent.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * A plain US:CA store.
+	 *
+	 * @return array
+	 */
+	private function default_store_settings() {
+		return array(
+			'street'   => '1 Store Way',
+			'city'     => 'Beverly Hills',
+			'state'    => 'CA',
+			'country'  => 'US',
+			'postcode' => '90210',
+		);
+	}
+
+	/**
+	 * Options for an in-state destination, so `calculate_tax()` runs past the
+	 * cross-state no-nexus gate and actually assembles a request.
+	 *
+	 * @return array
+	 */
+	private function in_state_options() {
+		return array(
+			'to_country'      => 'US',
+			'to_state'        => 'CA',
+			'to_zip'          => '94103',
+			'to_city'         => 'San Francisco',
+			'to_street'       => '1 Market St',
+			'shipping_amount' => 0,
+			'line_items'      => array(
+				array(
+					'id'         => 'test-item',
+					'quantity'   => 1,
+					'unit_price' => '25.00',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Point the store address at an arbitrary value for one test.
+	 *
+	 * Uses the public `taxjar_store_settings` filter rather than options, so nothing
+	 * leaks into global state.
+	 *
+	 * @param array $settings Store settings shape `{street, city, state, country, postcode}`.
+	 * @return callable The registered filter, for removal.
+	 */
+	private function force_store_settings( array $settings ) {
+		$filter = function () use ( $settings ) {
+			return $settings;
+		};
+
+		add_filter( 'taxjar_store_settings', $filter, 99 );
+
+		return $filter;
+	}
+
+	/**
+	 * Run `calculate_tax()` against an API client that intercepts the proxy call, and
+	 * return the decoded JSON body that would have gone to TaxJar.
+	 *
+	 * This is the only seam that shows the finished request: the
+	 * `woocommerce_taxjar_nexus_address` filter fires before `nexus_addresses` is
+	 * written, so a body captured there is always incomplete. Returning a `WP_Error`
+	 * ends the call cleanly — `calculate_tax()` logs and returns false, and no
+	 * transient is written.
+	 *
+	 * @param array         $options      Options passed to `calculate_tax()`.
+	 * @param callable|null $nexus_filter Optional `woocommerce_taxjar_nexus_address` callback.
+	 * @param array|null    $store        Store settings override; defaults to a US:CA store.
+	 * @return array|null Decoded request body, or null if no request was attempted.
+	 */
+	private function capture_taxjar_request_json( array $options, $nexus_filter = null, $store = null ) {
+		$sent = null;
+
+		$api_client = $this->getMockBuilder( 'WC_Connect_API_Client' )
+			->disableOriginalConstructor()
+			->getMock();
+		$api_client->method( 'proxy_request' )->willReturnCallback(
+			function ( $path, $args ) use ( &$sent ) {
+				$sent = $args['body'];
+
+				return new WP_Error( 'test_intercepted', 'Request intercepted by the test.' );
+			}
+		);
+
+		$logger = $this->getMockBuilder( 'WC_Connect_Logger' )
+			->disableOriginalConstructor()
+			->getMock();
+		$tracks = $this->getMockBuilder( 'WC_Connect_Tracks' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		// The notifier is optional on the constructor but dereferenced unguarded in
+		// `smartcalcs_cache_request()`, so it has to be supplied. A real instance
+		// rather than a mock: `clear_notices()` is static, which a mock cannot stand in for.
+		$notifier = new Automattic\WCServices\StoreNotices\StoreNoticesNotifier( false );
+
+		$integration = new WC_Connect_TaxJar_Integration( $api_client, $logger, 'https://example.com', $tracks, $notifier );
+
+		$store_filter = $this->force_store_settings( null === $store ? $this->default_store_settings() : $store );
+		if ( is_callable( $nexus_filter ) ) {
+			add_filter( 'woocommerce_taxjar_nexus_address', $nexus_filter, 10, 2 );
+		}
+		WC()->customer->set_is_vat_exempt( false );
+
+		try {
+			$integration->calculate_tax( $options );
+		} finally {
+			if ( is_callable( $nexus_filter ) ) {
+				remove_filter( 'woocommerce_taxjar_nexus_address', $nexus_filter, 10 );
+			}
+			remove_filter( 'taxjar_store_settings', $store_filter, 99 );
+		}
+
+		return null === $sent ? null : json_decode( $sent, true );
+	}
+
+	/**
+	 * A comma-separated store postcode must be reduced to its first segment, exactly
+	 * as the destination postcode already is.
+	 *
+	 * `calculate_tax()` applied `explode( ',', ... )` to `to_zip` but never to
+	 * `from_zip`, so a store postcode entered as a list reached
+	 * `validate_taxjar_request()` intact, failed `WC_Validation::is_postcode()`, and
+	 * aborted the calculation before any request was made — while the identical
+	 * customer-supplied value was handled.
+	 */
+	public function test_store_postcode_comma_list_is_reduced_like_the_destination() {
+		$store             = $this->default_store_settings();
+		$store['postcode'] = '90210, 90211';
+
+		$body = $this->capture_taxjar_request_json( $this->in_state_options(), null, $store );
+
+		$this->assertIsArray( $body, 'A comma-separated store postcode aborted the request instead of being reduced.' );
+		$this->assertSame( '90210', $body['nexus_addresses'][0]['zip'] );
+
+		// And again with the nexus address disabled, so the `from_*` fields are what
+		// actually carries the store postcode onto the wire.
+		$without_nexus = $this->capture_taxjar_request_json(
+			$this->in_state_options(),
+			'__return_false',
+			$store
+		);
+
+		$this->assertIsArray( $without_nexus, 'A comma-separated store postcode aborted the request instead of being reduced.' );
+		$this->assertArrayNotHasKey( 'nexus_addresses', $without_nexus );
+		$this->assertSame( '90210', $without_nexus['from_zip'] );
+	}
+
+	/**
+	 * `get_address_parts()` must report the postcodes the body actually carries.
+	 *
+	 * It upper-cased them before handing them to `validate_taxjar_request()`, so the
+	 * value that was validated was not the value that was sent. Country and state are
+	 * a different case: they are compared against the literal `'US'` and against each
+	 * other, and this is reachable from the public `validate_taxjar_request()` with a
+	 * hand-built body, so those stay normalized.
+	 */
+	public function test_get_address_parts_reports_postcodes_verbatim() {
+		$body = array(
+			'from_country' => 'CA',
+			'from_state'   => 'ON',
+			'from_zip'     => 'k1a 0b1',
+			'to_country'   => 'ca',
+			'to_state'     => 'on',
+			'to_zip'       => 'm5v 3l9',
+		);
+
+		$parts = $this->invoke_protected_method( 'get_address_parts', array( $body ) );
+
+		$this->assertSame( 'k1a 0b1', $parts['from_zip'], 'from_zip was validated in a different case than it is sent.' );
+		$this->assertSame( 'm5v 3l9', $parts['to_zip'], 'to_zip was validated in a different case than it is sent.' );
+		$this->assertSame( 'CA', $parts['to_country'], 'Country is compared against a literal and must stay normalized.' );
+		$this->assertSame( 'ON', $parts['to_state'], 'State is compared against from_state and must stay normalized.' );
+	}
+
+	/**
+	 * A nexus address whose required field is present but blank must be rejected, so
+	 * the request falls back to the store address.
+	 *
+	 * The old schema check skipped any field that was present-but-empty, so
+	 * `array( 'country' => '' )` passed validation, replaced the `from_*` fields, and
+	 * then failed the "From country is missing" gate — aborting a calculation that
+	 * would have succeeded had the nexus simply been dropped.
+	 */
+	public function test_blank_required_nexus_field_falls_back_instead_of_aborting() {
+		$body = $this->capture_taxjar_request_json(
+			$this->in_state_options(),
+			function ( $nexus_address ) {
+				$nexus_address['country'] = '';
+
+				return $nexus_address;
+			}
+		);
+
+		$this->assertIsArray( $body, 'A blank nexus country aborted the request instead of falling back to the store address.' );
+		$this->assertArrayNotHasKey( 'nexus_addresses', $body, 'An invalid nexus address was forwarded.' );
+		$this->assertSame( 'US', $body['from_country'] );
+	}
+
+	/**
+	 * A nexus address is validated in the same shape it is sent.
+	 *
+	 * The schema requires an upper-case country code, so a filter returning `'us'`
+	 * used to be discarded silently. Normalizing before validating accepts it and
+	 * sends the normalized value, so "what was checked" and "what was sent" are the
+	 * same string.
+	 */
+	public function test_nexus_address_is_sent_in_the_shape_it_was_validated() {
+		$body = $this->capture_taxjar_request_json(
+			$this->in_state_options(),
+			function ( $nexus_address ) {
+				$nexus_address['country'] = 'us';
+				$nexus_address['state']   = 'ca';
+
+				return $nexus_address;
+			}
+		);
+
+		$this->assertIsArray( $body );
+		$this->assertArrayHasKey(
+			'nexus_addresses',
+			$body,
+			'A lower-case country from the filter was dropped instead of being normalized.'
+		);
+		$this->assertSame( 'US', $body['nexus_addresses'][0]['country'] );
+		$this->assertSame( 'CA', $body['nexus_addresses'][0]['state'] );
+	}
+
+	/**
+	 * Keys the filter added that the value object does not know about must survive.
+	 *
+	 * `woocommerce_taxjar_nexus_address` is documented as array-in / array-or-false-out.
+	 * This passed before the change too — it is a guard against the new normalization
+	 * turning that contract into a whitelist, not a demonstration of a fixed bug.
+	 */
+	public function test_nexus_address_passes_through_unknown_keys() {
+		$body = $this->capture_taxjar_request_json(
+			$this->in_state_options(),
+			function ( $nexus_address ) {
+				$nexus_address['custom_key'] = 'kept';
+
+				return $nexus_address;
+			}
+		);
+
+		$this->assertIsArray( $body );
+		$this->assertArrayHasKey( 'nexus_addresses', $body );
+		$this->assertSame( 'kept', $body['nexus_addresses'][0]['custom_key'] );
+	}
+
+	/**
+	 * A non-scalar field must be rejected rather than coerced.
+	 *
+	 * The old schema check rejected non-strings outright. The value object casts every
+	 * field to string instead, so without an explicit guard an array would trigger an
+	 * array-to-string conversion and be sent as the literal `"Array"`. This passed
+	 * before the change too — it pins behaviour across the migration rather than
+	 * demonstrating a fixed bug.
+	 */
+	public function test_non_scalar_nexus_field_is_rejected() {
+		$body = $this->capture_taxjar_request_json(
+			$this->in_state_options(),
+			function ( $nexus_address ) {
+				$nexus_address['city'] = array( 'Beverly Hills' );
+
+				return $nexus_address;
+			}
+		);
+
+		$this->assertIsArray( $body );
+		$this->assertArrayNotHasKey( 'nexus_addresses', $body );
+	}
 }

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -2646,6 +2646,32 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * A key the filter removed must stay removed.
+	 *
+	 * Normalisation writes back only the keys the filter kept. Merging the full
+	 * normalised shape instead would resurrect a removed key as a blank string, so
+	 * a filter that unset `street` would start sending `"street": ""`.
+	 */
+	public function test_nexus_key_removed_by_filter_is_not_resurrected() {
+		$body = $this->capture_taxjar_request_json(
+			$this->in_state_options(),
+			function ( $nexus_address ) {
+				unset( $nexus_address['street'] );
+
+				return $nexus_address;
+			}
+		);
+
+		$this->assertIsArray( $body, 'Removing an optional nexus key aborted the request.' );
+		$this->assertArrayHasKey( 'nexus_addresses', $body );
+		$this->assertArrayNotHasKey(
+			'street',
+			$body['nexus_addresses'][0],
+			'A key the filter removed was resurrected as a blank string.'
+		);
+	}
+
+	/**
 	 * A non-scalar field must be rejected rather than coerced.
 	 *
 	 * The old schema check rejected non-strings outright. The value object casts every

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -34,6 +34,13 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	private $store_settings_filter;
 
 	/**
+	 * Error messages logged during the last `capture_taxjar_request_json()` run.
+	 *
+	 * @var string[]
+	 */
+	private $captured_taxjar_errors = array();
+
+	/**
 	 * Load required classes before running tests.
 	 */
 	public static function set_up_before_class() {
@@ -2468,6 +2475,8 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	private function capture_taxjar_request_json( array $options, $nexus_filter = null, $store = null ) {
 		$sent = null;
 
+		$this->captured_taxjar_errors = array();
+
 		$api_client = $this->getMockBuilder( 'WC_Connect_API_Client' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -2482,6 +2491,11 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$logger = $this->getMockBuilder( 'WC_Connect_Logger' )
 			->disableOriginalConstructor()
 			->getMock();
+		$logger->method( 'error' )->willReturnCallback(
+			function ( $message ) {
+				$this->captured_taxjar_errors[] = (string) $message;
+			}
+		);
 		$tracks = $this->getMockBuilder( 'WC_Connect_Tracks' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -2648,6 +2662,10 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		$this->assertIsArray( $body, 'A blank nexus country aborted the request instead of falling back to the store address.' );
 		$this->assertArrayNotHasKey( 'nexus_addresses', $body, 'An invalid nexus address was forwarded.' );
 		$this->assertSame( 'US', $body['from_country'] );
+		$this->assertNotEmpty(
+			preg_grep( '/Nexus Address ERRORS/', $this->captured_taxjar_errors ),
+			'The rejected nexus address was dropped without logging an error.'
+		);
 	}
 
 	/**
@@ -2669,7 +2687,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			}
 		);
 
-		$this->assertIsArray( $body );
+		$this->assertIsArray( $body, 'A lower-case nexus country aborted the request.' );
 		$this->assertArrayHasKey(
 			'nexus_addresses',
 			$body,
@@ -2696,7 +2714,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			}
 		);
 
-		$this->assertIsArray( $body );
+		$this->assertIsArray( $body, 'A nexus address with an unknown key aborted the request.' );
 		$this->assertArrayHasKey( 'nexus_addresses', $body );
 		$this->assertSame( 'kept', $body['nexus_addresses'][0]['custom_key'] );
 	}
@@ -2746,8 +2764,12 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			}
 		);
 
-		$this->assertIsArray( $body );
-		$this->assertArrayNotHasKey( 'nexus_addresses', $body );
+		$this->assertIsArray( $body, 'A non-scalar nexus field aborted the request instead of falling back.' );
+		$this->assertArrayNotHasKey( 'nexus_addresses', $body, 'A nexus address with a non-scalar field was forwarded.' );
+		$this->assertNotEmpty(
+			preg_grep( '/Nexus Address ERRORS/', $this->captured_taxjar_errors ),
+			'The rejected nexus address was dropped without logging an error.'
+		);
 	}
 
 	/**
@@ -2822,6 +2844,10 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			$body,
 			'A nexus address with a boolean field was forwarded.'
 		);
+		$this->assertNotEmpty(
+			preg_grep( '/Nexus Address ERRORS/', $this->captured_taxjar_errors ),
+			'The rejected nexus address was dropped without logging an error.'
+		);
 	}
 
 	/**
@@ -2843,7 +2869,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			}
 		);
 
-		$this->assertIsArray( $body );
+		$this->assertIsArray( $body, 'A non-scalar value under an unknown nexus key aborted the request.' );
 		$this->assertArrayHasKey(
 			'nexus_addresses',
 			$body,
@@ -2953,6 +2979,10 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			'nexus_addresses',
 			$body,
 			'A US nexus address with a blank state was forwarded.'
+		);
+		$this->assertNotEmpty(
+			preg_grep( '/Nexus Address ERRORS/', $this->captured_taxjar_errors ),
+			'The rejected nexus address was dropped without logging an error.'
 		);
 	}
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

### Stacked PR

**Base is `chore/wootax-313-r1-2` (#2985), not `trunk`.** This is R1.3 of the address/rate-table refactor. #2984 (R1.1, the value object) and #2985 (R1.2, the read seam) are both still open — review them first; this diff only makes sense on top of them. If they merge, this will be rebased down the stack and the base updated.

R1.1 landed `Automattic\WCServices\Tax\Address`. R1.2 wired the **read** seam. R1.3 wires the **request** seam: `calculate_tax()`'s body assembly, the nexus address, `is_nexus_address_valid()`, and `get_address_parts()`.

The invariant this PR establishes: **the address that gets validated is the address that gets sent.**

---

## 1. The `from_zip` divergence is two bugs, and the documented one is the harmless half

The refactor plan describes this as "`from_zip` is never upper-cased where it's sent but is upper-cased where it's validated, so the value validated differs from the value sent." That is true, and on its own it is **unreachable**:

`get_address_parts()` upper-cased both postcodes before handing them to `validate_taxjar_request()`. But the only postcode check there is `WC_Validation::is_postcode( …, 'US' )`, and core's US rule is digits-only:

```php
// WC core, includes/class-wc-validation.php
case 'US':
    $valid = (bool) preg_match( '/^([0-9]{5})(-[0-9]{4})?$/i', $postcode );
```

Case cannot change that verdict, and non-US postcodes never reach the branch at all. Real divergence, no symptom.

**The live bug is sitting next to it.** `calculate_tax()` reduced the *destination* postcode to its first comma-separated segment and never did the same for the store's:

```php
$to_zip = explode( ',', $to_zip );
$to_zip = array_shift( $to_zip );   // to_zip only

$from_zip = $store_settings['postcode'];   // verbatim
```

So a store postcode entered as `90210, 90211` reached `is_postcode()` intact, failed it, and `smartcalcs_request()` returned `false` **before any request was made** — no tax, no TaxJar call, and nothing in the response log to explain it. The identical value supplied by a *customer* was handled.

Both halves are fixed at the **source** rather than the reader: both ends of the body are now built from one `Address`, which comma-splits and normalises by construction.

```php
$destination   = Address::from_options( $options, 'to_' );
$store_address = Address::from_store_settings( $this->get_store_settings() );

$body = array_merge(
    $store_address->to_taxjar_body( 'from_' ),
    $destination->to_taxjar_body( 'to_' ),
    array( 'shipping' => $shipping_amount, 'plugin' => 'woo' )
);
```

Key order and field names are unchanged, so the request shape on the wire is the same.

## 2. `get_address_parts()` is now a projection, not a second normaliser

It returns the postcodes **verbatim**. Country and state stay upper-cased there, and that asymmetry is deliberate — it is on the method docblock so it does not get "finished" later:

- country and state are compared against the literal `'US'` and against each other;
- `validate_taxjar_request()` is **public**, so it can be handed a body this class never built.

Re-deriving anything else there is precisely what recreates a validated-≠-sent gap for a hand-built body.

## 3. `is_nexus_address_valid()` delegates to `Address::validate()`

The inlined 40-line schema is replaced by the value object's, which carries the same rules (`/^[A-Z]{2}$/` country, `/^[A-Z0-9\-]{1,100}$/` state, the same max lengths, country + state required).

Because the value object normalises on construction, validating a normalised value and then sending the raw one would only relocate the divergence. So the accepted nexus address is written back normalised:

```php
$normalized    = Address::from_nexus( $nexus_address )->to_nexus_array();
$nexus_address = array_merge( $nexus_address, array_intersect_key( $normalized, $nexus_address ) );
```

`array_intersect_key` is load-bearing: it rewrites **only the keys the filter actually supplied**. Without it, `woocommerce_taxjar_nexus_address`'s documented array-in / array-or-`false`-out contract would quietly become a whitelist, and a filter that omitted `street` would start sending `"street": ""`. Pinned by a test.

---

## Behaviour deltas a reviewer should look at

1. **A present-but-blank required nexus field now falls back instead of aborting.** The old loop did `if ( ! $exists || '' === $value ) continue;`, so `array( 'country' => '' )` *passed* validation, replaced the `from_*` fields, and then tripped the "From country is missing. Aborting." gate — killing a calculation that would have succeeded had the nexus simply been dropped. It is now rejected and the store address is used.
2. **Lower-case country/state codes from the filter are accepted.** The schema pattern is upper-case-only, so `'us'` used to be silently discarded and logged. Normalising before validating accepts it and sends `'US'`.
3. **A numeric postcode from the filter is accepted** rather than rejected as a non-string (the value object casts). Non-scalar values are still rejected — an explicit guard, because the cast would otherwise turn an array into the literal `"Array"`.
4. **Empty `to_city` / `to_street` reach the body as `""` rather than `false`**, and the store postcode may now differ from the raw setting. Both change the JSON, so `smartcalcs_cache_request()`'s `md5( $json )` key changes: **one cache generation is invalidated**, nothing else.
5. **Validation error text names the field `postcode` where it used to say `zip`** — log output only, no contract.

## Backward-compatibility impact (per AGENTS.md)

- **No public signature changes.** `calculate_tax()`, `smartcalcs_request()`, `smartcalcs_cache_request()` and `validate_taxjar_request()` are untouched. The three methods actually modified — `is_nexus_address_valid()` and `get_address_parts()` — are `private`.
- **Hooks.** `woocommerce_taxjar_nexus_address` keeps its `(array $nexus_address, array $body)` signature and its array-in / array-or-`false`-out contract, and still fires at the same point. `taxjar_store_settings` is unchanged. Nothing is added, removed, reordered or re-timed. What a filter *returns* is now normalised for the keys it supplied — deltas 2 and 3 above — which is a change in leniency, not in shape.
- **Version assumptions.** None introduced. `Address` is internal, every boundary converts back to arrays, and no new WooCommerce or WordPress symbol is referenced. No `class_exists` / `function_exists` guard was added or removed.
- **Globals.** No new global or `WC()->…` read. The pre-existing `WC()->countries->get_vat_countries()` and `WC()->customer->is_vat_exempt()` calls in the early-return gate are unchanged and unmoved.
- **Multisite / install layout.** No option or table access, no path or URL construction. Neither is a factor.
- **Grandfathered shipping installs.** Not touched — this is the tax request path only.

---

## Follow-up this PR deliberately does not action

`$this->notifier` is `?StoreNoticesNotifier = null` on the constructor but is dereferenced unguarded in `smartcalcs_cache_request()`:

```php
$this->notifier->clear_notices( 'taxjar' );
```

So constructing the integration with four arguments fatals on the first tax request. It is pre-existing and unrelated to this seam, and it belongs with the defensive-guard work in [WOOTAX-318](https://linear.app/a8c/issue/WOOTAX-318) rather than being bundled here — bundling unrelated concerns is one of the four reasons the earlier PR #2906 was closed. Surfaced because the new tests must pass a **real** `StoreNoticesNotifier`: `clear_notices()` is `static`, which PHPUnit cannot mock.

---

## Verification

- `composer test` → **OK (291 tests, 634 assertions)**. 285 on the base branch, +6 new, zero regressions.
- **Fail-first confirmed** by stashing only the production file and re-running: 4 of the 6 fail against the base branch. The other two (`test_nexus_address_passes_through_unknown_keys`, `test_non_scalar_nexus_field_is_rejected`) pass before *and* after by design — they pin behaviour across the migration rather than demonstrate a fix, and their docblocks say so.
- PHPCS → **zero new violations, net −6** against the base branch (3819 → 3813). Every changed sniff row decreased; no sniff appears that was not already present. Measured by diffing `phpcs --standard=./phpcs.xml.dist --report=source` before and after — `check-all` is **not** green on this repo's trunk (~3841 pre-existing violations, 2223 of them in `i18n/strings.php`), so "zero new" is the achievable bar, not "green". One violation *was* introduced and caught this way: an added log line used `print_r()` and pushed `WordPress.PHP.DevelopmentFunctions.error_log_print_r` from 3 to 4; swapped for `wp_json_encode()`.
- `php -l` clean on both changed files, matching the CI lint step.

### Note on the test harness, for whoever writes the R1.4 tests

`woocommerce_taxjar_nexus_address` is the *wrong* seam for asserting on a request body — it fires **before** `$body['nexus_addresses']` is assigned, so anything captured there is missing the key you want. The right seam is the `WC_Connect_API_Client` mock the test class already injects: stub `proxy_request()` with a callback that records `$args['body']` and returns a `WP_Error`. That yields the exact JSON that would go on the wire, ends the call cleanly, and writes no transient, so tests do not poison each other's cache.

### Related issue(s)

<!--
  Is there an issue open this PR addresses? If so, link to it for more information.
  GitHub link example: "Fixes #1234" Syntax: `[close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved] #1234`
  Note: Remove this section if this PR does not have a related issue.
-->

Part of [WOOTAX-313](https://linear.app/a8c/issue/WOOTAX-313) (R1.3 of four). Does not close it — R1.4, the rate-table seam, is still outstanding.

Stacked on #2985, which is stacked on #2984.

### Steps to reproduce & screenshots/GIFs

<!--
  Please include steps to reproduce, as well as screenshots or GIFs, showing the before & after.
  This helps expedite review and increase confidence for approval & merge.
-->

**Reproducing the live bug on the base branch:**

1. Configure a US store with Automated Taxes enabled.
2. In WooCommerce → Settings → General, set the store postcode to a comma-separated value, e.g. `90210, 90211`.
3. Add a product to the cart with a US destination in the same state and calculate totals.
4. **Before:** no tax is applied. The WCS Tax log shows `API request is stopped. Country store is set to US but the zip code has incorrect format.` and no request is ever sent.
5. **After:** the request is sent with `from_zip` (or `nexus_addresses[0].zip`) reduced to `90210`, and tax is calculated.

**Checking the nexus changes:**

6. Add a `woocommerce_taxjar_nexus_address` filter returning a lower-case `country` (e.g. `'us'`). **Before:** the nexus address is silently dropped and the log records `[country] field format is invalid`. **After:** it is normalised to `'US'` and sent.
7. Add a filter returning `array( 'country' => '' )`. **Before:** the whole calculation aborts with `From country is missing. Aborting.` **After:** the nexus is rejected and the store address is used, so tax still calculates.
8. Add a filter that sets an extra key on the array. Confirm it still reaches TaxJar untouched.

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added