### PR TITLE
[WOOTAX-338] Fix - Write the tax rate backup as real CSV instead of concatenated strings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,10 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.6.15 - 2026-xx-xx =
+* Fix   - Write the tax rate backup file as proper CSV, so cities and tax names containing a comma, a quote or an apostrophe are saved exactly as stored and no cell can be treated as a formula when the file is opened in a spreadsheet.
+
 = 3.6.14 - 2026-09-03 =
 * Fix   - Prevent a fatal error at checkout when a cart line's price is not numeric.
-* Fix   - Write the tax rate backup file as proper CSV, so cities and tax names containing a comma, a quote or an apostrophe are saved exactly as stored and no cell can be treated as a formula when the file is opened in a spreadsheet.
 * Tweak - Limit the WordPress.com connection banner to the Tax settings and Plugins pages, so it no longer appears on unrelated admin screens.
 * Tweak - Stop registering a redundant copy of the continents REST endpoint on requests that cannot reach it.
 * Tweak - WooCommerce 11.1 Compatibility.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 3.6.14 - 2026-xx-xx =
 * Fix   - Prevent a fatal error at checkout when a cart line's price is not numeric.
+* Fix   - Write the tax rate backup file as proper CSV, so cities and tax names containing a comma, a quote or an apostrophe are saved exactly as stored and no cell can be treated as a formula when the file is opened in a spreadsheet.
 * Tweak - Limit the WordPress.com connection banner to the Tax settings and Plugins pages, so it no longer appears on unrelated admin screens.
 * Tweak - Stop registering a redundant copy of the continents REST endpoint on requests that cannot reach it.
 * Tweak - WooCommerce 11.1 Compatibility.

--- a/classes/class-wc-connect-functions.php
+++ b/classes/class-wc-connect-functions.php
@@ -167,101 +167,46 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 				return false;
 			}
 
