### PR TITLE
[WOOTAX-343] Tweak - Limit the WooCommerce Tax connection banner to tax surfaces

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 3.6.14 - 2026-xx-xx =
 * Fix   - Prevent a fatal error at checkout when a cart line's price is not numeric.
+* Tweak - Limit the WordPress.com connection banner to the Tax settings and Plugins pages, so it no longer appears on unrelated admin screens.
 
 = 3.6.13 - 2026-08-24 =
 * Tweak - WordPress 7.1 Compatibility.

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -286,36 +286,28 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			return self::JETPACK_CONNECTED;
 		}
 
+		/**
+		 * Whether the WooCommerce Tax connection banner may render on the given screen.
+		 *
+		 * The banner only offers WooCommerce Tax, so it is confined to where WooCommerce
+		 * Tax is configured: WooCommerce » Settings » Tax, including that tab's rate-table
+		 * sections. The Plugins page is kept as well, since that is where a store lands
+		 * right after activating the plugin and has not connected yet.
+		 *
+		 * @param WP_Screen|null $screen Current admin screen.
+		 * @return bool
+		 */
 		public function should_display_nux_notice_on_screen( $screen ) {
-			if ( // Display if on any of these admin pages.
-				( // Products list.
-					'product' === $screen->post_type
-					&& 'edit' === $screen->base
-				)
-				|| ( // Orders list and edit order page when not using HPOS.
-					'shop_order' === $screen->post_type
-					&& in_array( $screen->base, array( 'edit', 'post' ), true )
-					)
-				|| ( // Orders list and edit order page when using HPOS.
-					wc_get_page_screen_id( 'shop_order' ) === $screen->id
-				)
-				|| ( // WooCommerce settings.
-					'woocommerce_page_wc-settings' === $screen->base
-					)
-				|| ( // WooCommerce featured extension page
-					'woocommerce_page_wc-addons' === $screen->base
-					&& isset( $_GET['section'] ) && 'featured' === $_GET['section']
-					)
-				|| ( // WooCommerce shipping extension page
-					'woocommerce_page_wc-addons' === $screen->base
-					&& isset( $_GET['section'] ) && 'shipping_methods' === $_GET['section']
-					)
-				|| 'plugins' === $screen->base
-			) {
+			if ( ! $screen || ! isset( $screen->base ) ) {
+				return false;
+			}
+
+			if ( 'plugins' === $screen->base ) {
 				return true;
 			}
 
-			return false;
+			return 'woocommerce_page_wc-settings' === $screen->base
+				&& isset( $_GET['tab'] ) && 'tax' === $_GET['tab'];
 		}
 
 		/**

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,7 @@ This plugin relies on the following external services:
 
 = 3.6.14 - 2026-xx-xx =
 * Fix   - Prevent a fatal error at checkout when a cart line's price is not numeric.
+* Tweak - Limit the WordPress.com connection banner to the Tax settings and Plugins pages, so it no longer appears on unrelated admin screens.
 
 = 3.6.13 - 2026-08-24 =
 * Tweak - WordPress 7.1 Compatibility.

--- a/tests/php/test-class_wc-connect-nux.php
+++ b/tests/php/test-class_wc-connect-nux.php
@@ -3,7 +3,7 @@
 class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 
 	public static function set_up_before_class() {
-		require_once dirname( __FILE__ ) . '/../../classes/class-wc-connect-nux.php';
+		require_once __DIR__ . '/../../classes/class-wc-connect-nux.php';
 	}
 
 	public function test_get_banner_type_to_display_dev_jp() {
@@ -178,5 +178,143 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 			),
 			false
 		);
+	}
+
+	/**
+	 * The banner gate does not touch instance state, so build the object without
+	 * running the constructor to avoid pulling in the tracks and shipping label deps.
+	 */
+	private function get_nux() {
+		$reflection = new ReflectionClass( 'WC_Connect_Nux' );
+
+		return $reflection->newInstanceWithoutConstructor();
+	}
+
+	/**
+	 * Build a minimal stand-in for WP_Screen carrying just the properties the gate reads.
+	 *
+	 * @param string $base Screen base.
+	 * @return stdClass
+	 */
+	private function make_screen( $base ) {
+		$screen       = new stdClass();
+		$screen->base = $base;
+		$screen->id   = $base;
+
+		return $screen;
+	}
+
+	/**
+	 * Clear the request globals the screen gate reads between tests.
+	 */
+	public function tear_down() {
+		unset( $_GET['tab'], $_GET['section'] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * The banner renders on WooCommerce » Settings » Tax.
+	 */
+	public function test_should_display_nux_notice_on_the_tax_settings_tab() {
+		$_GET['tab'] = 'tax';
+
+		$this->assertTrue(
+			$this->get_nux()->should_display_nux_notice_on_screen(
+				$this->make_screen( 'woocommerce_page_wc-settings' )
+			)
+		);
+	}
+
+	/**
+	 * Every section of the Tax tab, including the rate tables, still qualifies.
+	 */
+	public function test_should_display_nux_notice_on_every_section_of_the_tax_settings_tab() {
+		$_GET['tab'] = 'tax';
+
+		foreach ( array( 'standard', 'reduced-rate', 'zero-rate' ) as $section ) {
+			$_GET['section'] = $section;
+
+			$this->assertTrue(
+				$this->get_nux()->should_display_nux_notice_on_screen(
+					$this->make_screen( 'woocommerce_page_wc-settings' )
+				),
+				"Expected the banner to be allowed on the {$section} tax section."
+			);
+		}
+	}
+
+	/**
+	 * Other WooCommerce settings tabs no longer show the banner.
+	 */
+	public function test_should_not_display_nux_notice_on_other_settings_tabs() {
+		foreach ( array( 'general', 'products', 'shipping', 'checkout', 'advanced' ) as $tab ) {
+			$_GET['tab'] = $tab;
+
+			$this->assertFalse(
+				$this->get_nux()->should_display_nux_notice_on_screen(
+					$this->make_screen( 'woocommerce_page_wc-settings' )
+				),
+				"Expected the banner to be suppressed on the {$tab} settings tab."
+			);
+		}
+	}
+
+	/**
+	 * The settings landing page defaults to General, so it must not show the banner.
+	 */
+	public function test_should_not_display_nux_notice_on_settings_without_a_tab() {
+		$this->assertFalse(
+			$this->get_nux()->should_display_nux_notice_on_screen(
+				$this->make_screen( 'woocommerce_page_wc-settings' )
+			)
+		);
+	}
+
+	/**
+	 * The Plugins page stays a connection surface regardless of any tab in the URL.
+	 */
+	public function test_should_display_nux_notice_on_the_plugins_page() {
+		$this->assertTrue(
+			$this->get_nux()->should_display_nux_notice_on_screen( $this->make_screen( 'plugins' ) )
+		);
+
+		// The Plugins page carries no tab, and an unrelated one must not suppress it.
+		$_GET['tab'] = 'general';
+
+		$this->assertTrue(
+			$this->get_nux()->should_display_nux_notice_on_screen( $this->make_screen( 'plugins' ) )
+		);
+	}
+
+	/**
+	 * Product, order, extension and dashboard screens no longer show the banner.
+	 */
+	public function test_should_not_display_nux_notice_on_non_tax_screens() {
+		$_GET['tab'] = 'tax';
+
+		$screens = array(
+			'edit',
+			'post',
+			'woocommerce_page_wc-addons',
+			'woocommerce_page_wc-orders',
+			'dashboard',
+		);
+
+		foreach ( $screens as $base ) {
+			$this->assertFalse(
+				$this->get_nux()->should_display_nux_notice_on_screen( $this->make_screen( $base ) ),
+				"Expected the banner to be suppressed on the {$base} screen."
+			);
+		}
+	}
+
+	/**
+	 * A missing screen is handled without a fatal.
+	 */
+	public function test_should_not_display_nux_notice_without_a_screen() {
+		$_GET['tab'] = 'tax';
+
+		$this->assertFalse( $this->get_nux()->should_display_nux_notice_on_screen( null ) );
 	}
 }


### PR DESCRIPTION
## Description

The WordPress.com connection banner is branded entirely as WooCommerce Tax — "Connect your site to activate WooCommerce Tax", "…to activate WooCommerce Tax features" — but its screen gate allowed it on **seven** surfaces: the products list, the orders list and edit screens (legacy and HPOS), **every** WooCommerce settings tab (there was no `tab` check at all), `wc-addons&section=featured`, `wc-addons&section=shipping_methods`, and the Plugins page. Stores were prompted about tax while working in contexts where WooCommerce Tax plays no part.

This narrows [`WC_Connect_Nux::should_display_nux_notice_on_screen()`](https://github.com/Automattic/woocommerce-services/blob/trunk/classes/class-wc-connect-nux.php#L289) to the surfaces where the offer is actionable:

- **WooCommerce » Settings » Tax** — including that tab's rate-table sections (`standard`, `reduced-rate`, `zero-rate`).
- **Plugins** — kept per the issue DoD; it is where a store lands right after activating the plugin, before it has connected.

All four banner variants (`show_banner_before_connection`, `show_tos_banner`, `show_banner_after_connection`, `show_tos_informational_banner`) route through this single gate, so they narrow together.

Also adds a missing-screen guard, matching the defensive pattern already used in `WC_Connect_TaxJar_Integration::on_order_page()`. Dropping the `wc_get_page_screen_id()` call makes the method unit-testable, which it previously was not.

Out of scope: `should_display_nux_notice_for_current_store_locale()` is untouched.

### Backward compatibility

**Surface touched:** `WC_Connect_Nux::should_display_nux_notice_on_screen()` — a public method on a globally-namespaced `WC_Connect_*` class, so it must be treated as externally exposed.

- **Signature is unchanged** (same name, same single `$screen` argument, same `bool` return). Existing callers keep working; nothing fatals on load.
- **Behavior narrows.** Anything calling this to decide whether to render its own UI now gets `false` on the five dropped surfaces. There are no in-repo callers other than the four banner renderers. No hooks or filters were added, removed, reordered, or retimed.
- **Now tolerates `null`/screen-less input** instead of emitting a notice on `$screen->post_type` — strictly more permissive on input.
- **No global-state assumptions added.** The method reads only `$screen` and `$_GET['tab']`, both already read on this path, and it is only reachable from `admin_notices` — not from REST, cron, WP-CLI, or the Store API.
- **Multisite / install layout:** no options, paths, or URLs are read or built, so behavior is unchanged under multisite, subdirectory installs, and relocated `wp-content`.

**Reviewer call-out (Product Scope):** a **grandfathered shipping store that is not yet connected** loses the connect prompt on the orders list, the order edit screen, the products list, and `wc-addons&section=shipping_methods` — surfaces where they'd buy a label. They can still connect from the Plugins page and from WooCommerce » Settings » Tax, and the banner only ever offered WooCommerce Tax, so no shipping functionality is removed. Flagging it because it narrows a connection path those stores had.

### Related issue(s)

https://linear.app/a8c/issue/WOOTAX-343/limit-woocommerce-tax-connection-banner-to-tax-surfaces

### Steps to reproduce & screenshots/GIFs

**Before:** on a store that is not connected to WordPress.com, the "Connect your site to activate WooCommerce Tax" banner appears on the products list, the orders list, the order edit screen, every WooCommerce settings tab, the two WooCommerce extension sections, and the Plugins page.

**After:** it appears only on WooCommerce » Settings » Tax and on Plugins.

### Checklist

- [x] unit tests
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

### Testing instructions

Preconditions: a store whose base country is TaxJar-supported (US, CA, AU, or EU), with the site **not connected to WordPress.com** and the WooCommerce Tax TOS not yet accepted — this is what makes the "before connection" banner eligible. Log in as a user with `manage_woocommerce`.

1. Go to **WooCommerce » Settings » Tax** (`admin.php?page=wc-settings&tab=tax`). Confirm the "Connect your site to activate WooCommerce Tax" banner **is shown**.
2. Still on the Tax tab, open each rate-table section — **Standard rates**, **Reduced rate rates**, **Zero rate rates**. Confirm the banner **is still shown** on each.
3. Go to **Plugins** (`plugins.php`). Confirm the banner **is shown**.
4. Go to **WooCommerce » Settings » General**, then **Products**, then **Shipping**, then **Payments**, then **Advanced**. Confirm the banner **is not shown** on any of them.
5. Go to **WooCommerce » Settings** with no tab in the URL (`admin.php?page=wc-settings`, which lands on General). Confirm the banner **is not shown**.
6. Go to **Products » All Products**. Confirm the banner **is not shown**.
7. Go to **WooCommerce » Orders** and open an individual order. Confirm the banner **is not shown** on either the list or the edit screen. Repeat with HPOS both enabled and disabled if you can, since the old gate had a separate branch for each.
8. Go to **WooCommerce » Extensions** and open the **Featured** section, then the **Shipping methods** section. Confirm the banner **is not shown** on either.
9. Click **Connect** on the banner from the Tax tab and complete the WordPress.com connection. Confirm you are returned to the Tax tab and the "Setup complete." banner is shown there — the after-connection variant shares the same gate, so it must still land somewhere visible.

#### Cross-check against WooCommerce Shipping

This plugin renders a **second, unrelated admin notice** — the WCS&T → WooCommerce Shipping migration/upgrade banner — through a completely separate gate, [`WC_Connect_Loader::should_render_upgrade_banner()`](https://github.com/Automattic/woocommerce-services/blob/trunk/woocommerce-services.php#L1694), hooked on `current_screen` rather than `admin_init`. That gate independently allows all WooCommerce settings pages and the orders list (HPOS and non-HPOS), and **this PR does not touch it**. Since both are admin notices on overlapping screens, they are easy to conflate while running the steps above — these steps confirm the migration notice is still intact and that the two do not interfere.

Preconditions: a **grandfathered** store that passes both `is_eligible_for_migration()` and `is_store_eligible_for_shipping_label_creation()` — i.e. one that purchased at least one shipping label before deprecation — and that is still disconnected from WordPress.com so the connection banner remains eligible.

10. With the standalone **WooCommerce Shipping** plugin **not** active, go to **WooCommerce » Orders** (list view). Confirm the connection banner is **gone**, but the "migrate to WooCommerce Shipping" notice **is still shown**. Repeat with HPOS enabled and disabled — the upgrade gate has a separate branch for each (`edit-shop_order` vs `woocommerce_page_wc-orders`).
11. Go to **WooCommerce » Settings » General**. Same expectation: no connection banner, migration notice still present.
12. Go to **WooCommerce » Settings » Tax**. Confirm **both** notices can appear here and neither suppresses the other.
13. Open an individual order (`&action=edit`). The migration notice is intentionally absent there — `should_render_upgrade_banner()` bails when `action` is set — so confirm that is unchanged and that the connection banner is absent too.
14. Activate the standalone **WooCommerce Shipping** plugin and walk the same screens again. Confirm this PR introduces no interaction: WooCommerce Shipping's own admin notices behave exactly as they did before, and our connection banner still appears only on the Tax tab and the Plugins page.
15. Complete the migration to WooCommerce Shipping. Confirm the Tax tab **still** shows the connection banner while the store is disconnected — tax stays this plugin's surface after shipping migrates away, so the banner must survive migration.
16. Confirm the shipping label purchase flow on the order edit screen is unaffected throughout — this PR changes only where a banner renders, never any shipping capability.
