### PR TITLE
Surface an incomplete WordPress.com connection in Tax settings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Tax Changelog ***
 
+= 3.6.15 - 2026-xx-xx =
+* Add   - Prompt merchants to finish signing in to WordPress.com when the site is connected but no account is linked to it, so the missing step is named instead of hidden.
+
 = 3.6.14 - 2026-09-03 =
 * Fix   - Prevent a fatal error at checkout when a cart line's price is not numeric.
 * Tweak - Limit the WordPress.com connection banner to the Tax settings and Plugins pages, so it no longer appears on unrelated admin screens.

--- a/classes/class-wc-connect-jetpack.php
+++ b/classes/class-wc-connect-jetpack.php
@@ -120,6 +120,23 @@ if ( ! class_exists( 'WC_Connect_Jetpack' ) ) {
 		}
 
 		/**
+		 * Determines whether the site holds a WordPress.com token but has no connected owner.
+		 *
+		 * This is the "half connected" state: registration completed and left a blog token
+		 * behind, but nobody finished signing in with a WordPress.com account. Everything
+		 * that needs a user token - automated taxes included - stays unavailable, while
+		 * self::is_connected() reports false exactly as it does for a site that was never
+		 * connected at all. Callers that want to tell those two apart use this method.
+		 *
+		 * @return bool Whether the connection is site-level only.
+		 */
+		public static function is_site_only_connection() {
+			$connection_manager = self::get_connection_manager();
+
+			return $connection_manager->is_connected() && ! $connection_manager->has_connected_owner();
+		}
+
+		/**
 		 * Connects the site to Jetpack.
 		 * This code performs a redirection, so anything executed after it will be ignored.
 		 *

--- a/classes/class-wc-connect-nux.php
+++ b/classes/class-wc-connect-nux.php
@@ -231,6 +231,12 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 				1. show_banner_before_connection()
 				2. connect to JP
 				3. show_banner_after_connection(), which sets the TOS acceptance in options
+			- Case 1b: the site registered but nobody finished signing in, so there is a blog
+				token and no connection owner. Jetpack reports this as "not connected", which is
+				what gates the plugin, but the merchant needs to be told something different:
+				there is nothing left to connect, only a sign-in to finish.
+				1. show_banner_site_only_connection()
+				2. finish the WordPress.com sign-in, which lands on the same flow as Case 1
 			- Case 2: Jetpack connected, no TOS
 				1. show_tos_only_banner(), which accepts TOS on button click
 			- Case 3: Jetpack connected, and TOS accepted
@@ -238,6 +244,12 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			*/
 			switch ( $status['jetpack_connection_status'] ) {
 				case self::JETPACK_NOT_CONNECTED:
+					// Only callers that pass the key can get this banner, so older callers
+					// keep the behaviour they have always had.
+					if ( ! empty( $status['is_site_only_connection'] ) ) {
+						return 'site_only_connection';
+					}
+
 					return 'before_jetpack_connection';
 				case self::JETPACK_CONNECTED:
 				case self::JETPACK_OFFLINE_MODE:
@@ -379,6 +391,7 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					'tos_accepted'                    => WC_Connect_Options::get_option( 'tos_accepted' ),
 					'can_accept_tos'                  => WC_Connect_Jetpack::is_current_user_connection_owner() || WC_Connect_Jetpack::is_offline_mode(),
 					'should_display_after_cxn_banner' => WC_Connect_Options::get_option( self::SHOULD_SHOW_AFTER_CXN_BANNER ),
+					'is_site_only_connection'         => WC_Connect_Jetpack::is_site_only_connection(),
 				)
 			);
 
@@ -391,6 +404,15 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 					);
 					wp_enqueue_style( 'wc_connect_banner' );
 					add_action( 'admin_notices', array( $this, 'show_banner_before_connection' ), 9 );
+					break;
+				case 'site_only_connection':
+					wp_enqueue_script( 'wc_connect_banner' );
+					add_action(
+						'admin_post_register_woocommerce_services_jetpack',
+						array( $this, 'register_woocommerce_services_jetpack' )
+					);
+					wp_enqueue_style( 'wc_connect_banner' );
+					add_action( 'admin_notices', array( $this, 'show_banner_site_only_connection' ), 9 );
 					break;
 				case 'tos_only_banner':
 					wp_enqueue_style( 'wc_connect_banner' );
@@ -444,6 +466,55 @@ if ( ! class_exists( 'WC_Connect_Nux' ) ) {
 			);
 
 			$this->show_nux_banner( $banner_content );
