### PR TITLE
[WOOTAX-322] Refactor - Hoist the canonical-id exemption remap

### DIFF
--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1065,18 +1065,8 @@ class WC_Connect_TaxJar_Integration {
 			);
 		}
 
+		// Re-keys $non_taxable_line_items onto the canonical ids as it goes.
 		$line_items = $this->assign_canonical_line_item_ids( $line_items );
-
-		// The exempt record was keyed while ids were still context-specific; move it onto
-		// the canonical ids, which is what get_itemized_tax_rates() looks up.
-		$non_taxable = array();
-		foreach ( array_keys( $this->non_taxable_line_items ) as $legacy_key ) {
-			$item_key = substr( $legacy_key, (int) strpos( $legacy_key, '-' ) + 1 );
-			if ( isset( $line_items[ $item_key ] ) ) {
-				$non_taxable[ $line_items[ $item_key ]['id'] ] = true;
-			}
-		}
-		$this->non_taxable_line_items = $non_taxable;
 
 		return $line_items;
 	}
@@ -1150,18 +1140,8 @@ class WC_Connect_TaxJar_Integration {
 			}
 		}
 
+		// Re-keys $non_taxable_line_items onto the canonical ids as it goes.
 		$line_items = $this->assign_canonical_line_item_ids( $line_items );
-
-		// The exempt record was keyed while ids were still context-specific; move it onto
-		// the canonical ids, which is what get_itemized_tax_rates() looks up.
-		$non_taxable = array();
-		foreach ( array_keys( $this->non_taxable_line_items ) as $legacy_key ) {
-			$item_key = substr( $legacy_key, (int) strpos( $legacy_key, '-' ) + 1 );
-			if ( isset( $line_items[ $item_key ] ) ) {
-				$non_taxable[ $line_items[ $item_key ]['id'] ] = true;
-			}
-		}
-		$this->non_taxable_line_items = $non_taxable;
 
 		return $line_items;
 	}
