### PR TITLE
Add a dependency check to the PR checklist for releases

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,3 +30,6 @@
 - [ ] `changelog.txt` entry added
 - [ ] `readme.txt` entry added
 
+<!-- Release PRs only -->
+- [ ] `composer outdated --direct` and `npm outdated` run, and the `automattic/jetpack-*` packages are on their latest stable line
+


### PR DESCRIPTION
## Description
Releases go out as a PR into trunk, and nothing in that path asks whether our dependencies are current. Dependabot here covers GitHub Actions only. That is how `automattic/jetpack-connection` stayed on 7.1.1 from February.

This adds one release-only item to the PR checklist: run `composer outdated --direct` and `npm outdated`, and confirm the `automattic/jetpack-*` packages are on their latest stable line.

The bump itself is WOOTAX-348, not this PR.

### Related issue(s)

Related to WOOTAX-348

### Steps to reproduce & screenshots/GIFs

Read the diff. After merge, the line shows up under Checklist on every new PR.

### Checklist

- [ ] unit tests - N/A, template only
- [ ] `changelog.txt` entry added - N/A, template only
- [ ] `readme.txt` entry added - N/A, template only

Generated by an agent on behalf of rtiodev.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fxWM4iGh2HME12hje4iJg