+		}
+
+		/**
+		 * Banner for a site that is registered with WordPress.com but has no connected owner.
+		 *
+		 * Without it this store sees the same "connect your site" banner as a store that never
+		 * connected, and the Automated taxes setting is simply absent from WooCommerce >
+		 * Settings > Tax with nothing naming the reason. Both symptoms come from the same
+		 * place: WC_Connect_Jetpack::is_connected() requires a connected owner, so the plugin
+		 * never boots its tax integration. The sign-in is the only missing step, and the
+		 * existing connect handler already takes the merchant straight to it - a site that is
+		 * already registered skips registration and goes to the authorization flow.
+		 */
+		public function show_banner_site_only_connection() {
+			if ( ! $this->should_display_nux_notice_for_current_store_locale() ) {
+				return;
+			}
+
+			if ( ! $this->should_display_nux_notice_on_screen( get_current_screen() ) ) {
+				return;
+			}
+
+			// Remove Jetpack's connect banners since we're showing our own.
+			if ( class_exists( 'Jetpack_Connection_Banner' ) ) {
+				$jetpack_banner = Jetpack_Connection_Banner::init();
+
+				remove_action( 'admin_notices', array( $jetpack_banner, 'render_banner' ) );
+				remove_action( 'admin_notices', array( $jetpack_banner, 'render_connect_prompt_full_screen' ) );
+			}
+
+			// The after-connection banner is owed to whoever finishes the sign-in from here,
+			// exactly as it is for a store connecting from scratch.
+			WC_Connect_Options::delete_option( self::SHOULD_SHOW_AFTER_CXN_BANNER );
+
+			$country      = WC()->countries->get_base_country();
+			$feature_list = $this->get_feature_list_for_country( $country );
+
+			/* translators: %s: list of features, potentially comma separated */
+			$description_base = __( 'Your site is connected to WordPress.com, but no WordPress.com account is linked to it yet. Sign in to finish connecting and unlock %s.', 'woocommerce-services' );
+
+			$this->show_nux_banner(
+				array(
+					'title'             => __( 'Finish connecting your WordPress.com account', 'woocommerce-services' ),
+					'description'       => sprintf( $description_base, $feature_list ),
+					'button_text'       => __( 'Finish connecting', 'woocommerce-services' ),
+					'image_url'         => plugins_url( 'images/wcs-notice.png', __DIR__ ),
+					'should_show_terms' => true,
+				)
+			);
 		}
 
 		public function show_banner_after_connection() {

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ This plugin relies on the following external services:
 
 == Changelog ==
 
+= 3.6.15 - 2026-xx-xx =
+* Add   - Prompt merchants to finish signing in to WordPress.com when the site is connected but no account is linked to it, so the missing step is named instead of hidden.
+
 = 3.6.14 - 2026-09-03 =
 * Fix   - Prevent a fatal error at checkout when a cart line's price is not numeric.
 * Tweak - Limit the WordPress.com connection banner to the Tax settings and Plugins pages, so it no longer appears on unrelated admin screens.

--- a/tests/php/test-class_wc-connect-nux.php
+++ b/tests/php/test-class_wc-connect-nux.php
@@ -149,6 +149,124 @@ class WP_Test_WC_Connect_NUX extends WC_Unit_Test_Case {
 		);
 	}
 