@@ -1192,6 +1172,15 @@ class WC_Connect_TaxJar_Integration {
 	 * identical lines — an order can legitimately hold the same product twice at the
 	 * same price — distinct, so neither loses its rate.
 	 *
+	 * Rewriting the ids invalidates `$non_taxable_line_items`, which callers record
+	 * while ids are still context-specific but `get_itemized_tax_rates()` reads back
+	 * under the canonical id. So this method re-keys that map itself rather than
+	 * leaving each caller to repair it afterwards: the map is never observable in the
+	 * stale keying, and a future caller inherits the invariant instead of having to
+	 * remember it. Callers reset the map before building, so replacing it wholesale
+	 * here is safe — an entry whose line item did not survive into $line_items (the
+	 * order path skips zero-priced lines) is dropped, exactly as before.
+	 *
 	 * @since 3.6.12
 	 *
 	 * @param array $line_items Line items whose 'id' is currently the bare product ID.
@@ -1200,6 +1189,7 @@ class WC_Connect_TaxJar_Integration {
 	 */
 	private function assign_canonical_line_item_ids( array $line_items ): array {
 		$occurrences = array();
+		$non_taxable = array();
 
 		foreach ( $line_items as $key => $line_item ) {
 			$product_id = $line_item['id'];
@@ -1220,8 +1210,16 @@ class WC_Connect_TaxJar_Integration {
 
 			$occurrences[ $fingerprint ] = isset( $occurrences[ $fingerprint ] ) ? $occurrences[ $fingerprint ] + 1 : 0;
 
-			$line_items[ $key ]['id'] = $product_id . '-' . substr( $fingerprint, 0, 12 ) . '-' . $occurrences[ $fingerprint ];
+			$canonical_id = $product_id . '-' . substr( $fingerprint, 0, 12 ) . '-' . $occurrences[ $fingerprint ];
+
+			if ( isset( $this->non_taxable_line_items[ $product_id . '-' . $key ] ) ) {
+				$non_taxable[ $canonical_id ] = true;
+			}
+
+			$line_items[ $key ]['id'] = $canonical_id;
 		}
+
+		$this->non_taxable_line_items = $non_taxable;
 
 		return $line_items;
 	}

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -4140,6 +4140,87 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Rewriting the ids is what invalidates `$non_taxable_line_items`, so re-keying it
+	 * belongs to the method that does the rewriting — not to each caller afterwards.
+	 *
+	 * Called directly here, with no caller involved, precisely so a future third caller
+	 * of `assign_canonical_line_item_ids()` inherits the remap instead of having to
+	 * remember it. Forgetting it has already caused one silent regression: the map
+	 * stayed keyed by the pre-canonical id while `get_itemized_tax_rates()` looked up
+	 * the canonical one, so the non-taxable guard never fired and no test failed.
+	 */
+	public function test_assign_canonical_line_item_ids_rekeys_non_taxable_map() {
+		$line_items = array(
+			'cart_key_exempt'  => array(
+				'id'               => 101,
+				'product_tax_code' => '99999',
+				'quantity'         => 1,
+				'unit_price'       => '10.00',
+				'discount'         => '0.00',
+				'tax_location'     => 'shipping',
+			),
+			'cart_key_taxable' => array(
+				'id'               => 202,
+				'product_tax_code' => '',
+				'quantity'         => 1,
+				'unit_price'       => '20.00',
+				'discount'         => '0.00',
+				'tax_location'     => 'shipping',
+			),
+		);
+
+		// Keyed the way both callers record it: "<product_id>-<context-specific key>".
+		$this->set_private_property( 'non_taxable_line_items', array( '101-cart_key_exempt' => true ) );
+
+		$result   = $this->invoke_protected_method( 'assign_canonical_line_item_ids', array( $line_items ) );
+		$recorded = $this->get_private_property( 'non_taxable_line_items' );
+
+		$this->assertSame(
+			array( $result['cart_key_exempt']['id'] => true ),
+			$recorded,
+			'The helper must leave the map keyed by canonical id, since that is what get_itemized_tax_rates() looks up.'
+		);
+		$this->assertArrayNotHasKey(
+			'101-cart_key_exempt',
+			$recorded,
+			'The pre-canonical key must not survive, or the stale entry outlives the id it described.'
+		);
+	}
+
+	/**
+	 * Replacing the map wholesale is only safe because an entry with no surviving line
+	 * item is meant to be dropped.
+	 *
+	 * `get_backend_line_items()` records the exempt status before the `if ( $unit_price )`
+	 * guard decides whether the line is sent at all, so a zero-priced exempt item is
+	 * recorded and then omitted. It has no canonical id to be re-keyed onto, and TaxJar
+	 * never echoes a breakdown line for it, so carrying it forward would be dead state.
+	 */
+	public function test_assign_canonical_line_item_ids_drops_non_taxable_entries_without_a_line_item() {
+		$line_items = array(
+			'item_1' => array(
+				'id'               => 101,
+				'product_tax_code' => '',
+				'quantity'         => 1,
+				'unit_price'       => '10.00',
+				'discount'         => '0.00',
+				'tax_location'     => 'shipping',
+			),
+		);
+
+		// 303 was recorded as exempt but never made it into $line_items.
+		$this->set_private_property( 'non_taxable_line_items', array( '303-item_2' => true ) );
+
+		$this->invoke_protected_method( 'assign_canonical_line_item_ids', array( $line_items ) );
+
+		$this->assertSame(
+			array(),
+			$this->get_private_property( 'non_taxable_line_items' ),
+			'An exempt record with no line item to re-key onto must be dropped, not carried forward.'
+		);
+	}
+
+	/**
 	 * Build a representative TaxJar request body for cache-signature tests.
 	 *
 	 * @param array $overrides Values to replace.

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -4148,10 +4148,17 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	 * remember it. Forgetting it has already caused one silent regression: the map
 	 * stayed keyed by the pre-canonical id while `get_itemized_tax_rates()` looked up
 	 * the canonical one, so the non-taxable guard never fired and no test failed.
+	 *
+	 * Two exempt lines, not one, because the re-key accumulates: the assignment sits
+	 * inside an `isset()` guard, so with a single exempt line "add to the map" and
+	 * "replace the map" are indistinguishable and a suite of one-exempt-item fixtures
+	 * stays green either way. A cart with two exempt products would then leave only the
+	 * last one guarded, and the first one's 0% breakdown line would overwrite the shared
+	 * tax-class rate row — the exact WOOTAX-240 regression this seam exists to prevent.
 	 */
 	public function test_assign_canonical_line_item_ids_rekeys_non_taxable_map() {
 		$line_items = array(
-			'cart_key_exempt'  => array(
+			'cart_key_exempt'   => array(
 				'id'               => 101,
 				'product_tax_code' => '99999',
 				'quantity'         => 1,
@@ -4159,7 +4166,15 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 				'discount'         => '0.00',
 				'tax_location'     => 'shipping',
 			),
-			'cart_key_taxable' => array(
+			'cart_key_exempt_2' => array(
+				'id'               => 303,
+				'product_tax_code' => '99999',
+				'quantity'         => 1,
+				'unit_price'       => '30.00',
+				'discount'         => '0.00',
+				'tax_location'     => 'shipping',
+			),
+			'cart_key_taxable'  => array(
 				'id'               => 202,
 				'product_tax_code' => '',
 				'quantity'         => 1,
@@ -4170,15 +4185,24 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		);
 
 		// Keyed the way both callers record it: "<product_id>-<context-specific key>".
-		$this->set_private_property( 'non_taxable_line_items', array( '101-cart_key_exempt' => true ) );
+		$this->set_private_property(
+			'non_taxable_line_items',
+			array(
+				'101-cart_key_exempt'   => true,
+				'303-cart_key_exempt_2' => true,
+			)
+		);
 
 		$result   = $this->invoke_protected_method( 'assign_canonical_line_item_ids', array( $line_items ) );
 		$recorded = $this->get_private_property( 'non_taxable_line_items' );
 
 		$this->assertSame(
-			array( $result['cart_key_exempt']['id'] => true ),
+			array(
+				$result['cart_key_exempt']['id']   => true,
+				$result['cart_key_exempt_2']['id'] => true,
+			),
 			$recorded,
-			'The helper must leave the map keyed by canonical id, since that is what get_itemized_tax_rates() looks up.'
+			'Every exempt line must survive the re-key, accumulated onto its own canonical id — not just the last one.'
 		);
 		$this->assertArrayNotHasKey(
 			'101-cart_key_exempt',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Follow-up to #2983, filed from @Abdalsalaam's review there.

`assign_canonical_line_item_ids()` rewrites each TaxJar line item's `id`, and that rewrite is
exactly what invalidates `$non_taxable_line_items`: callers record that map while ids are still
context-specific, but `get_itemized_tax_rates()` reads it back under the canonical id. Landing
WOOTAX-258 and WOOTAX-240 together left the map keyed one way and the lookup the other, so the
non-taxable guard stopped firing and WOOTAX-240 silently regressed.

The fix shipped in #2983 repairs the map in the caller — an identical eight-line block duplicated
verbatim in `get_line_items()` and `get_backend_line_items()`. That leaves a coupling invariant
living one level below where it belongs: a third caller of `assign_canonical_line_item_ids()` that
omits the block reintroduces the same regression, silently, with nothing failing. That is the same
failure signature as the original bug.

This PR moves the remap **into** `assign_canonical_line_item_ids()`, which already holds both
`$key` and `$product_id` in scope:

```php
$canonical_id = $product_id . '-' . substr( $fingerprint, 0, 12 ) . '-' . $occurrences[ $fingerprint ];

if ( isset( $this->non_taxable_line_items[ $product_id . '-' . $key ] ) ) {
    $non_taxable[ $canonical_id ] = true;
}

$line_items[ $key ]['id'] = $canonical_id;
```

The map is no longer observable in the stale keying, and a future caller inherits the invariant
instead of having to remember it. Each call site keeps a one-line comment noting the side effect.

### Why this is behaviour-preserving

- Both callers already reset the map to `array()` before building (`:983` cart, `:1098` order), so
  replacing it wholesale inside the helper cannot clobber the other path's state.
- The old block dropped entries whose item key was absent from `$line_items`
  (`isset( $line_items[ $item_key ] )`). The new form iterates `$line_items`, so such an entry
  simply never appears — same result. This case is real, not theoretical: `get_backend_line_items()`
  records the exempt status *before* the `if ( $unit_price )` guard decides whether the line is
  emitted at all, so a zero-priced exempt item is recorded and then omitted.
- `$product_id . '-' . $key` reconstructs the caller's key exactly, so the lookup is equivalent to
  the old parse for every input the two callers can produce.

### One strict difference, unreachable today

The removed `substr( $legacy_key, strpos( $legacy_key, '-' ) + 1 )` mis-parses any key containing a
`-`. The new form does not parse at all, so it is robust where the old one was not. No current
caller can produce such a key — cart item keys are md5 hashes, order item IDs and product IDs are
integers — so this is unobservable in practice.

I deliberately did **not** add a test pinning it: asserting it would assert a behaviour change in a
refactor that is meant not to have one. Flagging it here instead, since it is the undocumented
assumption the ticket set out to remove.

### Backward compatibility

**No BC impact.** `assign_canonical_line_item_ids()` is `private` and `$non_taxable_line_items` is a
`private` property, both introduced in the current unreleased 3.6.12 — neither has ever been
reachable from outside this class. No hook is added, removed, reordered or retimed; no new read of a
global or of `WC()` state is introduced; no site-scoped option or path/URL construction is touched,
so multisite and non-root install layouts are unaffected.

### On the changelog checkboxes

Left unchecked deliberately, rather than overlooked. `assign_canonical_line_item_ids()` is
`@since 3.6.12` and `$non_taxable_line_items` came from the WOOTAX-240 fix, also in the 3.6.12
block — which is still unreleased (`2026-xx-xx` placeholder; `Stable tag: 3.6.11`). Both the code
being changed and the state it replaces are unreleased, so there is no user-visible delta to report
and an entry would document internal churn in a version that never shipped. Happy to add one if you
would rather the block record it.

### Related issue(s)

Closes [WOOTAX-322](https://linear.app/a8c/issue/WOOTAX-322)

Follow-up to #2983 (WOOTAX-258). Guards the fix for [WOOTAX-240](https://linear.app/a8c/issue/WOOTAX-240).

### Steps to reproduce & screenshots/GIFs

No user-visible change, so there is nothing to screenshot — this is a behaviour-preserving refactor
and the test suite is the evidence. To verify:

1. `composer test` — expect **401 tests / 978 assertions** green. Baseline on `trunk` is 399/975;
   the delta is exactly the two new tests added here.
2. Confirm the five behavioural guards from WOOTAX-240 / WOOTAX-258 pass **unmodified** — they are
   untouched in the diff, which is the point:
   ```
   ./vendor/bin/phpunit --filter '(test_get_itemized_tax_rates_non_taxable_line_does_not_zero_standard_rate|test_get_itemized_tax_rates_filtered_non_taxable_line_does_not_zero_standard_rate|test_get_itemized_tax_rates_shipping_only_line_does_not_zero_standard_rate|test_get_line_items_still_records_none_status_as_non_taxable|test_get_backend_line_items_sends_shipping_only_status_as_exempt)'
   ```
3. Optional end-to-end check of the underlying WOOTAX-240 behaviour: build a cart mixing a taxable
   Standard-class product with a non-taxable (Tax status "None") one and confirm the Standard rate
   row is not zeroed.

**PHPCS:** zero new violations. `--report=source` over the two changed files is identical to `trunk`
at 30 sniff types / 179 violations.

### Checklist

<!-- All testable code should have tests. -->
- [x] unit tests

<!-- An entry in the changelog file is always required -->
- [ ] `changelog.txt` entry added
- [ ] `readme.txt` entry added

#### On the two new tests

Both call the `private` helper **directly via reflection, with no caller involved**. That is
deliberate: a test entering through `get_line_items()` / `get_backend_line_items()` would stay green
if someone re-duplicated the block back into both callers, so it would pin the two known paths
rather than the contract. Testing at the seam is what makes a hypothetical third caller safe.

- `test_assign_canonical_line_item_ids_rekeys_non_taxable_map` — seeds the map in the legacy
  `<product_id>-<key>` shape and asserts it comes back keyed by canonical id, with the legacy key gone.
- `test_assign_canonical_line_item_ids_drops_non_taxable_entries_without_a_line_item` — pins the drop
  semantics that make replacing the map wholesale safe.