-			ob_start();
-			$header =
-				__( 'Country Code', 'woocommerce' ) . ',' .
-				__( 'State Code', 'woocommerce' ) . ',' .
-				__( 'ZIP/Postcode', 'woocommerce' ) . ',' .
-				__( 'City', 'woocommerce' ) . ',' .
-				__( 'Rate %', 'woocommerce' ) . ',' .
-				__( 'Tax Name', 'woocommerce' ) . ',' .
-				__( 'Priority', 'woocommerce' ) . ',' .
-				__( 'Compound', 'woocommerce' ) . ',' .
-				__( 'Shipping', 'woocommerce' ) . ',' .
-				__( 'Tax Class', 'woocommerce' ) . "\n";
-
-			echo $header; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			$rows = array(
+				array(
+					__( 'Country Code', 'woocommerce' ),
+					__( 'State Code', 'woocommerce' ),
+					__( 'ZIP/Postcode', 'woocommerce' ),
+					__( 'City', 'woocommerce' ),
+					__( 'Rate %', 'woocommerce' ),
+					__( 'Tax Name', 'woocommerce' ),
+					__( 'Priority', 'woocommerce' ),
+					__( 'Compound', 'woocommerce' ),
+					__( 'Shipping', 'woocommerce' ),
+					__( 'Tax Class', 'woocommerce' ),
+				),
+			);
 
 			foreach ( $rates as $rate ) {
-				if ( $rate->tax_rate_country ) {
-					echo esc_attr( $rate->tax_rate_country );
-				} else {
-					echo '*';
-				}
+				$postcodes = $wpdb->get_col( $wpdb->prepare( "SELECT location_code FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE location_type='postcode' AND tax_rate_id = %d ORDER BY location_code", $rate->tax_rate_id ) );
+				$cities    = $wpdb->get_col( $wpdb->prepare( "SELECT location_code FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE location_type='city' AND tax_rate_id = %d ORDER BY location_code", $rate->tax_rate_id ) );
 
-				echo ',';
-
-				if ( $rate->tax_rate_state ) {
-					echo esc_attr( $rate->tax_rate_state );
-				} else {
-					echo '*';
-				}
-
-				echo ',';
-
-				$locations = $wpdb->get_col( $wpdb->prepare( "SELECT location_code FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE location_type='postcode' AND tax_rate_id = %d ORDER BY location_code", $rate->tax_rate_id ) );
-
-				if ( $locations ) {
-					echo esc_attr( implode( '; ', $locations ) );
-				} else {
-					echo '*';
-				}
-
-				echo ',';
-
-				$locations = $wpdb->get_col( $wpdb->prepare( "SELECT location_code FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE location_type='city' AND tax_rate_id = %d ORDER BY location_code", $rate->tax_rate_id ) );
-				if ( $locations ) {
-					echo esc_attr( implode( '; ', $locations ) );
-				} else {
-					echo '*';
-				}
-
-				echo ',';
-
-				if ( $rate->tax_rate ) {
-					echo esc_attr( $rate->tax_rate );
-				} else {
-					echo '0';
-				}
-
-				echo ',';
-
-				if ( $rate->tax_rate_name ) {
-					echo esc_attr( $rate->tax_rate_name );
-				} else {
-					echo '*';
-				}
-
-				echo ',';
-
-				if ( $rate->tax_rate_priority ) {
-					echo esc_attr( $rate->tax_rate_priority );
-				} else {
-					echo '1';
-				}
-
-				echo ',';
-
-				if ( $rate->tax_rate_compound ) {
-					echo esc_attr( $rate->tax_rate_compound );
-				} else {
-					echo '0';
-				}
-
-				echo ',';
-
-				if ( $rate->tax_rate_shipping ) {
-					echo esc_attr( $rate->tax_rate_shipping );
-				} else {
-					echo '0';
-				}
-
-				echo ',';
-
-				echo "\n";
+				$rows[] = array(
+					$rate->tax_rate_country ? $rate->tax_rate_country : '*',
+					$rate->tax_rate_state ? $rate->tax_rate_state : '*',
+					$postcodes ? implode( '; ', $postcodes ) : '*',
+					$cities ? implode( '; ', $cities ) : '*',
+					$rate->tax_rate ? $rate->tax_rate : '0',
+					$rate->tax_rate_name ? $rate->tax_rate_name : '*',
+					$rate->tax_rate_priority ? $rate->tax_rate_priority : '1',
+					$rate->tax_rate_compound ? $rate->tax_rate_compound : '0',
+					$rate->tax_rate_shipping ? $rate->tax_rate_shipping : '0',
+					// Tax Class is left empty, as it has always been in this export.
+					'',
+				);
 			} // End foreach().
 
-			$csv        = ob_get_clean();
+			$csv = self::rows_to_csv( $rows );
+
+			if ( '' === $csv ) {
+				return false;
+			}
+
 			$upload_dir = wp_upload_dir();
 			$backup_dir = $upload_dir['basedir'] . '/woocommerce_uploads/taxes';
 