+	/**
+	 * A site that registered but never had an account linked gets its own banner.
+	 *
+	 * Jetpack reports this state as "not connected" - WC_Connect_Jetpack::is_connected()
+	 * requires a connected owner - so without this branch the store is told to connect a site
+	 * that is already connected, and the only missing step is never named.
+	 */
+	public function test_get_banner_type_to_display_site_only_connection() {
+		$this->assertEquals(
+			'site_only_connection',
+			WC_Connect_Nux::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_NOT_CONNECTED,
+					'tos_accepted'                    => false,
+					'can_accept_tos'                  => false,
+					'should_display_after_cxn_banner' => false,
+					'is_site_only_connection'         => true,
+				)
+			)
+		);
+
+		// TOS acceptance is irrelevant to it: nothing can be accepted without an owner anyway.
+		$this->assertEquals(
+			'site_only_connection',
+			WC_Connect_Nux::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_NOT_CONNECTED,
+					'tos_accepted'                    => true,
+					'can_accept_tos'                  => true,
+					'should_display_after_cxn_banner' => false,
+					'is_site_only_connection'         => true,
+				)
+			)
+		);
+	}
+
+	/**
+	 * A store with no connection at all keeps the original "connect your site" banner.
+	 */
+	public function test_get_banner_type_to_display_not_connected_is_not_site_only() {
+		$this->assertEquals(
+			'before_jetpack_connection',
+			WC_Connect_Nux::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_NOT_CONNECTED,
+					'tos_accepted'                    => false,
+					'can_accept_tos'                  => false,
+					'should_display_after_cxn_banner' => false,
+					'is_site_only_connection'         => false,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Callers that never pass the new key keep the exact behaviour they had before it existed.
+	 *
+	 * This method is public static on a globally-named class, so third-party code can call it
+	 * with the four keys it has always taken. Omitting the key must not reach the new banner.
+	 */
+	public function test_get_banner_type_to_display_without_the_site_only_key_is_unchanged() {
+		$this->assertEquals(
+			'before_jetpack_connection',
+			WC_Connect_Nux::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_NOT_CONNECTED,
+					'tos_accepted'                    => false,
+					'can_accept_tos'                  => false,
+					'should_display_after_cxn_banner' => false,
+				)
+			)
+		);
+	}
+
+	/**
+	 * The new flag only speaks for the not-connected branch and must not divert a real
+	 * connection, in offline mode or otherwise.
+	 */
+	public function test_site_only_flag_does_not_affect_connected_states() {
+		$this->assertEquals(
+			'tos_only_banner',
+			WC_Connect_Nux::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_CONNECTED,
+					'tos_accepted'                    => false,
+					'can_accept_tos'                  => true,
+					'should_display_after_cxn_banner' => false,
+					'is_site_only_connection'         => true,
+				)
+			)
+		);
+
+		$this->assertEquals(
+			'after_jetpack_connection',
+			WC_Connect_Nux::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_OFFLINE_MODE,
+					'tos_accepted'                    => false,
+					'can_accept_tos'                  => true,
+					'should_display_after_cxn_banner' => true,
+					'is_site_only_connection'         => true,
+				)
+			)
+		);
+
+		$this->assertFalse(
+			WC_Connect_Nux::get_banner_type_to_display(
+				array(
+					'jetpack_connection_status'       => WC_Connect_Nux::JETPACK_CONNECTED,
+					'tos_accepted'                    => true,
+					'can_accept_tos'                  => true,
+					'should_display_after_cxn_banner' => false,
+					'is_site_only_connection'         => true,
+				)
+			)
+		);
+	}
+
 	public function test_get_banner_type_to_display_with_jp_cxn_without_tos_acceptance_non_owner() {
 		// Jetpack is already connected, TOS was not yet accepted, user is not the connection owner
 		$this->assertEquals(


### PR DESCRIPTION
## Description

A WordPress.com connection has two parts: a token for the site, and a WordPress.com account linked to it. A store can end up with the first and not the second.

When that happens, the plugin reports the store as "not connected" — the same as a store that never connected at all. Two very different situations look identical, and the merchant gets two confusing symptoms at once:

- WooCommerce → Settings → Tax has **no Automated taxes setting**, with nothing explaining why.
- A banner asks them to **connect a site that is already connected**, so clicking it looks like it does nothing.

Nothing names the one step that is actually missing: signing in with a WordPress.com account.

This PR adds a banner for that state. It says the site is connected but no account is linked, and the button takes the merchant to the sign-in. Once they finish, Automated taxes appears on its own.

<details>
<summary>Why both symptoms happen (same cause)</summary>

`WC_Connect_Jetpack::is_connected()` requires *both* a site token and a connected owner, so a site-token-only store gets `false`.

That flows downhill:

1. `WC_Connect_Nux::get_jetpack_install_status()` returns `JETPACK_NOT_CONNECTED`.
2. `WC_Services::pre_wc_init()` returns early on that value.
3. So `attach_hooks()` never runs.
4. So `WC_Connect_TaxJar_Integration::init()` never runs.
5. So its `woocommerce_tax_settings` filter is never added — and the **Automated taxes** row is never added to the Tax settings screen.

The NUX banner is registered *before* that early return, so it still renders — which is why the store gets the "connect your site" prompt while the setting is missing.

On the support case behind this issue, that combination sent two sessions chasing a REST API block and a WooCommerce.com marketplace reconnect instead of the unfinished sign-in.
</details>

<details>
<summary>What I deliberately did not change</summary>

**The bootstrap gate stays as it is.** `JETPACK_NOT_CONNECTED` is the *right* answer for this store, because tax features genuinely cannot work without a user token. Only what the merchant is told was wrong, so only that changed. `get_jetpack_install_status()` still returns its three existing values.

**No new connection flow.** `WC_Connect_Jetpack::connect_site()` already does the right thing here — it calls `try_registration()` only when the site is *not* registered, and otherwise goes straight to `get_authorization_url()`. The new banner reuses the existing `admin_post_register_woocommerce_services_jetpack` handler, so the button already lands on the sign-in.

**The Status page health item.** On this kind of store, WooCommerce → Status → WooCommerce Tax does not exist at all: `WC_Connect_Help_View` is only constructed in `load_admin_dependencies()`, which is downstream of the same early return. Editing its "Not connected to WordPress.com" message would have been unreachable code that looked like coverage. Worth its own issue — the plugin's own diagnostic surface disappears in exactly the state support is trying to diagnose.
</details>

### Related issue(s)

WOOTAX-329. The docs half of the same problem is WOODOCS-3744 (Done).

### Steps to reproduce & screenshots/GIFs

This needs a store whose WordPress.com connection has a site token and no connected owner (report card: `is_connected: true`, `has_connected_owner: false`). You cannot get there by running the normal connect flow to the end, which is why the original issue was not reproduced in a sandbox either. The decision table is covered by unit tests instead of a screenshot.

**Before:** Tax settings shows *"Connect your site to activate WooCommerce Tax"* and no Automated taxes setting.

**After:** the same screen shows *"Finish connecting your WordPress.com account — Your site is connected to WordPress.com, but no WordPress.com account is linked to it yet. Sign in to finish connecting and unlock automated tax calculation."* with a **Finish connecting** button. Completing the sign-in makes Automated taxes appear.

A store that never connected is unaffected and still gets the original banner.

### Backward compatibility

Additive. Existing callers of the one shared method get identical results, and that is covered by a test.

<details>
<summary>Surface-by-surface detail</summary>

| Symbol | Change | Impact |
|---|---|---|
| `WC_Connect_Jetpack::is_site_only_connection()` | New `public static` method. | Additive. None. |
| `WC_Connect_Nux::show_banner_site_only_connection()` | New `public` method. | Additive. None. |
| `WC_Connect_Nux::get_banner_type_to_display()` | New optional `$status` key `is_site_only_connection`; new possible return value `'site_only_connection'`. | This is `public static` on a globally-named class, so third-party code may call it. **The new return value is reachable only when the caller passes the new key**, so any existing caller gets byte-identical results — there is a dedicated regression test for that. A caller that opts in and `switch`es on the result could hit an unhandled value and fall to its `default` (no banner). No fatal, no signature change. |
| `WC_Connect_Nux::get_jetpack_install_status()` | Unchanged. | None. A fourth status value would have changed what `pre_wc_init()`'s `===` comparison and any external consumer sees, for no benefit. |
| `admin_post_register_woocommerce_services_jetpack` | Unchanged, reused as-is. | None. |
| Script/style handles | `wc_connect_banner` reused. No handle added, renamed or removed. | None. |
| Hooks | No `do_action` / `apply_filters` added, removed, renamed or reordered. | None. |

**Multisite:** reads only Jetpack connection state, which is site-scoped, exactly as the code beside it already did. No new option reads, no `get_site_option`. Not tested on a multisite install.

**Install layout:** the banner image uses `plugins_url()`, matching the sibling banners. No path concatenation.

**Global state:** `WC()->countries` is dereferenced only inside the `admin_notices` callback, after `should_display_nux_notice_for_current_store_locale()` has already done so — same as every other banner in this class. Nothing new runs on a REST, cron or CLI path.
</details>

### Checklist

- [x] unit tests
- [x] `changelog.txt` entry added
- [x] `readme.txt` entry added

<details>
<summary>Verification results</summary>

- `composer test` → **OK (418 tests, 1015 assertions)**. Trunk baseline is 414 / 1008, so the delta is exactly the 4 tests and 7 assertions added here. No test reported as skipped.
- PHPCS on the three touched files, `--standard=phpcs.xml.dist --report=source`, at the same repo-relative paths on trunk and on this branch: **82 violations / 14 sources before and after — zero new.**
- Run in the main checkout rather than a worktree, so the known dot-directory false-pass does not apply; the progress line read `3 / 3`, confirming the files were actually scanned.
</details>

