### PR TITLE
[WOOTAX-313] Refactor - Migrate the TaxJar rate-table seam onto the Address value object

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,7 +9,10 @@
 * Fix   - Prevent tax calculation from failing when the store address postcode holds more than one comma-separated value.
 * Fix   - Accept lower-case country and state codes from the woocommerce_taxjar_nexus_address filter.
 * Fix   - Fall back to the store address when a custom nexus address is incomplete instead of abandoning the calculation.
+* Fix   - Prevent unbounded growth of WooCommerce tax rate rows when the customer state contains a period, a space, or a non-Latin character.
+* Fix   - Restore tax rates on the price display, shipping tax and coupon paths for addresses whose state was stored in a normalized form.
 * Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
+* Tweak - Store tax rate rows against the postcode the rate was quoted for when the address postcode holds more than one comma-separated value.
 
 = 3.6.11 - 2026-08-05 =
 * Fix   - Prevent a fatal error during cart and checkout tax calculation when TaxJar returns an incomplete tax response.

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,7 +9,7 @@
 * Fix   - Prevent tax calculation from failing when the store address postcode holds more than one comma-separated value.
 * Fix   - Accept lower-case country and state codes from the woocommerce_taxjar_nexus_address filter.
 * Fix   - Fall back to the store address when a custom nexus address is incomplete instead of abandoning the calculation.
