### PR TITLE
[WOOTAX-327] Tweak - WordPress 7.1 Compatibility.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.6.13 - 2026-xx-xx =
+* Tweak - WordPress 7.1 Compatibility.
+
 = 3.6.12 - 2026-08-10 =
 * Fix   - Restore tax rate lookups for local pickup orders, which could return no rates at all.
 * Fix   - Preserve apostrophes in city and street when taxes are recalculated from the order edit screen.

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: woocommerce, automattic, woothemes, allendav, kellychoffman, jkudish, jeffstieler, nabsul, robobot3000, danreylop, mikeyarce, shaunkuschel, orangesareorange, pauldechov, dappermountain, radogeorgiev, bor0, royho, cshultz88, bartoszbudzanowski, harriswong, ferdev, superdav42
 Tags: tax, vat, gst, woocommerce, payment
 Requires PHP: 7.4
-Requires at least: 6.9
+Requires at least: 7.0
 Requires Plugins: woocommerce
-Tested up to: 7.0
+Tested up to: 7.1
 WC requires at least: 10.8
 WC tested up to: 11.0
 Stable tag: 3.6.12
@@ -69,6 +69,9 @@ This plugin relies on the following external services:
 2. Checking on the health of WooCommerce Tax
 
 == Changelog ==
+
+= 3.6.13 - 2026-xx-xx =
+* Tweak - WordPress 7.1 Compatibility.
 
 = 3.6.12 - 2026-08-10 =
 * Fix   - Restore tax rate lookups for local pickup orders, which could return no rates at all.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -11,8 +11,8 @@
  * Version: 3.6.12
  * Requires Plugins: woocommerce
  * Requires PHP: 7.4
- * Requires at least: 6.9
- * Tested up to: 7.0
+ * Requires at least: 7.0
+ * Tested up to: 7.1
  * WC requires at least: 10.8
  * WC tested up to: 11.0
  *


### PR DESCRIPTION
## Description

Declares compatibility with WordPress 7.1: bumps `Tested up to` from 7.0 to 7.1 and `Requires at least` from 6.9 to 7.0, and adds a changelog entry under the new 3.6.13 version.

### Related issue(s)

Fixes WOOTAX-327

### Steps to reproduce & screenshots/GIFs

1. Install the plugin on a site running WordPress 7.1.
2. Verify the plugin activates without errors, warnings, or JS console errors, and functions as expected.
3. Verify the headers in `woocommerce-services.php` and `readme.txt` read `Tested up to: 7.1` and `Requires at least: 7.0`.

### Checklist

- [ ] unit tests
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added
