### PR TITLE
Fix checkout fatal when a cart line price is not numeric

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.6.14 - 2026-xx-xx =
+* Fix   - Prevent a fatal error at checkout when a cart line's price is not numeric.
+
 = 3.6.13 - 2026-08-24 =
 * Tweak - WordPress 7.1 Compatibility.
 

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1055,14 +1055,17 @@ class WC_Connect_TaxJar_Integration {
 				$this->_log( 'Tax location override for product ' . $id . ': ' . $default_location . ' -> ' . $tax_location );
 			}
 
-			$line_items[ $cart_item_key ] = array(
-				'id'               => $id,
-				'quantity'         => $quantity,
-				'product_tax_code' => $tax_code,
-				'unit_price'       => $unit_price,
-				'discount'         => $discount,
-				'tax_location'     => $tax_location,
-			);
+			// A malformed price reduces to '' or '-', which is fatal in the totals arithmetic. A 0 is legitimate.
+			if ( is_numeric( $unit_price ) ) {
+				$line_items[ $cart_item_key ] = array(
+					'id'               => $id,
+					'quantity'         => $quantity,
+					'product_tax_code' => $tax_code,
+					'unit_price'       => $unit_price,
+					'discount'         => $discount,
+					'tax_location'     => $tax_location,
+				);
+			}
 		}
 
 		// Re-keys $non_taxable_line_items onto the canonical ids as it goes.

--- a/classes/class-wc-connect-taxjar-integration.php
+++ b/classes/class-wc-connect-taxjar-integration.php
@@ -1065,6 +1065,9 @@ class WC_Connect_TaxJar_Integration {
 					'discount'         => $discount,
 					'tax_location'     => $tax_location,
 				);