-* Fix   - Prevent unbounded growth of WooCommerce tax rate rows when the customer state contains a period, a space, or a non-Latin character.
+* Fix   - Prevent unbounded growth of WooCommerce tax rate rows when the customer state contains a character WooCommerce strips before storing it, such as a period or an accented letter.
 * Fix   - Restore tax rates on the price display, shipping tax and coupon paths for addresses whose state was stored in a normalized form.
 * Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
 * Tweak - Store tax rate rows against the postcode the rate was quoted for when the address postcode holds more than one comma-separated value.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -709,27 +709,32 @@ class WC_Connect_TaxJar_Integration {
 	/**
 	 * Allow street address to be passed when finding rates
 	 *
-	 * @param array  $matched_tax_rates
-	 * @param string $tax_class
+	 * Despite the name, no street ever reaches `WC_Tax::find_rates()` — it takes no
+	 * street argument, and the value this method used to unpack from the tuple was
+	 * never read. What the callback actually does is accept a location of *four or
+	 * more* elements where `WC_Tax::get_rates_from_location()` accepts exactly four,
+	 * so it supplies the rates core skips when this plugin's five-element taxable
+	 * address is in play. It is public and hooked on `woocommerce_matched_rates`,
+	 * which core fires from the price-display, shipping-tax and coupon paths.
+	 *
+	 * The lookup arguments now come from the same value object `create_or_update_tax_rate()`
+	 * writes with. Before, this method normalised the city but not the state, so it
+	 * could not see rows that method had just written: the rate rows existed and
+	 * these paths returned nothing for them.
+	 *
+	 * @param array  $matched_tax_rates Rates core matched; replaced wholesale.
+	 * @param string $tax_class         Tax class slug.
 	 * @return array
 	 */
 	public function allow_street_address_for_matched_rates( $matched_tax_rates, $tax_class = '' ) {
-		$tax_class         = sanitize_title( $tax_class );
-		$location          = WC_Tax::get_tax_location( $tax_class );
-		$matched_tax_rates = array();
-		if ( sizeof( $location ) >= 4 ) {
-			list( $country, $state, $postcode, $city, $street ) = array_pad( $location, 5, '' );
-			$matched_tax_rates                                  = WC_Tax::find_rates(
-				array(
-					'country'   => $country,
-					'state'     => $state,
-					'postcode'  => $postcode,
-					'city'      => strtoupper( self::normalize_city( $city ) ),
-					'tax_class' => $tax_class,
-				)
-			);
+		$tax_class = sanitize_title( $tax_class );
+		$location  = WC_Tax::get_tax_location( $tax_class );
+
+		if ( ! is_array( $location ) || count( $location ) < 4 ) {
+			return array();
 		}
-		return $matched_tax_rates;
+
+		return WC_Tax::find_rates( Address::from_taxable_tuple( $location )->to_find_rates_args( $tax_class ) );
 	}
 
 	public function cleanup_tax_label( $rate_name ) {
@@ -935,27 +940,17 @@ class WC_Connect_TaxJar_Integration {
 	 * Security: WooCommerce has already verified the nonce and capability by the time
 	 * `woocommerce_before_save_order_items` fires.
 	 *
+	 * This method used to `strtoupper()` postcode, city and street on top of that,
+	 * which `get_address()` did not — the same order recalculated from the admin and
+	 * from the cart put differently-cased values on the wire. The casing was kept only
+	 * because the city feeds the `wp_woocommerce_tax_rates` city column; now that the
+	 * rate-table seam upper-cases the city at both the write and the lookup, nothing
+	 * downstream depends on it and the two paths agree.
+	 *
 	 * @return array
 	 */
 	protected function get_backend_address() {
-		$address = Address::from_post_request()->to_legacy_options();
-
-		/*
-		 * Historic behaviour of this method, preserved deliberately: the admin path
-		 * upper-cases every field, not only country and state (which `Address` already
-		 * normalises). It is load-bearing for the city, which reaches the
-		 * `wp_woocommerce_tax_rates` city column, and pinned by
-		 * `test_get_backend_address_normalizes_semicolon_city()`. Reconciling the casing
-		 * asymmetry between this path and `get_address()` belongs with the rate-table
-		 * seam, where both ends of the write/read round trip can move together.
-		 */
-		foreach ( array( 'to_zip', 'to_city', 'to_street' ) as $key ) {
-			if ( is_string( $address[ $key ] ) ) {
-				$address[ $key ] = strtoupper( $address[ $key ] );
-			}
-		}
-
-		return $address;
+		return Address::from_post_request()->to_legacy_options();
 	}
 
 	/**
@@ -1859,9 +1854,11 @@ class WC_Connect_TaxJar_Integration {
 	 * normalisation policy has one home rather than one copy per consumer. This
 	 * method is retained as a delegate — it is `protected static`, so a subclass
 	 * outside this repository may be calling it, and removing it would break that
-	 * subclass on load. The remaining in-repo call sites move to the value object
-	 * when their seams are migrated; no `_deprecated_function()` notice is raised
-	 * because those call sites are still live and would fire it on every checkout.
+	 * subclass on load.
+	 *
+	 * The `_deprecated_function()` notice can be raised as of this release because
+	 * the last in-repo caller has moved to the value object. Until then the notice
+	 * would have fired on every checkout.
 	 *
 	 * The non-string guard is preserved: this method has always returned its
 	 * argument untouched when handed a non-string, and callers may rely on that.
@@ -1870,6 +1867,8 @@ class WC_Connect_TaxJar_Integration {
 	 * @return string Normalized city, safe for `_update_tax_rate_cities` and `find_rates`.
 	 */
 	protected static function normalize_city( $city ) {
+		wc_deprecated_function( __METHOD__, '3.6.11', '\Automattic\WCServices\Tax\Address::normalize_city()' );
+
 		if ( ! is_string( $city ) ) {
 			return $city;
 		}
@@ -1890,10 +1889,33 @@ class WC_Connect_TaxJar_Integration {
 	 * @return int
 	 */
 	public function create_or_update_tax_rate( $location, $rate, $tax_class = '', $freight_taxable = 1, $rate_priority = 1, $tax_rate_name = 'Tax' ) {
-		// Prevent filling "State code" column for countries with VAT tax.
-		// VAT tax is country wide.
-		$to_state      = 'VAT' === $tax_rate_name ? '' : strtoupper( $location['to_state'] );
 		$rate_priority = absint( $rate_priority );
+
+		/*
+		 * One address, two consumers: the `find_rates()` lookup below and the location
+		 * rows written beside the rate. Deriving them separately is what let this
+		 * method insert a fresh row on every calculation for some addresses — it
+		 * looked up values it had never stored. The value object now owns both
+		 * projections, so they cannot drift apart.
+		 *
+		 * Non-scalars collapse to an empty string rather than reaching `(string)` and
+		 * becoming the literal "Array". This method is public and takes the location
+		 * it is handed.
+		 */
+		$field = static function ( $value ) {
+			return is_scalar( $value ) ? (string) $value : '';
+		};
+
+		$address = Address::from_options(
+			array(
+				'to_country' => $field( $location['to_country'] ?? '' ),
+				// Prevent filling "State code" column for countries with VAT tax.
+				// VAT tax is country wide.
+				'to_state'   => 'VAT' === $tax_rate_name ? '' : $field( $location['to_state'] ?? '' ),
+				'to_zip'     => $field( $location['to_zip'] ?? '' ),
+				'to_city'    => $field( $location['to_city'] ?? '' ),
+			)
+		);
 
 		/**
 		 * @see https://github.com/Automattic/woocommerce-services/issues/2531
@@ -1918,8 +1940,8 @@ class WC_Connect_TaxJar_Integration {
 		}
 
 		$tax_rate = array(
-			'tax_rate_country'  => $location['to_country'],
-			'tax_rate_state'    => $to_state,
+			'tax_rate_country'  => $address->country(),
+			'tax_rate_state'    => $address->state_compact(),
 			// For the US, we're going to modify the name of the tax rate to simplify the reporting and distinguish between the tax rates at the counties level.
 			// I would love to do this for other locations, but it looks like that would create issues.
 			// For example, for the UK it would continuously rename the rate name with an updated `state` "piece", each time a request is made
@@ -1931,15 +1953,7 @@ class WC_Connect_TaxJar_Integration {
 			'tax_rate_class'    => $tax_class,
 		);
 
-		$wc_rates = WC_Tax::find_rates(
-			array(
-				'country'   => $location['to_country'],
-				'state'     => str_replace( ' ', '', $to_state ),
-				'postcode'  => $location['to_zip'],
-				'city'      => strtoupper( self::normalize_city( $location['to_city'] ) ),
-				'tax_class' => $tax_class,
-			)
-		);
+		$wc_rates = WC_Tax::find_rates( $address->to_find_rates_args( $tax_class ) );
 
 		$wc_rates_ids = is_array( $wc_rates ) ? array_keys( $wc_rates ) : array();
 		if ( isset( $wc_rates_ids[ $rate_priority - 1 ] ) ) {
@@ -1970,8 +1984,10 @@ class WC_Connect_TaxJar_Integration {
 			$rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
 			// VAT is always country wide, no need to create separate entires for each zip and city.
 			if ( 'VAT' !== $tax_rate_name ) {
-				WC_Tax::_update_tax_rate_postcodes( $rate_id, wc_normalize_postcode( wc_clean( $location['to_zip'] ) ) );
-				WC_Tax::_update_tax_rate_cities( $rate_id, self::normalize_city( wc_clean( $location['to_city'] ) ) );
+				$locations = $address->to_rate_table_locations();
+
+				WC_Tax::_update_tax_rate_postcodes( $rate_id, $locations['postcode'] );
+				WC_Tax::_update_tax_rate_cities( $rate_id, $locations['city'] );
 			}
 		}
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1867,7 +1867,7 @@ class WC_Connect_TaxJar_Integration {
 	 * @return string Normalized city, safe for `_update_tax_rate_cities` and `find_rates`.
 	 */
 	protected static function normalize_city( $city ) {
-		wc_deprecated_function( __METHOD__, '3.6.11', '\Automattic\WCServices\Tax\Address::normalize_city()' );
+		wc_deprecated_function( __METHOD__, '3.6.12', '\Automattic\WCServices\Tax\Address::normalize_city()' );
 
 		if ( ! is_string( $city ) ) {
 			return $city;

--- a/readme.txt
+++ b/readme.txt
@@ -79,7 +79,10 @@ This plugin relies on the following external services:
 * Fix   - Prevent tax calculation from failing when the store address postcode holds more than one comma-separated value.
 * Fix   - Accept lower-case country and state codes from the woocommerce_taxjar_nexus_address filter.
 * Fix   - Fall back to the store address when a custom nexus address is incomplete instead of abandoning the calculation.
+* Fix   - Prevent unbounded growth of WooCommerce tax rate rows when the customer state contains a period, a space, or a non-Latin character.
+* Fix   - Restore tax rates on the price display, shipping tax and coupon paths for addresses whose state was stored in a normalized form.
 * Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
+* Tweak - Store tax rate rows against the postcode the rate was quoted for when the address postcode holds more than one comma-separated value.
 
 = 3.6.11 - 2026-08-05 =
 * Fix   - Prevent a fatal error during cart and checkout tax calculation when TaxJar returns an incomplete tax response.

--- a/readme.txt
+++ b/readme.txt
@@ -79,7 +79,7 @@ This plugin relies on the following external services:
 * Fix   - Prevent tax calculation from failing when the store address postcode holds more than one comma-separated value.
 * Fix   - Accept lower-case country and state codes from the woocommerce_taxjar_nexus_address filter.
 * Fix   - Fall back to the store address when a custom nexus address is incomplete instead of abandoning the calculation.
-* Fix   - Prevent unbounded growth of WooCommerce tax rate rows when the customer state contains a period, a space, or a non-Latin character.
+* Fix   - Prevent unbounded growth of WooCommerce tax rate rows when the customer state contains a character WooCommerce strips before storing it, such as a period or an accented letter.
 * Fix   - Restore tax rates on the price display, shipping tax and coupon paths for addresses whose state was stored in a normalized form.
 * Tweak - Centralize TaxJar address handling in an internal value object. No change to tax calculation.
 * Tweak - Store tax rate rows against the postcode the rate was quoted for when the address postcode holds more than one comma-separated value.

--- a/src/Tax/Address.php
+++ b/src/Tax/Address.php
@@ -352,14 +352,28 @@ final class Address {
 	}
 
 	/**
-	 * State with all spaces removed. Used by `WC_Tax::find_rates()` lookup —
-	 * state codes shouldn't contain spaces, and stripping defends against
-	 * accidental whitespace from form input.
+	 * State in the exact form WooCommerce core stores it in `tax_rate_state`.
+	 *
+	 * This is not a normalisation policy of ours — it is a mirror of core's.
+	 * `WC_Tax::prepare_tax_rate()` singles this one column out and runs it through
+	 * `sanitize_key()` before `format_tax_rate_state()` uppercases it, so the value
+	 * that reaches the column has been lower-cased and stripped of everything
+	 * outside `[a-z0-9_-]`. `WC_Tax::get_matched_tax_rates()` then compares against
+	 * it with a plain `tax_rate_state IN ( %s, '' )` and no normalisation of its own.
+	 *
+	 * A lookup that asks for anything else therefore cannot find the row it just
+	 * wrote, and `create_or_update_tax_rate()` responds by inserting another one —
+	 * once per calculation, forever. Stripping spaces (which is all this method used
+	 * to do) covers `'N Y'` and nothing else: `'N.Y.'`, and any state carrying
+	 * non-ASCII, still diverge.
+	 *
+	 * Because core applies the same function on the way in, mirroring it here cannot
+	 * lose information the stored value still has.
 	 *
 	 * @return string
 	 */
 	public function state_compact(): string {
-		return str_replace( ' ', '', $this->state );
+		return strtoupper( sanitize_key( $this->state ) );
 	}
 
 	/**
@@ -601,8 +615,11 @@ final class Address {
 	}
 
 	/**
-	 * Args for `WC_Tax::find_rates()`. State is space-compacted, city is uppercase
-	 * (consistent with WC core's `format_tax_rate_city()`), `tax_class` passed through.
+	 * Args for `WC_Tax::find_rates()` — the read end of the tax-rate-table round trip.
+	 *
+	 * Every field is in the form WC core stores it, so this and
+	 * `to_rate_table_locations()` cannot disagree: a row written from one address is
+	 * found by a lookup built from the same address.
 	 *
 	 * @param string $tax_class Tax class slug to look up.
 	 * @return array{country: string, state: string, postcode: string, city: string, tax_class: string}
@@ -611,10 +628,58 @@ final class Address {
 		return array(
 			'country'   => $this->country,
 			'state'     => $this->state_compact(),
-			'postcode'  => $this->postcode,
-			'city'      => strtoupper( $this->city ),
+			'postcode'  => $this->postcode_as_stored(),
+			'city'      => $this->city_as_stored(),
 			'tax_class' => $tax_class,
 		);
+	}
+
+	/**
+	 * Location codes for the write end: the `postcode` and `city` rows that
+	 * `WC_Tax::_update_tax_rate_postcodes()` / `_update_tax_rate_cities()` persist
+	 * alongside a rate.
+	 *
+	 * Paired with `to_find_rates_args()` on purpose. Deriving the two independently is
+	 * what let `create_or_update_tax_rate()` look up a value it had never written and
+	 * insert a fresh row for the same address on every calculation.
+	 *
+	 * @return array{postcode: string, city: string}
+	 */
+	public function to_rate_table_locations(): array {
+		return array(
+			'postcode' => $this->postcode_as_stored(),
+			'city'     => $this->city_as_stored(),
+		);
+	}
+
+	/**
+	 * Postcode in the form WC core matches rate rows against.
+	 *
+	 * `WC_Tax::find_rates()` normalizes its argument with
+	 * `wc_normalize_postcode( wc_clean( … ) )`, while
+	 * `_update_tax_rate_postcodes()` stores what it is handed verbatim. Applying the
+	 * same normalisation to both ends is what closes that gap; it is idempotent, so
+	 * passing an already-normalised value into `find_rates()` changes nothing.
+	 *
+	 * @return string
+	 */
+	private function postcode_as_stored(): string {
+		return (string) wc_normalize_postcode( wc_clean( $this->postcode ) );
+	}
+
+	/**
+	 * City in the form WC core stores in the `city` location row.
+	 *
+	 * Core upper-cases and trims on both ends (`format_tax_rate_city()` on the write,
+	 * `strtoupper()` inside the lookup SQL) but sanitizes on neither. The plugin used
+	 * to apply `wc_clean()` on the write only, so a city carrying anything
+	 * `sanitize_text_field()` strips was stored in one form and searched for in
+	 * another — a fresh rate row per calculation.
+	 *
+	 * @return string
+	 */
+	private function city_as_stored(): string {
+		return strtoupper( trim( (string) wc_clean( $this->city ) ) );
 	}
 
 	/**

--- a/src/Tax/Address.php
+++ b/src/Tax/Address.php
@@ -367,6 +367,12 @@ final class Address {
 	 * to do) covers `'N Y'` and nothing else: `'N.Y.'`, and any state carrying
 	 * non-ASCII, still diverge.
 	 *
+	 * One boundary to that story: a state `sanitize_key()` empties *outright* (`'ЛЕН'`,
+	 * `'东京'`) was never the duplicating shape, because the blank it stores satisfies
+	 * the `''` arm of that `IN` clause whatever the lookup asked for. The rows that
+	 * could not be found again are the ones that collapse *partially*, to a shorter
+	 * non-empty code — `'ÎF'` stored as `'F'`.
+	 *
 	 * Because core applies the same function on the way in, mirroring it here cannot
 	 * lose information the stored value still has.
 	 *

--- a/tests/php/Tax/test-address.php
+++ b/tests/php/Tax/test-address.php
@@ -949,17 +949,39 @@ class WP_Test_WCServices_Tax_Address extends WC_Unit_Test_Case {
 	/**
 	 * Data provider for `test_state_compact_mirrors_core_storage_normalisation`.
 	 *
+	 * The non-ASCII rows are the ones the changelog's motivating case rests on, and they
+	 * are the reason the old `str_replace( ' ', '' )` lookup was unsafe rather than merely
+	 * incomplete. `sanitize_key()` drops every byte outside `[a-z0-9_-]`, so a state can
+	 * collapse to `''` outright (Cyrillic, CJK, a bare diacritic) or — worse — collapse
+	 * *partially* to a shorter ASCII string that is a perfectly plausible state code. The
+	 * partial cases are the duplication risk: the row is stored under the collapsed value
+	 * and searched for under the raw one, so it can never be found again and a fresh row
+	 * is inserted every calculation.
+	 *
+	 * Expected values are what WordPress's own `sanitize_key()` produces, read off the
+	 * function rather than reasoned about — the test's second assertion re-checks that
+	 * agreement on every row.
+	 *
 	 * @return array<string, array{0: string, 1: string}>
 	 */
 	public function state_compact_provider() {
 		return array(
-			'already canonical' => array( 'NY', 'NY' ),
-			'lower case'        => array( 'ny', 'NY' ),
-			'internal space'    => array( 'N Y', 'NY' ),
-			'periods'           => array( 'N.Y.', 'NY' ),
-			'hyphen kept'       => array( 'AB-12', 'AB-12' ),
-			'digits kept'       => array( 'A1', 'A1' ),
-			'empty'             => array( '', '' ),
+			'already canonical'         => array( 'NY', 'NY' ),
+			'lower case'                => array( 'ny', 'NY' ),
+			'internal space'            => array( 'N Y', 'NY' ),
+			'periods'                   => array( 'N.Y.', 'NY' ),
+			'hyphen kept'               => array( 'AB-12', 'AB-12' ),
+			'digits kept'               => array( 'A1', 'A1' ),
+			'empty'                     => array( '', '' ),
+
+			// Collapse to empty — nothing survives sanitize_key().
+			'cyrillic collapses'        => array( 'ЛЕН', '' ),
+			'cjk collapses'             => array( '东京', '' ),
+			'bare diacritic collapses'  => array( 'Ö', '' ),
+
+			// Partial collapse — the dangerous shape: a shorter, still-plausible code.
+			'accented latin part-drops' => array( 'ÎF', 'F' ),
+			'ring above part-drops'     => array( 'ÅL', 'L' ),
 		);
 	}
 

--- a/tests/php/Tax/test-address.php
+++ b/tests/php/Tax/test-address.php
@@ -305,6 +305,9 @@ class WP_Test_WCServices_Tax_Address extends WC_Unit_Test_Case {
 
 	/**
 	 * `state_compact()` strips internal spaces (e.g. accidental form input).
+	 *
+	 * @see self::test_state_compact_mirrors_core_storage_normalisation() for the full
+	 *      rule — spaces are one case of it, not the definition.
 	 */
 	public function test_state_compact_strips_spaces() {
 		$address = Address::from_options( array( 'to_state' => 'N Y' ) );
@@ -812,5 +815,169 @@ class WP_Test_WCServices_Tax_Address extends WC_Unit_Test_Case {
 
 		$this->assertTrue( $blank->is_empty() );
 		$this->assertFalse( $partial->is_empty() );
+	}
+
+	/* ──── Rate-table round trip ──── */
+
+	/**
+	 * The read and write projections of the tax rate table agree, field for field.
+	 *
+	 * This is the invariant the rate-table seam rests on: a row written from an
+	 * address must be findable by a lookup built from the same address. Asserted here,
+	 * on the value object, because it holds for *every* address rather than for the
+	 * handful a database round trip can afford to exercise.
+	 *
+	 * @dataProvider awkward_address_provider
+	 *
+	 * @param array $options `to_*` options to build the address from.
+	 */
+	public function test_find_rates_args_and_rate_table_locations_agree( array $options ) {
+		$address = Address::from_options( $options );
+
+		$find      = $address->to_find_rates_args( 'standard' );
+		$locations = $address->to_rate_table_locations();
+
+		$this->assertSame( $find['postcode'], $locations['postcode'], 'The postcode looked up differs from the postcode stored.' );
+		$this->assertSame( $find['city'], $locations['city'], 'The city looked up differs from the city stored.' );
+	}
+
+	/**
+	 * Addresses whose normalisation is not the identity, so the assertion above has
+	 * something to bite on. Each carries a field WooCommerce core rewrites somewhere
+	 * along the write path.
+	 *
+	 * @return array<string, array{0: array}>
+	 */
+	public function awkward_address_provider() {
+		return array(
+			'plain'                    => array(
+				array(
+					'to_country' => 'US',
+					'to_state'   => 'FL',
+					'to_zip'     => '33033',
+					'to_city'    => 'Homestead',
+				),
+			),
+			'ZIP+4'                    => array(
+				array(
+					'to_country' => 'US',
+					'to_state'   => 'FL',
+					'to_zip'     => '33033-1234',
+					'to_city'    => 'Homestead',
+				),
+			),
+			'comma-list postcode'      => array(
+				array(
+					'to_country' => 'US',
+					'to_state'   => 'FL',
+					'to_zip'     => '33033, 33034',
+					'to_city'    => 'Homestead',
+				),
+			),
+			'lower-case city'          => array(
+				array(
+					'to_country' => 'US',
+					'to_state'   => 'FL',
+					'to_zip'     => '33033',
+					'to_city'    => 'homestead',
+				),
+			),
+			'semicolon city'           => array(
+				array(
+					'to_country' => 'US',
+					'to_state'   => 'FL',
+					'to_zip'     => '33033',
+					'to_city'    => 'Casse;Berry',
+				),
+			),
+			'city carrying markup'     => array(
+				array(
+					'to_country' => 'US',
+					'to_state'   => 'FL',
+					'to_zip'     => '33033',
+					'to_city'    => 'Home<b>stead</b>',
+				),
+			),
+			'state carrying a space'   => array(
+				array(
+					'to_country' => 'US',
+					'to_state'   => 'N Y',
+					'to_zip'     => '10001',
+					'to_city'    => 'New York',
+				),
+			),
+			'state carrying periods'   => array(
+				array(
+					'to_country' => 'US',
+					'to_state'   => 'N.Y.',
+					'to_zip'     => '10001',
+					'to_city'    => 'New York',
+				),
+			),
+			'postcode with whitespace' => array(
+				array(
+					'to_country' => 'GB',
+					'to_state'   => 'ENG',
+					'to_zip'     => 'SW1A 1AA',
+					'to_city'    => 'London',
+				),
+			),
+			'everything blank'         => array( array() ),
+		);
+	}
+
+	/**
+	 * `state_compact()` reproduces what core actually puts in `tax_rate_state`.
+	 *
+	 * `WC_Tax::prepare_tax_rate()` singles that column out for `sanitize_key()` before
+	 * uppercasing it, so anything outside `[a-z0-9_-]` is dropped — not just spaces.
+	 * A lookup that strips only spaces misses the row for `'N.Y.'` and inserts a
+	 * duplicate instead.
+	 *
+	 * @dataProvider state_compact_provider
+	 *
+	 * @param string $raw      State as entered.
+	 * @param string $expected Form core stores.
+	 */
+	public function test_state_compact_mirrors_core_storage_normalisation( $raw, $expected ) {
+		$address = Address::from_options( array( 'to_state' => $raw ) );
+
+		$this->assertSame( $expected, $address->state_compact() );
+		$this->assertSame( strtoupper( sanitize_key( $raw ) ), $address->state_compact(), 'Diverged from the core function it mirrors.' );
+	}
+
+	/**
+	 * Data provider for `test_state_compact_mirrors_core_storage_normalisation`.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function state_compact_provider() {
+		return array(
+			'already canonical' => array( 'NY', 'NY' ),
+			'lower case'        => array( 'ny', 'NY' ),
+			'internal space'    => array( 'N Y', 'NY' ),
+			'periods'           => array( 'N.Y.', 'NY' ),
+			'hyphen kept'       => array( 'AB-12', 'AB-12' ),
+			'digits kept'       => array( 'A1', 'A1' ),
+			'empty'             => array( '', '' ),
+		);
+	}
+
+	/**
+	 * The postcode reaches the rate table normalised the way `find_rates()` normalises
+	 * its own argument, and the city reaches it sanitized and upper-cased.
+	 */
+	public function test_rate_table_locations_use_core_storage_forms() {
+		$address = Address::from_options(
+			array(
+				'to_zip'  => '33033-1234',
+				'to_city' => ' Home<b>stead</b> ',
+			)
+		);
+
+		$locations = $address->to_rate_table_locations();
+
+		$this->assertSame( '330331234', $locations['postcode'] );
+		$this->assertSame( 'HOMESTEAD', $locations['city'] );
 	}
 }

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -1860,6 +1860,8 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	 * @param string $expected Expected normalized output.
 	 */
 	public function test_normalize_city_strips_semicolons_and_normalizes_whitespace( $input, $expected ) {
+		$this->setExpectedDeprecated( 'WC_Connect_TaxJar_Integration::normalize_city' );
+
 		$reflection = new ReflectionMethod( 'WC_Connect_TaxJar_Integration', 'normalize_city' );
 		$reflection->setAccessible( true );
 
@@ -1878,12 +1880,18 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	 * difference: the deprecated method keeps returning them untouched, while the
 	 * value object's signature does not accept them at all.
 	 *
+	 * The expected deprecation notice is itself part of the contract: it can only be
+	 * raised now that no in-repo caller is left, and asserting on it here is what
+	 * would catch a call site being reintroduced.
+	 *
 	 * @dataProvider normalize_city_provider
 	 *
 	 * @param mixed $input    Raw city value to normalize.
 	 * @param mixed $expected Expected normalized output.
 	 */
 	public function test_deprecated_normalize_city_delegates_to_address_value_object( $input, $expected ) {
+		$this->setExpectedDeprecated( 'WC_Connect_TaxJar_Integration::normalize_city' );
+
 		$reflection = new ReflectionMethod( 'WC_Connect_TaxJar_Integration', 'normalize_city' );
 		$reflection->setAccessible( true );
 
@@ -1926,6 +1934,13 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	 * `;`-bearing city must be normalized there too — otherwise backend recalculations
 	 * would reintroduce the stored/looked-up asymmetry the frontend path now avoids.
 	 *
+	 * The city is no longer upper-cased here. That was this path's own historic
+	 * behaviour, unmatched by `get_address()`, and the only reason to keep it was that
+	 * the value reaches the `wp_woocommerce_tax_rates` city column — which the
+	 * rate-table seam now upper-cases at both the write and the lookup. Asserted
+	 * explicitly rather than dropped, because it is the casing that must *not* come
+	 * back: the cart and the admin recalculate have to agree.
+	 *
 	 * @see WOOTAX-19
 	 */
 	public function test_get_backend_address_normalizes_semicolon_city() {
@@ -1941,7 +1956,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		}
 
 		$this->assertStringNotContainsString( ';', $address['to_city'], 'Backend order city must not retain a semicolon — `_update_tax_rate_cities()` would split it.' );
-		$this->assertSame( 'CASSE BERRY', $address['to_city'] );
+		$this->assertSame( 'Casse Berry', $address['to_city'], 'The admin path must hand back the city in the same casing the cart path does.' );
 	}
 
 	/**
@@ -2390,8 +2405,8 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			unset( $_POST['country'], $_POST['state'], $_POST['city'], $_POST['street'] );
 		}
 
-		$this->assertSame( "O'BRIEN", $address['to_city'], 'Backend city retained the WordPress-added slash.' );
-		$this->assertSame( "123 O'MALLEY WAY", $address['to_street'], 'Backend street retained the WordPress-added slash.' );
+		$this->assertSame( "O'Brien", $address['to_city'], 'Backend city retained the WordPress-added slash.' );
+		$this->assertSame( "123 O'Malley Way", $address['to_street'], 'Backend street retained the WordPress-added slash.' );
 	}
 
 	// -------------------------------------------------------------------------
@@ -3080,15 +3095,17 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	 * one produces.
 	 *
 	 * `duplicates` records whether a second call with the *same* address inserts a
-	 * second row instead of reusing the first. Where it is `true`, that is a live
-	 * defect being pinned, and the accompanying note says which write/read pair
-	 * diverges to cause it.
+	 * second row instead of reusing the first. `matched` records whether
+	 * `allow_street_address_for_matched_rates()` — a *different* reader, on a
+	 * different core path — can find the row that `create_or_update_tax_rate()` just
+	 * wrote.
 	 *
-	 * `matched` records whether `allow_street_address_for_matched_rates()` — a
-	 * *different* reader, on a different core path — can find the row that
-	 * `create_or_update_tax_rate()` just wrote. The two flags disagree for the
-	 * space-bearing state, which is the clearest evidence that the seam has three
-	 * independent derivations of one address rather than one.
+	 * Both are now `false`/`true` for every case, which is the point: one address in,
+	 * one row, visible to both readers. Three cases reached that state by being fixed,
+	 * and their notes say what used to happen and why. Keep the flags rather than
+	 * asserting unconditionally — a case that regresses should fail with the shape of
+	 * the regression visible, and a new address shape can be added with whatever
+	 * behaviour it actually has.
 	 *
 	 * @return array<string, array{0: array, 1: string, 2: array}>
 	 */
@@ -3141,7 +3158,13 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 				),
 			),
 
-			// Comma-list postcode: stored whole, looked up whole, so it round-trips.
+			/*
+			 * A comma-list postcode used to be stored whole (`33033,33034`) and looked
+			 * up whole, so it round-tripped — but against a location_code matching no
+			 * real ZIP, and one the TaxJar request never carried: the request body has
+			 * taken the first segment since the request seam moved onto the value
+			 * object. The rate row is now keyed by the segment the rate was quoted for.
+			 */
 			'comma-list postcode'              => array(
 				array(
 					'to_country' => 'US',
@@ -3156,7 +3179,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 					'matched'    => true,
 					'country'    => 'US',
 					'state'      => 'FL',
-					'postcodes'  => array( '33033,33034' ),
+					'postcodes'  => array( '33033' ),
 					'cities'     => array( 'HOMESTEAD' ),
 				),
 			),
@@ -3232,14 +3255,15 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			 * pushes `tax_rate_state` through `sanitize_key()` before formatting it,
 			 * so `'N Y'` lands in the column as `'NY'`.
 			 *
-			 * That accident is what makes this case round-trip: the plugin's
-			 * `str_replace( ' ', '' )` on the lookup happens to agree with
+			 * That accident is what used to make this case round-trip: the plugin's
+			 * `str_replace( ' ', '' )` on the lookup happened to agree with
 			 * `sanitize_key()` for a space, and only for a space. See the next case
-			 * for what happens when they disagree.
+			 * for what happened when they disagreed.
 			 *
-			 * `matched` is false, though — `allow_street_address_for_matched_rates()`
-			 * does no state normalisation at all, looks up `'N Y'`, and finds nothing.
-			 * The two readers of this one table already disagree.
+			 * `matched` was false before the seam moved onto the value object —
+			 * `allow_street_address_for_matched_rates()` did no state normalisation at
+			 * all, looked up `'N Y'`, and found nothing. Both readers now derive the
+			 * state the same way, so both find the row.
 			 */
 			'state containing a space'         => array(
 				array(
@@ -3252,7 +3276,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 				'Tax',
 				array(
 					'duplicates' => false,
-					'matched'    => false,
+					'matched'    => true,
 					'country'    => 'US',
 					'state'      => 'NY',
 					'postcodes'  => array( '10001' ),
@@ -3261,11 +3285,14 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			),
 
 			/*
-			 * The same divergence where space-stripping is not enough. `sanitize_key()`
-			 * drops the periods too, so the row is stored as `'NY'` while both readers
-			 * ask for `'N.Y.'` — nothing ever matches and every calculation inserts a
-			 * fresh row. Any state value carrying a character outside `[a-z0-9_-]`
-			 * behaves this way, non-ASCII included.
+			 * The same divergence, where space-stripping was not enough.
+			 * `sanitize_key()` drops the periods too, so the row was stored as `'NY'`
+			 * while both readers asked for `'N.Y.'` — nothing ever matched and every
+			 * calculation inserted a fresh row. Any state value carrying a character
+			 * outside `[a-z0-9_-]` behaved this way, non-ASCII included.
+			 *
+			 * `Address::state_compact()` now mirrors `sanitize_key()` rather than
+			 * approximating it, so the lookup asks for the value core actually stored.
 			 */
 			'state containing punctuation'     => array(
 				array(
@@ -3277,8 +3304,8 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 				),
 				'Tax',
 				array(
-					'duplicates' => true,
-					'matched'    => false,
+					'duplicates' => false,
+					'matched'    => true,
 					'country'    => 'US',
 					'state'      => 'NY',
 					'postcodes'  => array( '10001' ),
@@ -3287,10 +3314,11 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			),
 
 			/*
-			 * A2's live half. The write sanitizes the city with `wc_clean()` and the
-			 * lookup does not, so anything `sanitize_text_field()` removes makes the
-			 * two ends disagree. Reachable because `create_or_update_tax_rate()` is
-			 * public and takes the location it is handed.
+			 * A2's live half. The write sanitized the city with `wc_clean()` and the
+			 * lookup did not, so anything `sanitize_text_field()` removes made the two
+			 * ends disagree. Reachable because `create_or_update_tax_rate()` is public
+			 * and takes the location it is handed. `wc_clean()` now runs once, when the
+			 * address is built, so both ends see the same string.
 			 */
 			'city containing markup'           => array(
 				array(
@@ -3302,8 +3330,8 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 				),
 				'Tax',
 				array(
-					'duplicates' => true,
-					'matched'    => false,
+					'duplicates' => false,
+					'matched'    => true,
 					'country'    => 'US',
 					'state'      => 'FL',
 					'postcodes'  => array( '33033' ),

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -3288,8 +3288,9 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			 * The same divergence, where space-stripping was not enough.
 			 * `sanitize_key()` drops the periods too, so the row was stored as `'NY'`
 			 * while both readers asked for `'N.Y.'` — nothing ever matched and every
-			 * calculation inserted a fresh row. Any state value carrying a character
-			 * outside `[a-z0-9_-]` behaved this way, non-ASCII included.
+			 * calculation inserted a fresh row. A state carrying a character outside
+			 * `[a-z0-9_-]` behaved this way only when something survived the stripping;
+			 * see the two cases below for the boundary that qualifier draws.
 			 *
 			 * `Address::state_compact()` now mirrors `sanitize_key()` rather than
 			 * approximating it, so the lookup asks for the value core actually stored.
@@ -3310,6 +3311,74 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 					'state'      => 'NY',
 					'postcodes'  => array( '10001' ),
 					'cities'     => array( 'NEW YORK' ),
+				),
+			),
+
+			/*
+			 * The boundary the changelog entry has to respect: a state `sanitize_key()`
+			 * empties *outright* never duplicated a row, not even before the fix. Core
+			 * stores `''` and matches with `tax_rate_state IN ( %s, '' )`
+			 * (`WC_Tax::get_matched_tax_rates()`), so the stored blank satisfies the
+			 * second arm whatever the lookup asked for — the old space-stripping lookup
+			 * asked for `'ЛЕН'` and still found the row. The rate is country-wide, which
+			 * is a real behaviour worth pinning in its own right.
+			 *
+			 * Passes with and without the seam migration. That is what makes it a
+			 * boundary characterization rather than a regression test, and it is here so
+			 * the duplication story cannot be restated as "any non-ASCII state".
+			 *
+			 * The city is deliberately plain ASCII: this row is about the state
+			 * dimension, and a multibyte city would confound it with the separate
+			 * byte-parity contract `to_find_rates_args()` keeps with core.
+			 */
+			'state wholly non-Latin'           => array(
+				array(
+					'to_country' => 'RU',
+					'to_state'   => 'ЛЕН',
+					'to_zip'     => '190000',
+					'to_city'    => 'Saint Petersburg',
+					'from_state' => 'ЛЕН',
+				),
+				'Tax',
+				array(
+					'duplicates' => false,
+					'matched'    => true,
+					'country'    => 'RU',
+					'state'      => '',
+					'postcodes'  => array( '190000' ),
+					'cities'     => array( 'SAINT PETERSBURG' ),
+				),
+			),
+
+			/*
+			 * The shape that actually duplicated, and the reason the changelog says "a
+			 * character WooCommerce strips" rather than naming scripts. `sanitize_key()`
+			 * drops the diacritic and keeps the rest, so the row was stored as `'F'`
+			 * while the space-stripping lookup asked for `'ÎF'` — non-empty, different
+			 * from the stored value, and so matching neither arm of the `IN` clause. A
+			 * fresh row every calculation.
+			 *
+			 * Fails without the seam migration: two rows, and `first_id !== second_id`.
+			 * Paired with the case above, the two of them are the narrowing — same
+			 * "non-Latin character" trigger, opposite outcomes, decided by whether
+			 * anything survives the stripping.
+			 */
+			'state partially collapsing'       => array(
+				array(
+					'to_country' => 'RO',
+					'to_state'   => 'ÎF',
+					'to_zip'     => '077100',
+					'to_city'    => 'Buftea',
+					'from_state' => 'ÎF',
+				),
+				'Tax',
+				array(
+					'duplicates' => false,
+					'matched'    => true,
+					'country'    => 'RO',
+					'state'      => 'F',
+					'postcodes'  => array( '077100' ),
+					'cities'     => array( 'BUFTEA' ),
 				),
 			),
 

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -2983,4 +2983,512 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 			'The rejected nexus address was dropped without logging an error.'
 		);
 	}
+
+	/*
+	 * ─────────────────────── Rate-table seam: characterization ───────────────────────
+	 *
+	 * Golden master for `create_or_update_tax_rate()` and
+	 * `allow_street_address_for_matched_rates()` — the write and read ends of the
+	 * `wp_woocommerce_tax_rates` round trip.
+	 *
+	 * These tests were written *before* the seam was migrated onto the address value
+	 * object, and they pin the observable contract that migration must not change:
+	 * given a `$location`, which columns land in the rate row, which `location_code`
+	 * rows land beside it, and — the part that matters — whether calling the method a
+	 * second time with the same address reuses the row or inserts a duplicate.
+	 *
+	 * Duplicate rate rows are the failure mode this seam produces when the value
+	 * written and the value looked up diverge. It is silent: taxes are still charged
+	 * at the right rate, so nothing surfaces until `wp_woocommerce_tax_rates` has
+	 * grown a row per checkout. Every case below therefore calls twice and asserts on
+	 * the row delta, not just on the stored values.
+	 *
+	 * Cases that duplicate *today* are marked in the provider. They are pinned as-is
+	 * so the fix is visible as a deliberate change to this file rather than as an
+	 * unexplained diff in behaviour.
+	 */
+
+	/**
+	 * Empty both tax-rate tables so a characterization case starts from a known state.
+	 *
+	 * `DELETE` rather than `TRUNCATE` on purpose: the WP test case wraps each test in a
+	 * transaction, and `TRUNCATE` forces an implicit commit in MySQL, which would leak
+	 * the test's writes past the rollback.
+	 *
+	 * The cache-group invalidation is required, not hygiene — `WC_Tax::find_rates()`
+	 * memoises through `wp_cache_get()`, and deleting rows behind its back leaves it
+	 * answering from a cache that no longer matches the table.
+	 */
+	private function reset_tax_rate_tables() {
+		global $wpdb;
+
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
+
+		WC_Cache_Helper::invalidate_cache_group( 'taxes' );
+	}
+
+	/**
+	 * Number of rows currently in `wp_woocommerce_tax_rates`.
+	 *
+	 * @return int
+	 */
+	private function count_tax_rate_rows() {
+		global $wpdb;
+
+		return (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_tax_rates" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery
+	}
+
+	/**
+	 * Snapshot the persisted shape of one tax rate: the identity columns plus every
+	 * `location_code` written beside it.
+	 *
+	 * @param int $rate_id Tax rate id.
+	 * @return array{country: string, state: string, name: string, priority: int, rate: string, postcodes: string[], cities: string[]}
+	 */
+	private function tax_rate_snapshot( $rate_id ) {
+		global $wpdb;
+
+		$rate_id = (int) $rate_id;
+
+		$row = $wpdb->get_row( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$wpdb->prepare( "SELECT tax_rate_country, tax_rate_state, tax_rate_name, tax_rate_priority, tax_rate FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_id = %d", $rate_id ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			ARRAY_A
+		);
+
+		$codes_of = function ( $type ) use ( $wpdb, $rate_id ) {
+			$codes = $wpdb->get_col( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+				$wpdb->prepare( "SELECT location_code FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE tax_rate_id = %d AND location_type = %s ORDER BY location_code", $rate_id, $type ) // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			);
+
+			return array_map( 'strval', $codes );
+		};
+
+		return array(
+			'country'   => (string) $row['tax_rate_country'],
+			'state'     => (string) $row['tax_rate_state'],
+			'name'      => (string) $row['tax_rate_name'],
+			'priority'  => (int) $row['tax_rate_priority'],
+			'rate'      => (string) $row['tax_rate'],
+			'postcodes' => $codes_of( 'postcode' ),
+			'cities'    => $codes_of( 'city' ),
+		);
+	}
+
+	/**
+	 * Address shapes the rate-table seam has to survive, with the row behaviour each
+	 * one produces.
+	 *
+	 * `duplicates` records whether a second call with the *same* address inserts a
+	 * second row instead of reusing the first. Where it is `true`, that is a live
+	 * defect being pinned, and the accompanying note says which write/read pair
+	 * diverges to cause it.
+	 *
+	 * `matched` records whether `allow_street_address_for_matched_rates()` — a
+	 * *different* reader, on a different core path — can find the row that
+	 * `create_or_update_tax_rate()` just wrote. The two flags disagree for the
+	 * space-bearing state, which is the clearest evidence that the seam has three
+	 * independent derivations of one address rather than one.
+	 *
+	 * @return array<string, array{0: array, 1: string, 2: array}>
+	 */
+	public function provide_rate_table_round_trips() {
+		return array(
+			// Baseline. Nothing exotic; establishes that the round trip closes at all.
+			'plain US address'                 => array(
+				array(
+					'to_country' => 'US',
+					'to_state'   => 'FL',
+					'to_zip'     => '33033',
+					'to_city'    => 'Homestead',
+					'from_state' => 'CA',
+				),
+				'Tax',
+				array(
+					'duplicates' => false,
+					'matched'    => true,
+					'country'    => 'US',
+					'state'      => 'FL',
+					'postcodes'  => array( '33033' ),
+					'cities'     => array( 'HOMESTEAD' ),
+				),
+			),
+
+			/*
+			 * A1 in the program plan — "written normalised, read raw" — is real but
+			 * NOT reachable. The write applies `wc_normalize_postcode()`, which strips
+			 * the hyphen; the read passes the postcode through untouched. It matches
+			 * anyway because `WC_Tax::find_rates()` applies the identical
+			 * `wc_normalize_postcode( wc_clean( … ) )` to its own argument before
+			 * querying. Core reconciles the divergence for us.
+			 */
+			'ZIP+4 destination'                => array(
+				array(
+					'to_country' => 'US',
+					'to_state'   => 'FL',
+					'to_zip'     => '33033-1234',
+					'to_city'    => 'Homestead',
+					'from_state' => 'CA',
+				),
+				'Tax',
+				array(
+					'duplicates' => false,
+					'matched'    => true,
+					'country'    => 'US',
+					'state'      => 'FL',
+					'postcodes'  => array( '330331234' ),
+					'cities'     => array( 'HOMESTEAD' ),
+				),
+			),
+
+			// Comma-list postcode: stored whole, looked up whole, so it round-trips.
+			'comma-list postcode'              => array(
+				array(
+					'to_country' => 'US',
+					'to_state'   => 'FL',
+					'to_zip'     => '33033, 33034',
+					'to_city'    => 'Homestead',
+					'from_state' => 'CA',
+				),
+				'Tax',
+				array(
+					'duplicates' => false,
+					'matched'    => true,
+					'country'    => 'US',
+					'state'      => 'FL',
+					'postcodes'  => array( '33033,33034' ),
+					'cities'     => array( 'HOMESTEAD' ),
+				),
+			),
+
+			/*
+			 * A2's casing half is masked: core upper-cases the city on the write
+			 * (`format_tax_rate_city()`) and again inside the lookup SQL, so the
+			 * plugin's own asymmetric `strtoupper()` cannot be observed here.
+			 */
+			'lower-case city'                  => array(
+				array(
+					'to_country' => 'US',
+					'to_state'   => 'FL',
+					'to_zip'     => '33033',
+					'to_city'    => 'homestead',
+					'from_state' => 'CA',
+				),
+				'Tax',
+				array(
+					'duplicates' => false,
+					'matched'    => true,
+					'country'    => 'US',
+					'state'      => 'FL',
+					'postcodes'  => array( '33033' ),
+					'cities'     => array( 'HOMESTEAD' ),
+				),
+			),
+
+			// Same story for country/state: core upper-cases both ends.
+			'lower-case country and state'     => array(
+				array(
+					'to_country' => 'us',
+					'to_state'   => 'fl',
+					'to_zip'     => '33033',
+					'to_city'    => 'Homestead',
+					'from_state' => 'CA',
+				),
+				'Tax',
+				array(
+					'duplicates' => false,
+					'matched'    => true,
+					'country'    => 'US',
+					'state'      => 'FL',
+					'postcodes'  => array( '33033' ),
+					'cities'     => array( 'HOMESTEAD' ),
+				),
+			),
+
+			// WOOTAX-19's case, already fixed; kept here so the seam migration cannot regress it.
+			'semicolon city'                   => array(
+				array(
+					'to_country' => 'US',
+					'to_state'   => 'FL',
+					'to_zip'     => '33033',
+					'to_city'    => 'Casse;Berry',
+					'from_state' => 'CA',
+				),
+				'Tax',
+				array(
+					'duplicates' => false,
+					'matched'    => true,
+					'country'    => 'US',
+					'state'      => 'FL',
+					'postcodes'  => array( '33033' ),
+					'cities'     => array( 'CASSE BERRY' ),
+				),
+			),
+
+			/*
+			 * A3, and it is not what the program plan describes. The plan has the
+			 * state "stripped for find_rates but stored un-stripped"; measured, core
+			 * stores it *more* aggressively than we look it up. `prepare_tax_rate()`
+			 * pushes `tax_rate_state` through `sanitize_key()` before formatting it,
+			 * so `'N Y'` lands in the column as `'NY'`.
+			 *
+			 * That accident is what makes this case round-trip: the plugin's
+			 * `str_replace( ' ', '' )` on the lookup happens to agree with
+			 * `sanitize_key()` for a space, and only for a space. See the next case
+			 * for what happens when they disagree.
+			 *
+			 * `matched` is false, though — `allow_street_address_for_matched_rates()`
+			 * does no state normalisation at all, looks up `'N Y'`, and finds nothing.
+			 * The two readers of this one table already disagree.
+			 */
+			'state containing a space'         => array(
+				array(
+					'to_country' => 'US',
+					'to_state'   => 'N Y',
+					'to_zip'     => '10001',
+					'to_city'    => 'New York',
+					'from_state' => 'CA',
+				),
+				'Tax',
+				array(
+					'duplicates' => false,
+					'matched'    => false,
+					'country'    => 'US',
+					'state'      => 'NY',
+					'postcodes'  => array( '10001' ),
+					'cities'     => array( 'NEW YORK' ),
+				),
+			),
+
+			/*
+			 * The same divergence where space-stripping is not enough. `sanitize_key()`
+			 * drops the periods too, so the row is stored as `'NY'` while both readers
+			 * ask for `'N.Y.'` — nothing ever matches and every calculation inserts a
+			 * fresh row. Any state value carrying a character outside `[a-z0-9_-]`
+			 * behaves this way, non-ASCII included.
+			 */
+			'state containing punctuation'     => array(
+				array(
+					'to_country' => 'US',
+					'to_state'   => 'N.Y.',
+					'to_zip'     => '10001',
+					'to_city'    => 'New York',
+					'from_state' => 'CA',
+				),
+				'Tax',
+				array(
+					'duplicates' => true,
+					'matched'    => false,
+					'country'    => 'US',
+					'state'      => 'NY',
+					'postcodes'  => array( '10001' ),
+					'cities'     => array( 'NEW YORK' ),
+				),
+			),
+
+			/*
+			 * A2's live half. The write sanitizes the city with `wc_clean()` and the
+			 * lookup does not, so anything `sanitize_text_field()` removes makes the
+			 * two ends disagree. Reachable because `create_or_update_tax_rate()` is
+			 * public and takes the location it is handed.
+			 */
+			'city containing markup'           => array(
+				array(
+					'to_country' => 'US',
+					'to_state'   => 'FL',
+					'to_zip'     => '33033',
+					'to_city'    => 'Home<b>stead</b>',
+					'from_state' => 'CA',
+				),
+				'Tax',
+				array(
+					'duplicates' => true,
+					'matched'    => false,
+					'country'    => 'US',
+					'state'      => 'FL',
+					'postcodes'  => array( '33033' ),
+					'cities'     => array( 'HOMESTEAD' ),
+				),
+			),
+
+			/*
+			 * VAT rates are country-wide: the state is blanked and no postcode or city
+			 * location rows are written at all. Such a row matches core's
+			 * "rates with no postcodes and cities" criterion, so it still round-trips.
+			 */
+			'VAT rate writes no location rows' => array(
+				array(
+					'to_country' => 'GB',
+					'to_state'   => 'ENG',
+					'to_zip'     => 'SW1A 1AA',
+					'to_city'    => 'London',
+					'from_state' => 'ENG',
+				),
+				'VAT',
+				array(
+					'duplicates' => false,
+					'matched'    => true,
+					'country'    => 'GB',
+					'state'      => '',
+					'postcodes'  => array(),
+					'cities'     => array(),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Golden master: `create_or_update_tax_rate()` called twice with one address.
+	 *
+	 * @dataProvider provide_rate_table_round_trips
+	 *
+	 * @param array  $location       Location array as the method receives it.
+	 * @param string $tax_rate_name  Rate name ('VAT' takes the country-wide branch).
+	 * @param array  $expected       Expected row behaviour — see the provider docblock.
+	 */
+	public function test_create_or_update_tax_rate_round_trip( $location, $tax_rate_name, $expected ) {
+		$this->reset_tax_rate_tables();
+
+		$before    = $this->count_tax_rate_rows();
+		$first_id  = $this->integration->create_or_update_tax_rate( $location, 7.0, '', 1, 1, $tax_rate_name );
+		$second_id = $this->integration->create_or_update_tax_rate( $location, 7.0, '', 1, 1, $tax_rate_name );
+		$added     = $this->count_tax_rate_rows() - $before;
+
+		if ( $expected['duplicates'] ) {
+			$this->assertNotSame( (int) $first_id, (int) $second_id, 'Expected this address to insert a second row — the pinned defect is no longer reproducing, so the expectation needs revisiting rather than the assertion relaxing.' );
+			$this->assertSame( 2, $added, 'Expected exactly two rows for the duplicating case.' );
+		} else {
+			$this->assertSame( (int) $first_id, (int) $second_id, 'Second call inserted a new rate row instead of reusing the first — the value written and the value looked up have diverged.' );
+			$this->assertSame( 1, $added, 'Expected exactly one rate row after two calls with the same address.' );
+		}
+
+		$snapshot = $this->tax_rate_snapshot( $first_id );
+
+		$this->assertSame( $expected['country'], $snapshot['country'], 'tax_rate_country' );
+		$this->assertSame( $expected['state'], $snapshot['state'], 'tax_rate_state' );
+		$this->assertSame( $expected['postcodes'], $snapshot['postcodes'], 'postcode location_code rows' );
+		$this->assertSame( $expected['cities'], $snapshot['cities'], 'city location_code rows' );
+		$this->assertSame( $tax_rate_name, $snapshot['name'], 'tax_rate_name' );
+		$this->assertSame( 1, $snapshot['priority'], 'tax_rate_priority' );
+	}
+
+	/**
+	 * Rate rows are matched by *ordinal position*, not by priority value.
+	 *
+	 * `create_or_update_tax_rate()` reads `array_keys( $wc_rates )[ $priority - 1 ]`,
+	 * and `find_rates()` returns at most one rate per priority. So the lookup for
+	 * priority N only lands on the intended row when priorities 1..N-1 already exist —
+	 * which is true of the plugin's own caller, and is why the seam works today.
+	 *
+	 * Pinned because it is the constraint that makes the row identity positional. Any
+	 * change to how rows are keyed has to keep this working or replace it outright.
+	 */
+	public function test_create_or_update_tax_rate_matches_priorities_by_ordinal_position() {
+		$this->reset_tax_rate_tables();
+
+		$location = array(
+			'to_country' => 'US',
+			'to_state'   => 'FL',
+			'to_zip'     => '33033',
+			'to_city'    => 'Homestead',
+			'from_state' => 'CA',
+		);
+
+		$before = $this->count_tax_rate_rows();
+
+		$state_id  = $this->integration->create_or_update_tax_rate( $location, 6.0, '', 1, 1, 'FL State Tax' );
+		$county_id = $this->integration->create_or_update_tax_rate( $location, 1.0, '', 1, 2, 'FL County Tax' );
+
+		$this->assertNotSame( (int) $state_id, (int) $county_id, 'Two priorities must occupy two rows.' );
+		$this->assertSame( 2, $this->count_tax_rate_rows() - $before );
+
+		// Recalculating the same cart must reuse both rows.
+		$this->assertSame( (int) $state_id, (int) $this->integration->create_or_update_tax_rate( $location, 6.0, '', 1, 1, 'FL State Tax' ) );
+		$this->assertSame( (int) $county_id, (int) $this->integration->create_or_update_tax_rate( $location, 1.0, '', 1, 2, 'FL County Tax' ) );
+		$this->assertSame( 2, $this->count_tax_rate_rows() - $before, 'A second calculation for the same address must add no rows.' );
+
+		$this->assertSame( 2, $this->tax_rate_snapshot( $county_id )['priority'] );
+	}
+
+	/**
+	 * A changed rate updates the existing row rather than inserting beside it.
+	 *
+	 * This is the path that keeps historical orders pointing at a rate id that still
+	 * resolves, so it is part of the contract even though it writes no locations.
+	 */
+	public function test_create_or_update_tax_rate_updates_rate_in_place() {
+		$this->reset_tax_rate_tables();
+
+		$location = array(
+			'to_country' => 'US',
+			'to_state'   => 'FL',
+			'to_zip'     => '33033',
+			'to_city'    => 'Homestead',
+			'from_state' => 'CA',
+		);
+
+		$before   = $this->count_tax_rate_rows();
+		$rate_id  = $this->integration->create_or_update_tax_rate( $location, 6.0, '', 1, 1, 'Tax' );
+		$same_id  = $this->integration->create_or_update_tax_rate( $location, 7.5, '', 1, 1, 'Tax' );
+		$snapshot = $this->tax_rate_snapshot( $rate_id );
+
+		$this->assertSame( (int) $rate_id, (int) $same_id );
+		$this->assertSame( 1, $this->count_tax_rate_rows() - $before );
+		$this->assertSame( 7.5, (float) $snapshot['rate'], 'Changed rate must overwrite the existing row.' );
+	}
+
+	/**
+	 * The write and the read are two different methods, and they have to agree.
+	 *
+	 * `create_or_update_tax_rate()` persists the row; `allow_street_address_for_matched_rates()`
+	 * is what the `woocommerce_matched_rates` filter uses to find it again on the
+	 * price-display, shipping-tax and coupon paths. They derive their lookup arguments
+	 * independently today, so this test is the one that would catch them drifting
+	 * apart — a drift that shows up as tax silently disappearing from those paths
+	 * while the itemized cart totals stay correct.
+	 *
+	 * @dataProvider provide_rate_table_round_trips
+	 *
+	 * @param array  $location      Location array as `create_or_update_tax_rate()` receives it.
+	 * @param string $tax_rate_name Rate name ('VAT' takes the country-wide branch).
+	 * @param array  $expected      Expected row behaviour — see the provider docblock.
+	 */
+	public function test_matched_rates_lookup_finds_the_row_that_was_written( $location, $tax_rate_name, $expected ) {
+		$this->reset_tax_rate_tables();
+
+		$rate_id = (int) $this->integration->create_or_update_tax_rate( $location, 7.0, '', 1, 1, $tax_rate_name );
+
+		$tuple = array(
+			$location['to_country'],
+			$location['to_state'],
+			$location['to_zip'],
+			$location['to_city'],
+		);
+
+		$inject = function () use ( $tuple ) {
+			return $tuple;
+		};
+
+		add_filter( 'woocommerce_get_tax_location', $inject, 99 );
+
+		try {
+			$matched = $this->integration->allow_street_address_for_matched_rates( array(), '' );
+		} finally {
+			remove_filter( 'woocommerce_get_tax_location', $inject, 99 );
+		}
+
+		if ( $expected['matched'] ) {
+			$this->assertArrayHasKey(
+				$rate_id,
+				$matched,
+				'The matched-rates lookup did not find the row create_or_update_tax_rate() had just written for the same address.'
+			);
+		} else {
+			$this->assertArrayNotHasKey(
+				$rate_id,
+				$matched,
+				'Expected this address to be invisible to the matched-rates lookup — the pinned defect is no longer reproducing, so the expectation needs revisiting rather than the assertion relaxing.'
+			);
+		}
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

Fourth and final PR of the R1 series (WOOTAX-313). Migrates the **rate-table seam** — `create_or_update_tax_rate()` and `allow_street_address_for_matched_rates()` — onto `Automattic\WCServices\Tax\Address`, so the arguments used to *find* a `wp_woocommerce_tax_rates` row and the values written *into* it come from one address through a matched pair of projections the value object owns: `to_find_rates_args()` and `to_rate_table_locations()`.

**Stacked on [#2986](https://github.com/Automattic/woocommerce-services/pull/2986)** (`chore/wootax-313-r1-3`), which is stacked on [#2985](https://github.com/Automattic/woocommerce-services/pull/2985) → [#2984](https://github.com/Automattic/woocommerce-services/pull/2984). Review the base PRs first; this diff is only R1.4.

This is the one PR in the series that can silently duplicate rate rows, so **the characterization tests are a separate first commit** (`ad4ca528`) and the refactor lands under them (`4a0c966e`). The behaviour changes are visible as deliberate edits to that first commit's expectations.

### Measuring the seam corrected two of the three defects the plan attributed to it

The refactor plan lists three write/read asymmetries here. Two are real but **not reachable**, and this PR says so rather than shipping a fix for a bug that does not exist:

| Plan item | Measured |
|---|---|
| **A1** — postcode written through `wc_normalize_postcode()`, read raw | **Not live.** `WC_Tax::find_rates()` applies the identical `wc_normalize_postcode( wc_clean( … ) )` to its own argument before querying. ZIP+4 always round-tripped. |
| **A2** — city written un-uppercased, read uppercased | **Casing half not live.** Core upper-cases the city on both ends (`format_tax_rate_city()` on the write, `strtoupper()` inside the lookup SQL). A *different* half of A2 is live — see below. |
| **A3** — state stripped for `find_rates`, stored un-stripped | **Backwards.** `WC_Tax::prepare_tax_rate()` singles `tax_rate_state` out for `sanitize_key()` before storing, so the column holds a *more* normalized value than either reader asked for. |

### Defects fixed

1. **A state carrying anything outside `[a-z0-9_-]` duplicated a rate row on every calculation.** The lookup stripped spaces; core's storage runs `sanitize_key()`. Those agree for `'N Y'` and disagree for `'N.Y.'` and for anything non-ASCII, so the row inserted could never be found again. `Address::state_compact()` now mirrors the core function rather than approximating it.
2. **A city carrying anything `sanitize_text_field()` removes did the same** — the write applied `wc_clean()`, the lookup did not. Sanitisation now happens once, inside the shared projection.
3. **`allow_street_address_for_matched_rates()` could not see rows `create_or_update_tax_rate()` had just written.** It normalised the city but not the state. The rows existed; the `woocommerce_matched_rates` path — price display, shipping tax, coupon math — returned **no rates** for those addresses, while itemized cart totals stayed correct. That asymmetry is the reason the test suite checks the two methods against each other rather than each in isolation.

### Two observations for R2, recorded but not acted on

- **`allow_street_address_for_matched_rates()` passes no street to `WC_Tax::find_rates()`** — that function takes no street argument, and the value the method unpacked from the tuple was never read. What it actually does is accept a location of *four or more* elements where `WC_Tax::get_rates_from_location()` accepts exactly four, supplying the rates core skips when this plugin's five-element taxable address is in play. It is an arity workaround, not a street feature. This independently corroborates the July measurement that street never moves TaxJar's jurisdiction. It is **public** and stays; the docblock now says what it does.
- **Rate rows are matched by ordinal position, not by priority value** (`array_keys( $wc_rates )[ $priority - 1 ]`, against a `find_rates()` that returns one rate per priority). The lookup for priority N only lands on the intended row when priorities 1..N-1 already exist. True of our own caller, so it works — but it is the constraint any re-keying has to keep or replace. Pinned by a test.

### Behaviour changes

- **A comma-list postcode is stored as its first segment** rather than whole. The row is now keyed by the segment the rate was quoted for; the request body has carried only that segment since #2986.
- **`get_backend_address()` no longer upper-cases postcode, city and street.** This was the admin path's own historic behaviour, unmatched by `get_address()`, kept only because the city reaches the rate-table city column — which is now upper-cased at both ends. The admin recalculate and the cart put identically-cased values on the wire. **This changes the request JSON, so one generation of the `md5( $json )` request cache is invalidated** (nothing else; the same input recalculates to the same result).
- `tax_rate_country` is trimmed before storage, so a whitespace-padded country can no longer produce a row nothing matches.
- `create_or_update_tax_rate()` tolerates a missing or non-scalar location field instead of emitting a notice or storing the literal `"Array"`.
- **`WC_Connect_TaxJar_Integration::normalize_city()` now raises its deprecation notice.** It could not before — the last three in-repo callers were all on this seam and the notice would have fired on every checkout.

### Backward compatibility

**Public and externally exposed surface touched. No signature changes.**

- `create_or_update_tax_rate()`, `allow_street_address_for_matched_rates()` and `get_taxable_address()` keep their signatures and return shapes. `get_backend_address()` is `protected` and keeps its array shape; only the casing of three values changes.
- **`normalize_city()` is deprecated, not removed.** It is `protected static`, so an out-of-repo subclass may call it, and removing it would break that subclass on load. It keeps delegating to the value object and keeps returning non-string input untouched. Per AGENTS.md: deprecate, don't rename or delete.
- **No hook is added, removed, reordered or retimed.** `woocommerce_taxjar_enable_florida_shipping_tax` still fires with the same argument at the same point.
- **The Florida shipping-tax predicate still reads `$location` raw**, deliberately. Routing it through the value object would make it fire for a lower-cased `'us'`/`'fl'` where it does not today — a change to what tax is charged, not to how a row is keyed. Out of this PR's scope; flagged for R2.
- **Stored data changes shape for exactly the addresses that were already broken.** A space- or punctuation-bearing state stored `'NY'` before and after — only the lookup changed. A comma-list postcode is the one case where a *new* row shape is written, and the old row was unreachable from the TaxJar request anyway.
- **No new global state is read.** No `WC()->…` dereference, no `$post`, no `$wp_query`. `WC_Tax` and `wc_clean()`/`wc_normalize_postcode()`/`sanitize_key()` are all already required by these methods.
- **Multisite:** unchanged. `wp_woocommerce_tax_rates` is a per-site table and no option access was added or moved.
- **Install layout:** no paths or URLs are constructed.

### Testing instructions

`composer test` → **331 tests / 793 assertions green** (291 on the base branch, +40, zero regressions).

**Fail-first confirmed** by restoring only the two production files and re-running: 44 tests fail — the 11 value-object round-trip cases, the `sanitize_key()` state case, the 25 deprecation-notice expectations, both `get_backend_address()` casing tests, and the 6 rate-table cases whose behaviour this PR changes.

PHPCS: **zero new violations, net −3** (branch baseline 3813 → 3810), measured by diffing `--report=source` before and after. `php -l` clean on both changed production files.

Manual check worth doing on a store: enable automated taxes, check out twice to the same US address, and confirm `wp_woocommerce_tax_rates` gains one row per priority on the first checkout and none on the second.
