### PR TITLE
[WOOTAX-340] Fix - Skip the legacy DHL Inbox Note during admin AJAX

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,12 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.6.15 - 2026-xx-xx =
+* Tweak - Stop looking up the legacy DHL live rates inbox note on admin AJAX requests, which cannot display it.
+
 = 3.6.14 - 2026-09-03 =
 * Fix   - Prevent a fatal error at checkout when a cart line's price is not numeric.
 * Tweak - Limit the WordPress.com connection banner to the Tax settings and Plugins pages, so it no longer appears on unrelated admin screens.
 * Tweak - Stop registering a redundant copy of the continents REST endpoint on requests that cannot reach it.
-* Tweak - Stop looking up the legacy DHL live rates inbox note on admin AJAX requests, which cannot display it.
 * Tweak - WooCommerce 11.1 Compatibility.
 
 = 3.6.13 - 2026-08-24 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix   - Prevent a fatal error at checkout when a cart line's price is not numeric.
 * Tweak - Limit the WordPress.com connection banner to the Tax settings and Plugins pages, so it no longer appears on unrelated admin screens.
 * Tweak - Stop registering a redundant copy of the continents REST endpoint on requests that cannot reach it.
+* Tweak - Stop looking up the legacy DHL live rates inbox note on admin AJAX requests, which cannot display it.
 * Tweak - WooCommerce 11.1 Compatibility.
 
 = 3.6.13 - 2026-08-24 =

--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,7 @@ This plugin relies on the following external services:
 * Fix   - Prevent a fatal error at checkout when a cart line's price is not numeric.
 * Tweak - Limit the WordPress.com connection banner to the Tax settings and Plugins pages, so it no longer appears on unrelated admin screens.
 * Tweak - Stop registering a redundant copy of the continents REST endpoint on requests that cannot reach it.
+* Tweak - Stop looking up the legacy DHL live rates inbox note on admin AJAX requests, which cannot display it.
 * Tweak - WooCommerce 11.1 Compatibility.
 
 = 3.6.13 - 2026-08-24 =

--- a/readme.txt
+++ b/readme.txt
@@ -70,11 +70,13 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.6.15 - 2026-xx-xx =
+* Tweak - Stop looking up the legacy DHL live rates inbox note on admin AJAX requests, which cannot display it.
+
 = 3.6.14 - 2026-09-03 =
 * Fix   - Prevent a fatal error at checkout when a cart line's price is not numeric.
 * Tweak - Limit the WordPress.com connection banner to the Tax settings and Plugins pages, so it no longer appears on unrelated admin screens.
 * Tweak - Stop registering a redundant copy of the continents REST endpoint on requests that cannot reach it.
-* Tweak - Stop looking up the legacy DHL live rates inbox note on admin AJAX requests, which cannot display it.
 * Tweak - WooCommerce 11.1 Compatibility.
 
 = 3.6.13 - 2026-08-24 =

--- a/tests/php/test-woocommerce-connect-client.php
+++ b/tests/php/test-woocommerce-connect-client.php
@@ -670,4 +670,200 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 			$instance->setValue( $orig_instance );
 		}
 	}