+			} else {
+				// A cart left with no numeric line sends no request, so this is its only trace.
+				$this->_log( 'Skipping line item for product ' . $id . ': non-numeric price "' . $unit_price . '"' );
 			}
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.6.14 - 2026-xx-xx =
+* Fix   - Prevent a fatal error at checkout when a cart line's price is not numeric.
+
 = 3.6.13 - 2026-08-24 =
 * Tweak - WordPress 7.1 Compatibility.
 

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -447,9 +447,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * A pricing filter can empty a price after the item is already in the cart.
-	 * wc_format_decimal() passes that through, and a non-numeric unit price is fatal
-	 * in the totals arithmetic, so the line is skipped.
+	 * Test that a line emptied by a pricing filter after being added to the cart is skipped.
 	 */
 	public function test_get_line_items_skips_line_with_non_numeric_price() {
 		$this->product = WC_Helper_Product::create_simple_product();
@@ -465,10 +463,29 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * A zero price is legitimate and must keep reaching TaxJar, so the guard has to be
-	 * is_numeric() and not a truthiness check. See
-	 * test_zero_amount_response_persists_real_itemized_rates() for what the response to
-	 * a $0 line carries.
+	 * Test that a '-' price is skipped, being truthy and non-empty where '' is neither.
+	 */
+	public function test_get_line_items_skips_line_with_dash_price() {
+		$this->assertSame( '-', wc_format_decimal( '-' ) );
+
+		$this->product = WC_Helper_Product::create_simple_product();
+		$this->product->save();
+
+		WC()->cart->add_to_cart( $this->product->get_id(), 2 );
+
+		$dash_price = function () {
+			return '-';
+		};
+
+		add_filter( 'woocommerce_product_get_price', $dash_price );
+		$line_items = $this->invoke_protected_method( 'get_line_items', array( WC()->cart ) );
+		remove_filter( 'woocommerce_product_get_price', $dash_price );
+
+		$this->assertSame( array(), $line_items );
+	}
+
+	/**
+	 * Test that a zero price still reaches TaxJar, being falsy but numeric.
 	 */
 	public function test_get_line_items_keeps_line_priced_zero() {
 		$this->product = WC_Helper_Product::create_simple_product();

--- a/tests/php/test-class-wc-connect-taxjar-integration.php
+++ b/tests/php/test-class-wc-connect-taxjar-integration.php
@@ -87,6 +87,7 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 		remove_all_filters( 'woocommerce_tax_line_item_location' );
 		remove_all_filters( 'woocommerce_services_override_tax_rate' );
 		remove_all_filters( 'woocommerce_product_is_taxable' );
+		remove_all_filters( 'woocommerce_product_get_price' );
 
 		delete_option( 'woocommerce_calc_taxes' );
 
@@ -443,6 +444,44 @@ class WP_Test_WC_Connect_TaxJar_Integration extends WC_Unit_Test_Case {
 
 		// Assert quantity.
 		$this->assertEquals( 2, $item['quantity'] );
+	}
+
+	/**
+	 * A pricing filter can empty a price after the item is already in the cart.
+	 * wc_format_decimal() passes that through, and a non-numeric unit price is fatal
+	 * in the totals arithmetic, so the line is skipped.
+	 */
+	public function test_get_line_items_skips_line_with_non_numeric_price() {
+		$this->product = WC_Helper_Product::create_simple_product();
+		$this->product->save();
+
+		WC()->cart->add_to_cart( $this->product->get_id(), 2 );
+
+		add_filter( 'woocommerce_product_get_price', '__return_empty_string' );
+		$line_items = $this->invoke_protected_method( 'get_line_items', array( WC()->cart ) );
+		remove_filter( 'woocommerce_product_get_price', '__return_empty_string' );
+
+		$this->assertSame( array(), $line_items );
+	}
+
+	/**
+	 * A zero price is legitimate and must keep reaching TaxJar, so the guard has to be
+	 * is_numeric() and not a truthiness check. See
+	 * test_zero_amount_response_persists_real_itemized_rates() for what the response to
+	 * a $0 line carries.
+	 */
+	public function test_get_line_items_keeps_line_priced_zero() {
+		$this->product = WC_Helper_Product::create_simple_product();
+		$this->product->set_regular_price( 0 );
+		$this->product->set_price( 0 );
+		$this->product->save();
+
+		WC()->cart->add_to_cart( $this->product->get_id(), 2 );
+
+		$line_items = $this->invoke_protected_method( 'get_line_items', array( WC()->cart ) );
+
+		$this->assertCount( 1, $line_items );
+		$this->assertSame( '0', reset( $line_items )['unit_price'] );
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Description

- Guard the cart line item build in `get_line_items()` with `is_numeric( $unit_price )`, so a malformed price never reaches the totals arithmetic.

`wc_format_decimal( $product->get_price() )` reduces a malformed price to `''` or `'-'`, and `calculate_totals()` multiplies that by the quantity, which is a `TypeError` on PHP 8 that takes the whole checkout page down. The way in is a pricing plugin filtering `woocommerce_product_get_price` after the item is already in the cart, since WooCommerce will not let you add a product with no price.

`is_numeric()` rather than a truthiness check because `'-'` is truthy and would still fatal, and `'0'` is falsy and must not be dropped, see `test_zero_amount_response_persists_real_itemized_rates()` for what the response to a `$0` line carries.

The skipped line gets no tax row. Nothing is lost by that, on `trunk` it got none either because the page died and took the rest of the cart's tax with it.

### Related issue(s)

Closes WOOTAX-339

### Steps to reproduce & screenshots/GIFs

- Check out `trunk` and enable automated taxes.
- Set the store address to a US one, for example `1 Main St, Denver, CO 80202`.
- Log in as a customer whose billing and shipping address is the **same state, with a postcode and city filled in**. Without them the tax call aborts and nothing happens.
- Add this to a mu-plugin. Filtering globally instead would make the product unpurchasable and WooCommerce would drop it from the cart.

```php
add_action( 'woocommerce_after_calculate_totals', function () {
	add_filter( 'woocommerce_product_get_price', function () { return '-'; }, 99, 0 );
}, 19 );
add_action( 'woocommerce_after_calculate_totals', function () {
	remove_all_filters( 'woocommerce_product_get_price', 99 );
}, 21 );
```

- Add a product to the cart and open the checkout page.
- The page should show `Uncaught TypeError: Unsupported operand types: string * int` in `class-wc-connect-taxjar-integration.php:614`.
- Check out this PR branch and reload the checkout.
- The page should render, with its tax rows in the order table.

**A zero price must still be sent**

- Enable `debug_logging_enabled` so the `WCS Tax` log records `Requesting: taxjar/v2/taxes`.
- Remove the mu-plugin, then put a normally priced product and a product priced `0` in the cart.
- Open the checkout on `trunk` and on this branch.
- The logged request should carry `"unit_price":"0"` on **both**, and the order totals should be identical.

### Checklist

- [x] unit tests
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added
