### PR TITLE
[WOOTAX-328] Tweak - WooCommerce 11.1 Compatibility.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.6.14 - 2026-xx-xx =
+* Tweak - WooCommerce 11.1 Compatibility.
+
 = 3.6.13 - 2026-08-24 =
 * Tweak - WordPress 7.1 Compatibility.
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Requires PHP: 7.4
 Requires at least: 7.0
 Requires Plugins: woocommerce
 Tested up to: 7.1
-WC requires at least: 10.8
-WC tested up to: 11.0
+WC requires at least: 10.9
+WC tested up to: 11.1
 Stable tag: 3.6.13
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -69,6 +69,9 @@ This plugin relies on the following external services:
 2. Checking on the health of WooCommerce Tax
 
 == Changelog ==
+
+= 3.6.14 - 2026-xx-xx =
+* Tweak - WooCommerce 11.1 Compatibility.
 
 = 3.6.13 - 2026-08-24 =
 * Tweak - WordPress 7.1 Compatibility.

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -13,8 +13,8 @@
  * Requires PHP: 7.4
  * Requires at least: 7.0
  * Tested up to: 7.1
- * WC requires at least: 10.8
- * WC tested up to: 11.0
+ * WC requires at least: 10.9
+ * WC tested up to: 11.1
  *
  * Copyright (c) 2017-2023 Automattic
  *


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Description
<!-- Explain the motivation for making this change -->

Bumps WooCommerce compatibility to 11.1 and minimum required version to 10.9.

### Related issue(s)

Fixes WOOTAX-328

### Steps to reproduce & screenshots/GIFs

1. Install the plugin on a WordPress site running WooCommerce 11.1.
2. Verify the plugin activates without errors and functions as expected.

### Checklist

- [ ] unit tests
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added