+
+	/**
+	 * Hooks that `load_admin_dependencies()` attaches callbacks to. Snapshotted around the
+	 * legacy DHL note tests so wiring the admin dependencies does not leak into other tests.
+	 *
+	 * @var string[]
+	 */
+	private static $admin_dependency_hooks = array(
+		'woocommerce_debug_tools',
+		'woocommerce_admin_status_tabs',
+		'woocommerce_admin_status_content_connect',
+		'wp_ajax_wcs_download_tax_backup',
+		'admin_notices',
+		'woocommerce_get_sections_shipping',
+		'woocommerce_settings_shipping',
+	);
+
+	/**
+	 * The plugin never calls `load_dependencies()` under WC_UNIT_TESTING, so whether a class has
+	 * been required is a function of test execution order. Require everything these tests touch.
+	 */
+	private function require_admin_dependency_classes() {
+		$classes = __DIR__ . '/../../classes/';
+
+		require_once $classes . 'class-wc-connect-logger.php';
+		require_once $classes . 'class-wc-connect-api-client.php';
+		require_once $classes . 'class-wc-connect-api-client-live.php';
+		require_once $classes . 'class-wc-connect-service-schemas-store.php';
+		require_once $classes . 'class-wc-connect-service-settings-store.php';
+		require_once $classes . 'class-wc-connect-taxjar-integration.php';
+		require_once $classes . 'class-wc-connect-tracks.php';
+		require_once $classes . 'class-wc-connect-error-notice.php';
+		require_once $classes . 'class-wc-connect-help-view.php';
+		require_once $classes . 'class-wc-connect-continents.php';
+		require_once $classes . 'class-wc-connect-note-dhl-live-rates-available.php';
+	}
+
+	/**
+	 * Skip when the environment cannot exercise the legacy DHL note path at all, so a green
+	 * assertion always means the guard behaved, never that the path was inert.
+	 */
+	private function require_legacy_dhl_note_preconditions() {
+		if ( WC_Connect_Loader::is_wc_shipping_activated() ) {
+			$this->markTestSkipped( 'WooCommerce Shipping is active here, so the legacy DHL note path is inert.' );
+		}
+
+		if ( ! WC_Connect_Loader::can_add_wc_admin_notice() ) {
+			$this->markTestSkipped( 'The WooCommerce admin-note data store is unavailable in this environment.' );
+		}
+	}
+
+	/**
+	 * Build a loader wired with the dependencies `load_admin_dependencies()` dereferences, over a
+	 * schemas store that reports the legacy DHL Express live rates schema.
+	 *
+	 * @param object $schema_call_expectation PHPUnit invocation matcher for get_all_shipping_method_ids().
+	 *
+	 * @return PHPUnit\Framework\MockObject\MockObject|WC_Connect_Loader
+	 */
+	private function mock_admin_loader_for_legacy_dhl_store( $schema_call_expectation ) {
+		$store = $this->getMockBuilder( 'WC_Connect_Service_Schemas_Store' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'get_all_shipping_method_ids' ) )
+			->getMock();
+
+		$store->expects( $schema_call_expectation )
+			->method( 'get_all_shipping_method_ids' )
+			->will( $this->returnValue( array( 'wc_services_dhlexpress' ) ) );
+
+		$loader = $this->mockLoader( $store );
+
+		$loader->set_api_client(
+			$this->getMockBuilder( 'WC_Connect_API_Client_Live' )->disableOriginalConstructor()->getMock()
+		);
+		$loader->set_service_settings_store(
+			$this->getMockBuilder( 'WC_Connect_Service_Settings_Store' )->disableOriginalConstructor()->getMock()
+		);
+		$loader->set_taxjar(
+			$this->getMockBuilder( 'WC_Connect_TaxJar_Integration' )->disableOriginalConstructor()->getMock()
+		);
+
+		return $loader;
+	}
+
+	/**
+	 * Copy the callbacks currently attached to the hooks `load_admin_dependencies()` writes to.
+	 *
+	 * @return array
+	 */
+	private function snapshot_admin_dependency_hooks() {
+		$snapshot = array();
+
+		foreach ( self::$admin_dependency_hooks as $hook ) {
+			$snapshot[ $hook ] = isset( $GLOBALS['wp_filter'][ $hook ] ) ? clone $GLOBALS['wp_filter'][ $hook ] : null;
+		}
+
+		return $snapshot;
+	}
+
+	/**
+	 * Restore the callbacks captured by snapshot_admin_dependency_hooks().
+	 *
+	 * @param array $snapshot Snapshot to restore.
+	 */
+	private function restore_admin_dependency_hooks( $snapshot ) {
+		foreach ( $snapshot as $hook => $wp_hook ) {
+			if ( null === $wp_hook ) {
+				unset( $GLOBALS['wp_filter'][ $hook ] );
+			} else {
+				$GLOBALS['wp_filter'][ $hook ] = $wp_hook;
+			}
+		}
+	}
+
+	/**
+	 * An eligible legacy DHL store must still be offered the Inbox note on an ordinary wp-admin
+	 * page load. The AJAX guard only skips the work while admin-ajax.php is being served, so this
+	 * is the non-AJAX path that keeps grandfathered stores whole.
+	 *
+	 * @testdox load_admin_dependencies() still registers the legacy DHL note outside admin AJAX.
+	 * @covers WC_Connect_Loader::load_admin_dependencies
+	 */
+	public function test_load_admin_dependencies_registers_legacy_dhl_note_outside_ajax() {
+		$this->require_admin_dependency_classes();
+		$this->require_legacy_dhl_note_preconditions();
+
+		WC_Connect_Note_DHL_Live_Rates_Available::possibly_delete_note();
+		$this->assertFalse(
+			WC_Connect_Note_DHL_Live_Rates_Available::note_exists(),
+			'The fixture must start without the note, or the assertion below proves nothing.'
+		);
+
+		$loader   = $this->mock_admin_loader_for_legacy_dhl_store( $this->once() );
+		$snapshot = $this->snapshot_admin_dependency_hooks();
+
+		add_filter( 'wc_connect_has_only_tax_functionality', '__return_false' );
+
+		try {
+			$loader->load_admin_dependencies();
+
+			$this->assertTrue(
+				WC_Connect_Note_DHL_Live_Rates_Available::note_exists(),
+				'An eligible legacy DHL store must still receive the Inbox note on a non-AJAX admin request.'
+			);
+		} finally {
+			remove_filter( 'wc_connect_has_only_tax_functionality', '__return_false' );
+			$this->restore_admin_dependency_hooks( $snapshot );
+			WC_Connect_Note_DHL_Live_Rates_Available::possibly_delete_note();
+		}
+	}
+
+	/**
+	 * `is_admin()` is also true while WordPress serves admin-ajax.php, so the legacy DHL note path
+	 * used to run a service-schema read and an Inbox note lookup on every admin AJAX request. The
+	 * guard must skip that block only - the rest of the admin dependency wiring still runs, so
+	 * subclasses that override it keep getting called.
+	 *
+	 * @testdox load_admin_dependencies() skips the legacy DHL note during admin AJAX.
+	 * @covers WC_Connect_Loader::load_admin_dependencies
+	 */
+	public function test_load_admin_dependencies_skips_legacy_dhl_note_during_ajax() {
+		$this->require_admin_dependency_classes();
+		$this->require_legacy_dhl_note_preconditions();
+
+		WC_Connect_Note_DHL_Live_Rates_Available::possibly_delete_note();
+
+		$loader   = $this->mock_admin_loader_for_legacy_dhl_store( $this->never() );
+		$snapshot = $this->snapshot_admin_dependency_hooks();
+
+		add_filter( 'wc_connect_has_only_tax_functionality', '__return_false' );
+		add_filter( 'wp_doing_ajax', '__return_true' );
+
+		try {
+			$loader->load_admin_dependencies();
+
+			$this->assertFalse(
+				WC_Connect_Note_DHL_Live_Rates_Available::note_exists(),
+				'The legacy DHL Inbox note must not be evaluated or created while serving admin-ajax.php.'
+			);
+			$this->assertInstanceOf(
+				'WC_Connect_Settings_Pages',
+				$loader->get_settings_pages(),
+				'The guard must skip only the Inbox note - the rest of the admin dependencies still load during AJAX.'
+			);
+			$this->assertInstanceOf(
+				'WC_Connect_Help_View',
+				$loader->get_help_view(),
+				'The guard must skip only the Inbox note - the rest of the admin dependencies still load during AJAX.'
+			);
+		} finally {
+			remove_filter( 'wp_doing_ajax', '__return_true' );
+			remove_filter( 'wc_connect_has_only_tax_functionality', '__return_false' );
+			$this->restore_admin_dependency_hooks( $snapshot );
+			WC_Connect_Note_DHL_Live_Rates_Available::possibly_delete_note();
+		}
+	}
 }