@@ -284,6 +229,84 @@ if ( ! class_exists( 'WC_Connect_Functions' ) ) {
 			$backed_up   = file_put_contents( $backup_dir . '/' . $base_name . '-' . $hash_suffix . '.csv', $csv ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 
 			return (bool) $backed_up;
+		}
+
+		/**
+		 * Serialises rows of values into CSV text.
+		 *
+		 * Uses PHP's own CSV writer so that separators, quotes and line breaks inside a value
+		 * are quoted correctly instead of splitting the row, and neutralises every cell against
+		 * spreadsheet formula evaluation on the way out. Escaping is applied here, in one place,
+		 * so no caller can forget it for an individual column.
+		 *
+		 * @param array $rows List of rows; each row is a list of cell values.
+		 * @return string The CSV text, or an empty string if the temporary stream is unavailable.
+		 */
+		public static function rows_to_csv( $rows ) {
+			if ( ! is_array( $rows ) || empty( $rows ) ) {
+				return '';
+			}
+
+			// The explicit maxmemory is the stream default (2 MB), spelled out so large exports
+			// visibly spill to a temporary file rather than growing in memory.
+			$stream = fopen( 'php://temp/maxmemory:2097152', 'r+' );
+
+			if ( false === $stream ) {
+				return '';
+			}
+
+			foreach ( $rows as $row ) {
+				if ( ! is_array( $row ) ) {
+					continue;
+				}
+
+				// The empty escape character keeps backslashes literal and avoids relying on the
+				// escaping behaviour PHP deprecated in 8.4.
+				fputcsv( $stream, array_map( array( __CLASS__, 'escape_csv_value' ), $row ), ',', '"', '' );
+			}
+
+			rewind( $stream );
+			$csv = stream_get_contents( $stream );
+			fclose( $stream ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+
+			return false === $csv ? '' : $csv;
+		}
+
+		/**
+		 * Neutralises a single CSV cell against spreadsheet formula evaluation.
+		 *
+		 * Excel, Numbers and Google Sheets start evaluating a cell as a formula when its first
+		 * character is `=`, `+`, `-`, `@`, a tab or a carriage return. Values in the tax rate
+		 * tables come from customer checkout addresses and from remote API responses, so a cell
+		 * can be planted that runs when the merchant opens the downloaded file. Prefixing the
+		 * value with a single quote makes spreadsheet applications treat the cell as text.
+		 *
+		 * Numeric values are returned untouched: a number cannot open a formula, and prefixing it
+		 * would corrupt the value when the file is imported back (a negative tax rate is the
+		 * realistic case). Quoting of separators, quotes and line breaks is left to the CSV
+		 * writer; this function only removes the formula leader.
+		 *
+		 * @param mixed $value The raw cell value.
+		 * @return string The value, safe to hand to a CSV writer.
+		 */
+		public static function escape_csv_value( $value ) {
+			if ( is_array( $value ) || is_object( $value ) ) {
+				return '';
+			}
+
+			$value = (string) $value;
+
+			if ( '' === $value || is_numeric( $value ) ) {
+				return $value;
+			}
+
+			$formula_leaders = array( '=', '+', '-', '@', "\t", "\r" );
+
+			if ( in_array( $value[0], $formula_leaders, true ) ) {
+				return "'" . $value;
+			}
+
+			return $value;
 		}
 
 		/**

--- a/readme.txt
+++ b/readme.txt
@@ -70,9 +70,11 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.6.15 - 2026-xx-xx =
+* Fix   - Write the tax rate backup file as proper CSV, so cities and tax names containing a comma, a quote or an apostrophe are saved exactly as stored and no cell can be treated as a formula when the file is opened in a spreadsheet.
+
 = 3.6.14 - 2026-09-03 =
 * Fix   - Prevent a fatal error at checkout when a cart line's price is not numeric.
-* Fix   - Write the tax rate backup file as proper CSV, so cities and tax names containing a comma, a quote or an apostrophe are saved exactly as stored and no cell can be treated as a formula when the file is opened in a spreadsheet.
 * Tweak - Limit the WordPress.com connection banner to the Tax settings and Plugins pages, so it no longer appears on unrelated admin screens.
 * Tweak - Stop registering a redundant copy of the continents REST endpoint on requests that cannot reach it.
 * Tweak - WooCommerce 11.1 Compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,7 @@ This plugin relies on the following external services:
 
 = 3.6.14 - 2026-xx-xx =
 * Fix   - Prevent a fatal error at checkout when a cart line's price is not numeric.
+* Fix   - Write the tax rate backup file as proper CSV, so cities and tax names containing a comma, a quote or an apostrophe are saved exactly as stored and no cell can be treated as a formula when the file is opened in a spreadsheet.
 * Tweak - Limit the WordPress.com connection banner to the Tax settings and Plugins pages, so it no longer appears on unrelated admin screens.
 * Tweak - Stop registering a redundant copy of the continents REST endpoint on requests that cannot reach it.
 * Tweak - WooCommerce 11.1 Compatibility.

--- a/tests/php/test-class-wc-connect-functions.php
+++ b/tests/php/test-class-wc-connect-functions.php
@@ -1,0 +1,163 @@
+<?php
+
+if ( ! class_exists( 'WC_Connect_Functions' ) ) {
+	require_once __DIR__ . '/../../classes/class-wc-connect-functions.php';
+}
+
+/**
+ * Tests for the CSV serialisation used by the tax rate backup.
+ */
+class WP_Test_WC_Connect_Functions extends WC_Unit_Test_Case {
+
+	/**
+	 * Parses CSV text back into rows the way a spreadsheet or an importer would.
+	 *
+	 * @param string $csv CSV text.
+	 * @return array List of rows.
+	 */
+	private function parse_csv( $csv ) {
+		// phpcs:disable WordPress.WP.AlternativeFunctions -- An in-memory stream is the only way
+		// to read the text back with fgetcsv(); WP_Filesystem has no equivalent.
+		$rows   = array();
+		$stream = fopen( 'php://temp', 'r+' );
+
+		fwrite( $stream, $csv );
+		rewind( $stream );
+
+		while ( true ) {
+			$row = fgetcsv( $stream, 0, ',', '"', '' );
+
+			if ( false === $row || null === $row ) {
+				break;
+			}
+
+			$rows[] = $row;
+		}
+
+		fclose( $stream );
+		// phpcs:enable WordPress.WP.AlternativeFunctions
+
+		return $rows;
+	}
+
+	/* ──── escape_csv_value(): formula neutralisation ──── */
+
+	/**
+	 * Values that open a spreadsheet formula.
+	 *
+	 * @return array
+	 */
+	public function formula_leader_provider() {
+		return array(
+			'equals'          => array( '=1+1' ),
+			'plus'            => array( '+1+1' ),
+			'minus'           => array( '-1+1' ),
+			'at'              => array( '@SUM(A1)' ),
+			'tab'             => array( "\t=1+1" ),
+			'carriage return' => array( "\r=1+1" ),
+			'webservice'      => array( '=WEBSERVICE(CONCATENATE(CHAR(104)))' ),
+			'text leader'     => array( '-Dash Town' ),
+		);
+	}
+
+	/**
+	 * @dataProvider formula_leader_provider
+	 *
+	 * @param string $value A value whose first character starts a formula.
+	 */
+	public function test_escape_csv_value_prefixes_formula_leaders( $value ) {
+		$this->assertSame( "'" . $value, WC_Connect_Functions::escape_csv_value( $value ) );
+	}
+
+	/**
+	 * Ordinary values are handed through untouched — in particular the entity encoding that
+	 * esc_attr() used to apply must be gone, so the backup restores what it backed up.
+	 */
+	public function test_escape_csv_value_leaves_ordinary_values_verbatim() {
+		$this->assertSame( "O'Brien & Sons", WC_Connect_Functions::escape_csv_value( "O'Brien & Sons" ) );
+		$this->assertSame( 'Foo, Bar', WC_Connect_Functions::escape_csv_value( 'Foo, Bar' ) );
+		$this->assertSame( 'Kingston upon Hull', WC_Connect_Functions::escape_csv_value( 'Kingston upon Hull' ) );
+		$this->assertSame( '', WC_Connect_Functions::escape_csv_value( '' ) );
+		$this->assertSame( '', WC_Connect_Functions::escape_csv_value( null ) );
+	}
+
+	/**
+	 * A number cannot open a formula, and prefixing one would corrupt it on re-import.
+	 * The negative tax rate is the case that matters: it must survive verbatim.
+	 */
+	public function test_escape_csv_value_leaves_numbers_verbatim() {
+		$this->assertSame( '-5.0000', WC_Connect_Functions::escape_csv_value( '-5.0000' ) );
+		$this->assertSame( '8.5000', WC_Connect_Functions::escape_csv_value( '8.5000' ) );
+		$this->assertSame( '0', WC_Connect_Functions::escape_csv_value( '0' ) );
+		$this->assertSame( '+1', WC_Connect_Functions::escape_csv_value( '+1' ) );
+		$this->assertSame( '1', WC_Connect_Functions::escape_csv_value( 1 ) );
+	}
+
+	/* ──── rows_to_csv(): quoting, shape and round-trip ──── */
+
+	/**
+	 * A value containing the separator stays a single field instead of splitting the row.
+	 */
+	public function test_rows_to_csv_keeps_a_value_containing_a_comma_in_one_field() {
+		$csv    = WC_Connect_Functions::rows_to_csv( array( array( 'US', 'Foo, Bar', '8.5000' ) ) );
+		$parsed = $this->parse_csv( $csv );
+
+		$this->assertCount( 1, $parsed );
+		$this->assertSame( array( 'US', 'Foo, Bar', '8.5000' ), $parsed[0] );
+	}
+
+	/**
+	 * Quotes and line breaks inside a value survive a write/read round trip.
+	 */
+	public function test_rows_to_csv_round_trips_quotes_and_line_breaks() {
+		$row = array( 'US', 'Say "hi"', "line\nbreak", "O'Brien & Sons" );
+
+		$parsed = $this->parse_csv( WC_Connect_Functions::rows_to_csv( array( $row ) ) );
+
+		$this->assertSame( array( $row ), $parsed );
+	}
+
+	/**
+	 * Neutralisation is applied to every column, not only the ones that look attacker-controlled.
+	 */
+	public function test_rows_to_csv_neutralises_every_column() {
+		$csv    = WC_Connect_Functions::rows_to_csv( array( array( '=1+1', '=2+2', '=3+3' ) ) );
+		$parsed = $this->parse_csv( $csv );
+
+		$this->assertSame( array( "'=1+1", "'=2+2", "'=3+3" ), $parsed[0] );
+	}
+
+	/**
+	 * The row shape is preserved: every row keeps its column count, empty cells included.
+	 */
+	public function test_rows_to_csv_preserves_row_shape() {
+		$rows = array(
+			array( 'Country Code', 'City', 'Rate %', 'Tax Class' ),
+			array( 'US', 'Fargo', '8.5000', '' ),
+		);
+
+		$parsed = $this->parse_csv( WC_Connect_Functions::rows_to_csv( $rows ) );
+
+		$this->assertCount( 2, $parsed );
+		$this->assertCount( 4, $parsed[0] );
+		$this->assertCount( 4, $parsed[1] );
+		$this->assertSame( $rows[1], $parsed[1] );
+	}
+
+	/**
+	 * Rows are separated by a newline, as the previous hand-rolled writer did.
+	 */
+	public function test_rows_to_csv_ends_every_row_with_a_newline() {
+		$csv = WC_Connect_Functions::rows_to_csv( array( array( 'a' ), array( 'b' ) ) );
+
+		$this->assertSame( "a\nb\n", $csv );
+	}
+
+	/**
+	 * Nothing to serialise produces no file content.
+	 */
+	public function test_rows_to_csv_returns_an_empty_string_for_no_rows() {
+		$this->assertSame( '', WC_Connect_Functions::rows_to_csv( array() ) );
+		$this->assertSame( '', WC_Connect_Functions::rows_to_csv( 'not an array' ) );
+	}
+}


### PR DESCRIPTION
## Description

`WC_Connect_Functions::backup_existing_tax_rates()` built the backup file by echoing each database column through `esc_attr()` and joining with commas.

`esc_attr()` is an **HTML** escaper. It does not quote a CSV field, and it does not neutralise a leading `=`, `+`, `-` or `@`. City and postcode location rows in the tax rate tables are written from customer checkout addresses, and tax rate names come from TaxJar response property names — so a shopper can plant a cell that a spreadsheet evaluates when the merchant downloads and opens the backup.

**The same defect also made the file wrong as a backup, which is the only reason it exists.** A city containing a comma split into two columns, and `O'Brien & Sons` was written out as HTML entities — so the file no longer restored the values it was taken from.

**Fix.** Rows are serialised with `fputcsv()` on a `php://temp` stream, which quotes commas, quotes and newlines correctly, and `esc_attr()` is gone. Every cell — not only the ones that look attacker-controlled — passes through a new `escape_csv_value()` helper, which prefixes a single quote when the value starts with `=`, `+`, `-`, `@`, TAB (`\t`) or CR (`\r`).

One behaviour addition: if the stream cannot be opened the function returns `false`. That matters, because `WC_Connect_TaxJar_Integration::backup_existing_tax_rates()` only TRUNCATEs the tax tables on success.

### The round-trip trade-off, chosen deliberately

A leading apostrophe is lossy — WooCommerce's importer does not strip it. So **numeric cells are exempt**: `is_numeric()` values are returned verbatim, because a number cannot open a formula and prefixing one would corrupt it on re-import. The realistic case is a negative tax rate: `-5.0000` round-trips byte-for-byte, while `=1+1` becomes `'=1+1`.

For a non-numeric formula cell there is no lossless option — quoting alone does not stop a spreadsheet evaluating `"=1+1"` — so safety wins, and the loss applies only to values that were already hostile or malformed. Everything else now round-trips **better** than trunk, since the entity-encoding is gone.

One cosmetic change: `fputcsv` quotes fields containing a space, so header cells are now quoted. Valid CSV, parses identically.

### Related issue(s)

Linear: [WOOTAX-338 — Tax-rate backup CSV built by concatenation (formula injection)](https://linear.app/a8c/issue/WOOTAX-338)

Part of the *Security review of Escargot extensions* project. **Sibling: WOOTBRT-44** is the identical finding in Table Rate Shipping — see *Portability* below.

### Steps to reproduce & screenshots/GIFs

**Before this change:**

1. Add a tax rate whose **City** is `=1+1` (or, more realistically, place an order from a city with a name containing a comma or an apostrophe).
2. Go to **WooCommerce → Status → Tools** and run the CA tax-rate deletion tool, which takes a backup CSV first.
3. Download the backup from the plugin's help view and open it in Excel, Numbers or Google Sheets.
4. The `=1+1` cell evaluates to `2`. A city containing a comma has split across two columns, and `O'Brien & Sons` reads as `O&#039;Brien &amp; Sons`.

**After this change:**

- The formula cell is stored as `'=1+1` and displays literally instead of evaluating.
- Commas, quotes and apostrophes round-trip exactly, so the file restores what it was taken from.
- Numeric values including negative rates are unchanged — `-5.0000` stays `-5.0000`.
- The file name, the `wp_upload_dir()`-derived directory and the download handler's filename regex are all unchanged, so existing backups still download normally.

### Backward compatibility

**Two new public static methods** on the globally-namespaced `WC_Connect_Functions`: `rows_to_csv( $rows )` and `escape_csv_value( $value )`. Purely additive — no existing signature, hook, filter, script handle, file name or path changes, so no third-party consumer can break on load. The exposure to state plainly: they are now part of the published surface and cannot be renamed later without a deprecation window.

**The content of the backup file changes** for anyone parsing it: fields are properly quoted, HTML entities are gone, and hostile cells carry a leading `'`. A real CSV parser is unaffected. A hand-rolled comma split was already broken by any city containing a comma.

**No new global state** — both helpers are pure and need no WordPress bootstrap, so they are safe on every path that reaches tax calculation (Store API, REST, cron, WP-CLI, webhooks). **No multisite or install-layout assumptions introduced**; paths still come from `wp_upload_dir()`.

### Portability

`escape_csv_value()` is pure PHP with zero WordPress dependency, and `rows_to_csv()` depends only on it. Both copy to **WOOTBRT-44** verbatim; the only edit is the class reference inside `array( __CLASS__, 'escape_csv_value' )` if it lands in a differently-named class.

### Verification

| Check | Result |
|---|---|
| `php -l` (2 files) | No syntax errors detected |
| `composer test` (PHPUnit) | **430 tests / 1037 assertions, OK** (trunk baseline 414) |
| PHPCS, same path before/after | 26 violations / 12 sources → **26 / 12**, identical per-sniff distribution |
| New test file | 0 violations |

PHPCS was measured before and after **at an identical path** — output is path-sensitive, and the aggregator also excludes dot-directories, so an in-worktree run silently scans nothing.

To run just this suite:

```bash
composer test -- --filter WP_Test_WC_Connect_Functions
```

### Checklist

- [x] unit tests — 16 tests / 29 assertions over both helpers, covering each formula leader, the numeric exemption, quoting of commas/quotes/newlines, and round-trip parsing
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added
