### PR TITLE
Update wp-coding-standards/wpcs to 3.4.1 (GHSA-3pwp-g2mj-5p3v)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb1e6cf5a24c1661be2afa3dd329fb86",
+    "content-hash": "a892dd54e4ab2e79915fa6e762b177fc",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -617,16 +617,16 @@
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.2.0",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
@@ -709,7 +709,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-11T04:32:07+00:00"
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -2113,21 +2113,21 @@
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "b598aa890815b8df16363271b659d73280129101"
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/b598aa890815b8df16363271b659d73280129101",
-                "reference": "b598aa890815b8df16363271b659d73280129101",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/39467533fdb742446d68c1d10ac33d625ee0311c",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.2.0",
+                "phpcsstandards/phpcsutils": "^1.2.3",
                 "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
             },
             "require-dev": {
@@ -2191,20 +2191,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-12T23:06:57+00:00"
+            "time": "2026-07-27T11:13:17+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
                 "shasum": ""
             },
             "require": {
@@ -2284,7 +2284,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-12-08T14:27:58+00:00"
+            "time": "2026-07-27T10:28:41+00:00"
         },
         {
             "name": "phpstan/extension-installer",
@@ -4087,16 +4087,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.3.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6"
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
-                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/ec2ff942335f33683a5957a85d138753876a05cf",
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf",
                 "shasum": ""
             },
             "require": {
@@ -4105,9 +4105,9 @@
                 "ext-tokenizer": "*",
                 "ext-xmlreader": "*",
                 "php": ">=7.2",
-                "phpcsstandards/phpcsextra": "^1.5.0",
-                "phpcsstandards/phpcsutils": "^1.1.0",
-                "squizlabs/php_codesniffer": "^3.13.4"
+                "phpcsstandards/phpcsextra": "^1.5.1",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "squizlabs/php_codesniffer": "^3.13.5"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -4149,7 +4149,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-11-25T12:08:04+00:00"
+            "time": "2026-07-27T11:53:23+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description

`wp-coding-standards/wpcs` is affected by [GHSA-3pwp-g2mj-5p3v](https://github.com/advisories/GHSA-3pwp-g2mj-5p3v) (CVE-2026-45293), a HIGH severity arbitrary code execution advisory covering versions `>= 0.14.1, < 3.4.1`. It is patched in `3.4.1`.

`wpcs` is a `require-dev` dependency used only for local PHPCS linting and in CI, so no vulnerable code ships to merchants — exposure is limited to local dev environments and CI runners.

This PR bumps `wp-coding-standards/wpcs` from `3.3.0` to `3.4.1` by running `composer update -W wp-coding-standards/wpcs`. The existing `composer.json` constraint (`^3.3`) already permits `3.4.1`, so `composer.json` is unchanged — only `composer.lock` is updated. The `-W` (`--with-all-dependencies`) flag also updated three transitive dev dependencies that `wpcs` 3.4.1 requires tighter versions of:

- `dealerdirect/phpcodesniffer-composer-installer`: `v1.2.0` -> `v1.2.1`
- `phpcsstandards/phpcsextra`: `1.5.0` -> `1.5.1`
- `phpcsstandards/phpcsutils`: `1.2.2` -> `1.2.3`

No source/runtime code was modified.

Advisory: https://github.com/advisories/GHSA-3pwp-g2mj-5p3v
SIRT PSA: https://sirtp2.wordpress.com/2026/07/27/wordpress-coding-standards-arbitrary-command/

### Related issue(s)

Linear: WOOTAX-316

### Steps to reproduce & screenshots/GIFs

No user-facing behavior changed, so there is nothing to reproduce visually. To verify the fix:

1. Check out this branch.
2. Run `composer show wp-coding-standards/wpcs` and confirm the version is `3.4.1` (>= patched version, and outside the vulnerable `>= 0.14.1, < 3.4.1` range).
3. Run `git diff composer.json` and confirm it is empty (constraint unchanged, already permitted `3.4.1`).
4. Run `composer install`, then run PHPCS on this branch and on `trunk` and compare. PHPCS reports the same 1,411 pre-existing errors on both, i.e. the 3.4.1 ruleset surfaces no new violations here. Note this repo's PHPCS is **not** clean to begin with, so the check is "unchanged vs trunk", not "passes". The existing CI (`php_tests.yml`, `js_tests.yml`, `legacy_qit.yml`) is green on this PR.

### Checklist

<!-- All testable code should have tests. -->
- [ ] unit tests

Not applicable — this is a `require-dev`-only dependency version bump (a security patch for the PHPCS coding-standards ruleset used in local dev/CI). No production/runtime code changed, so there is no new behavior to unit test.

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

Not added. This change only affects a `require-dev` dependency (PHPCS linting rules used in local dev and CI) and does not modify any code that ships to merchants or change plugin behavior/version in any way, so there is nothing merchant-facing to note in `changelog.txt` or `readme.txt`. Confirmed no CI workflow in `.github/workflows/` enforces a changelog entry for this repo.