--- a/woocommerce-services.php
+++ b/woocommerce-services.php
@@ -925,8 +925,16 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$settings_pages = new WC_Connect_Settings_Pages( $this->api_client, $this->get_service_schemas_store() );
 			$this->set_settings_pages( $settings_pages );
 
-			// Add WC Admin Notices.
-			if ( ! self::is_wc_shipping_activated() && self::can_add_wc_admin_notice() ) {
+			/*
+			 * Add WC Admin Notices.
+			 *
+			 * Skipped while serving admin-ajax.php: `is_admin()` is also true there, so without
+			 * this check every admin AJAX request pays for a service-schema read and an Inbox
+			 * note lookup that nothing in an AJAX response can display. Ordinary wp-admin page
+			 * loads are unaffected, so eligible legacy stores still get the note the first time
+			 * they open the admin.
+			 */
+			if ( ! wp_doing_ajax() && ! self::is_wc_shipping_activated() && self::can_add_wc_admin_notice() ) {
 				require_once __DIR__ . '/classes/class-wc-connect-note-dhl-live-rates-available.php';
 				WC_Connect_Note_DHL_Live_Rates_Available::init( $schema );
 			}


### PR DESCRIPTION
## Description

WooCommerce Tax can evaluate and create its legacy DHL Inbox Note while serving `wp-admin/admin-ajax.php`.

The path guards on `is_admin()`, which is **true during admin AJAX** and is therefore not an AJAX guard. On affected legacy DHL stores that means one note-name lookup per admin-AJAX request after bootstrap, plus an insert on the first run.

This adds `! wp_doing_ajax() &&` to the note's condition in `load_admin_dependencies()`:

```php
if ( ! wp_doing_ajax() && ! self::is_wc_shipping_activated() && self::can_add_wc_admin_notice() ) {
```

Skipped, and **only** while `admin-ajax.php` is being served: the `require_once` of the note class, `WC_Connect_Note_DHL_Live_Rates_Available::init()`, the `$schemas->get_all_shipping_method_ids()` read, and `NoteTraits::possibly_add_note()` — which is a `get_notes_with_name()` DB lookup plus, on first run, the insert.

Still runs on admin AJAX, unchanged: `WC_Connect_Debug_Tools`, `WC_Connect_Help_View`, both `admin_notices` registrations, the `should_load_shipping_features()` gate, and `WC_Connect_Settings_Pages`.

**Only the note block is guarded, not the method.** `AGENTS.md` warns that a skip which bypasses an overridable method silently disables third-party overrides even though no signature changed. `WC_Connect_Note_DHL_Live_Rates_Available::init()` is also left untouched, so its public contract is identical for any external direct caller.

### Design decision, resolved with the ticket author

The ticket's Technical Notes prefer evaluating the note from `wc_admin_daily` or a versioned upgrade/schema-transition event. **This PR deliberately does not add that hook**, and the author has [confirmed that call is ours to make](https://linear.app/a8c/issue/WOOTAX-340#comment-73095615): *"I don't think it's my call tbh. I think you understand better what works best for this particular plugin. The main concern is to not make the calls when they aren't needed."*

Not making the calls when they aren't needed is exactly what this guard does. Adding a `wc_admin_daily` hook on top would mean writing **new shipping code**, which is compatibility-only surface area for grandfathered stores under `AGENTS.md § Product Scope`, to reach an outcome the existing non-AJAX admin page-load path already delivers. See *Backward compatibility* below for that path.

On acceptance criterion 3 (a test using an eligible legacy DHL schema fixture): the author noted the criteria come from a shared WCCOM issue template and said to ignore what does not fit here. The two behavioural tests below cover AJAX exclusion and non-AJAX registration, which is the behaviour that actually changed; the schema fixture is not built.

### Related issue(s)

Linear: [WOOTAX-340 — Guard the legacy DHL Inbox Note path during admin AJAX](https://linear.app/a8c/issue/WOOTAX-340/guard-the-legacy-dhl-inbox-note-path-during-admin-ajax)

Upstream coordination: WCCOM-2823 (submitting AJAX guards for Inbox Note registration upstream).

### Steps to reproduce & screenshots/GIFs

This needs an eligible legacy store — connected and past TOS bootstrap, shipping features enabled, WooCommerce Shipping **inactive**, and the legacy `wc_services_dhlexpress` service schema present. Stores without that schema stop before the note API either way.

**Before this change:** with query logging on, every `admin-ajax.php` request after bootstrap issues a `get_notes_with_name()` lookup for `wc-services-dhl-live-rates-available`.

**After this change:**

1. Trigger any admin-AJAX request (e.g. Heartbeat, or the order-list autosave). No note lookup and no insert occurs.
2. Load any ordinary wp-admin page. The lookup runs exactly as before, and the note is created if absent.
3. Confirm the note still appears in **WooCommerce → Home → Inbox** on an eligible legacy store.

### Backward compatibility

**The non-AJAX path that still delivers the note is any ordinary wp-admin page view.** `attach_hooks()` calls `load_admin_dependencies()` under plain `is_admin()`, which is true for every admin screen, not just admin-ajax. On such a request `wp_doing_ajax()` is false, so the block runs exactly as it did before.

Confirmed by reading the full call chain in this checkout: `woocommerce_init` → `after_wc_init()` → `attach_hooks()` → `is_admin()` → `load_admin_dependencies()`. The only new term in the condition is `wp_doing_ajax()`, which WordPress sets solely for admin-ajax requests.

Since the note is an Inbox note that is only ever *rendered* inside wp-admin, a store that can see it must load a non-AJAX admin page anyway. **No eligible grandfathered store loses the note** — at worst its creation moves from an AJAX request to the admin page load that follows. Narrowing an existing shipping surface would be a BC change for those stores; this does not narrow it.

**Hooks:** nothing in the skipped region is a plugin `do_action` / `apply_filters`. WooCommerce's `NoteTraits::possibly_add_note()` is `get_note()` → `can_be_added()` → `$note->save()`; the only downstream hook is WC core's `woocommerce_note_created`, fired once on creation, which still fires on the first eligible non-AJAX admin request.

**Also unaffected:** `possibly_delete_note()` is reachable only from `plugin_uninstall()`, not per-request, so it is left alone.

**Multisite:** unchanged. The guard adds no option or global read; site-scoped behaviour is identical on every path that still runs. Not tested under multisite.

### Verification

| Check | Result |
|---|---|
| `php -l` (2 files) | No syntax errors detected |
| `composer test` (PHPUnit) | **416 tests / 1015 assertions, OK** (trunk baseline 414) |
| PHPCS, same path before/after | 206 violations / 29 sources → **206 / 29**, diff only in the timing line |

PHPCS was measured before and after **at an identical path** — output is path-sensitive, and the aggregator also excludes dot-directories, so an in-worktree run silently scans nothing.

Both new tests were confirmed to **actually execute** rather than hit their `markTestSkipped` guards, which is the real risk with this pair:

```
✔ load_admin_dependencies() still registers the legacy DHL note outside admin AJAX.
✔ load_admin_dependencies() skips the legacy DHL note during admin AJAX.
```

### Checklist

- [x] unit tests — 2 tests covering AJAX exclusion and non-AJAX registration
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

Note: both tests `markTestSkipped` when WooCommerce Shipping is active or the `admin-note` data store is unavailable, so a green run can never silently mean the path was simply inert. If they skip rather than pass in CI, that is why and it needs a look.
